### PR TITLE
fix(Header): tooltip orientation fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13180,7 +13180,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fill-range": "^7.1.1"
@@ -18904,7 +18904,7 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -21627,7 +21627,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -21695,7 +21695,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -21803,7 +21803,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -27083,7 +27083,7 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",
@@ -27097,7 +27097,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -34683,7 +34683,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"

--- a/packages/ai-chat/src/chat/shared/components/header/Header.tsx
+++ b/packages/ai-chat/src/chat/shared/components/header/Header.tsx
@@ -16,7 +16,12 @@ import Menu from "@carbon/icons-react/es/Menu.js";
 import Restart from "@carbon/icons-react/es/Restart.js";
 import SidePanelClose from "@carbon/icons-react/es/SidePanelClose.js";
 import SubtractLarge from "@carbon/icons-react/es/SubtractLarge.js";
-import { Button, ButtonTooltipPosition, MenuItem } from "@carbon/react";
+import {
+  Button,
+  ButtonTooltipAlignment,
+  ButtonTooltipPosition,
+  MenuItem,
+} from "@carbon/react";
 import { AI_LABEL_SIZE } from "@carbon/web-components/es-custom/components/ai-label/defs.js";
 import { POPOVER_ALIGNMENT } from "@carbon/web-components/es-custom/components/popover/defs.js";
 import cx from "classnames";
@@ -416,7 +421,8 @@ function Header(props: HeaderProps, ref: Ref<HasRequestFocus>) {
               label={languagePack.buttons_restart}
               onClick={onClickRestart}
               buttonRef={restartButtonRef}
-              tooltipPosition={isRTL ? "right" : "left"}
+              tooltipAlignment={isRTL ? "start" : "end"}
+              tooltipPosition={"bottom"}
             >
               <Restart />
             </HeaderButton>
@@ -432,7 +438,8 @@ function Header(props: HeaderProps, ref: Ref<HasRequestFocus>) {
                 onClickClose();
               }}
               buttonRef={closeButtonRef}
-              tooltipPosition={isRTL ? "right" : "left"}
+              tooltipAlignment={isRTL ? "start" : "end"}
+              tooltipPosition={"bottom"}
               testId={makeTestId(PageObjectId.CLOSE_CHAT, testIdPrefix)}
             >
               {closeIcon}
@@ -444,7 +451,8 @@ function Header(props: HeaderProps, ref: Ref<HasRequestFocus>) {
               label={languagePack.header_ariaCloseRestart}
               onClick={() => setConfirmModelOpen(true)}
               buttonRef={closeAndRestartButtonRef}
-              tooltipPosition={isRTL ? "right" : "left"}
+              tooltipAlignment={isRTL ? "start" : "end"}
+              tooltipPosition={"bottom"}
             >
               <CloseLarge className="WACIcon__Close" />
             </HeaderButton>
@@ -492,6 +500,11 @@ interface HeaderButtonProps extends HasClassName, HasChildren {
    * Indicates if the icon should be reversible based on the document direction.
    */
   isReversible?: boolean;
+  /**
+   * Specify the alignment of the tooltip to the icon-only button.
+   * Can be one of: start, center, or end.
+   */
+  tooltipAlignment?: ButtonTooltipAlignment;
 
   /**
    * Specify the alignment of the tooltip to the icon-only button. Can be one of: start, center, or end.
@@ -515,6 +528,7 @@ function HeaderButton({
   children,
   buttonKind,
   isReversible = true,
+  tooltipAlignment,
   tooltipPosition,
   testId,
 }: HeaderButtonProps) {
@@ -527,6 +541,7 @@ function HeaderButton({
       iconDescription={label}
       size={ButtonSizeEnum.MEDIUM}
       kind={buttonKind || ButtonKindEnum.GHOST}
+      tooltipAlignment={tooltipAlignment}
       tooltipPosition={tooltipPosition}
       data-testid={testId}
     >


### PR DESCRIPTION
Closes #178

Header tooltip orientation should be bottom left instead of just left

#### Changelog

**New**

- Added `tooltipAlignment ` prop to the `HeaderButton ` component. 
- Updated `close`, `restart` and `back` buttons with `tooltipAlignment` prop. 
- Added conditional value to `tooltipAlignment` based os `isRTL`.

**Changed**

- Updated the value of `tooltipPosition` to `bottom`

#### Testing / Reviewing

- In the demo app, hover on the close icon in the header and the tooltip shoul appear on bottom left.
