### PR TITLE
fix(rtl): text alignment 

### DIFF
--- a/packages/ai-chat/src/chat/components-legacy/App.scss
+++ b/packages/ai-chat/src/chat/components-legacy/App.scss
@@ -1,6 +1,6 @@
-/* 
+/*
  *  Copyright IBM Corp. 2025
- *  
+ *
  *  This source code is licensed under the Apache-2.0 license found in the
  *  LICENSE file in the root directory of this source tree.
  */
@@ -288,10 +288,6 @@ in. */
 
 .cds-aichat.cds-aichat--human-agent-app {
   min-inline-size: unset;
-}
-
-.cds-aichat--container--render[dir="rtl"] .cds-aichat {
-  text-align: end;
 }
 
 .cds-aichat--main-window,


### PR DESCRIPTION
Closes #486 

In RTL, there are text alignment issues especially visible in full screen mode.

<img width="1426" height="1172" alt="Screenshot 2025-10-01 at 11 55 23 AM" src="https://github.com/user-attachments/assets/aa91d993-8892-4bf0-a49d-f23249292d25" />

<img width="1628" height="882" alt="Screenshot 2025-10-01 at 2 14 30 PM" src="https://github.com/user-attachments/assets/7972932b-c0a0-4bab-bba4-92c20a174899" />

We have styles that are setting the `text-align` attribute when in RTL, which is overriding the browsers natural text alignment for components like ordered-list and regular text.

#### Changelog

**Removed**

- remove styles that are setting the `text-align` attribute.

#### Testing / Reviewing

1. Go to demo deploy preview
2. Set full screen mode and open chat
3. Set direction to RTL 
4. Test with `inline error`, `ordered list`, and `unordered list` from dropdown options
