### PR TITLE
fix(scroll): disable autoscroll for streaming content

### DIFF
--- a/packages/ai-chat/src/chat/shared/containers/MessageComponent.scss
+++ b/packages/ai-chat/src/chat/shared/containers/MessageComponent.scss
@@ -55,6 +55,10 @@ $message-bar-width: 3px;
   inset-block-start: 0.5rem;
 }
 
+.WAC__message--withAvatarLine.WAC__message--lastMessage {
+  min-block-size: 100%;
+}
+
 .WAC__message.WAC__message--lastMessage.WAC__message--has-focus::after {
   block-size: calc(100% - #{layout.$spacing-07} + 0.5rem);
   inset-block-end: calc(#{layout.$spacing-07} - 0.5rem);

--- a/packages/ai-chat/src/chat/shared/containers/MessageComponent.scss
+++ b/packages/ai-chat/src/chat/shared/containers/MessageComponent.scss
@@ -1,6 +1,6 @@
-/* 
+/*
  *  Copyright IBM Corp. 2025
- *  
+ *
  *  This source code is licensed under the Apache-2.0 license found in the
  *  LICENSE file in the root directory of this source tree.
  */
@@ -11,6 +11,7 @@
 @use "@carbon/styles/scss/type";
 
 $message-bar-width: 3px;
+$one-line-message-height: 88px;
 
 @media screen and (prefers-reduced-motion: reduce) {
   .WAC__message {
@@ -56,7 +57,7 @@ $message-bar-width: 3px;
 }
 
 .WAC__message--withAvatarLine.WAC__message--lastMessage {
-  min-block-size: 100%;
+  min-block-size: calc(100% - $one-line-message-height);
 }
 
 .WAC__message.WAC__message--lastMessage.WAC__message--has-focus::after {

--- a/packages/ai-chat/src/chat/shared/containers/MessageTypeComponent.tsx
+++ b/packages/ai-chat/src/chat/shared/containers/MessageTypeComponent.tsx
@@ -348,7 +348,6 @@ function MessageTypeComponent(props: MessageTypeComponentProps) {
           MessageErrorState.FAILED_WHILE_STREAMING
         }
         removeHTML={removeHTML}
-        doAutoScroll={props.doAutoScroll}
       />
     );
   }

--- a/packages/ai-chat/src/chat/shared/containers/MessagesComponent.tsx
+++ b/packages/ai-chat/src/chat/shared/containers/MessagesComponent.tsx
@@ -40,6 +40,7 @@ import { IS_MOBILE } from "../utils/browserUtils";
 import {
   AUTO_SCROLL_EXTRA,
   AUTO_SCROLL_THROTTLE_TIMEOUT,
+  ONE_LINE_MESSAGE_HEIGHT,
   WriteableElementName,
 } from "../utils/constants";
 import { doScrollElement, getScrollBottom } from "../utils/domUtils";
@@ -414,7 +415,8 @@ class MessagesComponent extends PureComponent<MessagesProps, MessagesState> {
           // Scroll to the top of the message.
           const offsetTop =
             lastScrollableMessageComponent.ref.current?.offsetTop;
-          setScrollTop = offsetTop + AUTO_SCROLL_EXTRA;
+          setScrollTop =
+            offsetTop + AUTO_SCROLL_EXTRA - ONE_LINE_MESSAGE_HEIGHT;
           debugAutoScroll(
             `[doAutoScroll] Scrolling to message offsetTop=${offsetTop}`,
           );

--- a/packages/ai-chat/src/chat/shared/utils/constants.ts
+++ b/packages/ai-chat/src/chat/shared/utils/constants.ts
@@ -50,6 +50,9 @@ enum BrandColorKind {
 // padding above the message and we want to cut that down to just 8 so we scroll an extra 20px (28 - 8).
 const AUTO_SCROLL_EXTRA = 28 - 8;
 
+// Height of one line message including the message avatar line label
+const ONE_LINE_MESSAGE_HEIGHT = 88;
+
 // How much to throttle auto scrolling. When we are in test mode, we set this to zero.
 const AUTO_SCROLL_THROTTLE_TIMEOUT = 100;
 
@@ -67,4 +70,5 @@ export {
   CornersType,
   IncreaseOrDecrease,
   AUTO_SCROLL_EXTRA,
+  ONE_LINE_MESSAGE_HEIGHT,
 };


### PR DESCRIPTION
Closes #309

This PR solves an issue where content is streaming and the scrollbar continues to shift downwards due to auto scroll. If user tries to scroll upward, the scroll position would "fight" against user as auto scrolling is adjusting the scroll position at the same time. By disabling the autoscroll for streaming content we solve this issue.

We also adjust the scroll positioning for messages so that the last user utterance is always in view. If the last user utterance is only one line, the entire user utterance should be shown. If the user utterance is multiple lines, we show the bottom portion of the utterance if there is not enough scroll space for the bot response.

#### Changelog

**New**

- Added min-height attribute to last scrollable message 
- new constant to capture height of one liner message

**Changed**

- Added `ONE_LINE_MESSAGE_HEIGHT` to `setScrollTop` position calculation to ensure full or part of the last user utterance is shown.

**Removed**

- Removed doautoscroll for  `<StreamingRichText>`.

#### Testing / Reviewing

- Check the demo and test all the dropdown options to ensure the user message is shown (full or at least partial message)
- for the streaming options, test by manually scrolling up when content is streaming. The scroll should go up and stay in the position you stop scrolling at instead of shifting