### PR TITLE
fix(carbon react to WC): remove existing carbon react from shared

### DIFF
--- a/packages/ai-chat/src/chat/shared/components/responseTypes/options/OptionComponent.tsx
+++ b/packages/ai-chat/src/chat/shared/components/responseTypes/options/OptionComponent.tsx
@@ -7,7 +7,6 @@
  *  @license
  */
 
-import { OnChangeData } from "@carbon/react";
 import React, { Component, MouseEvent } from "react";
 import ChatButton, {
   CHAT_BUTTON_KIND,
@@ -29,6 +28,10 @@ import {
   SingleOption,
 } from "../../../../../types/messaging/Messages";
 import { MessageSendSource } from "../../../../../types/events/eventBusTypes";
+
+interface OnChangeData<ItemType> {
+  selectedItem: ItemType | null;
+}
 
 interface OptionProps extends HasServiceManager, HasLanguagePack {
   /**


### PR DESCRIPTION
Closes #

Remove any existing usage of `@carbon/react` from shared folder that were not lsited in the perfomance issue: #192 
- OptionComponent.tsx