### PR TITLE
feat: add git precommit hooks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "eslint-config-carbon": "3.10.0",
         "gitignore-to-glob": "^0.3.0",
         "globby": "^14.0.2",
-        "husky": "^9.1.6",
+        "husky": "^9.1.7",
         "lerna": "^8.1.8",
         "lint-staged": "^15.2.10",
         "prettier": "^3.0.0",
@@ -21191,7 +21191,6 @@
       "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
       "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
       "dev": true,
-      "license": "MIT",
       "bin": {
         "husky": "bin.js"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "carbon-ai-chat",
       "version": "0.0.0",
+      "hasInstallScript": true,
       "license": "Apache-2.0",
       "workspaces": [
         "demo",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "lint:license": "tools/check-license.js -a",
     "lint:license:staged": "tools/check-license.js -w",
     "lint:styles": "stylelint '**/*.scss' --report-needless-disables --report-invalid-scope-disables",
-    "test": "lerna run test --stream"
+    "test": "lerna run test --stream",
+    "prepare": "husky"
   },
   "devDependencies": {
     "@babel/core": "^7.24.7",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "lint:license:staged": "tools/check-license.js -w",
     "lint:styles": "stylelint '**/*.scss' --report-needless-disables --report-invalid-scope-disables",
     "test": "lerna run test --stream",
-    "prepare": "husky"
+    "postinstall": "husky"
   },
   "devDependencies": {
     "@babel/core": "^7.24.7",

--- a/package.json
+++ b/package.json
@@ -212,7 +212,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "npm run ci-check && npm run format:write && npm run lint && npm run lint:styles"
+      "pre-commit": "npm run ci-check && npm run format:write && npm run lint && npm run lint:license && npm run lint:styles"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -40,8 +40,7 @@
     "lint:license": "tools/check-license.js -a",
     "lint:license:staged": "tools/check-license.js -w",
     "lint:styles": "stylelint '**/*.scss' --report-needless-disables --report-invalid-scope-disables",
-    "test": "lerna run test --stream",
-    "prepare": "husky"
+    "test": "lerna run test --stream"
   },
   "devDependencies": {
     "@babel/core": "^7.24.7",

--- a/package.json
+++ b/package.json
@@ -212,7 +212,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "npm run ci-check && npm run format:write && npm run lint && npm run lint:license && npm run lint:styles"
+      "pre-commit": "npm run ci-check && npm run format:write && npm run lint && npm run lint:styles"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -209,10 +209,5 @@
   },
   "dependencies": {
     "@carbon/ai-chat": "^0.0.0"
-  },
-  "husky": {
-    "hooks": {
-      "pre-commit": "npm run ci-check && npm run format:write && npm run lint && npm run lint:license && npm run lint:styles"
-    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "lint:license": "tools/check-license.js -a",
     "lint:license:staged": "tools/check-license.js -w",
     "lint:styles": "stylelint '**/*.scss' --report-needless-disables --report-invalid-scope-disables",
-    "test": "lerna run test --stream"
+    "test": "lerna run test --stream",
+    "prepare": "husky"
   },
   "devDependencies": {
     "@babel/core": "^7.24.7",
@@ -57,7 +58,7 @@
     "eslint-config-carbon": "3.10.0",
     "gitignore-to-glob": "^0.3.0",
     "globby": "^14.0.2",
-    "husky": "^9.1.6",
+    "husky": "^9.1.7",
     "lerna": "^8.1.8",
     "lint-staged": "^15.2.10",
     "prettier": "^3.0.0",
@@ -208,5 +209,10 @@
   },
   "dependencies": {
     "@carbon/ai-chat": "^0.0.0"
+  },
+  "husky": {
+    "hooks": {
+      "pre-commit": "npm run ci-check && npm run format:write && npm run lint && npm run lint:license && npm run lint:styles"
+    }
   }
 }

--- a/packages/ai-chat/src/chat/shared/containers/MessagesComponent.tsx
+++ b/packages/ai-chat/src/chat/shared/containers/MessagesComponent.tsx
@@ -983,7 +983,7 @@ export default withServiceManager(
   )(MessagesComponent),
 );
 
-console.log("testing hooks with removal of prepare script");
+console.log("testing hooks with removal of prepare script again");
 
 export {
   MessagesComponent as MessagesComponentClass,

--- a/packages/ai-chat/src/chat/shared/containers/MessagesComponent.tsx
+++ b/packages/ai-chat/src/chat/shared/containers/MessagesComponent.tsx
@@ -983,7 +983,7 @@ export default withServiceManager(
   )(MessagesComponent),
 );
 
