### PR TITLE
chore(ai-chat): instrument with telemetry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4089,9 +4089,9 @@
       "integrity": "sha512-wuyglvk5dVTiOtRMlGhbRdu9zptl84CHLhjzuWPb2LwU3IiFlVWAirKaRKRv/AFwtAT9RoTtvT7spEyffdCzFw=="
     },
     "node_modules/@ibm/telemetry-js": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@ibm/telemetry-js/-/telemetry-js-1.8.0.tgz",
-      "integrity": "sha512-1u/8f5TtDHXWNQe+YfIESesZGX2PmhEfyU0znlyFvATch+xc5fPYjXj2gWKMTmdKsDawqAm/BkJBQjx2CDlZww==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@ibm/telemetry-js/-/telemetry-js-1.9.1.tgz",
+      "integrity": "sha512-qq8RPafUJHUQieXVCte1kbJEx6JctWzbA/YkXzopbfzIDRT2+hbR9QmgH+KH7bDDNRcDbdHWvHfwJKzThlMtPg==",
       "bin": {
         "ibmtelemetry": "dist/collect.js"
       }
@@ -34254,6 +34254,7 @@
       "dependencies": {
         "@carbon/styles": "^1.39.0",
         "@carbon/web-components": "^2.13.0",
+        "@ibm/telemetry-js": "^1.9.1",
         "lit": "^3.0.0",
         "tslib": "^2.6.3"
       },

--- a/packages/ai-chat/README.md
+++ b/packages/ai-chat/README.md
@@ -1,0 +1,9 @@
+# Carbon AI Chat
+
+## <picture><source height="20" width="20" media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-dark.svg"><source height="20" width="20" media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-light.svg"><img height="20" width="20" alt="IBM Telemetry" src="https://raw.githubusercontent.com/ibm-telemetry/telemetry-js/main/docs/images/ibm-telemetry-light.svg"></picture> IBM Telemetry
+
+This package uses IBM Telemetry to collect de-identified and anonymized metrics data. By installing
+this package as a dependency you are agreeing to telemetry collection. To opt out, see
+[Opting out of IBM Telemetry data collection](https://github.com/ibm-telemetry/telemetry-js/tree/main#opting-out-of-ibm-telemetry-data-collection).
+For more information on the data being collected, please see the
+[IBM Telemetry documentation](https://github.com/ibm-telemetry/telemetry-js/tree/main#ibm-telemetry-collection-basics).

--- a/packages/ai-chat/package.json
+++ b/packages/ai-chat/package.json
@@ -23,12 +23,14 @@
     "es/**/*",
     "dist/**/*",
     "custom-elements.json",
-    "package.json"
+    "package.json",
+    "telemetry.yml"
   ],
   "scripts": {
     "build": "npm run clean && npm run custom-elements && node tasks/build.js && node tasks/build-dist.js",
     "clean": "rimraf es dist storybook-static",
     "custom-elements": "cem analyze --config ./custom-elements-manifest.config.js",
+    "postinstall": "ibmtelemetry --config=telemetry.yml",
     "storybook": "npm run custom-elements && storybook dev -p 6006",
     "storybook:build": "npm run custom-elements && storybook build",
     "test": "web-test-runner \"src/components/**/*.test.ts\" --node-resolve",
@@ -37,6 +39,7 @@
   "dependencies": {
     "@carbon/styles": "^1.39.0",
     "@carbon/web-components": "^2.13.0",
+    "@ibm/telemetry-js": "^1.9.1",
     "lit": "^3.0.0",
     "tslib": "^2.6.3"
   },

--- a/packages/ai-chat/telemetry.yml
+++ b/packages/ai-chat/telemetry.yml
@@ -1,0 +1,11 @@
+# yaml-language-server: $schema=https://unpkg.com/@ibm/telemetry-config-schema@v1/dist/config.schema.json
+
+version: 1
+projectId: ef967584-5788-47d4-b9c2-a60da7ad901d
+endpoint: https://www-api.ibm.com/ibm-telemetry/v1/metrics
+collect:
+  npm:
+    dependencies: null
+  js:
+    functions: {}
+    tokens: null


### PR DESCRIPTION
Instruments the `@carbon/ai-chat` package with IBM Telemetry. Web component tracking isn't supported yet in IBM Telemetry, but like our other web component packages, we'll still be able to track package installations per repository (and product if applicable).
