### PR TITLE
chore: update @carbon/web-components package version

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -16,7 +16,7 @@
     "@carbon/ai-chat": "^1.0.0-rc.2",
     "@carbon/icons": "^11.53.0",
     "@carbon/react": "^1.68.0",
-    "@carbon/web-components": "^2.37.0",
+    "@carbon/web-components": "^2.40.1",
     "lit": "^3.1.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/examples/react/basic/package.json
+++ b/examples/react/basic/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@carbon/ai-chat": "^1.0.0-rc.2",
     "@carbon/icons": "^11.53.0",
-    "@carbon/web-components": "^2.37.0",
+    "@carbon/web-components": "^2.40.1",
     "lit": "^3.1.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/examples/react/custom-element/package.json
+++ b/examples/react/custom-element/package.json
@@ -16,7 +16,7 @@
     "@carbon/ai-chat": "^1.0.0-rc.2",
     "@carbon/icons": "^11.53.0",
     "@carbon/react": "^1.68.0",
-    "@carbon/web-components": "^2.25.0",
+    "@carbon/web-components": "^2.40.1",
     "lit": "^3.1.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/examples/react/history/package.json
+++ b/examples/react/history/package.json
@@ -16,7 +16,7 @@
     "@carbon/ai-chat": "^1.0.0-rc.2",
     "@carbon/icons": "^11.53.0",
     "@carbon/react": "^1.68.0",
-    "@carbon/web-components": "^2.25.0",
+    "@carbon/web-components": "^2.40.1",
     "lit": "^3.1.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/examples/react/watsonx/package.json
+++ b/examples/react/watsonx/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@carbon/ai-chat": "^1.0.0-rc.2",
     "@carbon/icons": "^11.53.0",
-    "@carbon/web-components": "^2.37.0",
+    "@carbon/web-components": "^2.40.1",
     "@microsoft/fetch-event-source": "^2.0.1",
     "cors": "^2.8.5",
     "dotenv": "^16.6.1",

--- a/examples/web-components/basic/package.json
+++ b/examples/web-components/basic/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@carbon/ai-chat": "^1.0.0-rc.2",
     "@carbon/icons": "^11.53.0",
-    "@carbon/web-components": "^2.37.0",
+    "@carbon/web-components": "^2.40.1",
     "lit": "^3.1.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/examples/web-components/custom-element/package.json
+++ b/examples/web-components/custom-element/package.json
@@ -16,7 +16,7 @@
     "@carbon/ai-chat": "^1.0.0-rc.2",
     "@carbon/icons": "^11.53.0",
     "@carbon/react": "^1.68.0",
-    "@carbon/web-components": "^2.25.0",
+    "@carbon/web-components": "^2.40.1",
     "lit": "^3.1.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/examples/web-components/history/package.json
+++ b/examples/web-components/history/package.json
@@ -16,7 +16,7 @@
     "@carbon/ai-chat": "^1.0.0-rc.2",
     "@carbon/icons": "^11.53.0",
     "@carbon/react": "^1.68.0",
-    "@carbon/web-components": "^2.25.0",
+    "@carbon/web-components": "^2.40.1",
     "lit": "^3.1.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/examples/web-components/watsonx/package.json
+++ b/examples/web-components/watsonx/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@carbon/ai-chat": "^1.0.0-rc.2",
     "@carbon/icons": "^11.53.0",
-    "@carbon/web-components": "^2.37.0",
+    "@carbon/web-components": "^2.40.1",
     "@microsoft/fetch-event-source": "^2.0.1",
     "concurrently": "^9.2.0",
     "cors": "^2.8.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,7 +60,7 @@
         "@carbon/ai-chat": "^1.0.0-rc.2",
         "@carbon/icons": "^11.53.0",
         "@carbon/react": "^1.68.0",
