### PR TITLE
chore: add triage label in workflow automation

### DIFF
--- a/.github/workflows/add-triage-label.yml
+++ b/.github/workflows/add-triage-label.yml
@@ -15,4 +15,4 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
           NUMBER: ${{ github.event.issue.number }}
-          LABELS: "status: needs triage 🕵️‍♀️"
+          LABELS: "status: needs triage :female_detective:"


### PR DESCRIPTION
Contributes to #189 

Adds the workflow automation from ibm-products to add `status: needs triage 🕵🏻‍♀️` for newly opened issues. which will be going to have a dedicated view in project.

#### Changelog

**New**

- adds a yml file in workflow folder

#### Testing / Reviewing

tested in an example repository
https://github.com/devadula-nandan/TD-TABLE/issues/6
