### PR TITLE
fix: use theme css variable in doImage and doCarousel

### DIFF
--- a/demo/src/customSendMessage/doCarousel.ts
+++ b/demo/src/customSendMessage/doCarousel.ts
@@ -37,7 +37,7 @@ function doCarousel(instance: ChatInstance) {
                 },
                 {
                   response_type: "text",
-                  text: '<span style="color: #4e4d4d">I\'m baby beard cornhole gatekeep, lyft hoodie disrupt locavore raw denim meggings.</span>',
+                  text: '<span style="color: var(--cds-text-secondary)">I\'m baby beard cornhole gatekeep, lyft hoodie disrupt locavore raw denim meggings.</span>',
                 },
                 {
                   response_type: "text",
@@ -70,7 +70,7 @@ function doCarousel(instance: ChatInstance) {
                 },
                 {
                   response_type: "text",
-                  text: '<span style="color: #4e4d4d">Street art banjo vaporware, hot chicken marxism art party neutra quinoa sustainable activated charcoal.</span>',
+                  text: '<span style="color: var(--cds-text-secondary)">Street art banjo vaporware, hot chicken marxism art party neutra quinoa sustainable activated charcoal.</span>',
                 },
                 {
                   response_type: "text",
@@ -103,7 +103,7 @@ function doCarousel(instance: ChatInstance) {
                 },
                 {
                   response_type: "text",
-                  text: '<span style="color: #4e4d4d">Succulents skateboard adaptogen solarpunk semiotics, viral locavore palo santo.</span>',
+                  text: '<span style="color: var(--cds-text-secondary)">Succulents skateboard adaptogen solarpunk semiotics, viral locavore palo santo.</span>',
                 },
                 {
                   response_type: "text",

--- a/demo/src/customSendMessage/doImage.ts
+++ b/demo/src/customSendMessage/doImage.ts
@@ -90,7 +90,7 @@ function doImage(instance: ChatInstance) {
               },
               {
                 response_type: MessageResponseTypes.TEXT,
-                text: '<span style="color: #4e4d4d">I\'m baby listicle synth migas air plant DSA cardigan helvetica fanny pack fit chillwave forage. Umami tacos subway tile sriracha skateboard activated charcoal roof party pinterest adaptogen ennui brunch bitters. Helvetica dreamcatcher viral fashion axe, coloring book four dollar toast vexillologist bushwick stumptown mumblecore slow-carb. Tote bag vinyl.</span>',
+                text: '<span style="color: var(--cds-text-secondary)">I\'m baby listicle synth migas air plant DSA cardigan helvetica fanny pack fit chillwave forage. Umami tacos subway tile sriracha skateboard activated charcoal roof party pinterest adaptogen ennui brunch bitters. Helvetica dreamcatcher viral fashion axe, coloring book four dollar toast vexillologist bushwick stumptown mumblecore slow-carb. Tote bag vinyl.</span>',
               },
             ],
             title: "Tanya panel",


### PR DESCRIPTION
Closes #497

uses text secondary css variable in place of hard coded color

#### Changelog

**Changed**

- change hard coded color to css variable

#### Testing / Reviewing

can be observed in doCarousel cards and doImage panel
