### PR TITLE
feat: Preserve user formatting in chat messages

### DIFF
--- a/packages/ai-chat/src/chat/shared/containers/MessageComponent.scss
+++ b/packages/ai-chat/src/chat/shared/containers/MessageComponent.scss
@@ -271,6 +271,7 @@ $message-bar-width: 3px;
 
 .WAC__sent--text > span {
   flex: 1;
+  white-space: pre-wrap;
 }
 
 .WAC__sent--text {


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon-ai-chat/issues/387

Preserve indentation and line breaks in chat messages so pasted or multi-line text keeps its formatting.

#### Changelog

**Changed**

- Updated MessagesComponent.tsx rendering to use white-space: pre-wrap, ensuring line breaks and indentation are preserved.

- Ensured sanitization still escapes HTML while preserving whitespace.

**Removed**

- None

#### Testing / Reviewing

older-version:

https://github.com/user-attachments/assets/743c8e89-3856-4626-afac-da6209fa45d0

new-version:

https://github.com/user-attachments/assets/1fb55342-ca62-4862-b441-2c28ad41d9ee
