### PR TITLE
fix: webpack dynamic import errors

### DIFF
--- a/packages/ai-chat/src/aiChatEntry.tsx
+++ b/packages/ai-chat/src/aiChatEntry.tsx
@@ -218,6 +218,7 @@ export {
   TourStepGenericItem,
   PartialResponse,
   MessageHistoryFeedback,
+  SearchResult,
 } from "./types/messaging/Messages";
 
 export { HistoryItem } from "./types/messaging/History";

--- a/packages/ai-chat/src/chat/dynamic-imports/dynamic-imports.ts
+++ b/packages/ai-chat/src/chat/dynamic-imports/dynamic-imports.ts
@@ -9,15 +9,16 @@
 
 /**
  * In this file we manage our dynamic imports for the entry of Carbon AI chat. See https://webpack.js.org/guides/code-splitting/#dynamic-imports.
+ *
+ * Dynamic imports are defined in a map to ensure they are statically analyzable by bundlers like webpack.
+ * This guarantees that the target components get built and are available when dynamic imports are resolved.
  */
 
 import React, { type ComponentType, type LazyExoticComponent } from "react";
 import { CreateHumanAgentServiceFunction } from "../shared/services/haa/HumanAgentService";
 
 async function loadHAA(): Promise<CreateHumanAgentServiceFunction> {
-  const { createService } = await import(
-    "../shared/services/haa/HumanAgentServiceImpl"
-  );
+  const { createService } = await DYNAMIC_IMPORTS.HumanAgentService();
   return createService;
 }
 
@@ -41,72 +42,54 @@ function lazyWithPreload<T extends ComponentType<any>>(
   return Component;
 }
 
