### PR TITLE
chore: update publish workflows

### DIFF
--- a/.github/workflows/create-release-tag-and-pr.yml
+++ b/.github/workflows/create-release-tag-and-pr.yml
@@ -109,3 +109,40 @@ jobs:
           name: "${{ github.event.inputs.tag }}"
           prerelease: true
           bodyFile: "./changelog.txt"
+
+  # This job dispatches workflow to push to staging / latest environments
+  dispatch-storybook-workflow:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    needs: create-release-tag
+    steps:
+      # After successfully creating tag for release candidate, trigger the staging storybook environment deployment workflow.
+      # Pass in the release branch name to the storybook deployment job so it build off the release branch
+      - name: Dispatch staging storybook deployment workflow
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          event-type: deploy-staging-storybook
+          client-payload: '{"branch": "${{ github.ref_name }}"}'
+
+      # After successfully creating a tag for full release, trigger the production storybook environment deployment workflow.
+      # Pass in the release branch name to the storybook deployment job so it build off the release branch
+      - name: Dispatch production storybook deployment workflow
+        if: contains(github.event.inputs.tag, '-rc.') == false
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          event-type: deploy-latest-storybook
+          client-payload: '{"branch": "${{ github.ref_name }}"}'
+
+  # This job dispatches workflow to publish staging / latest CDN artifacts
+  dispatch-cdn-workflow:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    needs: create-release-tag
+    steps:
+      # After successfully creating tag for the release candidate / full release, trigger the workflow to publish the CDN artifacts.
+      # Pass in the tag to the CDN publishing workflow.
+      - name: Dispatch CDN publishing workflow
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          event-type: publish-cdn-artifacts
+          client-payload: '{"tag": "${{ github.event.inputs.tag }}", "branch": "${{ github.ref_name }}"}'

--- a/.github/workflows/deploy-latest-storybook.yml
+++ b/.github/workflows/deploy-latest-storybook.yml
@@ -1,19 +1,12 @@
 # Deploy production storybook environment from release branch to Github Pages
 name: Deploy production storybook
 
-# This workflow is triggered from the `release-base` workflow when a full release
+# This workflow is triggered from the `create-release-tag-and-pr` workflow when a full release
 # has been successfully completed
 on:
   workflow_dispatch:
-  push:
-    tags:
-      # Matches tags that have the shape `vX.Y.Z`
-      # Reference: https://help.github.com/en/articles/workflow-syntax-for-github-actions#onpushpull_requesttagsbranches
-      - "v[0-9]+.[0-9]+.[0-9]+"
-
-      # Ignore tags that use a preid after `vX.Y.Z`, for example: vX.Y.Z-rc.0
-      # https://help.github.com/en/articles/workflow-syntax-for-github-actions#example-using-positive-and-negative-patterns
-      - "!v[0-9]+.[0-9]+.[0-9]+-*"
+  repository_dispatch:
+    types: [deploy-latest-storybook]
 
 jobs:
   deploy-latest-storybook:
@@ -23,6 +16,7 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1
         with:
           fetch-depth: "0"
