### PR TITLE
fix(avatarline): assistantName does not update

### DIFF
--- a/packages/ai-chat/src/chat/components-legacy/MessageComponent.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/MessageComponent.tsx
@@ -414,7 +414,10 @@ class MessageComponent extends PureComponent<
         iconClassName = "cds-aichat--message__avatar--agent";
         actorName = responseUserProfile?.nickname || "";
       } else {
-        actorName = assistantName || responseUserProfile?.nickname;
+        actorName =
+          responseUserProfile?.nickname === "watsonx" && assistantName
+            ? assistantName
+            : responseUserProfile?.nickname;
 
         let icon = <IconHolder icon={<ChatBot />} />;
 


### PR DESCRIPTION
Closes #470

setting the assistantName in the config doesn't appear to change the avatar line

#### Changelog

**Changed**

- In `packages/ai-chat/src/chat/components-legacy/MessageComponent.tsx`, `actorName` is set to   `assistantName || responseUserProfile?.nickname ` instead of `responseUserProfile?.nickname || assistantName `


#### Testing / Reviewing

In local, add  the following to `demo/src/framework/demo-body.tsx`
<pre>
window.setChatConfig({
 assistantName: "myBot",
});
</pre>
