### PR TITLE
chore: remove duplicate license snippets

### DIFF
--- a/packages/ai-chat-components/src/globals/internal/storybook-cdn.ts
+++ b/packages/ai-chat-components/src/globals/internal/storybook-cdn.ts
@@ -7,15 +7,6 @@
  *  @license
  */
 
-/**
- * @license
- *
- * Copyright IBM Corp. 2025
- *
- * This source code is licensed under the Apache-2.0 license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 import packageJson from "../../../package.json";
 
 /**

--- a/packages/ai-chat-components/src/globals/settings.ts
+++ b/packages/ai-chat-components/src/globals/settings.ts
@@ -7,15 +7,6 @@
  *  @license
  */
 
-/**
- * @license
- *
- * Copyright IBM Corp. 2025
- *
- * This source code is licensed under the Apache-2.0 license found in the
- * LICENSE file in the root directory of this source tree.
- */
-
 // Set this to a suitable prefix for your project to use in TS files
 const prefix = "cds-aichat";
 

--- a/packages/ai-chat-components/tasks/build-dist.js
+++ b/packages/ai-chat-components/tasks/build-dist.js
@@ -3,15 +3,8 @@
  *
  *  This source code is licensed under the Apache-2.0 license found in the
  *  LICENSE file in the root directory of this source tree.
- */
-
-/**
- * @license
  *
- * Copyright IBM Corp. 2025
- *
- * This source code is licensed under the Apache-2.0 license found in the
- * LICENSE file in the root directory of this source tree.
+ *  @license
  */
 
 "use strict";

--- a/packages/ai-chat-components/tools/postcss-fix-host-pseudo.js
+++ b/packages/ai-chat-components/tools/postcss-fix-host-pseudo.js
@@ -3,15 +3,8 @@
  *
  *  This source code is licensed under the Apache-2.0 license found in the
  *  LICENSE file in the root directory of this source tree.
- */
-
-/**
- * @license
  *
- * Copyright IBM Corp. 2025
- *
- * This source code is licensed under the Apache-2.0 license found in the
- * LICENSE file in the root directory of this source tree.
+ *  @license
  */
 
 import postcss from "postcss";

--- a/packages/ai-chat-components/tools/rollup-plugin-license.js
+++ b/packages/ai-chat-components/tools/rollup-plugin-license.js
@@ -3,15 +3,8 @@
  *
  *  This source code is licensed under the Apache-2.0 license found in the
  *  LICENSE file in the root directory of this source tree.
- */
-
-/**
- * @license
  *
- * Copyright IBM Corp. 2025
- *
- * This source code is licensed under the Apache-2.0 license found in the
- * LICENSE file in the root directory of this source tree.
+ *  @license
  */
 
 import path from "path";

--- a/packages/ai-chat-components/tools/rollup-plugin-lit-scss.js
+++ b/packages/ai-chat-components/tools/rollup-plugin-lit-scss.js
@@ -3,15 +3,8 @@
  *
  *  This source code is licensed under the Apache-2.0 license found in the
  *  LICENSE file in the root directory of this source tree.
- */
-
-/**
- * @license
  *
- * Copyright IBM Corp. 2025
- *
- * This source code is licensed under the Apache-2.0 license found in the
- * LICENSE file in the root directory of this source tree.
+ *  @license
  */
 
 import path from "path";


### PR DESCRIPTION
ref https://github.com/carbon-design-system/carbon-ai-chat/pull/513

removes duplicate license snippets

#### Changelog

**Removed**

- removes duplicate license snippets

#### Testing / Reviewing

ci must pass, else there must be a flaw in the setup.
