### PR TITLE
chore: update custom service desk docs

### DIFF
--- a/packages/ai-chat/docs/CustomServiceDesks.md
+++ b/packages/ai-chat/docs/CustomServiceDesks.md
@@ -146,7 +146,7 @@ filesSelectedForUpload(uploads: FileUpload[]): void {
   uploads.forEach(upload => {
     if (upload.file.size > this.maxFileSizeKB * 1024) {
       const maxSize = `${this.maxFileSizeKB}KB`;
-      const errorMessage = this.instance.getIntl().formatMessage({ id: 'fileSharing_fileTooLarge' }, { maxSize });
+      const errorMessage = `File exceeds ${maxSize}`;
       this.callback.setFileUploadStatus(upload.id, true, errorMessage);
     }
   });


### PR DESCRIPTION
We no longer support `instance.getIntl()`. This PR updates the documentation, directing adopter to provide a custom string instead.
