### PR TITLE
chore: output `es-custom` build folder

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5794,7 +5794,6 @@
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
@@ -5808,7 +5807,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
       "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -5818,7 +5816,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
       "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
@@ -8361,7 +8358,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-2.3.0.tgz",
       "integrity": "sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -13444,7 +13440,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fill-range": "^7.1.1"
@@ -18964,7 +18959,6 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
       "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -18981,7 +18975,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -19035,7 +19028,6 @@
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
       "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
@@ -19168,7 +19160,6 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -19485,10 +19476,9 @@
       "license": "MIT"
     },
     "node_modules/fs-extra": {
-      "version": "11.3.1",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.1.tgz",
-      "integrity": "sha512-eXvGGwZ5CL17ZSwHWd3bbgk7UUpF6IFHtP57NYYakPvHOs8GDgDe5KJI36jIJzDkJ6eJjuzRA8eBQb6SkKue0g==",
-      "dev": true,
+      "version": "11.3.2",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.2.tgz",
+      "integrity": "sha512-Xr9F6z6up6Ws+NjzMCZc6WXg2YFRlrLP9NQDO3VQrWrfiojdhS56TzueT88ze0uBdCTwEIhQ3ptnmKeWGFAe0A==",
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -20373,7 +20363,6 @@
       "version": "14.1.0",
       "resolved": "https://registry.npmjs.org/globby/-/globby-14.1.0.tgz",
       "integrity": "sha512-0Ia46fDOaT7k4og1PDW4YbodWWr3scS2vAr2lTbsplOt2WkKp0vQbkI9wKis/T5LV/dqPjO3bpS/z6GTJB82LA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@sindresorhus/merge-streams": "^2.1.0",
@@ -20394,7 +20383,6 @@
       "version": "7.0.5",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
       "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -20404,7 +20392,6 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
       "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14.16"
@@ -20417,7 +20404,6 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
       "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -20449,7 +20435,6 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/graphemer": {
@@ -21885,7 +21870,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -21953,7 +21937,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -22061,7 +22044,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -24274,7 +24256,6 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
       "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "universalify": "^2.0.0"
@@ -26730,7 +26711,6 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -27341,7 +27321,6 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",
@@ -27355,7 +27334,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -29571,7 +29549,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-6.0.0.tgz",
       "integrity": "sha512-Vj7sf++t5pBD637NSfkxpHSMfWaeig5+DKWLhcqIYx6mWQz5hdJTGDVMQiJcw1ZYkhs7AazKDGpRVji1LJCZUQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -30962,7 +30939,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -32047,7 +32023,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
       "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "iojs": ">=1.0.0",
@@ -32294,7 +32269,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
       "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -34941,7 +34915,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
@@ -36313,7 +36286,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
@@ -38820,6 +38792,8 @@
         "dayjs": "^1.11.10",
         "dompurify": "^3.1.6",
         "focus-trap-react": "^10.2.3",
+        "fs-extra": "^11.3.2",
+        "globby": "^14.1.0",
         "highlight.js": "^11.9.0",
         "intl-messageformat": "^10.7.15",
         "lodash-es": "^4.17.0",

--- a/packages/ai-chat/docs/Migration-1.0.0.md
+++ b/packages/ai-chat/docs/Migration-1.0.0.md
@@ -15,6 +15,10 @@ Version 1.0.0 introduces **live config updates**. Changes to `PublicConfig` now 
 - `themeConfig` -> removed (see theming below)
 - All `PublicConfig` properties are now top-level props (no more `config` prop)
 
+### Separate build folder for custom prefix:
+
+Instead of pulling from the `es-custom` folder and using the `cds-custom-*` components from `@carbon/web-components`, we are now using components straight from `es` and generating our own `es-custom` folder to handle the custom registry issues that may arise from using the `@carbon/ai-chat` package alongside `carbon-angular-components`. See migration examples below for details.
+
 ### Service Desk:
 
 - `serviceDesk` and `serviceDeskFactory` moved out of config to top-level props
@@ -132,6 +136,38 @@ const config = {
     },
   },
 };