-        "@carbon/web-components": "^2.37.0",
+        "@carbon/web-components": "^2.40.1",
         "lit": "^3.1.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -113,7 +113,7 @@
       "dependencies": {
         "@carbon/ai-chat": "^1.0.0-rc.2",
         "@carbon/icons": "^11.53.0",
-        "@carbon/web-components": "^2.37.0",
+        "@carbon/web-components": "^2.40.1",
         "lit": "^3.1.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -166,7 +166,7 @@
         "@carbon/ai-chat": "^1.0.0-rc.2",
         "@carbon/icons": "^11.53.0",
         "@carbon/react": "^1.68.0",
-        "@carbon/web-components": "^2.25.0",
+        "@carbon/web-components": "^2.40.1",
         "lit": "^3.1.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -220,7 +220,7 @@
         "@carbon/ai-chat": "^1.0.0-rc.2",
         "@carbon/icons": "^11.53.0",
         "@carbon/react": "^1.68.0",
-        "@carbon/web-components": "^2.25.0",
+        "@carbon/web-components": "^2.40.1",
         "lit": "^3.1.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -273,7 +273,7 @@
       "dependencies": {
         "@carbon/ai-chat": "^1.0.0-rc.2",
         "@carbon/icons": "^11.53.0",
-        "@carbon/web-components": "^2.37.0",
+        "@carbon/web-components": "^2.40.1",
         "@microsoft/fetch-event-source": "^2.0.1",
         "cors": "^2.8.5",
         "dotenv": "^16.6.1",
@@ -332,7 +332,7 @@
       "dependencies": {
         "@carbon/ai-chat": "^1.0.0-rc.2",
         "@carbon/icons": "^11.53.0",
-        "@carbon/web-components": "^2.37.0",
+        "@carbon/web-components": "^2.40.1",
         "lit": "^3.1.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -389,7 +389,7 @@
         "@carbon/ai-chat": "^1.0.0-rc.2",
         "@carbon/icons": "^11.53.0",
         "@carbon/react": "^1.68.0",
-        "@carbon/web-components": "^2.25.0",
+        "@carbon/web-components": "^2.40.1",
         "lit": "^3.1.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -446,7 +446,7 @@
         "@carbon/ai-chat": "^1.0.0-rc.2",
         "@carbon/icons": "^11.53.0",
         "@carbon/react": "^1.68.0",
-        "@carbon/web-components": "^2.25.0",
+        "@carbon/web-components": "^2.40.1",
         "lit": "^3.1.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -502,7 +502,7 @@
       "dependencies": {
         "@carbon/ai-chat": "^1.0.0-rc.2",
         "@carbon/icons": "^11.53.0",
-        "@carbon/web-components": "^2.37.0",
+        "@carbon/web-components": "^2.40.1",
         "@microsoft/fetch-event-source": "^2.0.1",
         "concurrently": "^9.2.0",
         "cors": "^2.8.5",
@@ -2679,9 +2679,9 @@
       "link": true
     },
     "node_modules/@carbon/colors": {
-      "version": "11.41.0",
-      "resolved": "https://registry.npmjs.org/@carbon/colors/-/colors-11.41.0.tgz",
-      "integrity": "sha512-Rr2R4sW4QaNaL6d3jEgrhiw3EkN/odpvU6qXYBd1iTxPEUWespbjuEKQjAGBa7RkpVnZjjrlzF9BW0kF9wVfQw==",
+      "version": "11.42.0",
+      "resolved": "https://registry.npmjs.org/@carbon/colors/-/colors-11.42.0.tgz",
+      "integrity": "sha512-kfEGVk2vzokkRrVwqUGYK8YLQ1Cn7cDhJ/lEz31kdBrUbR8vlgKSFq9GTqAgZiqxbTC0surR3nBF2kU3NTNPOg==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2699,13 +2699,13 @@
       }
     },
     "node_modules/@carbon/grid": {
-      "version": "11.44.0",
-      "resolved": "https://registry.npmjs.org/@carbon/grid/-/grid-11.44.0.tgz",
-      "integrity": "sha512-bB+yQ09Zw+Z0xkCNAeX+vla9PyZXUREQvzcz1WTcKqUKDwYJlAm1yxbPUM21ORy48EqfRHWUoLjTSKACi3syfg==",
+      "version": "11.45.0",
+      "resolved": "https://registry.npmjs.org/@carbon/grid/-/grid-11.45.0.tgz",
+      "integrity": "sha512-J8hh5li0Q0RRS6IGg+MVPQVfjp1ePxzQsyMyjQOHLux8i8HwiWJmKLQ+4lKMzRXorLG2RtEoPVl00EaKlQEgKQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@carbon/layout": "^11.42.0",
+        "@carbon/layout": "^11.43.0",
         "@ibm/telemetry-js": "^1.5.0"
       }
     },
@@ -2745,9 +2745,9 @@
       }
     },
     "node_modules/@carbon/layout": {
-      "version": "11.42.0",
-      "resolved": "https://registry.npmjs.org/@carbon/layout/-/layout-11.42.0.tgz",
-      "integrity": "sha512-+R1AxIt918TEcr73yvT+xNP/JL2+xBQfRt1qlLKwv492yAVqo7KhtISLQeku8nxNS5Osf+iBXvfUG88XX0BMUA==",
+      "version": "11.43.0",
+      "resolved": "https://registry.npmjs.org/@carbon/layout/-/layout-11.43.0.tgz",
+      "integrity": "sha512-aOUNqVv/5TGhNTn1HV+620ZlqhE7+Chs0TJoxwe/CCsLOdziCX9st3c5inyINPZDyvDK46mas1RmqvZwNYe/mA==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2755,9 +2755,9 @@
       }
     },
     "node_modules/@carbon/motion": {
-      "version": "11.36.0",
-      "resolved": "https://registry.npmjs.org/@carbon/motion/-/motion-11.36.0.tgz",
-      "integrity": "sha512-Zc8yocsWN5H3Usa9mzHMA0nhuP+SP5+HRxhyi2RHD5U/eN69j9Tr0TKafHmL4D0WxWBk+d3LPWyMJQ73Bknuzw==",
+      "version": "11.37.0",
+      "resolved": "https://registry.npmjs.org/@carbon/motion/-/motion-11.37.0.tgz",
+      "integrity": "sha512-bjFzY8Wy5Umj+g41ZGj3L3b/z2gDBDKfzfc9M3ZAHaj73PZ7Z/Z5jT0IFlihEv8wUwZfbhbtnb4jeNhckfLINA==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2798,26 +2798,26 @@
       }
     },
     "node_modules/@carbon/styles": {
-      "version": "1.91.0",
-      "resolved": "https://registry.npmjs.org/@carbon/styles/-/styles-1.91.0.tgz",
-      "integrity": "sha512-B4KPWQrUpKODms7TaII0tP3NrwH2MON1c4fdVm2iszVo/f34GOfOVj0HKDpCCvo9+4xjwBX0iz3qkOjL98qo+w==",
+      "version": "1.92.0",
+      "resolved": "https://registry.npmjs.org/@carbon/styles/-/styles-1.92.0.tgz",
+      "integrity": "sha512-g1bq/qpoq2e583LgxoR4Xt4wWeMb2U32QlLA9/3GPkb+NqtHuNbr8WhuLdaphieUOf78xQ76FWuHMX4FtzBLTg==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@carbon/colors": "^11.41.0",
+        "@carbon/colors": "^11.42.0",
         "@carbon/feature-flags": "^0.31.0",
-        "@carbon/grid": "^11.44.0",
-        "@carbon/layout": "^11.42.0",
-        "@carbon/motion": "^11.36.0",
-        "@carbon/themes": "^11.61.0",
-        "@carbon/type": "^11.48.0",
+        "@carbon/grid": "^11.45.0",
+        "@carbon/layout": "^11.43.0",
+        "@carbon/motion": "^11.37.0",
+        "@carbon/themes": "^11.62.0",
+        "@carbon/type": "^11.49.0",
         "@ibm/plex": "6.0.0-next.6",
         "@ibm/plex-mono": "1.1.0",
         "@ibm/plex-sans": "1.1.0",
         "@ibm/plex-sans-arabic": "1.1.0",
         "@ibm/plex-sans-devanagari": "1.1.0",
-        "@ibm/plex-sans-hebrew": "0.0.3-alpha.0",
-        "@ibm/plex-sans-thai": "0.0.3-alpha.0",
+        "@ibm/plex-sans-hebrew": "1.1.0",
+        "@ibm/plex-sans-thai": "1.1.0",
         "@ibm/plex-sans-thai-looped": "1.1.0",
         "@ibm/plex-serif": "1.1.0",
         "@ibm/telemetry-js": "^1.5.0"
@@ -2832,28 +2832,28 @@
       }
     },
     "node_modules/@carbon/themes": {
-      "version": "11.61.0",
-      "resolved": "https://registry.npmjs.org/@carbon/themes/-/themes-11.61.0.tgz",
-      "integrity": "sha512-z626NnhPOBzcpocvb0On9Awrrnr/+0RXZuG7uM8ALKjc9vAYLb1cCw+GXyWHnGGkKbB9OhFTerRzL5Tx3ZU42w==",
+      "version": "11.62.0",
+      "resolved": "https://registry.npmjs.org/@carbon/themes/-/themes-11.62.0.tgz",
+      "integrity": "sha512-/sPOiGaC4YtXBiA4uNx2PuBxPOAjVMOThrsHfdDbroUvm2yigvRZUJcJTivunOFKtfIC5EOoKxxAP3XzxWjf0Q==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@carbon/colors": "^11.41.0",
-        "@carbon/layout": "^11.42.0",
-        "@carbon/type": "^11.48.0",
+        "@carbon/colors": "^11.42.0",
+        "@carbon/layout": "^11.43.0",
+        "@carbon/type": "^11.49.0",
         "@ibm/telemetry-js": "^1.5.0",
         "color": "^4.0.0"
       }
     },
     "node_modules/@carbon/type": {
-      "version": "11.48.0",
-      "resolved": "https://registry.npmjs.org/@carbon/type/-/type-11.48.0.tgz",
-      "integrity": "sha512-zHD/od5FbuZjdP48yhfAHHnZ5wYML5OL4tyJ/s0fCmJ51rtxgby11kjOof0hKir3K5XgwKE1RzrAEZJy4Lfpqw==",
+      "version": "11.49.0",
+      "resolved": "https://registry.npmjs.org/@carbon/type/-/type-11.49.0.tgz",
+      "integrity": "sha512-5SwbuMj7VO7QAxB273MQVMoVLEvwcMVflhmriWA4I+YWMDwtoprPHiXseO6ueoRGJp+TOqnItvkPMPOdKz5sjQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@carbon/grid": "^11.44.0",
-        "@carbon/layout": "^11.42.0",
+        "@carbon/grid": "^11.45.0",
+        "@carbon/layout": "^11.43.0",
         "@ibm/telemetry-js": "^1.5.0"
       }
     },
