### PR TITLE
chore: add telemetry wc scope

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3946,10 +3946,9 @@
       "license": "OFL-1.1"
     },
     "node_modules/@ibm/telemetry-js": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@ibm/telemetry-js/-/telemetry-js-1.9.1.tgz",
-      "integrity": "sha512-qq8RPafUJHUQieXVCte1kbJEx6JctWzbA/YkXzopbfzIDRT2+hbR9QmgH+KH7bDDNRcDbdHWvHfwJKzThlMtPg==",
-      "license": "Apache-2.0",
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@ibm/telemetry-js/-/telemetry-js-1.10.2.tgz",
+      "integrity": "sha512-F8+/NNUwtm8BuFz18O9KPvIFTFDo8GUSoyhPxPjEpk7nEyEzWGfhIiEPhL00B2NdHRLDSljh3AiCfSnL/tutiQ==",
       "bin": {
         "ibmtelemetry": "dist/collect.js"
       }
@@ -38567,7 +38566,7 @@
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@ibm/telemetry-js": "^1.9.1",
+        "@ibm/telemetry-js": "^1.10.2",
         "@lit/react": "^1.0.6",
         "color": "^4.2.3",
         "compute-scroll-into-view": "^3.1.0",
@@ -38655,7 +38654,7 @@
       "dependencies": {
         "@carbon/styles": "^1.39.0",
         "@carbon/web-components": "^2.13.0",
-        "@ibm/telemetry-js": "^1.9.1",
+        "@ibm/telemetry-js": "^1.10.2",
         "lit": "^3.0.0",
         "tslib": "^2.6.3"
       },

--- a/packages/ai-chat-components/package.json
+++ b/packages/ai-chat-components/package.json
@@ -33,13 +33,14 @@
     "postinstall": "ibmtelemetry --config=telemetry.yml",
     "storybook": "npm run custom-elements && storybook dev -p 6006",
     "storybook:build": "npm run custom-elements && storybook build",
+    "telemetry:config": "npx -y @ibm/telemetry-js-config-generator generate --id 62aa153d-8a70-4d12-9e8d-069511e80e65 --endpoint https://www-api.ibm.com/ibm-telemetry/v1/metrics --files ./src/components --wc",
     "test": "web-test-runner \"src/components/**/*.test.ts\" --node-resolve",
     "test:updateSnapshot": "web-test-runner \"src/components/**/*.test.ts\" --node-resolve --update-snapshots"
   },
   "dependencies": {
     "@carbon/styles": "^1.39.0",
     "@carbon/web-components": "^2.13.0",
-    "@ibm/telemetry-js": "^1.9.1",
+    "@ibm/telemetry-js": "^1.10.2",
     "lit": "^3.0.0",
     "tslib": "^2.6.3"
   },

--- a/packages/ai-chat-components/telemetry.yml
+++ b/packages/ai-chat-components/telemetry.yml
@@ -1,9 +1,13 @@
 # yaml-language-server: $schema=https://unpkg.com/@ibm/telemetry-config-schema@v1/dist/config.schema.json
 
 version: 1
-projectId: ef967584-5788-47d4-b9c2-a60da7ad901d
+projectId: 62aa153d-8a70-4d12-9e8d-069511e80e65
 endpoint: https://www-api.ibm.com/ibm-telemetry/v1/metrics
 collect:
+  wc:
+    elements:
+      allowedAttributeNames: []
+      allowedAttributeStringValues: []
   npm:
     dependencies: null
   js:

--- a/packages/ai-chat/package.json
+++ b/packages/ai-chat/package.json
@@ -104,7 +104,7 @@
     "tabbable": ">=6.2.0 <7.0.0"
   },
   "dependencies": {
-    "@ibm/telemetry-js": "^1.9.1",
+    "@ibm/telemetry-js": "^1.10.2",
     "@lit/react": "^1.0.6",
     "color": "^4.2.3",
     "compute-scroll-into-view": "^3.1.0",
@@ -129,6 +129,7 @@
     "postinstall": "ibmtelemetry --config=telemetry.yml",
     "start": "rollup -c ./tasks/rollup.aichat.js --watch",
     "start:typedoc": "typedoc --watch",
+    "telemetry:config": "npx -y @ibm/telemetry-js-config-generator generate --id ef967584-5788-47d4-b9c2-a60da7ad901d --endpoint https://www-api.ibm.com/ibm-telemetry/v1/metrics --files ./src --wc",
     "test": "jest"
   },
   "repository": {

--- a/packages/ai-chat/telemetry.yml
+++ b/packages/ai-chat/telemetry.yml
@@ -4,6 +4,76 @@ version: 1
 projectId: ef967584-5788-47d4-b9c2-a60da7ad901d
 endpoint: https://www-api.ibm.com/ibm-telemetry/v1/metrics
 collect:
+  wc:
+    elements:
+      allowedAttributeNames:
+        # General
+        - config
+        - element
+        - onAfterRender
+        - onBeforeRender
+        # cds-aichat-chain-of-thought
+        - explainability-text
+        - input-label-text
+        - open
+        - output-label-text
+        - status-failed-label-text
+        - status-processing-label-text
+        - status-succeeded-label-text
+        - steps
+        - tool-label-text
+        # cds-aichat-chat-header-avatar
+        - alt
+        - corners
+        - onError
+        - url
+        # cds-aichat-feedback
+        - cancel-label
+        - categories
+        - class
+        - disclaimer
+        - id
+        - initial-values
+        - is-open
+        - is-readonly
+        - on-close
+        - on-submit
+        - prompt
+        - show-prompt
+        - show-text-area
+        - submit-label
+        - text-area-placeholder
+        - title
+        # cds-aichat-feedback-buttons
+        - has-negative-details
+        - has-positive-details
+        - is-negative-disabled
+        - is-negative-open
+        - is-negative-selected
+        - is-positive-disabled
+        - is-positive-open
+        - is-positive-selected
+        - negative-label
+        - on-click
+        - panel-id
+        - positive-label
+        # cds-aichat-stop-streaming-button
+        - disabled
+        - label
+        - onClick
+        - tooltip-alignment
+        # cds-aichat-tag-list
+        - initial-selected-tags
+        - multi-select
+        - on-tags-changed
+        - tags
+      allowedAttributeStringValues:
+        # General - boolean attributes
+        - "true"
+        - "false"
+        # cds-aichat-chat-header-avatar - corners
+        - round
+        - square
   npm:
     dependencies: null
   js:


### PR DESCRIPTION
This PR updates the IBM Telemetry dependency so we can now start to collect web component usage metrics. Now, whenever a unique component prop or prop value is added for the first time, we can run the `telemetry:config` scripts to update the Telemetry config.

#### Changelog

**New**

- Gave `@carbon/ai-chat-components` a proper Telemetry project ID
- `telemetry:config` npm scripts

**Changed**

- Version bumped `@ibm/telemetry-js` and added the `wc` scope to the telemetry configurations

**Removed**

- N/A

#### Testing / Reviewing

Not much to test as this is mostly updating the already-installed dependency and adding the web component scope.