+```
+
+### `es-custom` folder
+
+**Note:** You only need to import from the `es-custom` folder if you are facing component registry issues. This usually happens when using the `@carbon/ai-chat` package alongside `carbon-angular-components` where the component names clash with the underlying subcomponents from `@carbon/web-components`.
+
+If not using alongside `carbon-angular-components`, resume importing from the `es` folder and using the `cds-aichat` prefix.
+
+```ts
+// Before
+import "@carbon/ai-chat/dist/es/web-components/cds-aichat-container/index.js";
+import "@carbon/ai-chat/dist/es/web-components/cds-aichat-custom-element/index.js";
+
+...
+
+render() {
+  return html`
+    <cds-aichat-container ....> </cds-aichat-container>
+    <cds-aichat-custom-element ....> </cds-aichat-custom-element>
+  `;
+
+// After
+import "@carbon/ai-chat/dist/es-custom/web-components/cds-aichat-container/index.js";
+import "@carbon/ai-chat/dist/es-custom/web-components/cds-aichat-custom-element/index.js";
+
+...
+
+render() {
+  return html`
+    <cds-custom-aichat-container ....> </cds-custom-aichat-container>
+    <cds-custom-aichat-custom-element ....> </cds-custom-aichat-custom-element>
+  `;
 ```
 
 ### React Usage (Interface Flattening)

--- a/packages/ai-chat/docs/WebComponent.md
+++ b/packages/ai-chat/docs/WebComponent.md
@@ -108,6 +108,24 @@ export class MyApp extends LitElement {
 }
 ```
 
+#### Using alongside `carbon-angular-components`
+
+If you are using `@carbon/ai-chat` in your Angular application along with `carbon-angular-components`, you may run into component registry errors as the underlying `@carbon/web-components` subcomponents utilize the same naming structure as components in `carbon-angular-components`. In order to avoid this, import from the `es-custom` build folder rather than `es`. This build folder creates a separate prefix for all the Web Components.
+
+```
+import "@carbon/ai-chat/dist/es-custom/web-components/cds-aichat-container/index.js";
+import "@carbon/ai-chat/dist/es-custom/web-components/cds-aichat-custom-element/index.js";
+
+...
+
+render() {
+  return html`
+    <cds-custom-aichat-container ....> </cds-custom-aichat-container>
+    <cds-custom-aichat-custom-element ....> </cds-custom-aichat-custom-element>
+  `;
+}
+```
+
 ### Accessing instance methods
 
 You can use the {@link CdsAiChatContainerAttributes.onBeforeRender} or {@link CdsAiChatContainerAttributes.onAfterRender} props to access the Carbon AI Chat's instance if you need to call instance methods later. This example renders a button that toggles the Carbon AI Chat open and only renders after the instance becomes available. Refer to the following example.

--- a/packages/ai-chat/package.json
+++ b/packages/ai-chat/package.json
@@ -104,8 +104,9 @@
     "csv-stringify": "^6.5.2",
     "dayjs": "^1.11.10",
     "dompurify": "^3.1.6",
-    "use-sync-external-store": "^1.2.0",
     "focus-trap-react": "^10.2.3",
+    "fs-extra": "^11.3.2",
+    "globby": "^14.1.0",
     "highlight.js": "^11.9.0",
     "intl-messageformat": "^10.7.15",
     "lodash-es": "^4.17.0",
@@ -114,7 +115,8 @@
     "react-intl": "^7.1.6",
     "react-player": "2.15.1",
     "swiper": "^11.1.1",
-    "tabbable": "^6.2.0"
+    "tabbable": "^6.2.0",
+    "use-sync-external-store": "^1.2.0"
   },
   "scripts": {
     "build": "npm run build:chat && npm run build:typedoc",

--- a/packages/ai-chat/package.json
+++ b/packages/ai-chat/package.json
@@ -27,7 +27,8 @@
       "types": "./dist/types/aiChatEntry.d.ts",
       "import": "./dist/es/web-components/cds-aichat-custom-element/index.js"
     },
-    "./dist/es/": "./dist/es/"
+    "./dist/es/": "./dist/es/",
+    "./dist/es-custom/": "./dist/es-custom/"
   },
   "files": [
     "dist/es",

--- a/packages/ai-chat/tasks/rollup.aichat.js
+++ b/packages/ai-chat/tasks/rollup.aichat.js
@@ -1,6 +1,6 @@
-/* 
+/*
  *  Copyright IBM Corp. 2025
- *  
+ *
  *  This source code is licensed under the Apache-2.0 license found in the
  *  LICENSE file in the root directory of this source tree.
  */
@@ -20,6 +20,8 @@ import postcss from 'rollup-plugin-postcss';
 import { visualizer } from 'rollup-plugin-visualizer';
 import { parseJsonConfigFileContent, sys } from 'typescript';
 import { fileURLToPath } from 'url';
+import fs from 'fs-extra';
+import { globby } from 'globby';
 
 import pkg from '../package.json' with { type: 'json' };
 
@@ -91,14 +93,14 @@ async function runRollup() {
       input: {
         // Main entry - becomes es/aiChatEntry.js
         'aiChatEntry': path.join(paths.src, '/aiChatEntry.tsx'),
-        
+
         // Server entry without web component side effects - becomes es/serverEntry.js
         'serverEntry': path.join(paths.src, '/serverEntry.ts'),
-        
+
         // Web components - becomes es/web-components/cds-aichat-container/index.js
         'web-components/cds-aichat-container/index': path.join(paths.src, '/web-components/cds-aichat-container/index.ts'),
-        
-        // Web components - becomes es/web-components/cds-aichat-custom-element/index.js  
+
+        // Web components - becomes es/web-components/cds-aichat-custom-element/index.js
         'web-components/cds-aichat-custom-element/index': path.join(paths.src, '/web-components/cds-aichat-custom-element/index.ts'),
       },
       output: {
@@ -201,10 +203,65 @@ async function runRollup() {
         dts({
           compilerOptions: parsedDtsTsConfig.compilerOptions,
         }),
+        postBuildPlugin(),
       ],
     },
   ];
   return config;
+}
+
+async function postBuild() {
+  const sourceDir = path.resolve(__dirname, "../dist/es");
+  const targetDir = path.resolve(__dirname, "../dist/es-custom");
+
+  // Copy `es` directory to `es-custom`
+  await fs.copy(sourceDir, targetDir);
+
+  // Find all files in the `es-custom` directory
+  const files = await globby([`${targetDir}/**/*`], { onlyFiles: true });
+
+  // Replace "cds" with "cds-custom" in all files
+  await Promise.all(
+    files.map(async (file) => {
+      const lines = (await fs.promises.readFile(file, "utf8")).split("\n");
+
+      const updatedLines = lines.map((line) => {
+        // Replace __cds_aichat to __cds_custom_aichat
+        let newLine = line.replace(/__cds_aichat/g, "__cds_custom_aichat");
+
+        // Replace "cds" only if line does NOT contain 'import' or 'from'
+        if (!/\b(import|from)\b/.test(newLine)) {
+          newLine = newLine.replace(/\bcds\b/g, (match, offset, str) => {
+            // Skip if preceded by -- (ie. --cds-variables)
+            if (offset >= 2 && str.slice(offset - 2, offset) === "--") {
+              return match;
+            }
+            return "cds-custom";
+          });
+        }
+
+        // Rewrite @carbon/web-components imports
+        newLine = newLine.replace(
+          /import\s+['"]@carbon\/web-components\/es\/components\/(.*?)['"]/g,
+          "import '@carbon/web-components/es-custom/components/$1'"
+        );
+
+        return newLine;
+      });
+
+      await fs.promises.writeFile(file, updatedLines.join("\n"));
+    })
+  );
+}
+
+function postBuildPlugin() {
+  return {
+    name: "postbuild-plugin",
+    async writeBundle() {
+      console.log("outputting es-custom folder...");
+      await postBuild();
+    },
+  };
 }
 
 export default () => runRollup();

--- a/packages/ai-chat/tasks/rollup.aichat.js
+++ b/packages/ai-chat/tasks/rollup.aichat.js
@@ -220,39 +220,76 @@ async function postBuild() {
   // Find all files in the `es-custom` directory
   const files = await globby([`${targetDir}/**/*`], { onlyFiles: true });
 
-  // Replace "cds" with "cds-custom" in all files
   await Promise.all(
     files.map(async (file) => {
-      const lines = (await fs.promises.readFile(file, "utf8")).split("\n");
+      let content = await fs.promises.readFile(file, "utf8");
 
-      const updatedLines = lines.map((line) => {
-        // Replace __cds_aichat to __cds_custom_aichat
-        let newLine = line.replace(/__cds_aichat/g, "__cds_custom_aichat");
+      // Find import/export lines and transform only the small, allowed parts in them.
+      // Then replace those lines with placeholders so global replacements don't touch them.
+      const importExportRegex = /^[ \t]*(?:import|export)[^\r\n]*(?:\r?\n|$)/gm;
+      const placeholders = [];
 
-        // Replace "cds" only if line does NOT contain 'import' or 'from'
-        if (!/\b(import|from)\b/.test(newLine)) {
-          newLine = newLine.replace(/\bcds\b/g, (match, offset, str) => {
-            // Skip if preceded by -- (ie. --cds-variables)
-            if (offset >= 2 && str.slice(offset - 2, offset) === "--") {
-              return match;
-            }
-            return "cds-custom";
-          });
-        }
+      const masked = content.replace(importExportRegex, (match) => {
+        /**
+         *  In import/export lines we allow:
+         *  1. __cds_aichat -> __cds_custom_aichat
+         *     This is in particular for the
+         *     "export { default as __cds_custom_aichat_container_register } from "../cds-aichat-container/index.js";
+         *     line in the `dist/es/web-components/cds-aichat-custom-element/index.js` file
+         *.  2. rewrite carbon import paths to es-custom
+         *
+         *  but we DO NOT do the generic 'cds' -> 'cds-custom' replacement here.
+         **/
+        let mod = match
+          .replace(/__cds_aichat/g, "__cds_custom_aichat")
+          .replace(
+            /@carbon\/web-components\/es\/components\/(.*?)(?=['"\s;])/g,
+            "@carbon/web-components/es-custom/components/$1"
+          );
 
-        // Rewrite @carbon/web-components imports
-        newLine = newLine.replace(
-          /import\s+['"]@carbon\/web-components\/es\/components\/(.*?)['"]/g,
-          "import '@carbon/web-components/es-custom/components/$1'"
-        );
-
-        return newLine;
+        const token = `__IE_PLACEHOLDER_${placeholders.length}__`;
+        placeholders.push(mod);
+        return token;
       });
 
-      await fs.promises.writeFile(file, updatedLines.join("\n"));
+      /**
+       * On the rest of the file (masked), perform the global replacements:
+       *  1. cds-aichat -> cds-custom-aichat (class names, etc.)
+       *  2. generic cds -> cds-custom (but skip:
+       *     - occurrences preceded by '-' (so --cds is preserved)
+       *     - occurrences already followed by -custom/_custom to prevent double replace)
+       *  3. rewrite any remaining @carbon import paths that weren't in import/export lines
+       **/
+      let transformed = masked;
+
+      // convert cds-aichat (CSS class prefixes and similar)
+      transformed = transformed.replace(/cds-aichat/g, "cds-custom-aichat");
+
+      // generic cds -> cds-custom with guards:
+      //  (?<!-)  : not immediately preceded by '-'  (so `--cds` or `-cds` won't match)
+      //  (?!-custom|_custom) : not already followed by -custom or _custom (prevent double replace)
+      transformed = transformed.replace(
+        /(?<!-)cds(?!-custom|_custom)([A-Za-z0-9_-]*)/g,
+        (_m, suffix) => `cds-custom${suffix}`
+      );
+
+      // rewrite @carbon paths anywhere else (catch any non-import appearances too)
+      transformed = transformed.replace(
+        /@carbon\/web-components\/es\/components\/(.*?)(?=['"\s;])/g,
+        "@carbon/web-components/es-custom/components/$1"
+      );
+
+      // 3) restore the import/export placeholders back into the content
+      const restored = transformed.replace(/__IE_PLACEHOLDER_(\d+)__/g, (_m, idx) => {
+        return placeholders[Number(idx)];
+      });
+
+      // 4) write file back
+      await fs.promises.writeFile(file, restored);
     })
   );
 }
+
 
 function postBuildPlugin() {
   return {

--- a/packages/ai-chat/tasks/rollup.aichat.js
+++ b/packages/ai-chat/tasks/rollup.aichat.js
@@ -279,12 +279,12 @@ async function postBuild() {
         "@carbon/web-components/es-custom/components/$1"
       );
 
-      // 3) restore the import/export placeholders back into the content
+      // restore the import/export placeholders back into the content
       const restored = transformed.replace(/__IE_PLACEHOLDER_(\d+)__/g, (_m, idx) => {
         return placeholders[Number(idx)];
       });
 
-      // 4) write file back
+      // write file back
       await fs.promises.writeFile(file, restored);
     })
   );


### PR DESCRIPTION
Closes #353 

This PR outputs a new `es-custom` build folder. This `es-custom` build folder swaps out occurrences of `<cds-*` for `<cds-custom-*` so the components don't clash for folders using carbon angular where the component tag names are the same as the tag names used for `@carbon/web-components`

In order to avoid clashing with carbon angular, users will have to:
- import from the `es-custom` folder
```
import "@carbon/ai-chat/dist/es-custom/web-components/cds-aichat-container/index.js";
import "@carbon/ai-chat/dist/es-custom/web-components/cds-aichat-custom-element/index.js";
```
- use the `custom` component tags
```
<cds-custom-aichat-container ....> </cds-custom-aichat-container>
<cds-custom-aichat-custom-element ....> </cds-custom-aichat-custom-element>
```

A `postBuild` rollup plugin copies over the generated `es` folder and replaces occurrences of `cds` with `cds-custom` with exceptions to a few areas:
 - `import/export` statements - the file names include the `cds` prefix so we don't want to swap those out as the file names don't change
 - css variables
 
 
<img width="2570" height="1650" alt="Screenshot 2025-09-19 at 12 06 54 PM" src="https://github.com/user-attachments/assets/1e87ef42-4346-4b01-9090-bc3d597aeb49" />

 
#### Changelog

**New**

- `postBuildPlugin` that gets triggered after rollup finishes bundling
- add export field for the `es-custom` build folder in `package.json`

#### Testing / Reviewing

- Pull this PR down and run the `npm run aiChat:build` command in the root
- Notice a new `es-custom` folder is generated within `packages/ai-chat/dist`
- In the `demo-app.ts` file, replace
```
import "@carbon/ai-chat/dist/es/web-components/cds-aichat-container/index.js";
import "@carbon/ai-chat/dist/es/web-components/cds-aichat-custom-element/index.js";
```
with
```
import "@carbon/ai-chat/dist/es-custom/web-components/cds-aichat-container/index.js";
import "@carbon/ai-chat/dist/es-custom/web-components/cds-aichat-custom-element/index.js";
```
- also replace the instances of `<cds-aichat-container` and `<cds-aichat-custom-element` with `<cds-custom-aichat-container` and `<cds-custom-aichat-custom-element` respectively
- Run `npm run aiChat:start` from root and select the "Web Component" framework in the demo page
- notice the chat app looks and works the same as it does currently
