### PR TITLE
feat: add version dropdown for demo/docs

### DIFF
--- a/demo/src/framework/demo-body.tsx
+++ b/demo/src/framework/demo-body.tsx
@@ -30,6 +30,7 @@ import "./demo-layout-config-switcher";
 import "./demo-launcher-switcher";
 import "./demo-chat-instance-switcher";
 import "./demo-direction-switcher";
+import "./demo-chat-version-switcher";
 import "@carbon/web-components/es/components/button/index.js";
 
 const { defaultConfig, defaultSettings } = getSettings();
@@ -79,7 +80,8 @@ export class DemoBody extends LitElement {
     demo-chat-theme-switcher,
     demo-homescreen-switcher,
     demo-writeable-elements-switcher,
-    demo-direction-switcher {
+    demo-direction-switcher,
+    demo-chat-version-switcher {
       display: block;
       margin-block-start: 1rem;
     }
@@ -104,6 +106,7 @@ export class DemoBody extends LitElement {
 
     /* First item in each accordion doesn't need top margin */
     demo-page-theme-switcher,
+    cds-accordion-item demo-chat-version-switcher:first-child,
     cds-accordion-item demo-version-switcher:first-child {
       margin-block-start: 0;
     }
@@ -460,6 +463,15 @@ export class DemoBody extends LitElement {
         : !this.isSetChatConfigMode
           ? html`<div class="nav-block" data-testid="config_sidebar">
               <cds-accordion>
+                <cds-accordion-item title="Choose Chat Component">
+                  <demo-chat-version-switcher></demo-chat-version-switcher>
+                  <demo-version-switcher
+                    .settings=${this.settings}
+                  ></demo-version-switcher>
+                  <demo-layout-switcher
+                    .settings=${this.settings}
+                  ></demo-layout-switcher>
+                </cds-accordion-item>
                 <cds-accordion-item title="Page Settings">
                   <demo-page-theme-switcher></demo-page-theme-switcher>
                   <demo-direction-switcher
@@ -468,14 +480,6 @@ export class DemoBody extends LitElement {
                   <demo-writeable-elements-switcher
                     .settings=${this.settings}
                   ></demo-writeable-elements-switcher>
-                </cds-accordion-item>
-                <cds-accordion-item title="Choose Chat Component">
-                  <demo-version-switcher
-                    .settings=${this.settings}
-                  ></demo-version-switcher>
-                  <demo-layout-switcher
-                    .settings=${this.settings}
-                  ></demo-layout-switcher>
                 </cds-accordion-item>
                 <cds-accordion-item title="Chat Configuration">
                   <demo-theme-switcher

--- a/demo/src/framework/demo-chat-version-switcher.ts
+++ b/demo/src/framework/demo-chat-version-switcher.ts
@@ -1,0 +1,267 @@
+/*
+ *  Copyright IBM Corp. 2025
+ *
+ *  This source code is licensed under the Apache-2.0 license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ *  @license
+ */
+
+import { html, LitElement, css } from "lit";
+import { customElement } from "lit/decorators.js";
+import "@carbon/web-components/es/components/dropdown/index.js";
+
+interface VersionOption {
+  label: string;
+  value: string;
+  href: string;
+  selected: boolean;
+  divider?: boolean;
+}
+
+interface VersionInfo {
+  type: "tag" | "version" | "local";
+  value: string;
+}
+
+/**
+ * `VersionDropdown` is a custom Lit element for selecting versions.
+ */
+@customElement("demo-chat-version-switcher")
+export class VersionDropdown extends LitElement {
+  private options: VersionOption[] = [];
+  private selectedValue = "";
+
+  static styles = css`
+    :host {
+      display: block;
+    }
+
+    cds-dropdown {
+      width: 100%;
+    }
+  `;
+
+  connectedCallback() {
+    super.connectedCallback();
+    this.initVersionDropdown();
+  }
+
+  private getCurrentVersionInfo(): VersionInfo {
+    const path = window.location.pathname;
+
+    // Check if we're on a tag (latest/next)
+    const tagMatch = path.match(/\/tag\/(latest|next)\//);
+    if (tagMatch) {
+      return { type: "tag", value: tagMatch[1] };
+    }
+
+    // Check if we're on a versioned path
+    const versionMatch = path.match(/\/version\/(v[\d.]+(?:-rc\.\d+)?)\//);
+    if (versionMatch) {
+      return { type: "version", value: versionMatch[1] };
+    }
+
+    // Check if we're on localhost (with or without port)
+    const hostname = window.location.hostname;
+    if (
+      hostname === "localhost" ||
+      hostname === "127.0.0.1" ||
+      hostname === "0.0.0.0"
+    ) {
+      return { type: "local", value: "local" };
+    }
+
+    // Default to latest if we can't determine
+    return { type: "tag", value: "latest" };
+  }
+
+  private getVersionPath(versionInfo: VersionInfo): string {
+    if (versionInfo.type === "tag") {
+      return `/tag/${versionInfo.value}/demo/index.html`;
+    } else {
+      return `/version/${versionInfo.value}/demo/index.html`;
+    }
+  }
+
+  private getVersionsPath(): string {
+    const currentInfo = this.getCurrentVersionInfo();
+
+    // If we're on localhost, fetch from local file
+    if (currentInfo.type === "local") {
+      return "./versions.js";
+    }
+
+    // For deployed sites, always fetch from the canonical location
+    return "https://chat.carbondesignsystem.com/versions.js";
+  }
+
+  private formatOptionLabel(currentInfo: VersionInfo): string {
+    if (currentInfo.type === "tag") {
+      return (
+        currentInfo.value.charAt(0).toUpperCase() + currentInfo.value.slice(1)
+      );
+    }
+
+    if (currentInfo.type === "local") {
+      return "Local";
+    }
+
+    return currentInfo.value;
+  }
+
+  private createCurrentVersionOption(
+    currentInfo: VersionInfo,
+  ): VersionOption | null {
+    switch (currentInfo.type) {
+      case "version": {
+        const href = `${window.location.origin}${this.getVersionPath(currentInfo)}`;
+        return {
+          label: currentInfo.value,
+          value: currentInfo.value,
+          href,
+          selected: true,
+        };
+      }
+
+      case "tag": {
+        const href = `${window.location.origin}${this.getVersionPath(currentInfo)}`;
+        return {
+          label: this.formatOptionLabel(currentInfo),
+          value: `tag:${currentInfo.value}`,
+          href,
+          selected: true,
+        };
+      }
+
+      case "local":
+        return {
+          label: this.formatOptionLabel(currentInfo),
+          value: "local",
+          href: window.location.href,
+          selected: true,
+        };
+
+      default:
+        return null;
+    }
+  }
+
+  private async initVersionDropdown() {
+    try {
+      const versionsPath = this.getVersionsPath();
+      const response = await fetch(versionsPath);
+
+      if (!response.ok) {
+        console.warn("Failed to fetch versions.js from", versionsPath);
+        return;
+      }
+
+      const text = await response.text();
+
+      // Extract the AI_CHAT_VERSIONS array from the file
+      const match = text.match(/export const AI_CHAT_VERSIONS = (\[.*?\]);/s);
+      if (!match) {
+        console.warn("Failed to parse versions.js");
+        return;
+      }
+
+      // Replace single quotes with double quotes for valid JSON
+      const arrayString = match[1].replace(/'/g, '"');
+      const versions: string[] = JSON.parse(arrayString);
+
+      // Build the dropdown options
+      const currentInfo = this.getCurrentVersionInfo();
+      let options: VersionOption[] = versions.map((version) => {
+        const selected =
+          currentInfo.type === "version" && currentInfo.value === version;
+        return {
+          label: version,
+          value: version,
+          href: `https://chat.carbondesignsystem.com${this.getVersionPath({ type: "version", value: version })}`,
+          selected,
+        };
+      });
+
+      let selectedValue =
+        options.find((opt) => opt.selected && !opt.divider)?.value ?? null;
+
+      if (!selectedValue) {
+        const currentOption = this.createCurrentVersionOption(currentInfo);
+
+        if (currentOption) {
+          const existingIndex = options.findIndex(
+            (opt) => opt.value === currentOption.value,
+          );
+
+          if (existingIndex >= 0) {
+            options[existingIndex] = {
+              ...options[existingIndex],
+              selected: true,
+            };
+          } else {
+            options = [currentOption, ...options];
+          }
+
+          selectedValue = currentOption.value;
+        }
+      }
+
+      if (!selectedValue) {
+        selectedValue = options[0]?.value ?? "local";
+      }
+
+      const normalizedOptions = options.map((option) => ({
+        ...option,
+        selected: option.value === selectedValue,
+      }));
+
+      this.options = normalizedOptions;
+      this.selectedValue = selectedValue;
+      this.requestUpdate();
+    } catch (error) {
+      console.error("Error initializing version dropdown:", error);
+    }
+  }
+
+  private handleChange(event: CustomEvent) {
+    const selectedValue = event.detail?.item?.value ?? event.detail?.value;
+    const selectedOption = this.options.find(
+      (opt) => !opt.divider && opt.value === selectedValue,
+    );
+    if (selectedOption && selectedOption.href !== "#") {
+      window.location.href = selectedOption.href;
+    }
+  }
+
+  render() {
+    if (this.options.length === 0) {
+      return html``;
+    }
+
+    return html`
+      <cds-dropdown
+        title-text="Select @carbon/ai-chat version"
+        helper-text="Changing will reset all other settings"
+        size="sm"
+        .value=${this.selectedValue}
+        @cds-dropdown-selected=${this.handleChange}
+      >
+        ${this.options.map((option) =>
+          option.divider
+            ? html`<cds-dropdown-item divider></cds-dropdown-item>`
+            : html`<cds-dropdown-item value="${option.value}">
+                ${option.label}
+              </cds-dropdown-item>`,
+        )}
+      </cds-dropdown>
+    `;
+  }
+}
+
+// Register the custom element if not already defined
+declare global {
+  interface HTMLElementTagNameMap {
+    "demo-chat-version-switcher": VersionDropdown;
+  }
+}

