### PR TITLE
chore: use carbon wc icon loader utility

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -16,7 +16,7 @@
     "@carbon/ai-chat": "^0.5.0",
     "@carbon/icons": "^11.53.0",
     "@carbon/react": "^1.68.0",
-    "@carbon/web-components": "^2.25.0",
+    "@carbon/web-components": "^2.37.0",
     "lit": "^3.1.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/demo/src/framework/demo-side-bar-nav.ts
+++ b/demo/src/framework/demo-side-bar-nav.ts
@@ -7,20 +7,10 @@
  *  @license
  */
 
-import { toString } from "@carbon/icon-helpers";
+import { iconLoader } from "@carbon/web-components/es/globals/internal/icon-loader.js";
 import RightPanelOpen16 from "@carbon/icons/es/right-panel--open/16.js";
 import { css, html, LitElement } from "lit";
 import { customElement, property } from "lit/decorators.js";
-import { unsafeSVG } from "lit/directives/unsafe-svg.js";
-
-const RightPanelOpen16svg = toString({
-  ...RightPanelOpen16,
-  attrs: {
-    ...RightPanelOpen16.attrs,
-    slot: "icon",
-  },
-});
-
 @customElement("demo-side-bar-nav")
 class DemoSideBarNav extends LitElement {
   static styles = css`
@@ -41,7 +31,7 @@ class DemoSideBarNav extends LitElement {
   render() {
     return html`<div class="demo-sidebar-nav">
       <cds-icon-button kind="ghost" @click="${this.openSideBar}">
-        ${unsafeSVG(RightPanelOpen16svg)}
+        ${iconLoader(RightPanelOpen16, { slot: "icon" })}
       </cds-icon-button>
     </div>`;
   }

--- a/examples/react/basic/package.json
+++ b/examples/react/basic/package.json
@@ -16,7 +16,7 @@
     "@carbon/ai-chat": "^0.5.0",
     "@carbon/icons": "^11.53.0",
     "@carbon/react": "^1.68.0",
-    "@carbon/web-components": "^2.25.0",
+    "@carbon/web-components": "^2.37.0",
     "lit": "^3.1.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/examples/react/watsonx/package.json
+++ b/examples/react/watsonx/package.json
@@ -18,7 +18,7 @@
     "@carbon/ai-chat": "^0.5.0",
     "@carbon/icons": "^11.53.0",
     "@carbon/react": "^1.68.0",
-    "@carbon/web-components": "^2.25.0",
+    "@carbon/web-components": "^2.37.0",
     "@microsoft/fetch-event-source": "^2.0.1",
     "cors": "^2.8.5",
     "dotenv": "^16.6.1",

--- a/examples/web-components/basic/package.json
+++ b/examples/web-components/basic/package.json
@@ -16,7 +16,7 @@
     "@carbon/ai-chat": "^0.5.0",
     "@carbon/icons": "^11.53.0",
     "@carbon/react": "^1.68.0",
-    "@carbon/web-components": "^2.25.0",
+    "@carbon/web-components": "^2.37.0",
     "lit": "^3.1.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/examples/web-components/watsonx/package.json
+++ b/examples/web-components/watsonx/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@carbon/ai-chat": "^0.5.0",
     "@carbon/icons": "^11.53.0",
-    "@carbon/web-components": "^2.25.0",
+    "@carbon/web-components": "^2.37.0",
     "@microsoft/fetch-event-source": "^2.0.1",
     "concurrently": "^9.2.0",
     "cors": "^2.8.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,7 @@
         "@carbon/ai-chat": "^0.5.0",
         "@carbon/icons": "^11.53.0",
         "@carbon/react": "^1.68.0",
-        "@carbon/web-components": "^2.25.0",
+        "@carbon/web-components": "^2.37.0",
         "lit": "^3.1.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -105,7 +105,7 @@
         "@carbon/ai-chat": "^0.5.0",
         "@carbon/icons": "^11.53.0",
         "@carbon/react": "^1.68.0",
-        "@carbon/web-components": "^2.25.0",
+        "@carbon/web-components": "^2.37.0",
         "lit": "^3.1.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -158,7 +158,7 @@
         "@carbon/ai-chat": "^0.5.0",
         "@carbon/icons": "^11.53.0",
         "@carbon/react": "^1.68.0",
-        "@carbon/web-components": "^2.25.0",
+        "@carbon/web-components": "^2.37.0",
         "@microsoft/fetch-event-source": "^2.0.1",
         "cors": "^2.8.5",
         "dotenv": "^16.6.1",
@@ -237,7 +237,7 @@
         "@carbon/ai-chat": "^0.5.0",
         "@carbon/icons": "^11.53.0",
         "@carbon/react": "^1.68.0",
-        "@carbon/web-components": "^2.25.0",
+        "@carbon/web-components": "^2.37.0",
         "lit": "^3.1.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -295,7 +295,7 @@
       "dependencies": {
         "@carbon/ai-chat": "^0.5.0",
         "@carbon/icons": "^11.53.0",
-        "@carbon/web-components": "^2.25.0",
+        "@carbon/web-components": "^2.37.0",
         "@microsoft/fetch-event-source": "^2.0.1",
         "concurrently": "^9.2.0",
         "cors": "^2.8.5",
@@ -2435,9 +2435,9 @@
       "link": true
     },
     "node_modules/@carbon/colors": {
-      "version": "11.38.0",
-      "resolved": "https://registry.npmjs.org/@carbon/colors/-/colors-11.38.0.tgz",
-      "integrity": "sha512-5cTvIZalgauRalk4g15rDvYmNufuZWsGh6WTBCLlvynyLRnXbS6wpNrhYj9D+HTJb0jzon+6nYcMJ5H8kfUNqw==",
+      "version": "11.39.0",
+      "resolved": "https://registry.npmjs.org/@carbon/colors/-/colors-11.39.0.tgz",
+      "integrity": "sha512-H1hL9NW1I1vks469KuIV/YY4zHUiDQJ/MOlJgv8iCLi0SQS4DWkDslccXAhce8U8qRtx1JPfePhiYkRBbjgKgw==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2455,13 +2455,13 @@
       }
     },
     "node_modules/@carbon/grid": {
-      "version": "11.41.0",
-      "resolved": "https://registry.npmjs.org/@carbon/grid/-/grid-11.41.0.tgz",
-      "integrity": "sha512-bZCiSt6mdmbMBhdWyiGQhminPhyjFXpOSq8hlG/vxi/HhZo4/Uo2U9FdjFUhWens52C3zKumSpvRmDWGlnhpgw==",
+      "version": "11.42.0",
+      "resolved": "https://registry.npmjs.org/@carbon/grid/-/grid-11.42.0.tgz",
+      "integrity": "sha512-l91wFV7uMhaf2PX89cW1zS5iMnzrFVY2d81Xf7U9OdNu8sBTQWxUPtj1RnZyep4F7v/HG8U4DOzfa+nO5GgZeA==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@carbon/layout": "^11.39.0",
+        "@carbon/layout": "^11.40.0",
         "@ibm/telemetry-js": "^1.5.0"
       }
     },
@@ -2501,9 +2501,9 @@
       }
     },
     "node_modules/@carbon/layout": {
-      "version": "11.39.0",
-      "resolved": "https://registry.npmjs.org/@carbon/layout/-/layout-11.39.0.tgz",
-      "integrity": "sha512-QBDBHl/icUOwMM+1qWtmlf0kLEPw8eTPkqv0BRhsj+eiKf0Fj+QzMTQntwHM7gEk4VA2246MDc12YJLdlk7Geg==",
+      "version": "11.40.0",
+      "resolved": "https://registry.npmjs.org/@carbon/layout/-/layout-11.40.0.tgz",
+      "integrity": "sha512-2wIOPJZFjt5Y+TZ7NwPTf0l3zif14hBiPwv/nQo76J2Wr1i/NJrYNfBTpUnKxoq6IZEsVd0e6Ab4RLGGIP2eVA==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2511,9 +2511,9 @@
       }
     },
     "node_modules/@carbon/motion": {
-      "version": "11.33.0",
-      "resolved": "https://registry.npmjs.org/@carbon/motion/-/motion-11.33.0.tgz",
-      "integrity": "sha512-ZfWSbIfYdjfgUPfFiPVE0cYjIHiQljAaxuOhElnLmFqNMhBZengnhLiIgKgAMZg1cy5Iog/0T4b+obCFmEuKeg==",
+      "version": "11.34.0",
+      "resolved": "https://registry.npmjs.org/@carbon/motion/-/motion-11.34.0.tgz",
+      "integrity": "sha512-Gc5VcfXO70un5jeCUqlplKal8PpRLzUfxg8x8b1LwKfzjWrgxilHtNk3B4dGj190M9dyrTKVfCCrLKlVtyhEQw==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2554,23 +2554,23 @@
       }
     },
     "node_modules/@carbon/styles": {
-      "version": "1.88.0",
-      "resolved": "https://registry.npmjs.org/@carbon/styles/-/styles-1.88.0.tgz",
-      "integrity": "sha512-Hwm5FQqyQSJ3sBQuCA6Tylv7qWPTCNooPYXUYLOQ536bo0crlEoeV0jIm84t+WW4cAAyHtuMKKqocCTW4oHz+g==",
+      "version": "1.89.0",
+      "resolved": "https://registry.npmjs.org/@carbon/styles/-/styles-1.89.0.tgz",
+      "integrity": "sha512-KJtGLwV23Fqte6VMjL6ZIhBV7FC5BbaWkQyBqG64HruN/dJszuOptphBQtkFQMh020/vFmA0nVNfZB0mY4HlmQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@carbon/colors": "^11.38.0",
+        "@carbon/colors": "^11.39.0",
         "@carbon/feature-flags": "^0.30.0",
-        "@carbon/grid": "^11.41.0",
-        "@carbon/layout": "^11.39.0",
-        "@carbon/motion": "^11.33.0",
-        "@carbon/themes": "^11.58.0",
-        "@carbon/type": "^11.45.0",
+        "@carbon/grid": "^11.42.0",
+        "@carbon/layout": "^11.40.0",
+        "@carbon/motion": "^11.34.0",
+        "@carbon/themes": "^11.59.0",
+        "@carbon/type": "^11.46.0",
         "@ibm/plex": "6.0.0-next.6",
-        "@ibm/plex-mono": "0.0.3-alpha.0",
+        "@ibm/plex-mono": "1.1.0",
         "@ibm/plex-sans": "0.0.3-alpha.0",
-        "@ibm/plex-sans-arabic": "0.0.3-alpha.0",
+        "@ibm/plex-sans-arabic": "1.1.0",
         "@ibm/plex-sans-devanagari": "0.0.3-alpha.0",
         "@ibm/plex-sans-hebrew": "0.0.3-alpha.0",
         "@ibm/plex-sans-thai": "0.0.3-alpha.0",
@@ -2588,28 +2588,28 @@
       }
     },
     "node_modules/@carbon/themes": {
-      "version": "11.58.0",
-      "resolved": "https://registry.npmjs.org/@carbon/themes/-/themes-11.58.0.tgz",
-      "integrity": "sha512-gzL1xWlHN/KBVeB4SNSaMdWPfPatMo5NkyIcZTW5H5hZpTI3OW6VfGHPpPlzpArLIvlMDxxpQvfDtFhbIlhuzA==",
+      "version": "11.59.0",
+      "resolved": "https://registry.npmjs.org/@carbon/themes/-/themes-11.59.0.tgz",
+      "integrity": "sha512-vnFuKTuThYVGQ9f8G/amO0laun6pyr8Nze1KuD6LrOJl6waEC2LPJqNz3rg4ySLievFg9+993R0GNUI9HjC2bw==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@carbon/colors": "^11.38.0",
-        "@carbon/layout": "^11.39.0",
-        "@carbon/type": "^11.45.0",
+        "@carbon/colors": "^11.39.0",
+        "@carbon/layout": "^11.40.0",
+        "@carbon/type": "^11.46.0",
         "@ibm/telemetry-js": "^1.5.0",
         "color": "^4.0.0"
       }
     },
     "node_modules/@carbon/type": {
-      "version": "11.45.0",
-      "resolved": "https://registry.npmjs.org/@carbon/type/-/type-11.45.0.tgz",
-      "integrity": "sha512-qmUhQA01bFGY9cpSMdZE+7FCcWH6RVlaU9cyBBht/JPsLawyRdYRTVFSuaaHrc7g21xZnn0wTviVWFZzctq0sA==",
+      "version": "11.46.0",
+      "resolved": "https://registry.npmjs.org/@carbon/type/-/type-11.46.0.tgz",
+      "integrity": "sha512-Xt2lhYsRuRrpEESy8BW+xjsf1TXnzv4CdxgAvjL+YSQxzdD0gbMnIhEIpJiDAyWddviqH8ZwxIdlnlfqKrA9rg==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@carbon/grid": "^11.41.0",
-        "@carbon/layout": "^11.39.0",
+        "@carbon/grid": "^11.42.0",
+        "@carbon/layout": "^11.40.0",
         "@ibm/telemetry-js": "^1.5.0"
       }
     },
@@ -2625,15 +2625,15 @@
       }
     },
     "node_modules/@carbon/web-components": {
-      "version": "2.36.0",
-      "resolved": "https://registry.npmjs.org/@carbon/web-components/-/web-components-2.36.0.tgz",
-      "integrity": "sha512-yZqB+0SDNLtLupaZNUHsaBQmYxhcqcDUG9RTInu/g7XF/Mjw68D+r75Ujb5k0Vzt5IWOR8chnnYE8FO7UX/9uQ==",
+      "version": "2.37.0",
+      "resolved": "https://registry.npmjs.org/@carbon/web-components/-/web-components-2.37.0.tgz",
+      "integrity": "sha512-GTjVC2pRRLkmfwl+dnAa2zXK/65k5g6OcQHslQaUOt1/CTwgxXiIIxfbP2EXPdO4Tdk5/cZPpz2K+TZa1iLu/w==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@carbon/styles": "^1.88.0",
+        "@carbon/styles": "^1.89.0",
         "@floating-ui/dom": "^1.6.3",
-        "@ibm/telemetry-js": "^1.5.0",
+        "@ibm/telemetry-js": "^1.10.1",
         "@lit/context": "^1.1.3",
         "flatpickr": "4.6.13",
         "lit": "^3.1.0",
@@ -3898,10 +3898,14 @@
       }
     },
     "node_modules/@ibm/plex-mono": {
-      "version": "0.0.3-alpha.0",
-      "resolved": "https://registry.npmjs.org/@ibm/plex-mono/-/plex-mono-0.0.3-alpha.0.tgz",
-      "integrity": "sha512-xSa/c1vrzGmMR5xQr/aWP/q62jUD41mKwm2w4kFsvIVyT9fxC3wq81UYMSGBxQZ6+P1AROMSefF22aLXkv6uqw==",
-      "license": "OFL-1.1"
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@ibm/plex-mono/-/plex-mono-1.1.0.tgz",
+      "integrity": "sha512-hpsdRxR3BRJkC6wGM4MZcUFD6C8M+mmK76RtAy/hlsfPro9FzpXVdIWC+G3jeQOXof109dxlUvmeKxpeKUG68A==",
+      "hasInstallScript": true,
+      "license": "OFL-1.1",
+      "dependencies": {
+        "@ibm/telemetry-js": "^1.6.1"
+      }
     },
     "node_modules/@ibm/plex-sans": {
       "version": "0.0.3-alpha.0",
@@ -3910,10 +3914,14 @@
       "license": "OFL-1.1"
     },
     "node_modules/@ibm/plex-sans-arabic": {
-      "version": "0.0.3-alpha.0",
-      "resolved": "https://registry.npmjs.org/@ibm/plex-sans-arabic/-/plex-sans-arabic-0.0.3-alpha.0.tgz",
-      "integrity": "sha512-tFi6soIKl/A2xWf5/N9kCkMhv+MOcEewWWFM9Bz9U0YO5I4KR0qdUTU7rN4jTjvCJGPExwPFukQKBNz7djuShg==",
-      "license": "OFL-1.1"
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@ibm/plex-sans-arabic/-/plex-sans-arabic-1.1.0.tgz",
+      "integrity": "sha512-u8wIS6szLAOFvlBjCFZmtpKIqbhuIuniG2N0J+sio8vV6INH58hP0t0QNYrSl9SZtCv2Fwb4oQGuZJY3kJ4+QA==",
+      "hasInstallScript": true,
+      "license": "OFL-1.1",
+      "dependencies": {
+        "@ibm/telemetry-js": "^1.6.1"
+      }
     },
     "node_modules/@ibm/plex-sans-devanagari": {
       "version": "0.0.3-alpha.0",
@@ -3946,9 +3954,9 @@
       "license": "OFL-1.1"
     },
     "node_modules/@ibm/telemetry-js": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@ibm/telemetry-js/-/telemetry-js-1.9.1.tgz",
-      "integrity": "sha512-qq8RPafUJHUQieXVCte1kbJEx6JctWzbA/YkXzopbfzIDRT2+hbR9QmgH+KH7bDDNRcDbdHWvHfwJKzThlMtPg==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@ibm/telemetry-js/-/telemetry-js-1.10.1.tgz",
+      "integrity": "sha512-aQcDq03BKbgNnkHujHbA950wJVHtJnY0PsMHKyxgRvr3XPgInWjDfgxJQmKIp9I8Vy2wpfe0cGmduJfIX0HewQ==",
       "license": "Apache-2.0",
       "bin": {
         "ibmtelemetry": "dist/collect.js"
@@ -13180,7 +13188,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fill-range": "^7.1.1"
@@ -18904,7 +18912,7 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -21627,7 +21635,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -21695,7 +21703,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -21803,7 +21811,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -27083,7 +27091,7 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",
@@ -27097,7 +27105,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -34683,7 +34691,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
@@ -38230,10 +38238,9 @@
       "devDependencies": {
         "@babel/preset-env": "^7.28.0",
         "@babel/preset-react": "^7.27.1",
-        "@carbon/icon-helpers": "^10.60.0",
         "@carbon/icons": "^11.53.0",
         "@carbon/react": "^1.68.0",
-        "@carbon/web-components": "^2.25.0",
+        "@carbon/web-components": "^2.37.0",
         "@rollup/plugin-babel": "^6.0.4",
         "@rollup/plugin-commonjs": "^28.0.6",
         "@rollup/plugin-json": "^6.1.0",
@@ -38275,10 +38282,9 @@
         "typedoc": "^0.28.0"
       },
       "peerDependencies": {
-        "@carbon/icon-helpers": ">=10.53.0 <11.0.0",
         "@carbon/icons": ">=11.53.0 <12.0.0",
         "@carbon/react": ">=1.68.0 <2.0.0",
-        "@carbon/web-components": ">=2.25.0 <3.0.0",
+        "@carbon/web-components": ">=2.37.0 <3.0.0",
         "@floating-ui/react": ">=0.25.0 <1.0.0",
         "classnames": ">=2.5.0 <3.0.0",
         "lit": ">=3.1.0 <4.0.0",
@@ -38297,14 +38303,13 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@carbon/styles": "^1.39.0",
-        "@carbon/web-components": "^2.13.0",
+        "@carbon/web-components": "^2.37.0",
         "@ibm/telemetry-js": "^1.9.1",
         "lit": "^3.0.0",
         "tslib": "^2.6.3"
       },
       "devDependencies": {
         "@carbon/grid": "^11.20.0",
-        "@carbon/icon-helpers": "^10.44.0",
         "@carbon/icons": "^11.28.0",
         "@carbon/layout": "^11.19.0",
         "@carbon/themes": "^11.25.0",

--- a/packages/ai-chat-components/package.json
+++ b/packages/ai-chat-components/package.json
@@ -38,14 +38,13 @@
   },
   "dependencies": {
     "@carbon/styles": "^1.39.0",
-    "@carbon/web-components": "^2.13.0",
+    "@carbon/web-components": "^2.37.0",
     "@ibm/telemetry-js": "^1.9.1",
     "lit": "^3.0.0",
     "tslib": "^2.6.3"
   },
   "devDependencies": {
     "@carbon/grid": "^11.20.0",
-    "@carbon/icon-helpers": "^10.44.0",
     "@carbon/icons": "^11.28.0",
     "@carbon/layout": "^11.19.0",
     "@carbon/themes": "^11.25.0",

--- a/packages/ai-chat/package.json
+++ b/packages/ai-chat/package.json
@@ -42,10 +42,9 @@
     "**/web-components/**/*.js"
   ],
   "devDependencies": {
-    "@carbon/icon-helpers": "^10.60.0",
     "@carbon/icons": "^11.53.0",
     "@carbon/react": "^1.68.0",
-    "@carbon/web-components": "^2.25.0",
+    "@carbon/web-components": "^2.37.0",
     "@rollup/plugin-babel": "^6.0.4",
     "@rollup/plugin-commonjs": "^28.0.6",
     "@rollup/plugin-json": "^6.1.0",
@@ -89,10 +88,9 @@
     "typedoc": "^0.28.0"
   },
   "peerDependencies": {
-    "@carbon/icon-helpers": ">=10.53.0 <11.0.0",
     "@carbon/icons": ">=11.53.0 <12.0.0",
     "@carbon/react": ">=1.68.0 <2.0.0",
-    "@carbon/web-components": ">=2.25.0 <3.0.0",
+    "@carbon/web-components": ">=2.37.0 <3.0.0",
     "@floating-ui/react": ">=0.25.0 <1.0.0",
     "classnames": ">=2.5.0 <3.0.0",
     "lit": ">=3.1.0 <4.0.0",

--- a/packages/ai-chat/src/chat/web-components/components/chainOfThought/src/chainOfThoughtElement.template.ts
+++ b/packages/ai-chat/src/chat/web-components/components/chainOfThought/src/chainOfThoughtElement.template.ts
@@ -10,12 +10,11 @@
 import "../../markdownText/cds-aichat-markdown-text";
 import "@carbon/web-components/es-custom/components/inline-loading/index.js";
 
-import { toString } from "@carbon/icon-helpers";
+import { iconLoader } from "@carbon/web-components/es/globals/internal/icon-loader.js";
 import CheckmarkFilled16 from "@carbon/icons/es/checkmark--filled/16.js";
 import ChevronRight16 from "@carbon/icons/es/chevron--right/16.js";
 import ErrorFilled16 from "@carbon/icons/es/error--filled/16.js";
 import { html } from "lit";
-import { unsafeSVG } from "lit/directives/unsafe-svg.js";
 
 import { parseUnknownDataToMarkdown } from "../../../../shared/utils/lang/stringUtils";
 import { CSS_CLASS_PREFIX } from "../../../settings";
@@ -43,10 +42,6 @@ interface ChainOfThoughtStepWithToggle extends ChainOfThoughtStep {
   open: boolean;
 }
 
-const ChevronRight16svg = toString(ChevronRight16);
-const CheckmarkFilled16svg = toString(CheckmarkFilled16);
-const ErrorFilled16svg = toString(ErrorFilled16);
-
 /**
  * Returns the correct icon given the status of the step. If there is no status, we assume it is successful.
  */
@@ -66,13 +61,13 @@ function stepStatus(
       return html`<span
         class="${CSS_CLASS_STATUS_PREFIX}--${ChainOfThoughtStepStatus.FAILURE}"
         aria-label="${statusFailedLabelText}"
-        >${unsafeSVG(ErrorFilled16svg)}</span
+        >${iconLoader(ErrorFilled16)}</span
       >`;
     default:
       return html`<span
         class="${CSS_CLASS_STATUS_PREFIX}--${ChainOfThoughtStepStatus.SUCCESS}"
         aria-label="${statusSucceededLabelText}"
-        >${unsafeSVG(CheckmarkFilled16svg)}</span
+        >${iconLoader(CheckmarkFilled16)}</span
       >`;
   }
 }
@@ -173,7 +168,7 @@ function accordionContent(customElementClass: ChainOfThoughtElement) {
           <span
             class="${CSS_CLASS_PREFIX}-chain-of-thought-accordion-item-header-chevron"
             ?data-open=${item.open}
-            >${unsafeSVG(ChevronRight16svg)}</span
+            >${iconLoader(ChevronRight16)}</span
           >
           <span
             class="${CSS_CLASS_PREFIX}-chain-of-thought-accordion-item-header-title"
@@ -224,7 +219,7 @@ function chainOfThoughtElementTemplate(
       aria-controls=${_chainOfThoughtPanelID}
     >
       <span class="${CSS_CLASS_PREFIX}-chain-of-thought-button-chevron"
-        >${unsafeSVG(ChevronRight16svg)}</span
+        >${iconLoader(ChevronRight16)}</span
       >
       ${explainabilityText}
     </button>

--- a/packages/ai-chat/src/chat/web-components/components/feedbackButtonsElement/src/feedbackButtonsElement.template.ts
+++ b/packages/ai-chat/src/chat/web-components/components/feedbackButtonsElement/src/feedbackButtonsElement.template.ts
@@ -10,22 +10,16 @@
 import "@carbon/web-components/es-custom/components/textarea/index.js";
 import "@carbon/web-components/es-custom/components/icon-button/index.js";
 
-import { toString } from "@carbon/icon-helpers";
+import { iconLoader } from "@carbon/web-components/es/globals/internal/icon-loader.js";
 import ThumbsDown16 from "@carbon/icons/es/thumbs-down/16.js";
 import ThumbsDownFilled16 from "@carbon/icons/es/thumbs-down--filled/16.js";
 import ThumbsUp16 from "@carbon/icons/es/thumbs-up/16.js";
 import ThumbsUpFilled16 from "@carbon/icons/es/thumbs-up--filled/16.js";
 import { html, nothing } from "lit";
-import { unsafeSVG } from "lit/directives/unsafe-svg.js";
 
 import { CSS_CLASS_PREFIX } from "../../../settings";
 import { FeedbackButtonsElement } from "./FeedbackButtonsElement.js";
 import { enLanguagePack } from "../../../../../types/instance/apiTypes";
-
-const ThumbsDown16svg = toString(ThumbsDown16);
-const ThumbsDownFilled16svg = toString(ThumbsDownFilled16);
-const ThumbsUp16svg = toString(ThumbsUp16);
-const ThumbsUpFilled16svg = toString(ThumbsUpFilled16);
 
 function feedbackButtonsElementTemplate(
   customElementClass: FeedbackButtonsElement,
@@ -61,9 +55,7 @@ function feedbackButtonsElementTemplate(
       @click="${() => onClick(true)}"
     >
       <span slot="icon"
-        >${unsafeSVG(
-          isPositiveSelected ? ThumbsUpFilled16svg : ThumbsUp16svg,
-        )}</span
+        >${iconLoader(isPositiveSelected ? ThumbsUpFilled16 : ThumbsUp16)}</span
       >
       <span slot="tooltip-content"
         >${positiveLabel || enLanguagePack.feedback_positiveLabel}</span
@@ -84,8 +76,8 @@ function feedbackButtonsElementTemplate(
       @click="${() => onClick(false)}"
     >
       <span slot="icon"
-        >${unsafeSVG(
-          isNegativeSelected ? ThumbsDownFilled16svg : ThumbsDown16svg,
+        >${iconLoader(
+          isNegativeSelected ? ThumbsDownFilled16 : ThumbsDown16,
         )}</span
       >
       <span slot="tooltip-content"

--- a/packages/ai-chat/src/chat/web-components/components/stopStreamingButton/src/stopStreamingButton.template.ts
+++ b/packages/ai-chat/src/chat/web-components/components/stopStreamingButton/src/stopStreamingButton.template.ts
@@ -9,10 +9,9 @@
 
 import "@carbon/web-components/es-custom/components/icon-button/index.js";
 
-import { toString } from "@carbon/icon-helpers";
+import { iconLoader } from "@carbon/web-components/es/globals/internal/icon-loader.js";
 import StopFilled16 from "@carbon/icons/es/stop--filled/16.js";
 import { html } from "lit";
-import { unsafeSVG } from "lit/directives/unsafe-svg.js";
 
 import { CSS_CLASS_PREFIX } from "../../../settings";
 import { StopStreamingButtonElement } from "./StopStreamingButtonElement";
@@ -20,8 +19,6 @@ import {
   ButtonKindEnum,
   ButtonSizeEnum,
 } from "../../../../../types/utilities/carbonTypes";
-
-const StopFilled16svg = toString(StopFilled16);
 
 export function stopStreamingButtonTemplate({
   label,
@@ -41,7 +38,7 @@ export function stopStreamingButtonTemplate({
       <span
         class="${disabled ? `${CSS_CLASS_PREFIX}-stop-icon` : ""}"
         slot="icon"
-        >${unsafeSVG(StopFilled16svg)}</span
+        >${iconLoader(StopFilled16)}</span
       >
       <span slot="tooltip-content">${label}</span>
     </cds-custom-icon-button>

--- a/packages/ai-chat/src/chat/web-components/components/table/src/table.template.ts
+++ b/packages/ai-chat/src/chat/web-components/components/table/src/table.template.ts
@@ -12,21 +12,12 @@ import "@carbon/web-components/es-custom/components/checkbox/index.js";
 import "@carbon/web-components/es-custom/components/button/index.js";
 import "@carbon/web-components/es-custom/components/layer/index.js";
 
-import { toString } from "@carbon/icon-helpers";
+import { iconLoader } from "@carbon/web-components/es/globals/internal/icon-loader.js";
 import Download16 from "@carbon/icons/es/download/16.js";
 import { html } from "lit";
-import { unsafeSVG } from "lit/directives/unsafe-svg.js";
 import { repeat } from "lit-html/directives/repeat.js";
 
 import type { TableElement } from "../cds-aichat-table";
-
-const Download16svg = toString({
-  ...Download16,
-  attrs: {
-    ...Download16.attrs,
-    slot: "icon",
-  },
-});
 
 /**
  * Table view logic.
@@ -54,7 +45,7 @@ function tableTemplate(tableElement: TableElement) {
             ></cds-custom-table-toolbar-search>`
           : ""}
         <cds-custom-button @click=${handleDownload}
-          >${unsafeSVG(Download16svg)}</cds-custom-button
+          >${iconLoader(Download16)}</cds-custom-button
         >
       </cds-custom-table-toolbar-content>
     </cds-custom-table-toolbar>`;


### PR DESCRIPTION
Closes #379 

Utilizes the new `iconLoader` utility from `@carbon/web-components` which handles the icon transformation needed for the icons to work in web components

#### Changelog

**Changed**

- use `iconLoader` util from `@carbon/web-components`
- update `@carbon/web-components` version to latest version `v2.37.0`

**Removed**

- no longer need `@carbon/icon-helpers` package to transform the icons

#### Testing / Reviewing

make sure the icons in the touched files are visible and look correct