@@ -2869,13 +2869,14 @@
       }
     },
     "node_modules/@carbon/web-components": {
-      "version": "2.39.1",
-      "resolved": "https://registry.npmjs.org/@carbon/web-components/-/web-components-2.39.1.tgz",
-      "integrity": "sha512-CGV6dV8Yn1ZfSJyGiGbe/Jp+K3RJoC4Ji2c2L0uYWSuWp01IEfek1LZGD663YGzO+uPHCqTjedb/SxK/d3Fefg==",
+      "version": "2.40.1",
+      "resolved": "https://registry.npmjs.org/@carbon/web-components/-/web-components-2.40.1.tgz",
+      "integrity": "sha512-/COmL+rfvKnfoi8htgA9AnwzEntMmA7EL60iOdYTEl2ArFaqu1awt82WwL4OXGnSIir0F7YI4emgJcTNzz4CHA==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@carbon/styles": "^1.91.0",
+        "@carbon/icon-helpers": "10.47.0",
+        "@carbon/styles": "^1.92.0",
         "@floating-ui/dom": "^1.6.3",
         "@ibm/telemetry-js": "^1.10.2",
         "@lit/context": "^1.1.3",
@@ -2883,6 +2884,16 @@
         "lit": "^3.1.0",
         "lodash-es": "^4.17.21",
         "tslib": "^2.6.3"
+      }
+    },
+    "node_modules/@carbon/web-components/node_modules/@carbon/icon-helpers": {
+      "version": "10.47.0",
+      "resolved": "https://registry.npmjs.org/@carbon/icon-helpers/-/icon-helpers-10.47.0.tgz",
+      "integrity": "sha512-vv2Wkuw7lYkYVKrn5ABzlZD+6ioAYwMuyKi2XPqYY3hrHYoL4CQUnuSFDhlj0DR2HHCB0L5MGRLxHLucx5cc7g==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ibm/telemetry-js": "^1.2.1"
       }
     },
     "node_modules/@commitlint/cli": {
@@ -4182,16 +4193,24 @@
       }
     },
     "node_modules/@ibm/plex-sans-hebrew": {
-      "version": "0.0.3-alpha.0",
-      "resolved": "https://registry.npmjs.org/@ibm/plex-sans-hebrew/-/plex-sans-hebrew-0.0.3-alpha.0.tgz",
-      "integrity": "sha512-sMsn1jU8kyYfSlWMfjcbvpGXJIIXGOZD+sxtBcogZz4umnCq5ys+bmsqlzkfGR25DCB49WvseD2IHbejes0/aA==",
-      "license": "OFL-1.1"
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@ibm/plex-sans-hebrew/-/plex-sans-hebrew-1.1.0.tgz",
+      "integrity": "sha512-iix0rLpUD0E8dE8q+/t3B7u1or7h6gEzoy6TK9NwP41AN31WE55f2cFwQAXomBDwr0Ozc9sHYy97NutEukZXzQ==",
+      "hasInstallScript": true,
+      "license": "OFL-1.1",
+      "dependencies": {
+        "@ibm/telemetry-js": "^1.6.1"
+      }
     },
     "node_modules/@ibm/plex-sans-thai": {
-      "version": "0.0.3-alpha.0",
-      "resolved": "https://registry.npmjs.org/@ibm/plex-sans-thai/-/plex-sans-thai-0.0.3-alpha.0.tgz",
-      "integrity": "sha512-3RteUFhshRTmP5Swq9LYravDXmVvjxtxsZ7qeSqjn31CUgeSuZKprDWb+RzSQrO+Jg7AI4g1lolzTr/jG/LnxA==",
-      "license": "OFL-1.1"
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@ibm/plex-sans-thai/-/plex-sans-thai-1.1.0.tgz",
+      "integrity": "sha512-vk7IrjdO69eEElJpFBppCha/wvU48DFyVuDewcfIf5L6Z11s0vbROANCvKipVPRUz1LE4ron8KoitWGcl3AlfA==",
+      "hasInstallScript": true,
+      "license": "OFL-1.1",
+      "dependencies": {
+        "@ibm/telemetry-js": "^1.6.1"
+      }
     },
     "node_modules/@ibm/plex-sans-thai-looped": {
       "version": "1.1.0",
@@ -39316,7 +39335,7 @@
         "@carbon/icons": "^11.53.0",
         "@carbon/styles": "^1.88.0",
         "@carbon/themes": "^11.58.0",
-        "@carbon/web-components": "^2.37.0",
+        "@carbon/web-components": "^2.40.1",
         "@rollup/plugin-babel": "^6.0.4",
         "@rollup/plugin-commonjs": "^28.0.6",
         "@rollup/plugin-json": "^6.1.0",
@@ -39358,7 +39377,7 @@
       },
       "peerDependencies": {
         "@carbon/icons": ">=11.53.0 <12.0.0",
-        "@carbon/web-components": ">=2.37.0 <3.0.0",
+        "@carbon/web-components": ">=2.40.1 <3.0.0",
         "lit": ">=3.1.0 <4.0.0",
         "react": ">=17.0.0 <20.0.0",
         "react-dom": ">=17.0.0 <20.0.0"
@@ -39371,7 +39390,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@carbon/styles": "^1.39.0",
-        "@carbon/web-components": "^2.37.0",
+        "@carbon/web-components": "^2.40.1",
         "@ibm/telemetry-js": "^1.10.2",
         "lit": "^3.0.0",
         "tslib": "^2.6.3"

--- a/packages/ai-chat-components/package.json
+++ b/packages/ai-chat-components/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@carbon/styles": "^1.39.0",
-    "@carbon/web-components": "^2.37.0",
+    "@carbon/web-components": "^2.40.1",
     "@ibm/telemetry-js": "^1.10.2",
     "lit": "^3.0.0",
     "tslib": "^2.6.3"

--- a/packages/ai-chat/package.json
+++ b/packages/ai-chat/package.json
@@ -51,7 +51,7 @@
     "@carbon/icons": "^11.53.0",
     "@carbon/styles": "^1.88.0",
     "@carbon/themes": "^11.58.0",
-    "@carbon/web-components": "^2.37.0",
+    "@carbon/web-components": "^2.40.1",
     "@rollup/plugin-babel": "^6.0.4",
     "@rollup/plugin-commonjs": "^28.0.6",
     "@rollup/plugin-json": "^6.1.0",
@@ -93,7 +93,7 @@
   },
   "peerDependencies": {
     "@carbon/icons": ">=11.53.0 <12.0.0",
-    "@carbon/web-components": ">=2.37.0 <3.0.0",
+    "@carbon/web-components": ">=2.40.1 <3.0.0",
     "lit": ">=3.1.0 <4.0.0",
     "react": ">=17.0.0 <20.0.0",
     "react-dom": ">=17.0.0 <20.0.0"


### PR DESCRIPTION
Closes #

Noticed an issue when running the react example stackblitz: https://stackblitz.com/github/carbon-design-system/carbon-ai-chat/tree/main/examples/react/basic?file=package.json (Not breaking anymore though because it's pulling the patched `@carbon/web-components` version

<img width="1984" height="716" alt="Screenshot 2025-10-08 at 2 40 32 PM" src="https://github.com/user-attachments/assets/8040984d-b0df-4aa0-b163-aef931f2974c" />


where the `@carbon/icons-helper` package used in `@carbon/web-components` can't be resolved. This was fixed in `@carbon/web-components` v2.40.1, so this PR updates the versions in our packages, demo, and example apps.

#### Changelog

**Changed**

- bump up `@carbon/web-components` dependency version

#### Testing / Reviewing

{{ Add descriptions, steps or a checklist for how reviewers can verify this PR works or not }}