--- a/demo/webpack.config.js
+++ b/demo/webpack.config.js
@@ -9,9 +9,27 @@ import HtmlWebpackPlugin from "html-webpack-plugin";
 import path from "path";
 import { fileURLToPath } from "url";
 import portfinder from "portfinder";
+import { promises as fs } from "fs";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
+
+// Simple plugin to copy versions.js from root to dist
+class CopyVersionsPlugin {
+  apply(compiler) {
+    compiler.hooks.afterEmit.tapPromise("CopyVersionsPlugin", async () => {
+      const source = path.resolve(__dirname, "..", "versions.js");
+      const dest = path.resolve(__dirname, "dist", "versions.js");
+
+      try {
+        await fs.copyFile(source, dest);
+        console.log("Copied versions.js to dist/");
+      } catch (error) {
+        console.warn("Failed to copy versions.js:", error.message);
+      }
+    });
+  }
+}
 
 export default async (_env, args) => {
   const port = await portfinder.getPortPromise({
@@ -61,6 +79,7 @@ export default async (_env, args) => {
         template: "./index.html",
         inject: "body",
       }),
+      new CopyVersionsPlugin(),
     ],
     devtool: "source-map",
     devServer:

--- a/packages/ai-chat/docs/WebComponent.md
+++ b/packages/ai-chat/docs/WebComponent.md
@@ -339,7 +339,7 @@ export class Demo extends LitElement {
 }
 ```
 
-You may also want your `user_defined` responses to stream. In that case, you will want to listen for both {@link BusEventType.USER*DEFINED_RESPONSE} and {@link BusEventType.CHUNK_USER_DEFINED_RESPONSE} events, and make use of the `partialItems` that accumulate over time. The partialItems come back as an array of every chunk received. They are \_not* concatenated for you. Some folks pass in stringified JSON or JSON that needs to be passed through an optimistic JSON parser (one that auto fixes up partial JSON), so unlike the text response_type, we leave that concatenation to your use case.
+You may also want your `user_defined` responses to stream. In that case, you will want to listen for both {@link BusEventType.USER_DEFINED_RESPONSE} and {@link BusEventType.CHUNK_USER_DEFINED_RESPONSE} events, and make use of the `partialItems` that accumulate over time. The partialItems come back as an array of every chunk received. They are \_not\* concatenated for you. Some folks pass in stringified JSON or JSON that needs to be passed through an optimistic JSON parser (one that auto fixes up partial JSON), so unlike the text response_type, we leave that concatenation to your use case.
 
 ```typescript
 import "@carbon/ai-chat/dist/es/web-components/cds-aichat-container/index.js";

--- a/packages/ai-chat/docs/typedoc/carbonThemePlugin.js
+++ b/packages/ai-chat/docs/typedoc/carbonThemePlugin.js
@@ -16,6 +16,8 @@ const CARBON_ASSETS = [
   "redirectToOverview.js",
   "carbonTheme.css",
   "cookiePreferences.js",
+  "versionDropdown.js",
+  "experimentalToPreview.js",
 ];
 
 export function load(app) {
@@ -63,6 +65,16 @@ export function load(app) {
       await fs.copyFile(carbonStylesSource, carbonStylesTarget);
     } catch (error) {
       app.logger.warn(`Failed to copy Carbon styles: ${error.message}`);
+    }
+
+    // Copy versions.js from root
+    const versionsSource = join(process.cwd(), "..", "..", "versions.js");
+    const versionsTarget = join(event.outputDirectory, "versions.js");
+
+    try {
+      await fs.copyFile(versionsSource, versionsTarget);
+    } catch (error) {
+      app.logger.warn(`Failed to copy versions.js: ${error.message}`);
     }
   });
 }

