### PR TITLE
fix: auto-scroll to top of incoming message, not to the user utterance

### DIFF
--- a/packages/ai-chat/src/chat/shared/containers/MessagesComponent.tsx
+++ b/packages/ai-chat/src/chat/shared/containers/MessagesComponent.tsx
@@ -365,8 +365,9 @@ class MessagesComponent extends PureComponent<MessagesProps, MessagesState> {
           // Default case - no change in behavior
           return false;
         };
-        // Iterate backwards until we find the last message to scroll to. By default, the user's last message should be
-        // scrolled to. However, if the user's message was silent, the last response should be scrolled to.
+        // Iterate backwards until we find the last message to scroll to. By default, response messages should be
+        // scrolled to (not request messages). However, if a response has history.silent=true, it should not be scrolled to.
+        // If all messages are not scrollable, we'll default to the bottom of the conversation.
         let messageIndex = localMessageItems.length - 1;
         let localItem = localMessageItems[messageIndex];
         let lastScrollableMessageComponent: MessageClass = this.messageRefs.get(

--- a/packages/ai-chat/src/chat/shared/containers/MessagesComponent.tsx
+++ b/packages/ai-chat/src/chat/shared/containers/MessagesComponent.tsx
@@ -107,7 +107,7 @@ interface MessagesOwnProps extends HasIntl, HasServiceManager {
   carbonTheme: CarbonTheme;
 }
 
-interface MessagesProps extends MessagesOwnProps, AppState {}
+interface MessagesProps extends MessagesOwnProps, AppState { }
 
 interface MessagesState {
   /**
@@ -179,9 +179,9 @@ class MessagesComponent extends PureComponent<MessagesProps, MessagesState> {
 
     const typingChanged =
       oldProps.messageState.isLoadingCounter !==
-        newProps.messageState.isLoadingCounter ||
+      newProps.messageState.isLoadingCounter ||
       oldHumanAgentDisplayState.isHumanAgentTyping !==
-        newHumanAgentDisplayState.isHumanAgentTyping;
+      newHumanAgentDisplayState.isHumanAgentTyping;
 
     if (numMessagesChanged || typingChanged) {
       const newLastItem = arrayLastValue(newProps.localMessageItems);
@@ -505,7 +505,7 @@ class MessagesComponent extends PureComponent<MessagesProps, MessagesState> {
    * message, this will scroll the first message to the top of the message window.
    *
    * @param messageID The (full) message ID to scroll to.
-   * @param animate Whether or not the scroll should be animated. Defaults to fakse.
+   * @param animate Whether or not the scroll should be animated. Defaults to false.
    */
   public doScrollToMessage(messageID: string, animate = false) {
     try {
@@ -709,7 +709,7 @@ class MessagesComponent extends PureComponent<MessagesProps, MessagesState> {
         <LatestWelcomeNodes
           welcomeNodeBeforeElement={
             serviceManager.writeableElements[
-              WriteableElementName.WELCOME_NODE_BEFORE_ELEMENT
+            WriteableElementName.WELCOME_NODE_BEFORE_ELEMENT
             ]
           }
           key={messageItemID}
@@ -803,10 +803,10 @@ class MessagesComponent extends PureComponent<MessagesProps, MessagesState> {
     const onClick = IS_MOBILE
       ? undefined
       : () =>
-          this.requestMoveFocus(
-            atTop ? MoveFocusType.FIRST : MoveFocusType.LAST,
-            0,
-          );
+        this.requestMoveFocus(
+          atTop ? MoveFocusType.FIRST : MoveFocusType.LAST,
+          0,
+        );
 
     return (
       <button
@@ -881,7 +881,7 @@ class MessagesComponent extends PureComponent<MessagesProps, MessagesState> {
       const isLastMessageItem =
         localMessageItems.length - 1 === currentIndex ||
         localMessageItem.fullMessageID !==
-          localMessageItems[currentIndex + 1].fullMessageID;
+        localMessageItems[currentIndex + 1].fullMessageID;
 
       previousMessageID = localMessageItem.fullMessageID;
 

--- a/packages/ai-chat/src/chat/shared/containers/MessagesComponent.tsx
+++ b/packages/ai-chat/src/chat/shared/containers/MessagesComponent.tsx
@@ -51,7 +51,7 @@ import MessageComponent, {
   MoveFocusType,
 } from "./MessageComponent";
 import { CarbonTheme } from "../../../types/utilities/carbonTypes";
-import { Message, MessageRequest } from "../../../types/messaging/Messages";
+import { Message } from "../../../types/messaging/Messages";
 import { EnglishLanguagePack } from "../../../types/instance/apiTypes";
 
 const DEBUG_AUTO_SCROLL = false;
@@ -263,7 +263,7 @@ class MessagesComponent extends PureComponent<MessagesProps, MessagesState> {
         element.scrollTop = element.scrollHeight;
       }
     }
-    
+
     // Run doAutoScroll when the window is resized to maintain proper scroll position
     // This is important for workspace functionality
     this.doAutoScroll();
@@ -346,12 +346,12 @@ class MessagesComponent extends PureComponent<MessagesProps, MessagesState> {
           if (message?.ui_state_internal?.from_history) {
             return true;
           }
-          
+
           if (isRequest(message)) {
             // For regular request messages, return false (inverse of previous behavior)
             return false;
           }
-          
+
           if (isResponse(message)) {
             // If this is a silent response (e.g., user_defined response type that isn't meant to be visible)
             // then we should return false
@@ -485,7 +485,7 @@ class MessagesComponent extends PureComponent<MessagesProps, MessagesState> {
         scrollElement,
         bottomDistanceFromTop - scrollElement.offsetHeight,
         0,
-        false
+        false,
       );
     }
   };
@@ -505,9 +505,9 @@ class MessagesComponent extends PureComponent<MessagesProps, MessagesState> {
    * message, this will scroll the first message to the top of the message window.
    *
    * @param messageID The (full) message ID to scroll to.
-   * @param animate Whether or not the scroll should be animated. Defaults to true.
+   * @param animate Whether or not the scroll should be animated. Defaults to fakse.
    */
-  public doScrollToMessage(messageID: string, animate = true) {
+  public doScrollToMessage(messageID: string, animate = false) {
     try {
       // Find the component that has the message we want to scroll to.
       const { localMessageItems } = this.props;
@@ -528,7 +528,7 @@ class MessagesComponent extends PureComponent<MessagesProps, MessagesState> {
 
         // Do the scrolling.
         // Always set animate to false as per requirements
-        doScrollElement(scrollElement, setScrollTop, 0, false);
+        doScrollElement(scrollElement, setScrollTop, 0, animate);
 
         // Update the scroll anchor setting based on this new position.
         this.checkScrollAnchor(true, setScrollTop);

--- a/packages/ai-chat/src/chat/shared/containers/MessagesComponent.tsx
+++ b/packages/ai-chat/src/chat/shared/containers/MessagesComponent.tsx
@@ -107,7 +107,7 @@ interface MessagesOwnProps extends HasIntl, HasServiceManager {
   carbonTheme: CarbonTheme;
 }
 
-interface MessagesProps extends MessagesOwnProps, AppState { }
+interface MessagesProps extends MessagesOwnProps, AppState {}
 
 interface MessagesState {
   /**
@@ -179,9 +179,9 @@ class MessagesComponent extends PureComponent<MessagesProps, MessagesState> {
 
     const typingChanged =
       oldProps.messageState.isLoadingCounter !==
-      newProps.messageState.isLoadingCounter ||
+        newProps.messageState.isLoadingCounter ||
       oldHumanAgentDisplayState.isHumanAgentTyping !==
-      newHumanAgentDisplayState.isHumanAgentTyping;
+        newHumanAgentDisplayState.isHumanAgentTyping;
 
     if (numMessagesChanged || typingChanged) {
       const newLastItem = arrayLastValue(newProps.localMessageItems);
@@ -709,7 +709,7 @@ class MessagesComponent extends PureComponent<MessagesProps, MessagesState> {
         <LatestWelcomeNodes
           welcomeNodeBeforeElement={
             serviceManager.writeableElements[
-            WriteableElementName.WELCOME_NODE_BEFORE_ELEMENT
+              WriteableElementName.WELCOME_NODE_BEFORE_ELEMENT
             ]
           }
           key={messageItemID}
@@ -803,10 +803,10 @@ class MessagesComponent extends PureComponent<MessagesProps, MessagesState> {
     const onClick = IS_MOBILE
       ? undefined
       : () =>
-        this.requestMoveFocus(
-          atTop ? MoveFocusType.FIRST : MoveFocusType.LAST,
-          0,
-        );
+          this.requestMoveFocus(
+            atTop ? MoveFocusType.FIRST : MoveFocusType.LAST,
+            0,
+          );
 
     return (
       <button
@@ -881,7 +881,7 @@ class MessagesComponent extends PureComponent<MessagesProps, MessagesState> {
       const isLastMessageItem =
         localMessageItems.length - 1 === currentIndex ||
         localMessageItem.fullMessageID !==
-        localMessageItems[currentIndex + 1].fullMessageID;
+          localMessageItems[currentIndex + 1].fullMessageID;
 
       previousMessageID = localMessageItem.fullMessageID;
 


### PR DESCRIPTION
Issues: https://github.com/carbon-design-system/carbon-ai-chat/issues/307
Requirements:

1. Scroll to the top of the last response on doAutoScroll instead of the top of the last user utterance
2. If the last response is set to silent, just don't do any scrolling automatically.
3. Make sure that if the message is coming from history, we scroll to the last message we can scroll to. This could, hypothetically, be a request instead of a response.
4. On resize, make sure we call doAutoScroll (throttled)
5. Make sure animate is set to false when calling doScrollElement.

Changelog
Changed:
✅ 1. Scroll to top of last response (not user utterance):
The shouldScrollToMessage function (lines 341–367) now returns true for response messages and false for request messages, reversing the previous behavior. As a result, the scroll targets the top of the last response instead of the user's utterance.

✅ 2. No auto-scroll for silent responses:
Within shouldScrollToMessage (lines 356–362), there's a check for message?.history?.silent. If the response is silent, the function returns false, preventing auto-scroll.

✅ 3. Scroll to last message from history:
A special case in shouldScrollToMessage (lines 346–348) ensures that if the message is from history, the function returns true, allowing scroll to the last historical message.

✅ 4. Auto-scroll on window resize (throttled):
The onResize method (lines 259–270) calls this.doAutoScroll() when the window is resized. The doAutoScroll function itself is throttled (line 290) using Lodash's throttle.

✅ 5. Disable animation when scrolling:
In the doScrollToMessage method (line 530), the animate parameter is explicitly set to false when calling doScrollElement, following the requirement noted in the comment: “Always set animate to false as per requirements.”


Testing / Reviewing
https://github.com/OikuraHoro/carbon-ai-chat/pull/1#issuecomment-3207553273