+          ref: ${{ github.event.client_payload.branch }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/deploy-staging-storybook.yml
+++ b/.github/workflows/deploy-staging-storybook.yml
@@ -1,16 +1,12 @@
 # Deploy staging storybook environment from release branch to Github Pages
 name: Deploy staging storybook
 
-# Gets triggered every time a release candidate has been published from the `release-base` workflow
-# or can be manually triggered
+# Gets triggered every time a release candidate tag has been published from the
+# `create-release-tag-and-pr` workflow or can be manually triggered
 on:
   workflow_dispatch:
-  push:
-    tags:
-      # Matches tags that have the shape `vX.Y.Z` or `vX.Y.Z-rc.X` Reference:
-      # https://help.github.com/en/articles/workflow-syntax-for-github-actions#onpushpull_requesttagsbranches
-      - "v[0-9]+.[0-9]+.[0-9]+"
-      - "v[0-9]+.[0-9]+.[0-9]+-*"
+  repository_dispatch:
+    types: [deploy-staging-storybook]
 
 jobs:
   deploy-staging-storybook:
@@ -20,6 +16,7 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1
         with:
           fetch-depth: "0"
+          ref: ${{ github.event.client_payload.branch }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/publish-cdn.yml
+++ b/.github/workflows/publish-cdn.yml
@@ -1,7 +1,8 @@
 # Publish the staging / latest / versioned CDN artifacts to Cloud Object Storage
 name: Publish CDN artifacts
 
-# occurs when a new tag has been pushed or can be manually triggered with tag provided
+# This workflow is triggered from the `create-release-tag-and-pr` workflow when a new tag is created
+# Or can be manually triggered with tag provided
 on:
   workflow_dispatch:
     inputs:
@@ -11,12 +12,8 @@ on:
         description: "release tag (ie. v1.1.0-rc.0 or v1.1.0)"
         type: string
         default: "v1.1.0-rc.0"
-  push:
-    tags:
-      # Matches tags that have the shape `vX.Y.Z` or `vX.Y.Z-rc.X` Reference:
-      # https://help.github.com/en/articles/workflow-syntax-for-github-actions#onpushpull_requesttagsbranches
-      - "v[0-9]+.[0-9]+.[0-9]+"
-      - "v[0-9]+.[0-9]+.[0-9]+-*"
+  repository_dispatch:
+    types: [publish-cdn-artifacts]
 
 concurrency:
   group: deploy-${{ github.ref }}
@@ -29,6 +26,7 @@ jobs:
       - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4.2.1
         with:
           fetch-depth: "0"
+          ref: ${{ github.event.client_payload.branch }}
       - name: Use Node.js 20.x
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/release-base.yml
+++ b/.github/workflows/release-base.yml
@@ -18,6 +18,10 @@ on:
         description: "Run dry run?"
         type: boolean
         default: true
+      force-publish:
+        description: "Force publish?"
+        type: boolean
+        default: false
 
 jobs:
   release:
@@ -64,27 +68,37 @@ jobs:
             echo "PUBLISH=--yes" >> $GITHUB_ENV
           fi
 
+      # Set the FORCE environment variable to be used later in the Lerna publish command.
+      # Lerna has force-publish off by default, but is to be used in circumstances when Lerna doesn't detect changes
+      # and we want to bump the version up regardless.
+      # Use with dry-run set to true first to confirm the version bump before running again with dry-run set to false
+      - name: Set force publish env variable
+        run: |
+          if [ "${{ github.event.inputs.force-publish }}" == "true"  ]; then
+            echo "FORCE=--force-publish" >> $GITHUB_ENV
+          fi
+
       - name: Publish full minor release (ie. v1.x.0)
         if: github.event.inputs.type == 'full minor release'
         run: |
-          npm lerna publish minor --conventional-graduate $(echo "${{ env.PUBLISH }}")
+          npm lerna publish minor --conventional-graduate ${{ env.PUBLISH }} ${{ env.FORCE }}
 
       - name: Publish first minor RC (ie. v1.x.0-rc.0)
         if: github.event.inputs.type == 'first minor rc'
         run: |
-          npm lerna publish preminor --conventional-prerelease --preid rc --pre-dist-tag next $(echo "${{ env.PUBLISH }}")
+          npm lerna publish preminor --conventional-prerelease --preid rc --pre-dist-tag next ${{ env.PUBLISH }} ${{ env.FORCE }}
 
       - name: Publish full patch release (ie. v1.0.x)
         if: github.event.inputs.type == 'full patch release'
         run: |
-          npm run lerna publish patch --conventional-graduate $(echo "${{ env.PUBLISH }}")
+          npm run lerna publish patch --conventional-graduate ${{ env.PUBLISH }} ${{ env.FORCE }}
 
       - name: Publish first patch RC (ie. v1.0.x-rc.0)
         if: github.event.inputs.type == 'first patch rc'
         run: |
-          npm lerna publish prepatch --conventional-prerelease --preid rc --pre-dist-tag next $(echo "${{ env.PUBLISH }}")
+          npm lerna publish prepatch --conventional-prerelease --preid rc --pre-dist-tag next ${{ env.PUBLISH }} ${{ env.FORCE }}
 
       - name: Publish subsequent RC (ie. v1.0.0-rc.x)
         if: github.event.inputs.type == 'subsequent rc'
         run: |
-          npm lerna publish --conventional-prerelease --preid rc --pre-dist-tag next $(echo "${{ env.PUBLISH }}")
+          npm lerna publish --conventional-prerelease --preid rc --pre-dist-tag next ${{ env.PUBLISH }} ${{ env.FORCE }}

--- a/.github/workflows/release-minor.yml
+++ b/.github/workflows/release-minor.yml
@@ -23,6 +23,11 @@ on:
         description: "Run dry run?"
         type: boolean
         default: true
+      force-publish:
+        # May need to force publish at times when lerna doesn't detect changes
+        description: "Force publish?"
+        type: boolean
+        default: false
 
 jobs:
   Release:
@@ -31,4 +36,5 @@ jobs:
     with:
       type: ${{ inputs.type }}
       dry-run: ${{ inputs.dry-run }}
+      force-publish: ${{ inputs.force-publish}}
     secrets: inherit

--- a/.github/workflows/release-patch.yml
+++ b/.github/workflows/release-patch.yml
@@ -23,6 +23,11 @@ on:
         description: "Run dry run?"
         type: boolean
         default: true
+      force-publish:
+        # May need to force publish at times when lerna doesn't detect changes
+        description: "Force publish?"
+        type: boolean
+        default: false
 
 jobs:
   Release:
@@ -31,4 +36,5 @@ jobs:
     with:
       type: ${{ inputs.type }}
       dry-run: ${{ inputs.dry-run }}
+      force-publish: ${{ inputs.force-publish}}
     secrets: inherit

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,5 @@
+es
+lib
+dist
+umd
+node_modules

--- a/docs/publishing-releases.md
+++ b/docs/publishing-releases.md
@@ -1,6 +1,6 @@
 # Release
 
-> How we version and release packages in the Carbon Monorepo Template
+> How we version and release packages in the Carbon AI Chat monorepo
 
 ## Table of Contents
 
@@ -95,8 +95,7 @@ release team will need to do the following:
       inputs as above, but this time with dry run unchecked.
 - [ ] Once job has completed, check the packages on npm to ensure they have been
       published under the `next` tag:
-  - [ ] `@carbon/monorepo-template`:
-        [replace link here with npm versions page]
+  - [ ] `@carbon/ai-chat`: https://www.npmjs.com/package/@carbon/ai-chat
 - [ ] Run the
       [create github tag and PR workflow](https://github.com/carbon-design-system/carbon-ai-chat/actions/workflows/create-release-tag-and-pr.yml).
       This workflow creates the release tag, generates the release with notes,
@@ -117,8 +116,8 @@ release team will need to do the following:
           Once this workflow has completed, check the
           staging environment on GitHub Pages and ensure the version in the storybook top left header has been updated.
     - [ ] The [publish cdn workflow](https://github.com/carbon-design-system/carbon-ai-chat/actions/workflows/publish-cdn.yml). Once this workflow has completed, check that the CDN for the staging tag and version has been published.
-- [ ] Post a message to the `#support-channel` Slack channel to announce the
-      new version of `@carbon/monorepo-template`.
+- [ ] Post a message to the `#carbon-ai-chat` Slack channel to announce the
+      new version of `@carbon/ai-chat`.
 
 ### Subsequent Prerelease
 
@@ -143,8 +142,7 @@ from the release branch for further testing. To publish subsequent prereleases,
       inputs as above, but this time with dry run unchecked.
 - [ ] Once job has completed, check the packages on npm to ensure they have been
       published under the `next` tag:
-  - [ ]`@carbon/monorepo-template`:
-    [replace link here with npm versions page]
+  - [ ]`@carbon/ai-chat`: https://www.npmjs.com/package/@carbon/ai-chat
 - [ ] Run the
       [create github tag and PR workflow](https://github.com/carbon-design-system/carbon-ai-chat/actions/workflows/create-release-tag-and-pr.yml).
       This workflow creates the release tag, generates the release with notes,
@@ -165,7 +163,7 @@ from the release branch for further testing. To publish subsequent prereleases,
           Once this workflow has completed, check the
           staging environment on GitHub Pages and ensure the version in the storybook top left header has been updated.
     - [ ] The [publish cdn workflow](https://github.com/carbon-design-system/carbon-ai-chat/actions/workflows/publish-cdn.yml). Once this workflow has completed, check that the CDN for the staging tag and version has been published.
-- [ ] Post a message to the `#support-channel` Slack channel to announce the
+- [ ] Post a message to the `#carbon-ai-chat` Slack channel to announce the
       new version of `@carbon/monorepo-template`.
 
 ### Stable release
@@ -191,10 +189,14 @@ validated. During this stage, the release team will do the following:
       `v0.10.0-rc.1 ---> v0.10.0`).
 - [ ] If the version bumps are expected, run the workflow again with the same
       inputs as above, but this time with dry run unchecked.
+      **Note:**If you run into an issue where Lerna detects no changes (usually when bumping from release candidate to full release), you can run with the `force publish` option.
+      ![Screenshot of lerna not updating due to no changes detected](https://github.com/user-attachments/assets/8c43bd62-f440-45c7-be8d-55daca9a9e4f)
+      Run the workflow again with both `dry run` and `force publish` options set to true so you can confirm the version bump before re-running with `force publish` set to true and `dry run` set to false.
+      ![Screenshot of minor release workflow with force publish option](https://github.com/user-attachments/assets/a1535d5c-058d-4784-a46f-ae65fed3b286)
+
 - [ ] Once job has completed, check the packages on npm to ensure they have been
       published under the `latest` tag:
-  - [ ]`@carbon/monorepo-template`:
-    [replace link here with npm versions page]
+  - [ ]`@carbon/ai-chat`: https://www.npmjs.com/package/@carbon/ai-chat
 - [ ] Run the
       [create github tag and PR workflow](https://github.com/carbon-design-system/carbon-ai-chat/actions/workflows/create-release-tag-and-pr.yml).
       This workflow creates the release tag, generates the release with notes,
@@ -220,8 +222,8 @@ validated. During this stage, the release team will do the following:
         `latest`.
         ![Screenshot of release label with latest option selected](https://github.com/user-attachments/assets/f3afc692-d691-4c04-b891-73d0406be7b0)
 
-- [ ] Post a message to the `#support-channel` Slack channel to announce the
-      new version of `@carbon/monorepo-template`.
+- [ ] Post a message to the `#carbon-ai-chat` Slack channel to announce the
+      new version of `@carbon/ai-chat`.
 
 - [ ] Remove the branch protections for `release/v.*` by changing the branch
       name pattern to `released/v*`

--- a/lerna.json
+++ b/lerna.json
@@ -11,7 +11,7 @@
   ],
   "command": {
     "version": {
-      "message": "chore(release): %s"
+      "message": "chore(release): publish"
     }
   },
   "$schema": "node_modules/lerna/schemas/lerna-schema.json"

--- a/packages/ai-chat/package.json
+++ b/packages/ai-chat/package.json
@@ -8,6 +8,10 @@
     "url": "https://github.com/carbon-design-system/carbon-ai-chat",
     "directory": "packages/ai-chat"
   },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "exports": {
     "./es/": "./es/",
     "./dist/": "./dist/",


### PR DESCRIPTION
This PR makes updates to a workflows involved in the release process 

- `create-release-tag-and-pr` updated to trigger the staging + latest storybook workflows and the CDN publishing workflow as I noticed the on push of the git tags from the `create-release-tag-and-pr` doesn't trigger those workflows. 
- noticed with the full releases, Lerna will not bump the versions when there is no change detected. This needs to be overrode as we want to bump the version from release candidate to full release - added a `force publish` option to the release workflows in order to override that
- Updated the publish release documentation