### PR TITLE
chore: add merge group for merge queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,8 @@ on:
     branches: [ main, carbon-react-web-components-integration ]
   pull_request:
     branches: [ main, carbon-react-web-components-integration ]
+  merge_group:
+    types: [checks_requested]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Add `merge_group` field to `ci` workflow to allow the merge queue to run those checks