-function lazyChat() {
-  return lazyWithPreload(() => import("../shared/components/Chat"));
-}
-
-function lazyCatastrophicError() {
-  return lazyWithPreload(() =>
+/**
+ * Map of all dynamic imports used by the application.
+ *
+ * By defining imports in this centralized map, we ensure they are statically analyzable
+ * by bundlers and will be included in builds even with preserveModules: true.
+ *
+ * When adding new dynamic imports, add them to this map first, then create the corresponding
+ * lazy function below.
+ */
+const DYNAMIC_IMPORTS = {
+  Chat: () => import("../shared/components/Chat"),
+  CatastrophicError: () =>
     import("../shared/components/CatastrophicError").then((mod) => ({
       default: mod.CatastrophicError,
-    }))
-  );
-}
-
-function lazyDisclaimer() {
-  return lazyWithPreload(() =>
+    })),
+  Disclaimer: () =>
     import("../shared/components/Disclaimer").then((mod) => ({
       default: mod.Disclaimer,
-    }))
-  );
-}
-
-function lazyHomeScreenContainer() {
-  return lazyWithPreload(() =>
+    })),
+  HomeScreenContainer: () =>
     import("../shared/components/homeScreen/HomeScreenContainer").then(
       (mod) => ({
         default: mod.HomeScreenContainer,
       })
-    )
-  );
-}
-
-function lazyIFramePanel() {
-  return lazyWithPreload(() =>
+    ),
+  IFramePanel: () =>
     import("../shared/components/responseTypes/iframe/IFramePanel").then(
       (mod) => ({
         default: mod.IFramePanel,
       })
-    )
-  );
-}
-
-function lazyViewSourcePanel() {
-  return lazyWithPreload(() =>
+    ),
+  ViewSourcePanel: () =>
     import(
       "../shared/components/responseTypes/util/citations/ViewSourcePanel"
     ).then((mod) => ({
       default: mod.ViewSourcePanel,
-    }))
-  );
-}
-
-function lazyBodyAndFooterPanelComponent() {
-  return lazyWithPreload(() =>
+    })),
+  BodyAndFooterPanelComponent: () =>
     import("../shared/components/panels/BodyAndFooterPanelComponent").then(
       (mod) => ({
         default: mod.BodyAndFooterPanelComponent,
       })
-    )
-  );
-}
-
-function lazyTourComponent() {
-  return React.lazy(() => import("../shared/components/tour/TourContainer"));
-}
-
-function lazyMediaPlayer(): LazyExoticComponent<ComponentType<any>> {
-  return React.lazy(() =>
+    ),
+  TourContainer: () => import("../shared/components/tour/TourContainer"),
+  Carousel: () =>
+    import("../shared/components/responseTypes/carousel/Carousel"),
+  // Special handling for react-player due to CJS/ESM confusion
+  MediaPlayer: () =>
     import("react-player/lazy/index.js").then((mod: any) => {
       // react-player 2.x is old and is confused in their cjs vs mjs usage.
       // mod might be:
@@ -118,14 +101,52 @@ function lazyMediaPlayer(): LazyExoticComponent<ComponentType<any>> {
         exported = exported.default;
       }
       return { default: exported };
-    })
-  );
+    }),
+  // Container components
+  AppContainer: () => import("../react/components/AppContainer"),
+  // Service imports (non-React components)
+  HumanAgentService: () =>
+    import("../shared/services/haa/HumanAgentServiceImpl"),
+};
+
+function lazyChat() {
+  return lazyWithPreload(DYNAMIC_IMPORTS.Chat);
+}
+
+function lazyCatastrophicError() {
+  return lazyWithPreload(DYNAMIC_IMPORTS.CatastrophicError);
+}
+
+function lazyDisclaimer() {
+  return lazyWithPreload(DYNAMIC_IMPORTS.Disclaimer);
+}
+
+function lazyHomeScreenContainer() {
+  return lazyWithPreload(DYNAMIC_IMPORTS.HomeScreenContainer);
+}
+
+function lazyIFramePanel() {
+  return lazyWithPreload(DYNAMIC_IMPORTS.IFramePanel);
+}
+
+function lazyViewSourcePanel() {
+  return lazyWithPreload(DYNAMIC_IMPORTS.ViewSourcePanel);
+}
+
+function lazyBodyAndFooterPanelComponent() {
+  return lazyWithPreload(DYNAMIC_IMPORTS.BodyAndFooterPanelComponent);
+}
+
+function lazyTourComponent() {
+  return React.lazy(DYNAMIC_IMPORTS.TourContainer);
+}
+
+function lazyMediaPlayer(): LazyExoticComponent<ComponentType<any>> {
+  return React.lazy(DYNAMIC_IMPORTS.MediaPlayer);
 }
 
 function lazyCarousel() {
-  return React.lazy(
-    () => import("../shared/components/responseTypes/carousel/Carousel")
-  );
+  return React.lazy(DYNAMIC_IMPORTS.Carousel);
 }
 
 export {
@@ -140,4 +161,5 @@ export {
   lazyViewSourcePanel,
   lazyBodyAndFooterPanelComponent,
   loadHAA,
+  DYNAMIC_IMPORTS,
 };

--- a/packages/ai-chat/src/chat/web-components/internal/cds-aichat-internal.tsx
+++ b/packages/ai-chat/src/chat/web-components/internal/cds-aichat-internal.tsx
@@ -22,6 +22,7 @@ import { consoleWarn } from "../../shared/utils/miscUtils";
 import { carbonElement } from "../decorators/customElement";
 import { PublicConfig } from "../../../types/config/PublicConfig";
 import { ChatInstance } from "../../../types/instance/ChatInstance";
+import { DYNAMIC_IMPORTS } from "../../dynamic-imports/dynamic-imports";
 
 @carbonElement("cds-aichat-internal")
 class ChatContainerInternal extends LitElement {
@@ -94,9 +95,7 @@ class ChatContainerInternal extends LitElement {
   root: Root;
 
   async renderReactApp() {
-    const { AppContainer } = await import(
-      "../../../chat/react/components/AppContainer"
-    );
+    const { AppContainer } = await DYNAMIC_IMPORTS.AppContainer();
     const previousContainer: HTMLElement = this.shadowRoot.querySelector(
       ".cds--aichat-react-app"
     );

--- a/packages/ai-chat/src/react/ChatContainer.tsx
+++ b/packages/ai-chat/src/react/ChatContainer.tsx
@@ -22,6 +22,7 @@ import {
   BusEventUserDefinedResponse,
 } from "../types/events/eventBusTypes";
 import { ChatInstance } from "../types/instance/ChatInstance";
+import { DYNAMIC_IMPORTS } from "../chat/dynamic-imports/dynamic-imports";
 
 /**
  * This component creates a custom element protected by a ShadowRoot to render the React application into. It creates
@@ -98,7 +99,7 @@ function ChatContainer({
       return;
     }
 
-    import("../chat/react/components/AppContainer").then((appContainer) => {
+    DYNAMIC_IMPORTS.AppContainer().then((appContainer) => {
       setAppContainerComponent(() => appContainer.AppContainer);
     });
   });

--- a/packages/ai-chat/src/types/messaging/Messages.ts
+++ b/packages/ai-chat/src/types/messaging/Messages.ts
@@ -46,7 +46,6 @@ interface MessageRequest<TInputType extends BaseMessageInput = MessageInput> {
   context?: unknown;
 
   /**
-   * @internal
    * The ID of the thread this request belongs to. This is here to prepare for input message editing and regenerating
    * responses.
    */
@@ -168,7 +167,6 @@ interface MessageResponse<TGenericType = GenericItem[]> {
   context?: unknown;
 
   /**
-   * @internal
    * The ID of the thread this request belongs to. This is here to prepare for input message editing and regenerating
    * responses.
    */

--- a/packages/ai-chat/tasks/rollup.aichat.js
+++ b/packages/ai-chat/tasks/rollup.aichat.js
@@ -134,7 +134,7 @@ const workerBuild = {
 
 async function runRollup() {
   const config = [
-    // Main bundle for es exports
+    // Main build with preserveModules for tree-shaking
     {
       input: [
         path.join(paths.src, '/aiChatEntry.tsx'),
@@ -147,7 +147,7 @@ async function runRollup() {
         preserveModules: true,
         preserveModulesRoot: 'src',
         entryFileNames: '[name].js',
-        chunkFileNames: '[name]-[hash].js',
+        chunkFileNames: '[name].js',
       },
       external,
       treeshake,
@@ -209,7 +209,7 @@ async function runRollup() {
             beautify: true,
             indent_level: 2,
             // keep only comments that contain @license
-            comments: (astNode, comment) => {
+            comments: (_astNode, comment) => {
               const text = comment.value;
               // comment.type === "comment2" for /* … */
               if (comment.type === 'comment2') {


### PR DESCRIPTION
Some webpack builds I was testing with were treeshaking away the dynamic imports because they were too deeply nested.