### PR TITLE
fix: re-enable full width user_defined responses

### DIFF
--- a/demo/src/customSendMessage/doUserDefined.ts
+++ b/demo/src/customSendMessage/doUserDefined.ts
@@ -31,6 +31,14 @@ function doUserDefined(instance: ChatInstance) {
             text: FAKE_DATA,
           },
         } as UserDefinedItem,
+        {
+          response_type: MessageResponseTypes.USER_DEFINED,
+          user_defined: {
+            user_defined_type: "green",
+            text: "As full width",
+          },
+          full_width: true,
+        } as UserDefinedItem,
       ],
     },
   });

--- a/packages/ai-chat/src/chat/shared/containers/MessageComponent.tsx
+++ b/packages/ai-chat/src/chat/shared/containers/MessageComponent.tsx
@@ -37,6 +37,7 @@ import { FileStatusValue } from "../utils/constants";
 import { doFocusRef } from "../utils/domUtils";
 import {
   isConnectToAgent,
+  isFullWidthUserDefined,
   isOptionItem,
   isRequest,
   isResponse,
@@ -718,8 +719,9 @@ class MessageComponent extends PureComponent<
                       responseType === MessageResponseTypes.BUTTON,
                     "WAC__received--grid":
                       responseType === MessageResponseTypes.GRID,
-                    "WAC__received--fullWidth":
-                      localMessageItem.ui_state.fullWidth,
+                    "WAC__received--fullWidth": isFullWidthUserDefined(
+                      localMessageItem.item
+                    ),
                     "WAC__message--historical": fromHistory,
                   }
                 )}

--- a/packages/ai-chat/src/chat/shared/events/ChatActionsImpl.ts
+++ b/packages/ai-chat/src/chat/shared/events/ChatActionsImpl.ts
@@ -783,21 +783,10 @@ class ChatActionsImpl {
           fullMessage: originalMessage,
           element,
           slot: slotName,
-          fullWidth: false,
         },
       };
 
       await this.serviceManager.fire(userDefinedResponseEvent);
-
-      if (userDefinedResponseEvent.data.fullWidth) {
-        this.serviceManager.store.dispatch(
-          actions.setMessageUIProperty(
-            localMessage.ui_state.id,
-            "fullWidth",
-            true
-          )
-        );
-      }
     } else if (isResponseWithNestedItems(localMessage.item)) {
       const {
         itemsLocalMessageItemIDs,
@@ -866,7 +855,6 @@ class ChatActionsImpl {
     messageItem: DeepPartial<GenericItem>
   ) {
     if (renderAsUserDefinedMessage(messageItem)) {
-      const { store } = this.serviceManager;
       const itemID = streamItemID(messageID, messageItem);
 
       let element: HTMLElement;
@@ -883,24 +871,10 @@ class ChatActionsImpl {
           chunk,
           element,
           slot: slotName,
-          fullWidth: false,
         },
       };
 
       await this.serviceManager.fire(userDefinedResponseEvent);
-
-      if (
-        store.getState().allMessageItemsByID[itemID].ui_state.fullWidth !==
-        userDefinedResponseEvent.data.fullWidth
-      ) {
-        store.dispatch(
-          actions.setMessageUIProperty(
-            itemID,
-            "fullWidth",
-            userDefinedResponseEvent.data.fullWidth
-          )
-        );
-      }
     }
   }
 

--- a/packages/ai-chat/src/chat/shared/utils/messageUtils.ts
+++ b/packages/ai-chat/src/chat/shared/utils/messageUtils.ts
@@ -44,6 +44,7 @@ import {
   SingleOption,
   StreamChunk,
   TextItem,
+  UserDefinedItem,
   WithBodyAndFooter,
 } from "../../../types/messaging/Messages";
 
@@ -480,6 +481,16 @@ function isSingleItemCarousel(
   return isCarouselResponseType(messageItem) && messageItem.items.length === 1;
 }
 
+function isFullWidthUserDefined(
+  messageItem: GenericItem
+): messageItem is UserDefinedItem {
+  return isUserDefinedItem(messageItem) && messageItem.full_width;
+}
+
+function isUserDefinedItem(item: GenericItem): item is UserDefinedItem {
+  return (item?.response_type as string) === MessageResponseTypes.USER_DEFINED;
+}
+
 function isGridResponseType(item: GenericItem): item is GridItem {
   return (item?.response_type as string) === MessageResponseTypes.GRID;
 }
@@ -594,4 +605,5 @@ export {
   getMediaDimensions,
   getLastBotResponseWithContext,
   THREAD_ID_MAIN,
+  isFullWidthUserDefined,
 };

--- a/packages/ai-chat/src/types/events/eventBusTypes.ts
+++ b/packages/ai-chat/src/types/events/eventBusTypes.ts
@@ -622,12 +622,6 @@ export interface BusEventUserDefinedResponse extends BusEvent {
      * The slot name for users of the web components cds-aichat-container or cds-aichat-custom-element.
      */
     slot?: string;
-
-    /**
-     * An assignable property that the event listener can assign that will indicate if the response is supposed to
-     * be full width.
-     */
-    fullWidth?: boolean;
   };
 }
 
@@ -656,12 +650,6 @@ export interface BusEventChunkUserDefinedResponse extends BusEvent {
      * The slot name for users of the web components cds-aichat-container or cds-aichat-custom-element.
      */
     slot?: string;
-
-    /**
-     * An assignable property that the event listener can assign that will indicate if the response is supposed to
-     * be full width.
-     */
-    fullWidth?: boolean;
   };
 }
 

--- a/packages/ai-chat/src/types/messaging/LocalMessageItem.ts
+++ b/packages/ai-chat/src/types/messaging/LocalMessageItem.ts
@@ -138,12 +138,6 @@ interface LocalMessageUIState<
   gridLocalMessageItemIDs?: string[][][];
 
   /**
-   * Indicates if this message should be rendered full width. This will remove all padding on the sides and hide the
-   * avatar.
-   */
-  fullWidth?: boolean;
-
-  /**
    * If this item is currently streaming, this will contain the current streaming status.
    */
   streamingState?: LocalMessageItemStreamingState<TGenericItemType>;

--- a/packages/ai-chat/src/types/messaging/Messages.ts
+++ b/packages/ai-chat/src/types/messaging/Messages.ts
@@ -629,8 +629,13 @@ interface GenericItem<TUserDefinedType = Record<string, unknown>> {
  *
  * @category Messaging
  */
-type UserDefinedItem<TUserDefinedType = Record<string, unknown>> =
-  GenericItem<TUserDefinedType>;
+interface UserDefinedItem<TUserDefinedType = Record<string, unknown>>
+  extends GenericItem<TUserDefinedType> {
+  /**
+   * If the user_defined response type should be rendered as full width and ignore margin on the "start".
+   */
+  full_width?: boolean;
+}
 
 /**
  * A text item returned in a message response from a back-end.


### PR DESCRIPTION
Closes #200 

Moving from updating `fullWidth` on the user_defined event to just including it as part of the message.

#### Changelog

**Changed**

- Added `full_width` as a property on the user_defined response type
- Added a full width example to the demo site when you select `user_defined`

**Removed**

- fullWidth in the event
- 
#### Testing / Reviewing

View user_defined on the demo site. Notice the 2nd message goes full width.
