### PR TITLE
fix: default focus improvements

### DIFF
--- a/packages/ai-chat/src/chat/components-legacy/AssistantChat.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/AssistantChat.tsx
@@ -22,7 +22,6 @@ import {
 } from "../../types/state/AppState";
 import { AutoScrollOptions } from "../../types/utilities/HasDoAutoScroll";
 import HasIntl from "../../types/utilities/HasIntl";
-import { HasRequestFocus } from "../../types/utilities/HasRequestFocus";
 import { LocalMessageItem } from "../../types/messaging/LocalMessageItem";
 import ObjectMap from "../../types/utilities/ObjectMap";
 import { WriteableElementName } from "../utils/constants";
@@ -76,7 +75,6 @@ class AssistantChat extends Component<ChatInterfaceProps, ChatInterfaceState> {
   };
 
   private inputRef: RefObject<InputFunctions | null> = React.createRef();
-  private headerRef: RefObject<HasRequestFocus | null> = React.createRef();
   private messagesRef: RefObject<MessagesComponentClass | null> =
     React.createRef();
   private messagesToArray = createUnmappingMemoizer<LocalMessageItem>();
@@ -135,8 +133,15 @@ class AssistantChat extends Component<ChatInterfaceProps, ChatInterfaceState> {
     this.props.serviceManager.humanAgentService.endChat(true);
   };
 
-  private requestDefaultFocus = () => {
-    if (!this.headerRef?.current?.requestFocus()) {
+  private requestDefaultFocus = async () => {
+    // Wait a short delay to check if the input becomes available
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    // Double-check if input is now available (allow focusing even if disabled)
+    if (this.inputRef.current && this.props.inputState.fieldVisible) {
+      this.inputRef.current.takeFocus();
+    } else {
+      // Skip header and fallback directly to messages scroll area
       doFocusRef(this.messagesRef.current?.scrollHandleRef);
     }
   };
@@ -318,7 +323,6 @@ class AssistantChat extends Component<ChatInterfaceProps, ChatInterfaceState> {
     return (
       <div data-testid={PageObjectId.MAIN_PANEL} className="cds-aichat">
         <AssistantHeader
-          ref={this.headerRef}
           onClose={onClose}
           onRestart={onRestart}
           headerDisplayName={headerDisplayName}

--- a/packages/ai-chat/src/chat/components-legacy/main/MainWindow.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/main/MainWindow.tsx
@@ -193,6 +193,17 @@ class MainWindow
     React.createRef();
 
   /**
+   * A React ref to the {@link CustomPanel}.
+   */
+  private customPanelRef: RefObject<HasRequestFocus | null> = React.createRef();
+
+  /**
+   * A React ref to the response panel component.
+   */
+  private responsePanelRef: RefObject<HasRequestFocus | null> =
+    React.createRef();
+
+  /**
    * The observer used to monitor for changes in the main window size.
    */
   private mainWindowObserver: ResizeObserver;
@@ -448,6 +459,21 @@ class MainWindow
           if (this.iframePanelRef.current) {
             // Focus the iframe panel close button.
             this.iframePanelRef.current.requestFocus();
+          }
+        } else if (this.props.viewSourcePanelState.isOpen) {
+          if (this.viewSourcePanelRef.current) {
+            // Focus the view source panel close button.
+            this.viewSourcePanelRef.current.requestFocus();
+          }
+        } else if (this.props.customPanelState.isOpen) {
+          if (this.customPanelRef.current) {
+            // Focus the custom panel close button.
+            this.customPanelRef.current.requestFocus();
+          }
+        } else if (this.props.responsePanelState.isOpen) {
+          if (this.responsePanelRef.current) {
+            // Focus the response panel close button.
+            this.responsePanelRef.current.requestFocus();
           }
         } else if (this.botChatRef.current) {
           // Focus the bot input field.
@@ -889,6 +915,7 @@ class MainWindow
   renderCustomPanel() {
     return (
       <CustomPanel
+        ref={this.customPanelRef}
         onClose={this.onClose}
         onClickRestart={this.onRestart}
         onPanelOpenStart={() => this.onPanelOpenStart(true)}
@@ -913,6 +940,7 @@ class MainWindow
 
     return (
       <BodyAndFooterPanelComponent
+        ref={this.responsePanelRef}
         eventName={eventName}
         eventDescription={eventDescription}
         overlayPanelName={overlayPanelName}

--- a/packages/ai-chat/src/chat/components-legacy/panels/BodyAndFooterPanelComponent.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/panels/BodyAndFooterPanelComponent.tsx
@@ -8,7 +8,7 @@
  */
 
 import cx from "classnames";
-import React from "react";
+import React, { forwardRef, Ref, useRef } from "react";
 import { useSelector } from "../../hooks/useSelector";
 
 import { useLanguagePack } from "../../hooks/useLanguagePack";
@@ -125,7 +125,10 @@ interface BodyAndFooterPanelComponentProps
 /**
  * This component handles rendering a panel with body/footer content.
  */
-function BodyAndFooterPanelComponent(props: BodyAndFooterPanelComponentProps) {
+function BodyAndFooterPanelComponent(
+  props: BodyAndFooterPanelComponentProps,
+  ref: Ref<HasRequestFocus>,
+) {
   const {
     isOpen,
     isMessageForInput,
@@ -160,6 +163,17 @@ function BodyAndFooterPanelComponent(props: BodyAndFooterPanelComponentProps) {
   const closeAnimation = disableAnimation
     ? AnimationOutType.NONE
     : AnimationOutType.SLIDE_OUT_TO_BOTTOM;
+  const basePanelRef = useRef<HasRequestFocus>(null);
+
+  // Expose the BasePanelComponent's requestFocus method through the forwarded ref
+  React.useImperativeHandle(ref, () => ({
+    requestFocus: () => {
+      if (basePanelRef.current) {
+        return basePanelRef.current.requestFocus();
+      }
+      return false;
+    },
+  }));
 
   return (
     <OverlayPanel
@@ -175,6 +189,7 @@ function BodyAndFooterPanelComponent(props: BodyAndFooterPanelComponentProps) {
       overlayPanelName={overlayPanelName}
     >
       <BasePanelComponent
+        ref={basePanelRef}
         className={cx("cds-aichat--body-and-footer-component", className)}
         eventName={eventName}
         eventDescription={eventDescription}
@@ -202,6 +217,10 @@ function BodyAndFooterPanelComponent(props: BodyAndFooterPanelComponentProps) {
   );
 }
 
-export { BodyAndFooterPanelComponent };
+const BodyAndFooterPanelComponentExport = React.memo(
+  forwardRef(BodyAndFooterPanelComponent),
+);
 
-export default BodyAndFooterPanelComponent;
+export { BodyAndFooterPanelComponentExport as BodyAndFooterPanelComponent };
+
+export default BodyAndFooterPanelComponentExport;


### PR DESCRIPTION
Closes #59 

Was getting complaints about how often the chat was putting focus on the close button. In doing so realized that we had started to forget to add our various panels to the "requestDefaultFocus" function which was causing improper fallback behavior more often.