### PR TITLE
chore: check for peer dependency changes

### DIFF
--- a/.github/workflows/check-peer-dependencies.yml
+++ b/.github/workflows/check-peer-dependencies.yml
@@ -1,0 +1,109 @@
+# Check for peer dependency changes in packages/ai-chat/package.json
+# and update peer-dependency-changes.md file if there are changes
+name: Check for peer dependency changes
+
+# Gets triggered every time a full/stable release tag has been published from the
+# `create-release-tag-and-pr` workflow
+on:
+  workflow_dispatch:
+  repository_dispatch:
+    types: [check-peer-dependencies]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check-peer-dependencies:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          fetch-depth: "0"
+          ref: ${{ github.event.client_payload.branch }}
+
+      - name: Get package.json from previous release
+        run: |
+          git show ${{ github.event.client_payload.previous-tag }}:packages/ai-chat/package.json > package-old.json
+
+      - name: Get package.json from current release
+        run: |
+          cp packages/ai-chat/package.json package-new.json
+
+      - name: Compare peerDependencies and prepend to release notes
+        id: diff
+        run: |
+          node <<'EOF'
+          const fs = require('fs');
+          const path = 'docs/peer-dependency-changes.md';
+
+          const oldPkg = JSON.parse(fs.readFileSync('package-old.json', 'utf8'));
+          const newPkg = JSON.parse(fs.readFileSync('package-new.json', 'utf8'));
+
+          const version = newPkg.version || "Unspecified Version";
+          const oldPeers = oldPkg.peerDependencies || {};
+          const newPeers = newPkg.peerDependencies || {};
+
+          const added = [];
+          const removed = [];
+          const updated = [];
+
+          const allDeps = new Set([...Object.keys(oldPeers), ...Object.keys(newPeers)]);
+
+          for (const dep of allDeps) {
+            const oldVer = oldPeers[dep];
+            const newVer = newPeers[dep];
+
+            if (!oldVer && newVer) {
+              added.push(`- **${dep}**: \`${newVer}\``);
+            } else if (oldVer && !newVer) {
+              removed.push(`- **${dep}** (was \`${oldVer}\`)`);
+            } else if (oldVer !== newVer) {
+              updated.push(`- **${dep}**: \`${oldVer}\` → \`${newVer}\``);
+            }
+          }
+
+          let hasChanges = false;
+          let content = fs.readFileSync(path, 'utf8');
+
+          if (added.length > 0 || removed.length > 0 || updated.length > 0) {
+            hasChanges = true;
+            let newSection = `\n\n---\n\n# Version ${version}\n`;
+
+            if (added.length > 0) {
+              newSection += "\n**Added**\n" + added.join("\n");
+            }
+            if (removed.length > 0) {
+              newSection += "\n**Removed**\n" + removed.join("\n");
+            }
+            if (updated.length > 0) {
+              newSection += "\n**Updated**\n" + updated.join("\n");
+            }
+
+            // Prepend new changes below description
+            const firstLineBreak = content.indexOf('\n\n');
+            if (firstLineBreak >= 0) {
+              const description = content.slice(0, firstLineBreak + 2);
+              const oldContent = content.slice(firstLineBreak + 2);
+              content = description + newSection + oldContent;
+            } else {
+              content = newSection + content;
+            }
+
+            fs.writeFileSync(path, content, 'utf8');
+          }
+
+          console.log(hasChanges ? "changes" : "no-changes");
+          EOF
+
+      - name: Commit updated peer-dependency-changes.md
+        if: steps.diff.outputs == 'changes'
+        run: |
+          git config --global user.email ${{ secrets.CARBON_BOT_EMAIL }}
+          git config --global user.name ${{ secrets.CARBON_BOT_NAME }}
+          git add docs/peer-dependency-changes.md
+          git commit -m "chore: update peer dependency changes"
+          git push origin chore/${{ github.event.client_payload.tag }}-release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/create-release-tag-and-pr.yml
+++ b/.github/workflows/create-release-tag-and-pr.yml
@@ -63,6 +63,7 @@ jobs:
   create-release-tag:
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    needs: create-pull-request
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
@@ -76,6 +77,21 @@ jobs:
         run: |
           git tag -a ${{ github.event.inputs.tag }} -m "Release ${{ github.event.inputs.tag }}"
           git push origin ${{ github.event.inputs.tag }}
+
+  # This job dispatches workflow to check if there is a change in peerDependencies and updates
+  # the peer-dependency-changes.md file
+  check-change-in-peer-dependencies:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    needs: create-release-tag
+    steps:
+      # Triggers only if it is a full release
+      - name: Check for peer dependency changes
+        if: contains(github.event.inputs.tag, '-rc.') == false
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          event-type: check-peer-dependencies
+          client-payload: '{"branch": "${{ github.ref_name }}", "previous-tag": "${{ github.event.inputs.previous-tag }}", "tag": "${{ github.event.inputs.tag }}"}'
 
   # This job creates the release with the git tag pushed from job above with the corresponding
   # release notes from the previous version to current

--- a/docs/peer-dependency-changes.md
+++ b/docs/peer-dependency-changes.md
@@ -1,0 +1,4 @@
+# Peer Dependency Changes
+
+This file tracks changes to the `peerDependencies` of the `packages/ai-chat` package over time.
+Each section corresponds to a specific version of the package and includes any dependencies that were added, removed, or updated.


### PR DESCRIPTION
Closes #247 

This PR adds a workflow to check for changes in `peerDependencies` within the `packages/ai-chat/package.json` file when the release occurs.

If there are changes, the changes are documented in the `docs/peer-dependency-changes.md` file.

#### Changelog

**New**

- `peer-dependency-changes.md` file to track changes

**Changed**

- Add step in the `.github/workflows/create-release-tag-and-pr.yml` file to trigger workflow


#### Testing / Reviewing

Currently trying to test in my own fork
