### PR TITLE
chore: adding a wildcard to the export path

### DIFF
--- a/packages/ai-chat/package.json
+++ b/packages/ai-chat/package.json
@@ -23,7 +23,7 @@
       "types": "./dist/types/aiChatEntry.d.ts",
       "import": "./dist/es/web-components/cds-aichat-custom-element/index.js"
     },
-    "./dist/es/": "./dist/es/"
+    "./dist/es/*": "./dist/es/"
   },
   "files": [
     "dist/es",


### PR DESCRIPTION
Looks like we have to do this to get "wildcard" behavior here