### PR TITLE
feat: add optional ability to provide different feedback categories

### DIFF
--- a/demo/src/customSendMessage/doText.ts
+++ b/demo/src/customSendMessage/doText.ts
@@ -346,6 +346,13 @@ function doText(
            * Indicates whether the prompt line should be shown.
            */
           show_prompt: true,
+
+          /**
+           * We want a list of negative feedback categories, but don't care about positive.
+           */
+          categories: {
+            negative: ["Wrong answer", "Do not like the answer"],
+          },
         },
       },
     };

--- a/packages/ai-chat/src/chat/shared/containers/MessageTypeComponent.tsx
+++ b/packages/ai-chat/src/chat/shared/containers/MessageTypeComponent.tsx
@@ -782,6 +782,17 @@ function MessageTypeComponent(props: MessageTypeComponentProps) {
       const isOpen =
         isFeedbackOpen &&
         (isPositive ? isPositiveFeedbackSelected : isNegativeFeedbackSelected);
+
+      let filteredCategories;
+      // Categories can be an array of strings or an object with positive and negative arrays.
+      if (Array.isArray(categories)) {
+        filteredCategories = categories;
+      } else if (isPositive) {
+        filteredCategories = categories?.positive;
+      } else {
+        filteredCategories = categories?.negative;
+      }
+
       return (
         <FeedbackComponent
           class={`${CSS_CLASS_PREFIX}-feedbackDetails-${
@@ -803,7 +814,7 @@ function MessageTypeComponent(props: MessageTypeComponentProps) {
           showPrompt={show_prompt}
           title={title || languagePack.feedback_defaultTitle}
           prompt={prompt || languagePack.feedback_defaultPrompt}
-          categories={categories}
+          categories={filteredCategories}
           placeholder={placeholder || languagePack.feedback_defaultPlaceholder}
           disclaimer={disclaimer}
           submitLabel={languagePack.feedback_submitLabel}

--- a/packages/ai-chat/src/types/messaging/Messages.ts
+++ b/packages/ai-chat/src/types/messaging/Messages.ts
@@ -533,7 +533,26 @@ export interface GenericItemMessageOptions {
 }
 
 /**
- * Controls the display of feedback options (thumbs up/down) for a message item.
+ * If you want to have different categories for positive and negative feedback, you can provide two different arrays.
+ *
+ * You may not provide one of the arrays. e.g. you want negative categories but don't care about positive categories.
+ *
+ * @category Messaging
+ */
+export interface GenericItemMessageFeedbackCategories {
+  /**
+   * List of strings for positive feedback categories.
+   */
+  positive?: string[];
+
+  /**
+   * List of strings for negative feedback categories.
+   */
+  negative?: string[];
+}
+
+/**
+ * Controls the display of a feedback options (thumbs up/down) for a message item.
  *
  * @category Messaging
  */
@@ -581,9 +600,11 @@ export interface GenericItemMessageFeedbackOptions {
   prompt?: string;
 
   /**
-   * An optional set of categories to allow the user to choose from.
+   * An optional set of categories to allow the user to choose from. This can either be an array of strings for
+   * both positive and negative feedback or a {@link GenericItemMessageFeedbackCategories} object to make different
+   * configuration for both.
    */
-  categories?: string[];
+  categories?: string[] | GenericItemMessageFeedbackCategories;
 
   /**
    * The placeholder to show in the text area. A default value will be used if no value is provided here.


### PR DESCRIPTION
Closes #284 

Make categories a union type that takes either the array of categories or different categories for positive and negative feedback

#### Changelog

**Changed**

- Made categories a union type

#### Testing / Reviewing

On the demo site, try all the combos in doText. Note that the component passed in the "selected" list of categories and everything else from there flows as before.
