### PR TITLE
chore: bump carbon web components to fix ai-label issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37936,7 +37936,7 @@
         "@carbon/icons": "^11.53.0",
         "@carbon/styles": "^1.88.0",
         "@carbon/themes": "^11.58.0",
-        "@carbon/web-components": "^2.37.0",
+        "@carbon/web-components": "^2.39.1",
         "@rollup/plugin-babel": "^6.0.4",
         "@rollup/plugin-commonjs": "^28.0.6",
         "@rollup/plugin-json": "^6.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -37977,7 +37977,7 @@
       },
       "peerDependencies": {
         "@carbon/icons": ">=11.53.0 <12.0.0",
-        "@carbon/web-components": ">=2.37.0 <3.0.0",
+        "@carbon/web-components": ">=2.39.1 <3.0.0",
         "lit": ">=3.1.0 <4.0.0",
         "react": ">=17.0.0 <20.0.0",
         "react-dom": ">=17.0.0 <20.0.0"

--- a/packages/ai-chat/package.json
+++ b/packages/ai-chat/package.json
@@ -50,7 +50,7 @@
     "@carbon/icons": "^11.53.0",
     "@carbon/styles": "^1.88.0",
     "@carbon/themes": "^11.58.0",
-    "@carbon/web-components": "^2.37.0",
+    "@carbon/web-components": "^2.39.1",
     "@rollup/plugin-babel": "^6.0.4",
     "@rollup/plugin-commonjs": "^28.0.6",
     "@rollup/plugin-json": "^6.1.0",

--- a/packages/ai-chat/package.json
+++ b/packages/ai-chat/package.json
@@ -91,7 +91,7 @@
   },
   "peerDependencies": {
     "@carbon/icons": ">=11.53.0 <12.0.0",
-    "@carbon/web-components": ">=2.37.0 <3.0.0",
+    "@carbon/web-components": ">=2.39.1 <3.0.0",
     "lit": ">=3.1.0 <4.0.0",
     "react": ">=17.0.0 <20.0.0",
     "react-dom": ">=17.0.0 <20.0.0"


### PR DESCRIPTION
Closes #179 

This pr bumps carbon web components version, to get our previous fixes to carbon. into our app.

#### Changelog

**Changed**

- "@carbon/web-components": "^2.39.1"

#### Testing / Reviewing

https://github.com/user-attachments/assets/af417420-c8f5-4cdf-9b6b-4fc0ec7074ae