-console.log("testing hooks with adding in prepare script");
+console.log("testing hooks with adding in post install script");
 
 export {
   MessagesComponent as MessagesComponentClass,

--- a/packages/ai-chat/src/chat/shared/containers/MessagesComponent.tsx
+++ b/packages/ai-chat/src/chat/shared/containers/MessagesComponent.tsx
@@ -983,7 +983,7 @@ export default withServiceManager(
   )(MessagesComponent),
 );
 
-console.log("testing hooks");
+console.log("testing hooks with removal of prepare script");
 
 export {
   MessagesComponent as MessagesComponentClass,

--- a/packages/ai-chat/src/chat/shared/containers/MessagesComponent.tsx
+++ b/packages/ai-chat/src/chat/shared/containers/MessagesComponent.tsx
@@ -983,8 +983,6 @@ export default withServiceManager(
   )(MessagesComponent),
 );
 
-console.log("testing commit hooks");
-
 export {
   MessagesComponent as MessagesComponentClass,
   ScrollElementIntoViewFunction,

--- a/packages/ai-chat/src/chat/shared/containers/MessagesComponent.tsx
+++ b/packages/ai-chat/src/chat/shared/containers/MessagesComponent.tsx
@@ -983,8 +983,6 @@ export default withServiceManager(
   )(MessagesComponent),
 );
 
-console.log("testing hooks with adding in post install script");
-
 export {
   MessagesComponent as MessagesComponentClass,
   ScrollElementIntoViewFunction,

--- a/packages/ai-chat/src/chat/shared/containers/MessagesComponent.tsx
+++ b/packages/ai-chat/src/chat/shared/containers/MessagesComponent.tsx
@@ -983,6 +983,8 @@ export default withServiceManager(
   )(MessagesComponent),
 );
 
+console.log("testing hooks");
+
 export {
   MessagesComponent as MessagesComponentClass,
   ScrollElementIntoViewFunction,

--- a/packages/ai-chat/src/chat/shared/containers/MessagesComponent.tsx
+++ b/packages/ai-chat/src/chat/shared/containers/MessagesComponent.tsx
@@ -983,7 +983,7 @@ export default withServiceManager(
   )(MessagesComponent),
 );
 
-console.log("testing hooks with removal of prepare");
+console.log("testing hooks with adding in prepare script");
 
 export {
   MessagesComponent as MessagesComponentClass,

--- a/packages/ai-chat/src/chat/shared/containers/MessagesComponent.tsx
+++ b/packages/ai-chat/src/chat/shared/containers/MessagesComponent.tsx
@@ -983,6 +983,8 @@ export default withServiceManager(
   )(MessagesComponent),
 );
 
+console.log("testing commit hooks");
+
 export {
   MessagesComponent as MessagesComponentClass,
   ScrollElementIntoViewFunction,

--- a/packages/ai-chat/src/chat/shared/containers/MessagesComponent.tsx
+++ b/packages/ai-chat/src/chat/shared/containers/MessagesComponent.tsx
@@ -983,7 +983,7 @@ export default withServiceManager(
   )(MessagesComponent),
 );
 
-console.log("testing hooks with removal of prepare script again");
+console.log("testing hooks with removal of prepare");
 
 export {
   MessagesComponent as MessagesComponentClass,


### PR DESCRIPTION
Closes #383

- Accelerates development speed by reducing manual labour of running the lint scripts before pushing commits to the codebase
- Using Husky, this gives us a prepare script to allow git hooks to run without manual setup
- Post install script is automatically run after the next `npm install`

When a developer tries to commit to the codebase, the scripts will automatically run:
- npm run lint
- npm run format:write
- npm run ci-check
- npm run lint:styles

#### Changelog

**New**

- Husky npm package installed in dev dependencies
- Git pre commit hooks are run before a developer can commit to the codebase

**Changed**

- Developer no longer needs to run the lint commands manually before commiting/pushing to contribute
- Linting is now automated with the git commit command

#### Testing / Reviewing

- make some changes to code
- `git add .`
- `git commit -m "<subject>: <message>"`
- the hook should automatically run once you try to commit, and if your code passes, you can do `git push`
