### PR TITLE
fix: modal focus traps

### DIFF
--- a/.github/ISSUE_TEMPLATE/ACCESSIBILITY_ISSUE.yaml
+++ b/.github/ISSUE_TEMPLATE/ACCESSIBILITY_ISSUE.yaml
@@ -75,8 +75,8 @@ body:
   - type: input
     id: wcag
     attributes:
-      label: WCAG 2.1 violation
-      description: 'Does this violate a specific WCAG 2.1 checkpoint?'
+      label: WCAG 2.2 violation
+      description: 'Does this violate a specific WCAG 2.2 checkpoint?'
       placeholder: e.g Success Criterion 1.4.3 Contrast (Minimum)
   - type: input
     id: example-url

--- a/packages/ai-chat/docs/Overview.md
+++ b/packages/ai-chat/docs/Overview.md
@@ -110,7 +110,7 @@ Carbon AI Chat allows you to extend the Carbon AI Chat with support for [various
 
 IBM strives to provide products with usable access for everyone, regardless of age or ability.
 
-The Carbon AI Chat integration complies with the [Web Content Accessibility 2.1 Level AA](https://www.w3.org/WAI/standards-guidelines/wcag/new-in-21/) standard.
+The Carbon AI Chat integration complies with the [Web Content Accessibility 2.2 Level AA](https://www.w3.org/WAI/standards-guidelines/wcag/new-in-22/) standard.
 
 ### Internationalization
 

--- a/packages/ai-chat/src/chat/components-legacy/App.scss
+++ b/packages/ai-chat/src/chat/components-legacy/App.scss
@@ -54,6 +54,26 @@
   inline-size: 100%;
 }
 
+.cds-aichat--modal-host {
+  position: fixed;
+  z-index: calc(#{chat-theme.$z-index} + 1);
+  block-size: 100vh;
+  inline-size: 100vw;
+  inset-block-start: 0;
+  inset-inline-start: 0;
+  /* Allow pointer events only when there are child elements (modals) */
+  pointer-events: none;
+}
+
+/* When there are modal children, enable pointer events on them and block interaction with background */
+.cds-aichat--modal-host:has(> *) {
+  pointer-events: auto;
+}
+
+.cds-aichat--modal-host > * {
+  pointer-events: auto;
+}
+
 .cds-aichat--widget {
   position: relative;
   display: flex;
@@ -113,18 +133,6 @@
   inset-inline-start: 0;
 }
 
-/* Generic background cover before rounded variants */
-.cds-aichat--background-cover {
-  position: absolute;
-  z-index: 2;
-  animation: cds-chat-anim-background-cover motion.$duration-moderate-02
-    motion.motion(standard, productive);
-  background: theme.$overlay;
-  block-size: 100%;
-  inline-size: 100%;
-  opacity: 0.5;
-}
-
 /* These selectors apply a border radius to containers/elements that need to match the widget frame's border radius when
 
 rounded corners are enabled. */
@@ -140,8 +148,7 @@ rounded corners are enabled. */
   .cds-aichat--widget__animation-container,
   .cds-aichat--bot-container,
   .cds-aichat--overlay-panel,
-  .cds-aichat--hydrating-container,
-  .cds-aichat--background-cover {
+  .cds-aichat--hydrating-container {
     border-end-end-radius: layout.$spacing-03;
     border-end-start-radius: layout.$spacing-03;
     border-start-end-radius: layout.$spacing-03;
@@ -312,27 +319,6 @@ svg.cds-aichat--icon__logout--reverse {
 
 .cds-aichat--container--render[dir="rtl"] .cds-aichat--icon__logout--reverse {
   transform: none;
-}
-
-@media screen and (prefers-reduced-motion: reduce) {
-  .cds-aichat--background-cover {
-    position: absolute;
-    z-index: 2;
-    animation: none;
-    background: theme.$overlay;
-    block-size: 100%;
-    inline-size: 100%;
-    opacity: 0.5;
-  }
-}
-
-.cds-aichat--background-cover.cds-aichat--background-cover__non-header,
-.cds-aichat--widget.cds-aichat--widget--rounded
-  .cds-aichat--background-cover.cds-aichat--background-cover__non-header {
-  block-size: calc(100% - 40px);
-  border-start-end-radius: 0;
-  border-start-start-radius: 0;
-  inset-block-start: 40px;
 }
 
 .cds-aichat--scroll-focus:focus-visible::before {

--- a/packages/ai-chat/src/chat/components-legacy/AppRegion.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/AppRegion.tsx
@@ -7,7 +7,7 @@
  *  @license
  */
 
-import React, { useRef } from "react";
+import React, { useRef, useState } from "react";
 import { useIntl } from "react-intl";
 import { useSelector } from "../hooks/useSelector";
 
@@ -40,6 +40,8 @@ export default function AppRegion({
       state.persistedToBrowserStorage.viewState.launcher,
   );
   const mainWindowRef = useRef<MainWindowFunctions>();
+  const [modalPortalHostElement, setModalPortalHostElement] =
+    useState<Element | null>(null);
 
   useOnMount(() => {
     function requestFocus() {
@@ -65,8 +67,10 @@ export default function AppRegion({
       <MainWindow
         mainWindowRef={mainWindowRef}
         useCustomHostElement={Boolean(hostElement)}
+        modalPortalHostElement={modalPortalHostElement}
       />
       {showLauncher && <LauncherContainer />}
+      <div className="cds-aichat--modal-host" ref={setModalPortalHostElement} />
     </div>
   );
 }

--- a/packages/ai-chat/src/chat/components-legacy/main/MainWindow.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/main/MainWindow.tsx
@@ -90,18 +90,16 @@ interface MainWindowOwnProps extends HasServiceManager {
    * The mutable ref object for accessing the main window functions.
    */
   mainWindowRef: MutableRefObject<MainWindowFunctions>;
+
+  /**
+   * The host element for modal portals, provided from a higher level component.
+   */
+  modalPortalHostElement: Element | null;
 }
 
 interface MainWindowState {
   open: boolean;
   closing: boolean;
-
-  /**
-   * This is a reference to the Element that acts as the host for elements from {@link ModalPortal}. We set this in
-   * state instead of a class property to make sure the component re-renders and the context is updated with this
-   * value after the component is mounted.
-   */
-  modalPortalHostElement: Element;
 
   /**
    * Counter to track if there are any panels open. If this is 0, the regular bot content will be visible.
@@ -143,7 +141,6 @@ class MainWindow
   public readonly state: Readonly<MainWindowState> = {
     closing: false,
     open: this.props.persistedToBrowserStorage.viewState.mainWindow,
-    modalPortalHostElement: null,
     numPanelsOpen: 0,
     numPanelsAnimating: 0,
     numPanelsCovering: 0,
@@ -467,15 +464,6 @@ class MainWindow
     }
   };
 
-  /**
-   * Sets the element that is used as the host for {@link ModalPortal}.
-   */
-  setModalPortalHostElement = (ref: Element) => {
-    if (this.state.modalPortalHostElement !== ref) {
-      this.setState({ modalPortalHostElement: ref });
-    }
-  };
-
   onSendInput = async (
     text: string,
     source: MessageSendSource,
@@ -717,12 +705,7 @@ class MainWindow
    * otherwise it appears for a split second before home screen is loaded.
    */
   renderChat() {
-    const { isHydrated, config, chatWidthBreakpoint } = this.props;
-
-    const showCovering =
-      this.state.numPanelsCovering > 0 &&
-      config.derived.layout.hasContentMaxWidth &&
-      chatWidthBreakpoint === ChatWidthBreakpoint.WIDE;
+    const { isHydrated } = this.props;
 
     return (
       <div className="cds-aichat--widget--content">
@@ -735,7 +718,6 @@ class MainWindow
             {this.renderHomeScreenPanel()}
             {this.renderIFramePanel()}
             {this.renderViewSourcePanel()}
-            {showCovering && <div className="cds-aichat--background-cover" />}
             {this.renderBotChat()}
           </>
         )}
@@ -1162,10 +1144,6 @@ class MainWindow
                   {this.renderChat()}
                 </div>
               )}
-              <div
-                className="cds-aichat--main-window-modal-host"
-                ref={this.setModalPortalHostElement}
-              />
             </div>
           </div>
         </Layer>
@@ -1175,7 +1153,7 @@ class MainWindow
 
   render() {
     return (
-      <ModalPortalRootProvider hostElement={this.state.modalPortalHostElement}>
+      <ModalPortalRootProvider hostElement={this.props.modalPortalHostElement}>
         {this.renderWidget()}
       </ModalPortalRootProvider>
     );

--- a/packages/ai-chat/src/chat/components-legacy/modals/ConfirmModal.scss
+++ b/packages/ai-chat/src/chat/components-legacy/modals/ConfirmModal.scss
@@ -25,8 +25,12 @@
 }
 
 .cds-aichat--confirm-modal .cds-aichat--confirm-modal__container {
-  margin: layout.$spacing-06;
+  margin: auto;
   background-color: theme.$background;
+  max-inline-size: min(
+    calc(#{chat-theme.$max-width} - calc(#{layout.$spacing-05} * 2)),
+    512px
+  );
 }
 
 .cds-aichat--confirm-modal .cds-aichat--confirm-modal__title {
@@ -49,13 +53,4 @@
 
 .cds-aichat--confirm-modal .cds-aichat--confirm-modal__button-container * {
   flex: 1;
-}
-
-.cds-aichat--wide-width
-  .cds-aichat--confirm-modal
-  .cds-aichat--confirm-modal__container {
-  margin: auto;
-  max-inline-size: calc(
-    #{chat-theme.$max-width} - calc(#{layout.$spacing-05} * 2)
-  );
 }


### PR DESCRIPTION
Closes #460 

If you go to a human agent and then "disconnect" you are given a "confirmation" modal. At somepoint we will likely want design to review the whole pattern, but, as is, this confirmation modal only showed up on the size of the chat itself:

<img width="1347" height="776" alt="Screenshot 2025-09-23 at 1 56 27 PM" src="https://github.com/user-attachments/assets/3ccdba2a-a80d-472b-bf77-525a572e2a53" />
<img width="1712" height="866" alt="Screenshot 2025-09-23 at 1 56 59 PM" src="https://github.com/user-attachments/assets/b24f217e-685e-4f56-bc71-99befbe7a069" />

What is problematic here is that contents outside the modal "cover" are not clickable even if they look clickable!

So, instead:


<img width="857" height="393" alt="Screenshot 2025-09-23 at 1 55 13 PM" src="https://github.com/user-attachments/assets/17ed76e7-db66-4016-9514-a7d2758fccda" />
<img width="1716" height="818" alt="Screenshot 2025-09-23 at 1 55 52 PM" src="https://github.com/user-attachments/assets/1e926116-e2e7-4c40-b182-694bf343c5ff" />