--- a/packages/ai-chat/docs/typedoc/theme/assets/versionDropdown.js
+++ b/packages/ai-chat/docs/typedoc/theme/assets/versionDropdown.js
@@ -1,0 +1,180 @@
+/*
+ *  Copyright IBM Corp. 2025
+ *
+ *  This source code is licensed under the Apache-2.0 license found in the
+ *  LICENSE file in the root directory of this source tree.
+ */
+
+(function () {
+  "use strict";
+
+  // Determine the current version and type from the URL
+  function getCurrentVersionInfo() {
+    const path = window.location.pathname;
+
+    // Check if we're on a tag (latest/next)
+    const tagMatch = path.match(/\/tag\/(latest|next)\//);
+    if (tagMatch) {
+      return { type: "tag", value: tagMatch[1] };
+    }
+
+    // Check if we're on a versioned path
+    const versionMatch = path.match(/\/version\/(v[\d.]+(?:-rc\.\d+)?)\//);
+    if (versionMatch) {
+      return { type: "version", value: versionMatch[1] };
+    }
+
+    // Check if we're on localhost (with or without port)
+    const hostname = window.location.hostname;
+    if (
+      hostname === "localhost" ||
+      hostname === "127.0.0.1" ||
+      hostname === "0.0.0.0"
+    ) {
+      return { type: "local", value: "local" };
+    }
+
+    // Default to latest if we can't determine
+    return { type: "tag", value: "latest" };
+  }
+
+  // Get the base path for a given version
+  function getVersionPath(versionInfo) {
+    if (versionInfo.type === "tag") {
+      return `/tag/${versionInfo.value}/docs/documents/Overview.html`;
+    } else {
+      return `/version/${versionInfo.value}/docs/documents/Overview.html`;
+    }
+  }
+
+  // Get the path to versions.js based on current location
+  function getVersionsPath() {
+    const currentInfo = getCurrentVersionInfo();
+
+    // If we're on localhost, fetch from TypeDoc root
+    // We need to find the base path from the current location
+    if (currentInfo.type === "local") {
+      // Get the data-base attribute from the html element which tells us the path to root
+      const htmlElement = document.documentElement;
+      const basePath = htmlElement.getAttribute("data-base") || "./";
+      return basePath + "versions.js";
+    }
+
+    // For deployed sites, always fetch from the canonical location
+    return "https://chat.carbondesignsystem.com/versions.js";
+  }
+
+  // Fetch and populate the version dropdown
+  async function initVersionDropdown() {
+    try {
+      const versionsPath = getVersionsPath();
+      const response = await fetch(versionsPath);
+
+      if (!response.ok) {
+        console.warn("Failed to fetch versions.js from", versionsPath);
+        return;
+      }
+
+      const text = await response.text();
+
+      // Extract the AI_CHAT_VERSIONS array from the file
+      const match = text.match(/export const AI_CHAT_VERSIONS = (\[.*?\]);/s);
+      if (!match) {
+        console.warn("Failed to parse versions.js");
+        return;
+      }
+
+      // Replace single quotes with double quotes for valid JSON
+      const arrayString = match[1].replace(/'/g, '"');
+      const versions = JSON.parse(arrayString);
+
+      // Get current version info to determine which option should be selected
+      const currentInfo = getCurrentVersionInfo();
+
+      // Build the dropdown options - start with an empty array
+      let options = [];
+
+      // Add "Pre-release" option for next tag
+      options.push({
+        label: "Pre-release",
+        value: "tag:next",
+        href: `https://chat.carbondesignsystem.com${getVersionPath({ type: "tag", value: "next" })}`,
+        selected: currentInfo.type === "tag" && currentInfo.value === "next",
+      });
+
+      // Add all version options from the array
+      // If current version is "latest" tag, select the first version in the array
+      const isLatest =
+        currentInfo.type === "tag" && currentInfo.value === "latest";
+      options = options.concat(
+        versions.map(function (version, index) {
+          const isFirstVersion = index === 0;
+          const selected =
+            (currentInfo.type === "version" && currentInfo.value === version) ||
+            (isLatest && isFirstVersion);
+          return {
+            label: version,
+            value: version,
+            href: `https://chat.carbondesignsystem.com${getVersionPath({ type: "version", value: version })}`,
+            selected: selected,
+          };
+        }),
+      );
+
+      // Add "Local" option if we're on localhost
+      if (currentInfo.type === "local") {
+        options.unshift({
+          label: "Local",
+          value: "local",
+          href: window.location.href,
+          selected: true,
+        });
+      }
+
+      // Determine the selected value
+      let selectedValue =
+        options.find((opt) => opt.selected)?.value ||
+        options[0]?.value ||
+        "local";
+
+      // Find the dropdown element
+      const dropdown = document.getElementById("versions-dropdown");
+      if (!dropdown) {
+        console.warn("Versions dropdown element not found");
+        return;
+      }
+
+      // Set the selected value
+      dropdown.value = selectedValue;
+
+      // Populate the dropdown with items
+      options.forEach(function (option) {
+        const item = document.createElement("cds-dropdown-item");
+        item.setAttribute("value", option.value);
+        item.textContent = option.label;
+        item.dataset.href = option.href;
+        dropdown.appendChild(item);
+      });
+
+      // Add event listener for selection changes
+      dropdown.addEventListener("cds-dropdown-selected", function (event) {
+        const selectedValue = event.detail?.item?.value ?? event.detail?.value;
+        const selectedOption = options.find(
+          (opt) => opt.value === selectedValue,
+        );
+        if (selectedOption && selectedOption.href) {
+          window.location.href = selectedOption.href;
+        }
+      });
+    } catch (error) {
+      console.error("Error initializing version dropdown:", error);
+    }
+  }
+
+  // Initialize when DOM is ready
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", initVersionDropdown);
+  } else {
+    initVersionDropdown();
+  }
+})();

--- a/packages/ai-chat/docs/typedoc/theme/layouts/default.js
+++ b/packages/ai-chat/docs/typedoc/theme/layouts/default.js
@@ -270,6 +270,10 @@ export const defaultLayout = (context, template, props) => {
         src: "https://1.www.s81c.com/common/carbon/web-components/tag/latest/modal.min.js",
       }),
       JSX.createElement("script", {
+        type: "module",
+        src: "https://1.www.s81c.com/common/carbon/web-components/tag/latest/dropdown.min.js",
+      }),
+      JSX.createElement("script", {
         defer: true,
         src: context.relativeURL("assets/carbonSearchModal.js", true),
       }),
@@ -288,6 +292,10 @@ export const defaultLayout = (context, template, props) => {
       JSX.createElement("script", {
         defer: true,
         src: context.relativeURL("assets/experimentalToPreview.js", true),
+      }),
+      JSX.createElement("script", {
+        defer: true,
+        src: context.relativeURL("assets/versionDropdown.js", true),
       }),
       context.hook("head.end", context),
     ),

--- a/packages/ai-chat/src/aiChatEntry.tsx
+++ b/packages/ai-chat/src/aiChatEntry.tsx
@@ -22,6 +22,8 @@ export {
   ViewType,
 } from "./types/instance/apiTypes";
 
+export { PersistedState } from "./types/state/AppState";
+
 export { ChatHeaderConfig } from "./types/config/ChatHeaderConfig";
 
 export {
@@ -90,6 +92,7 @@ export {
   HomeScreenConfig,
   HomeScreenStarterButton,
   HomeScreenStarterButtons,
+  HomeScreenState,
 } from "./types/config/HomeScreenConfig";
 
 export {
@@ -112,7 +115,10 @@ export {
   PublicConfigMessaging,
 } from "./types/config/PublicConfig";
 
+export { PersistedHumanAgentState } from "./types/state/PersistedHumanAgentState";
+
 export { DeepPartial } from "../src/types/utilities/DeepPartial";
+export type { default as ObjectMap } from "./types/utilities/ObjectMap";
 
 export {
   AdditionalDataToAgent,

--- a/packages/ai-chat/src/serverEntry.ts
+++ b/packages/ai-chat/src/serverEntry.ts
@@ -89,10 +89,15 @@ export {
   ViewChangeReason,
 } from "./types/events/eventBusTypes";
 
+export { PersistedState } from "./types/state/AppState";
+
+export { PersistedHumanAgentState } from "./types/state/PersistedHumanAgentState";
+
 export {
   HomeScreenConfig,
   HomeScreenStarterButton,
   HomeScreenStarterButtons,
+  HomeScreenState,
 } from "./types/config/HomeScreenConfig";
 
 export {
@@ -116,6 +121,7 @@ export {
 } from "./types/config/PublicConfig";
 
 export { DeepPartial } from "../src/types/utilities/DeepPartial";
+export type { default as ObjectMap } from "./types/utilities/ObjectMap";
 
 export {
   AdditionalDataToAgent,

--- a/packages/ai-chat/src/types/config/PublicConfig.ts
+++ b/packages/ai-chat/src/types/config/PublicConfig.ts
@@ -340,8 +340,8 @@ export interface PublicConfigMessaging {
 
   /**
    * Controls how long AI chat should wait before showing the loading indicator. If set to 0, the chat will never show
-   * the loading indicator. This is tied to either {@link ChatInstance.messaging.addMessage} or {@link ChatInstance.messaging.addMessageChunk}
-   * being called after this message was sent.
+   * the loading indicator. This is tied to either {@link ChatInstanceMessaging.addMessage} or
+   * {@link ChatInstanceMessaging.addMessageChunk} being called after this message was sent.
    *
    * If set to 0, the chat will never automatically show a loading indicator.
    */

--- a/packages/ai-chat/src/types/state/AppState.ts
+++ b/packages/ai-chat/src/types/state/AppState.ts
@@ -250,8 +250,8 @@ interface PersistedState {
   viewState: ViewState;
 
   /**
-   * Indicates if we should show an unread indicator on the launcher. This is a custom flag that is set by
-   * {@link ChatActions.updateBotUnreadIndicatorVisibility} and will display an empty circle on
+   * Indicates if we should show an unread indicator on the launcher. This is set by
+   * {@link ChatInstance.updateBotUnreadIndicatorVisibility} and will display an empty circle on
    * the launcher. This setting is overridden if there are any unread human agent messages in which case a circle
    * with a number is displayed.
    */
@@ -291,15 +291,15 @@ interface PersistedState {
 
   /**
    * If the user has received a message beyond the welcome node. We use this to mark if the chat has been interacted
-   * with. Note that this is a duplicate of the property on {@link PersistedChatState.hasSentNonWelcomeMessage}. It
-   * is duplicated here so that this information may be available before hydration and before the user is known.
+   * with. This flag is duplicated so the information is available before hydration and before the user is known.
    * Note that this property reflects only the last user and should only be used when an approximate value is
    * acceptable.
    */
   hasSentNonWelcomeMessage: boolean;
 
   /**
-   * Map of if a disclaimer has been accepted on a given window.hostname value.
+   * Map of if a disclaimer has been accepted on a given window.hostname value, keyed by hostname via
+   * {@link ObjectMap}.
    */
   disclaimersAccepted: ObjectMap<boolean>;
 

--- a/packages/ai-chat/src/types/utilities/ObjectMap.ts
+++ b/packages/ai-chat/src/types/utilities/ObjectMap.ts
@@ -16,6 +16,8 @@
  * keys in the map and the values of those properties are all of the same type (TPropertyType). The type of the keys
  * defaults to any string but you can specify a type that is a string enum instead if you want a map that contains
  * only keys for a given enum (or other similar type).
+ *
+ * @category Utilities
  */
 type ObjectMap<
   TPropertyType,

--- a/versions.js
+++ b/versions.js
@@ -1,0 +1,17 @@
+/*
+ *  Copyright IBM Corp. 2025
+ *
+ *  This source code is licensed under the Apache-2.0 license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ *  @license
+ */
+
+/**
+ * Array of full release versions to populate the demo / documentation dropdowns to allow
+ * adopters to easily switch between demo / documentation versions.
+ *
+ * Note: Only include full releases (e.g., v1.0.0), not RC or pre-release versions.
+ * The array should be ordered with newest versions first, there is no sorting later on.
+ */
+export const AI_CHAT_VERSIONS = ["v0.5.1", "v0.5.0", "v0.4.0"];


### PR DESCRIPTION
Add ability to navigate to other versions easily.

Still need to add auto-generation of the versions.js file and auto-upload it.

Both the demo site and the docs site now have dropdowns for you to select what version of the docs/demo you want to see.

If you are in on a version that isn't in the dropdown (e.g. Local) we stuff it in the dropdown so something is correctly selected.

Contributes to #482 