### PR TITLE
fix: missing label to tooltipText prop update

### DIFF
--- a/packages/ai-chat/src/chat/react/carbon/Button.tsx
+++ b/packages/ai-chat/src/chat/react/carbon/Button.tsx
@@ -17,7 +17,7 @@ import {
   BUTTON_TOOLTIP_POSITION,
 } from "@carbon/web-components/es/components/button/defs.js";
 // Export the actual class for the component that will *directly* be wrapped with React.
-import CarbonButtonElement from "@carbon/web-components/es-custom/components/button/button.js";
+import CarbonButtonElement from "@carbon/web-components/es/components/button/button.js";
 
 const Button = createComponent({
   tagName: "cds-button",

--- a/packages/ai-chat/src/chat/shared/components/header/Header.tsx
+++ b/packages/ai-chat/src/chat/shared/components/header/Header.tsx
@@ -374,7 +374,7 @@ function Header(props: HeaderProps, ref: Ref<HasRequestFocus>) {
     leftContent = (
       <HeaderButton
         className="WACHeader__BackButton"
-        label={labelBackButton}
+        tooltipText={labelBackButton}
         onClick={onClickBack}
         buttonRef={backButtonRef}
         buttonKind={backButtonType}
@@ -460,7 +460,7 @@ function Header(props: HeaderProps, ref: Ref<HasRequestFocus>) {
           {showRestartButton && (
             <HeaderButton
               className="WACHeader__RestartButton"
-              label={languagePack.buttons_restart}
+              tooltipText={languagePack.buttons_restart}
               onClick={onClickRestart}
               buttonRef={restartButtonRef}
               tooltipAlignment={
@@ -479,7 +479,7 @@ function Header(props: HeaderProps, ref: Ref<HasRequestFocus>) {
                 WACReverseIcon: closeReverseIcon,
               })}
               isReversible={closeIsReversible}
-              label={languagePack.launcher_isOpen}
+              tooltipText={languagePack.launcher_isOpen}
               onClick={async () => {
                 onClickClose();
               }}
@@ -498,7 +498,7 @@ function Header(props: HeaderProps, ref: Ref<HasRequestFocus>) {
           {showCloseAndRestartButton && (
             <HeaderButton
               className="WACHeader__CloseAndRestartButton"
-              label={languagePack.header_ariaCloseRestart}
+              tooltipText={languagePack.header_ariaCloseRestart}
               onClick={() => setConfirmModelOpen(true)}
               buttonRef={closeAndRestartButtonRef}
               tooltipAlignment={
@@ -545,9 +545,9 @@ interface HeaderButtonProps extends HasClassName, HasChildren {
   buttonRef: RefObject<CDSButton>;
 
   /**
-   * The aria label to use on the button.
+   * Specify the text to be rendered in the tooltip.
    */
-  label: string;
+  tooltipText: string;
 
   /**
    * The carbon button kind to use.
@@ -587,6 +587,7 @@ function HeaderButton({
   isReversible = true,
   tooltipAlignment,
   tooltipPosition,
+  tooltipText,
   testId,
 }: HeaderButtonProps) {
   const buttonKindVal = buttonKind || BUTTON_KIND.GHOST;
@@ -599,6 +600,7 @@ function HeaderButton({
       kind={buttonKindVal as BUTTON_KIND}
       tooltipAlignment={tooltipAlignment}
       tooltipPosition={tooltipPosition}
+      tooltipText={tooltipText}
       data-testid={testId}
     >
       {children}


### PR DESCRIPTION
Contributes #257 

Restores missing tooltip from header buttons, which was lost in translation from React->WC where it was handled by `label` prop previously.
observed during merging main into integration branch

#### Changelog

**Changed**

- added tooltipText which now renders a tooltip in WC.

#### Testing / Reviewing

check the header buttons now render tooltips as before
<img width="395" height="192" alt="image" src="https://github.com/user-attachments/assets/50829786-1702-4bca-893b-071324f9f8f5" />


