### PR TITLE
feat: add config item for input config

### DIFF
--- a/packages/ai-chat/src/chat/components-legacy/BotChat.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/BotChat.tsx
@@ -211,6 +211,7 @@ class BotChat extends Component<ChatInterfaceProps, ChatInterfaceState> {
       languagePack,
       messageState,
       intl,
+      config,
       allMessageItemsByID,
       isHydrated,
       serviceManager,
@@ -283,6 +284,7 @@ class BotChat extends Component<ChatInterfaceProps, ChatInterfaceState> {
           placeholder={languagePack[inputPlaceholderKey]}
           isStopStreamingButtonVisible={stopStreamingButtonState.isVisible}
           isStopStreamingButtonDisabled={stopStreamingButtonState.isDisabled}
+          maxInputChars={config.public.input?.maxInputCharacters}
         />
         {this.state.showEndChatConfirmation && (
           <EndHumanAgentChatModal

--- a/packages/ai-chat/src/chat/components-legacy/CatastrophicError.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/CatastrophicError.tsx
@@ -24,8 +24,7 @@ import { ErrorMessageDark } from "./ErrorMessageDark";
 import { ErrorMessageLight } from "./ErrorMessageLight";
 import { BotHeader } from "./header/BotHeader";
 import RichText from "./responseTypes/util/RichText";
-import { LanguagePack } from "../../types/config/PublicConfig";
-import { CarbonTheme } from "../../types/config/PublicConfig";
+import { CarbonTheme, LanguagePack } from "../../types/config/PublicConfig";
 
 const Restart = carbonIconToReact(Restart16);
 

--- a/packages/ai-chat/src/chat/components-legacy/homeScreen/HomeScreen.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/homeScreen/HomeScreen.tsx
@@ -30,6 +30,7 @@ import {
   HomeScreenConfig,
   HomeScreenStarterButton,
 } from "../../../types/config/HomeScreenConfig";
+import { InputConfig } from "../../../types/config/PublicConfig";
 
 interface HomeScreenProps {
   isHydrated: boolean;
@@ -69,6 +70,11 @@ interface HomeScreenProps {
    * The callback that can be called to toggle between the home screen and the bot view.
    */
   onToggleHomeScreen: () => void;
+
+  /**
+   * Config for the input field located on the homescreen.
+   */
+  inputConfig?: InputConfig;
 }
 
 function HomeScreenComponent({
@@ -80,6 +86,7 @@ function HomeScreenComponent({
   onClose,
   onRestart,
   onToggleHomeScreen,
+  inputConfig,
 }: HomeScreenProps) {
   const languagePack = useLanguagePack();
   const serviceManager = useServiceManager();
@@ -210,6 +217,7 @@ function HomeScreenComponent({
               disableSend={false}
               languagePack={languagePack}
               serviceManager={serviceManager}
+              maxInputChars={inputConfig?.maxInputCharacters}
             />
           </div>
         </div>

--- a/packages/ai-chat/src/chat/components-legacy/homeScreen/HomeScreenContainer.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/homeScreen/HomeScreenContainer.tsx
@@ -117,6 +117,10 @@ function HomeScreenContainer({
   const isCustomPanelOpen = useSelector(
     (state: AppState) => state.customPanelState.isOpen,
   );
+  const inputConfig = useSelector(
+    (state: AppState) => state.config.public.input,
+  );
+
   const prevIsHydrationAnimationComplete = usePrevious(
     isHydrationAnimationComplete,
   );
@@ -179,6 +183,7 @@ function HomeScreenContainer({
         onClose={onClose}
         onRestart={onRestart}
         onToggleHomeScreen={onToggleHomeScreen}
+        inputConfig={inputConfig}
       />
     </OverlayPanel>
   );

--- a/packages/ai-chat/src/chat/components-legacy/input/Input.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/input/Input.tsx
@@ -69,10 +69,9 @@ const Attachment = carbonIconToReact(Attachment16);
 const STOP_TYPING_PERIOD = 5000;
 
 /**
- * The maximum number of characters to all the user to enter into the input field. The number was chosen to match
- * the limit imposed by the API.
+ * The maximum number of characters to all the user to enter into the input field.
  */
-const INPUT_MAX_CHARS = 2048;
+const INPUT_MAX_CHARS = 10000;
 
 interface InputProps extends HasServiceManager, HasLanguagePack {
   /**
@@ -161,6 +160,11 @@ interface InputProps extends HasServiceManager, HasLanguagePack {
    * the process of cancelling a streamed response is in progress.
    */
   isStopStreamingButtonDisabled?: boolean;
+
+  /**
+   * Maximum number of characters allowed to be typed into the input field.
+   */
+  maxInputChars?: number;
 }
 
 interface InputFunctions {
@@ -194,6 +198,7 @@ function Input(props: InputProps, ref: Ref<InputFunctions>) {
     languagePack,
     isStopStreamingButtonVisible,
     isStopStreamingButtonDisabled,
+    maxInputChars,
   } = props;
 
   const inputID = `${serviceManager.namespace.suffix}-${useCounter()}`;
@@ -483,7 +488,7 @@ function Input(props: InputProps, ref: Ref<InputFunctions>) {
                 autoSize
                 ariaLabel={input_ariaLabel}
                 disabled={disableInput}
-                maxLength={INPUT_MAX_CHARS}
+                maxLength={maxInputChars ? maxInputChars : INPUT_MAX_CHARS}
                 onChange={onChange}
                 onKeyDown={onKeyDown}
                 placeholder={usePlaceHolder}

--- a/packages/ai-chat/src/react/ChatContainer.tsx
+++ b/packages/ai-chat/src/react/ChatContainer.tsx
@@ -100,6 +100,7 @@ function ChatContainer({
   locale,
   homescreen,
   launcher,
+  input,
 }: ChatContainerProps) {
   // Reconstruct PublicConfig from flattened props
   const config = useMemo(
@@ -124,6 +125,7 @@ function ChatContainer({
       locale,
       homescreen,
       launcher,
+      input,
     }),
     [
       onError,
@@ -146,6 +148,7 @@ function ChatContainer({
       locale,
       homescreen,
       launcher,
+      input,
     ],
   );
   const wrapperRef = useRef(null); // Ref for the React wrapper component

--- a/packages/ai-chat/src/react/ChatCustomElement.tsx
+++ b/packages/ai-chat/src/react/ChatCustomElement.tsx
@@ -132,6 +132,7 @@ function ChatCustomElement({
   locale,
   homescreen,
   launcher,
+  input,
 }: ChatCustomElementProps) {
   const [customElement, setCustomElement] = useState<HTMLDivElement>();
 
@@ -201,6 +202,7 @@ function ChatCustomElement({
           renderUserDefinedResponse={renderUserDefinedResponse}
           renderWriteableElements={renderWriteableElements}
           element={customElement}
+          input={input}
         />
       )}
     </div>

--- a/packages/ai-chat/src/types/config/PublicConfig.ts
+++ b/packages/ai-chat/src/types/config/PublicConfig.ts
@@ -191,6 +191,11 @@ export interface PublicConfig {
   launcher?: LauncherConfig;
 
   /**
+   * Configuration for the main input field on the chat.
+   */
+  input?: InputConfig;
+
+  /**
    * Optional partial language pack overrides. Values merge with defaults.
    */
   strings?: DeepPartial<LanguagePack>;
@@ -239,6 +244,20 @@ export enum MinimizeButtonIconType {
 }
 
 /**
+ * Configuration for the input field in the main chat and homescreen.
+ *
+ * @category Config
+ */
+export interface InputConfig {
+  /**
+   * The maximum number of characters allowed in the input field. Defaults to 10000.
+   */
+  maxInputCharacters?: number;
+}
+
+/**
+ * Configuration for the main header of the chat.
+ *
  * @category Config
  */
 export interface HeaderConfig {

--- a/packages/ai-chat/src/web-components/cds-aichat-container/index.ts
+++ b/packages/ai-chat/src/web-components/cds-aichat-container/index.ts
@@ -25,6 +25,7 @@ import {
   HeaderConfig,
   LayoutConfig,
   PublicConfigMessaging,
+  InputConfig,
 } from "../../types/config/PublicConfig";
 import { DeepPartial } from "../../types/utilities/DeepPartial";
 import { LanguagePack } from "../../types/config/PublicConfig";
@@ -116,6 +117,9 @@ class ChatContainer extends LitElement {
 
   @property({ type: Object })
   header?: HeaderConfig;
+
+  @property({ type: Object })
+  input?: InputConfig;
 
   @property({ type: Object })
   layout?: LayoutConfig;
@@ -257,6 +261,9 @@ class ChatContainer extends LitElement {
     }
     if (this.header !== undefined) {
       resolvedConfig.header = this.header;
+    }
+    if (this.input !== undefined) {
+      resolvedConfig.input = this.input;
     }
     if (this.layout !== undefined) {
       resolvedConfig.layout = this.layout;

--- a/packages/ai-chat/src/web-components/cds-aichat-custom-element/index.ts
+++ b/packages/ai-chat/src/web-components/cds-aichat-custom-element/index.ts
@@ -27,6 +27,7 @@ import {
   LayoutConfig,
   PublicConfigMessaging,
   LanguagePack,
+  InputConfig,
 } from "../../types/config/PublicConfig";
 import { DeepPartial } from "../../types/utilities/DeepPartial";
 import { HomeScreenConfig } from "../../types/config/HomeScreenConfig";
@@ -161,6 +162,9 @@ class ChatCustomElement extends LitElement {
 
   @property({ type: Object })
   header?: HeaderConfig;
+
+  @property({ type: Object })
+  input?: InputConfig;
 
   @property({ type: Object })
   layout?: LayoutConfig;
@@ -299,6 +303,9 @@ class ChatCustomElement extends LitElement {
     }
     if (this.header !== undefined) {
       resolvedConfig.header = this.header;
+    }
+    if (this.input !== undefined) {
+      resolvedConfig.input = this.input;
     }
     if (this.layout !== undefined) {
       resolvedConfig.layout = this.layout;


### PR DESCRIPTION
initial config item is only controlling maxInputLength

Be sure to test both react and web component versions.

http://localhost:3001/?config=setChatConfig

And then set `window.setChatConfig({ input: { maxInputCharacters: 10 }})` in the console and only 10 characters will be allowed in the input field. 

And then do same for web component version: http://localhost:3001/?settings=%7B%22framework%22%3A%22web-component%22%2C%22layout%22%3A%22float%22%2C%22writeableElements%22%3A%22false%22%2C%22direction%22%3A%22default%22%7D&config=setChatConfig