### PR TITLE
fix: cancel streaming bugs

### DIFF
--- a/demo/src/customSendMessage/customSendMessage.ts
+++ b/demo/src/customSendMessage/customSendMessage.ts
@@ -18,12 +18,13 @@ import { RESPONSE_MAP } from "./responseMap";
 
 async function customSendMessage(
   request: MessageRequest,
-  _requestOptions: CustomSendMessageOptions,
+  requestOptions: CustomSendMessageOptions,
   instance: ChatInstance,
 ) {
   if (request.input.message_type !== "event") {
     if (request.input.text && request.input.text in RESPONSE_MAP) {
-      await RESPONSE_MAP[request.input.text](instance);
+      const handler = RESPONSE_MAP[request.input.text];
+      await handler(instance, requestOptions);
     } else {
       doWelcomeText(instance);
     }

--- a/demo/src/customSendMessage/doCode.ts
+++ b/demo/src/customSendMessage/doCode.ts
@@ -7,7 +7,11 @@
  *  @license
  */
 
-import { ChatInstance, MessageResponseTypes } from "@carbon/ai-chat";
+import {
+  ChatInstance,
+  CustomSendMessageOptions,
+  MessageResponseTypes,
+} from "@carbon/ai-chat";
 
 import { CODE } from "./constants";
 import { doTextStreaming } from "./doText";
@@ -25,8 +29,20 @@ function doCode(instance: ChatInstance) {
   });
 }
 
-function doCodeStreaming(instance: ChatInstance) {
-  doTextStreaming(instance, CODE, true);
+function doCodeStreaming(
+  instance: ChatInstance,
+  requestOptions?: CustomSendMessageOptions,
+) {
+  doTextStreaming(
+    instance,
+    CODE,
+    true,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    requestOptions,
+  );
 }
 
 export { doCode, doCodeStreaming };

--- a/demo/src/customSendMessage/doConversationalSearch.ts
+++ b/demo/src/customSendMessage/doConversationalSearch.ts
@@ -8,8 +8,8 @@
  */
 
 import {
-  BusEventType,
   ChatInstance,
+  CustomSendMessageOptions,
   ConversationalSearchItem,
   MessageResponseTypes,
   StreamChunk,
@@ -74,20 +74,19 @@ function doConversationalSearch(instance: ChatInstance) {
 async function doConversationalSearchStreaming(
   instance: ChatInstance,
   text: string = TEXT,
+  requestOptions?: CustomSendMessageOptions,
 ) {
+  const signal = requestOptions?.signal;
   const responseID = crypto.randomUUID();
   const words = text.split(" ");
   let isCanceled = false;
   let lastWordIndex = 0;
 
-  const stopGeneratingEvent = {
-    type: BusEventType.STOP_STREAMING,
-    handler: () => {
-      isCanceled = false;
-      instance.off(stopGeneratingEvent);
-    },
+  // Listen to abort signal (handles both stop button and restart/clear)
+  const abortHandler = () => {
+    isCanceled = true;
   };
-  instance.on(stopGeneratingEvent);
+  signal?.addEventListener("abort", abortHandler);
 
   try {
     for (let index = 0; index < words.length && !isCanceled; index++) {
@@ -153,12 +152,11 @@ async function doConversationalSearchStreaming(
       },
     };
 
-    instance.off(stopGeneratingEvent);
     await instance.messaging.addMessageChunk({
       final_response: finalResponse,
     } as StreamChunk);
   } finally {
-    instance.off(stopGeneratingEvent);
+    signal?.removeEventListener("abort", abortHandler);
   }
 }
 

--- a/demo/src/customSendMessage/doTable.ts
+++ b/demo/src/customSendMessage/doTable.ts
@@ -7,7 +7,12 @@
  *  @license
  */
 
-import { ChatInstance, MessageResponseTypes, TableItem } from "@carbon/ai-chat";
+import {
+  ChatInstance,
+  CustomSendMessageOptions,
+  MessageResponseTypes,
+  TableItem,
+} from "@carbon/ai-chat";
 
 import { TABLE } from "./constants";
 import { doText, doTextStreaming } from "./doText";
@@ -17,11 +22,19 @@ function doTable(instance: ChatInstance) {
   doText(instance, `A markdown table in the text response type.\n\n${TABLE}`);
 }
 
-async function doTableStreaming(instance: ChatInstance) {
+async function doTableStreaming(
+  instance: ChatInstance,
+  requestOptions?: CustomSendMessageOptions,
+) {
   await doTextStreaming(
     instance,
     `A periodic table in markdown format.\n\n${TABLE}`,
     true,
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    requestOptions,
   );
 }
 

--- a/demo/src/customSendMessage/doText.ts
+++ b/demo/src/customSendMessage/doText.ts
@@ -8,7 +8,6 @@
  */
 
 import {
-  BusEventType,
   ChainOfThoughtStep,
   ChainOfThoughtStepStatus,
   ChatInstance,
@@ -147,7 +146,9 @@ async function doTextStreaming(
   userProfile?: ResponseUserProfile,
   chainOfThought?: ChainOfThoughtStep[],
   feedback?: GenericItemMessageFeedbackOptions,
+  requestOptions?: CustomSendMessageOptions,
 ) {
+  const signal = requestOptions?.signal;
   const responseID = crypto.randomUUID();
   const words = text.split(" ");
   const totalWords = words.length;
@@ -177,14 +178,11 @@ async function doTextStreaming(
   let isCanceled = false;
   let lastWordIndex = 0;
 
-  const stopGeneratingEvent = {
-    type: BusEventType.STOP_STREAMING,
-    handler: () => {
-      isCanceled = true;
-      instance.off(stopGeneratingEvent);
-    },
+  // Listen to abort signal (handles both stop button and restart/clear)
+  const abortHandler = () => {
+    isCanceled = true;
   };
-  instance.on(stopGeneratingEvent);
+  signal?.addEventListener("abort", abortHandler);
 
   try {
     for (let index = 0; index < words.length && !isCanceled; index++) {
@@ -284,7 +282,7 @@ async function doTextStreaming(
       final_response: finalResponse,
     } as StreamChunk);
   } finally {
-    instance.off(stopGeneratingEvent);
+    signal?.removeEventListener("abort", abortHandler);
   }
 }
 
@@ -418,8 +416,18 @@ async function doTextStreamingWithNonWatsonAssistantProfile(
   text: string = MARKDOWN,
   cancellable = true,
   userProfile: ResponseUserProfile = defaultAlternativeAssistantProfile,
+  requestOptions?: CustomSendMessageOptions,
 ) {
-  return doTextStreaming(instance, text, cancellable, WORD_DELAY, userProfile);
+  return doTextStreaming(
+    instance,
+    text,
+    cancellable,
+    WORD_DELAY,
+    userProfile,
+    undefined,
+    undefined,
+    requestOptions,
+  );
 }
 
 async function doTextChainOfThoughtStreaming(
@@ -428,6 +436,7 @@ async function doTextChainOfThoughtStreaming(
   cancellable = true,
   userProfile?: ResponseUserProfile,
   chainOfThought: ChainOfThoughtStep[] = fullChainOfThought,
+  requestOptions?: CustomSendMessageOptions,
 ) {
   doTextStreaming(
     instance,
@@ -436,6 +445,8 @@ async function doTextChainOfThoughtStreaming(
     300,
     userProfile,
     chainOfThought,
+    undefined,
+    requestOptions,
   );
 }
 
@@ -466,6 +477,7 @@ async function doHTMLStreaming(
   wordDelay = WORD_DELAY,
   userProfile?: ResponseUserProfile,
   chainOfThought?: ChainOfThoughtStep[],
+  requestOptions?: CustomSendMessageOptions,
 ) {
   await doTextStreaming(
     instance,
@@ -474,6 +486,8 @@ async function doHTMLStreaming(
     wordDelay,
     userProfile,
     chainOfThought,
+    undefined,
+    requestOptions,
   );
 }
 
@@ -496,7 +510,10 @@ function doTextWithFeedback(instance: ChatInstance) {
   doText(instance, feedbackText, undefined, undefined, feedback);
 }
 
-async function doTextWithFeedbackStreaming(instance: ChatInstance) {
+async function doTextWithFeedbackStreaming(
+  instance: ChatInstance,
+  requestOptions?: CustomSendMessageOptions,
+) {
   const feedbackText =
     "We'd love to hear your thoughts on Carbon! This versatile element forms the backbone of all organic chemistry and is essential for life as we know it. How do you feel about this fundamental building block of matter? Please use the feedback buttons below to share your opinion.";
 
@@ -520,6 +537,7 @@ async function doTextWithFeedbackStreaming(instance: ChatInstance) {
     undefined,
     undefined,
     feedback,
+    requestOptions,
   );
 }
 

--- a/demo/src/customSendMessage/responseMap.ts
+++ b/demo/src/customSendMessage/responseMap.ts
@@ -7,7 +7,7 @@
  *  @license
  */
 
-import { ChatInstance } from "@carbon/ai-chat";
+import { ChatInstance, CustomSendMessageOptions } from "@carbon/ai-chat";
 
 import { doAudio } from "./doAudio";
 import { doButton } from "./doButton";
@@ -47,43 +47,86 @@ import { doVideo } from "./doVideo";
 
 const RESPONSE_MAP: Record<
   string,
-  (instance: ChatInstance) => Promise<void> | void
+  (
+    instance: ChatInstance,
+    requestOptions?: CustomSendMessageOptions,
+  ) => Promise<void> | void
 > = {
-  audio: doAudio,
-  button: doButton,
-  card: doCard,
-  carousel: doCarousel,
-  code: doCode,
-  "code (stream)": doCodeStreaming,
-  "conversational search": doConversationalSearch,
-  "conversational search (stream)": doConversationalSearchStreaming,
-  date: doDate,
-  grid: doGrid,
-  "human agent": doHumanAgent,
-  iframe: doIFrame,
-  "inline error": doError,
-  image: doImage,
-  "unordered list": doList,
-  "option list": doOption,
-  "ordered list": doOrderedList,
-  table: doTable,
-  "table (stream)": doTableStreaming,
-  text: doText,
-  "text (stream)": doTextStreaming,
-  "text with feedback": doTextWithFeedback,
-  "text with feedback (stream)": doTextWithFeedbackStreaming,
-  "text from watsonx agent": doTextWithWatsonAgentProfile,
-  "text from third party human": doTextWithHumanProfile,
-  "text from third party bot": doTextWithNonWatsonAssistantProfile,
-  "text (stream) from third party bot":
-    doTextStreamingWithNonWatsonAssistantProfile,
-  "text with chain of thought": doTextChainOfThought,
-  "text (stream) with chain of thought": doTextChainOfThoughtStreaming,
-  html: doHTML,
-  "html (stream)": doHTMLStreaming,
-  user_defined: doUserDefined,
-  "user_defined (stream)": doUserDefinedStreaming,
-  video: doVideo,
+  audio: (instance) => doAudio(instance),
+  button: (instance) => doButton(instance),
+  card: (instance) => doCard(instance),
+  carousel: (instance) => doCarousel(instance),
+  code: (instance) => doCode(instance),
+  "code (stream)": (instance, requestOptions) =>
+    doCodeStreaming(instance, requestOptions),
+  "conversational search": (instance) => doConversationalSearch(instance),
+  "conversational search (stream)": (instance, requestOptions) =>
+    doConversationalSearchStreaming(instance, undefined, requestOptions),
+  date: (instance) => doDate(instance),
+  grid: (instance) => doGrid(instance),
+  "human agent": (instance) => doHumanAgent(instance),
+  iframe: (instance) => doIFrame(instance),
+  "inline error": (instance) => doError(instance),
+  image: (instance) => doImage(instance),
+  "unordered list": (instance) => doList(instance),
+  "option list": (instance) => doOption(instance),
+  "ordered list": (instance) => doOrderedList(instance),
+  table: (instance) => doTable(instance),
+  "table (stream)": (instance, requestOptions) =>
+    doTableStreaming(instance, requestOptions),
+  text: (instance) => doText(instance),
+  "text (stream)": (instance, requestOptions) =>
+    doTextStreaming(
+      instance,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      requestOptions,
+    ),
+  "text with feedback": (instance) => doTextWithFeedback(instance),
+  "text with feedback (stream)": (instance, requestOptions) =>
+    doTextWithFeedbackStreaming(instance, requestOptions),
+  "text from watsonx agent": (instance) =>
+    doTextWithWatsonAgentProfile(instance),
+  "text from third party human": (instance) => doTextWithHumanProfile(instance),
+  "text from third party bot": (instance) =>
+    doTextWithNonWatsonAssistantProfile(instance),
+  "text (stream) from third party bot": (instance, requestOptions) =>
+    doTextStreamingWithNonWatsonAssistantProfile(
+      instance,
+      undefined,
+      undefined,
+      undefined,
+      requestOptions,
+    ),
+  "text with chain of thought": (instance) => doTextChainOfThought(instance),
+  "text (stream) with chain of thought": (instance, requestOptions) =>
+    doTextChainOfThoughtStreaming(
+      instance,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      requestOptions,
+    ),
+  html: (instance) => doHTML(instance),
+  "html (stream)": (instance, requestOptions) =>
+    doHTMLStreaming(
+      instance,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      requestOptions,
+    ),
+  user_defined: (instance) => doUserDefined(instance),
+  "user_defined (stream)": (instance, requestOptions) =>
+    doUserDefinedStreaming(instance, requestOptions),
+  video: (instance) => doVideo(instance),
 };
 
 export { RESPONSE_MAP };

--- a/examples/react/basic/src/customSendMessage.ts
+++ b/examples/react/basic/src/customSendMessage.ts
@@ -79,53 +79,92 @@ print(generate_lorem_ipsum(2))  # Generates 2 paragraphs of Lorem Ipsum text
 
 const WORD_DELAY = 40;
 
-async function doFakeTextStreaming(instance: ChatInstance) {
+async function doFakeTextStreaming(
+  instance: ChatInstance,
+  signal?: AbortSignal,
+) {
   const responseID = crypto.randomUUID();
   const words = TEXT.split(" ");
+  let isCanceled = false;
+  const timeouts: number[] = [];
 
-  words.forEach((word, index) => {
-    setTimeout(() => {
-      instance.messaging.addMessageChunk({
-        partial_item: {
-          response_type: MessageResponseTypes.TEXT,
-          text: `${word} `,
-          streaming_metadata: {
-            id: "1",
-          },
+  // Listen to abort signal (handles both stop button and restart/clear)
+  const abortHandler = () => {
+    isCanceled = true;
+    // Clear all pending timeouts
+    timeouts.forEach((timeoutId) => clearTimeout(timeoutId));
+  };
+  signal?.addEventListener("abort", abortHandler);
+
+  try {
+    words.forEach((word, index) => {
+      const timeoutId = setTimeout(() => {
+        if (!isCanceled) {
+          instance.messaging.addMessageChunk({
+            partial_item: {
+              response_type: MessageResponseTypes.TEXT,
+              text: `${word} `,
+              streaming_metadata: {
+                id: "1",
+                cancellable: true,
+              },
+            },
+            streaming_metadata: {
+              response_id: responseID,
+            },
+          });
+        }
+      }, index * WORD_DELAY);
+      timeouts.push(timeoutId as unknown as number);
+    });
+
+    await sleep(words.length * WORD_DELAY);
+
+    if (!isCanceled) {
+      const completeItem = {
+        response_type: MessageResponseTypes.TEXT,
+        text: `${TEXT}\n\nMore stuff on the end when adding as a complete item.`,
+        streaming_metadata: {
+          id: "1",
         },
+      };
+      instance.messaging.addMessageChunk({
+        complete_item: completeItem,
         streaming_metadata: {
           response_id: responseID,
         },
-      });
-    }, index * WORD_DELAY);
-  });
+      } as StreamChunk);
 
-  await sleep(words.length * WORD_DELAY);
+      const finalResponse = {
+        id: responseID,
+        output: {
+          generic: [completeItem],
+        },
+      };
 
-  const completeItem = {
-    response_type: MessageResponseTypes.TEXT,
-    text: `${TEXT}\n\nMore stuff on the end when adding as a complete item.`,
-    streaming_metadata: {
-      id: "1",
-    },
-  };
-  instance.messaging.addMessageChunk({
-    complete_item: completeItem,
-    streaming_metadata: {
-      response_id: responseID,
-    },
-  } as StreamChunk);
-
-  const finalResponse = {
-    id: responseID,
-    output: {
-      generic: [completeItem],
-    },
-  };
-
-  instance.messaging.addMessageChunk({
-    final_response: finalResponse,
-  } as StreamChunk);
+      instance.messaging.addMessageChunk({
+        final_response: finalResponse,
+      } as StreamChunk);
+    } else {
+      // Send stream_stopped marker
+      const completeItem = {
+        response_type: MessageResponseTypes.TEXT,
+        text: words.slice(0, Math.floor(words.length * 0.3)).join(" "),
+        streaming_metadata: {
+          id: "1",
+          stream_stopped: true,
+        },
+      };
+      instance.messaging.addMessageChunk({
+        complete_item: completeItem,
+        streaming_metadata: {
+          response_id: responseID,
+        },
+      } as StreamChunk);
+    }
+  } finally {
+    signal?.removeEventListener("abort", abortHandler);
+  }
 }
 
 async function sleep(milliseconds: number) {
@@ -208,7 +247,7 @@ async function customSendMessage(
         });
         break;
       case "stream text":
-        doFakeTextStreaming(instance as ChatInstance);
+        doFakeTextStreaming(instance as ChatInstance, requestOptions.signal);
         break;
       default:
         instance.messaging.addMessage({

--- a/examples/react/history/src/customSendMessage.ts
+++ b/examples/react/history/src/customSendMessage.ts
@@ -76,53 +76,92 @@ print(generate_lorem_ipsum(2))  # Generates 2 paragraphs of Lorem Ipsum text
 
 const WORD_DELAY = 40;
 
-async function doFakeTextStreaming(instance: ChatInstance) {
+async function doFakeTextStreaming(
+  instance: ChatInstance,
+  signal?: AbortSignal,
+) {
   const responseID = crypto.randomUUID();
   const words = TEXT.split(" ");
+  let isCanceled = false;
+  const timeouts: number[] = [];
 
-  words.forEach((word, index) => {
-    setTimeout(() => {
-      instance.messaging.addMessageChunk({
-        partial_item: {
-          response_type: MessageResponseTypes.TEXT,
-          text: `${word} `,
-          streaming_metadata: {
-            id: "1",
-          },
+  // Listen to abort signal (handles both stop button and restart/clear)
+  const abortHandler = () => {
+    isCanceled = true;
+    // Clear all pending timeouts
+    timeouts.forEach((timeoutId) => clearTimeout(timeoutId));
+  };
+  signal?.addEventListener("abort", abortHandler);
+
+  try {
+    words.forEach((word, index) => {
+      const timeoutId = setTimeout(() => {
+        if (!isCanceled) {
+          instance.messaging.addMessageChunk({
+            partial_item: {
+              response_type: MessageResponseTypes.TEXT,
+              text: `${word} `,
+              streaming_metadata: {
+                id: "1",
+                cancellable: true,
+              },
+            },
+            streaming_metadata: {
+              response_id: responseID,
+            },
+          });
+        }
+      }, index * WORD_DELAY);
+      timeouts.push(timeoutId as unknown as number);
+    });
+
+    await sleep(words.length * WORD_DELAY);
+
+    if (!isCanceled) {
+      const completeItem = {
+        response_type: MessageResponseTypes.TEXT,
+        text: `${TEXT}\n\nMore stuff on the end when adding as a complete item.`,
+        streaming_metadata: {
+          id: "1",
         },
+      };
+      instance.messaging.addMessageChunk({
+        complete_item: completeItem,
         streaming_metadata: {
           response_id: responseID,
         },
-      });
-    }, index * WORD_DELAY);
-  });
+      } as StreamChunk);
 
-  await sleep(words.length * WORD_DELAY);
+      const finalResponse = {
+        id: responseID,
+        output: {
+          generic: [completeItem],
+        },
+      };
 
-  const completeItem = {
-    response_type: MessageResponseTypes.TEXT,
-    text: `${TEXT}\n\nMore stuff on the end when adding as a complete item.`,
-    streaming_metadata: {
-      id: "1",
-    },
-  };
-  instance.messaging.addMessageChunk({
-    complete_item: completeItem,
-    streaming_metadata: {
-      response_id: responseID,
-    },
-  } as StreamChunk);
-
-  const finalResponse = {
-    id: responseID,
-    output: {
-      generic: [completeItem],
-    },
-  };
-
-  instance.messaging.addMessageChunk({
-    final_response: finalResponse,
-  } as StreamChunk);
+      instance.messaging.addMessageChunk({
+        final_response: finalResponse,
+      } as StreamChunk);
+    } else {
+      // Send stream_stopped marker
+      const completeItem = {
+        response_type: MessageResponseTypes.TEXT,
+        text: words.slice(0, Math.floor(words.length * 0.3)).join(" "),
+        streaming_metadata: {
+          id: "1",
+          stream_stopped: true,
+        },
+      };
+      instance.messaging.addMessageChunk({
+        complete_item: completeItem,
+        streaming_metadata: {
+          response_id: responseID,
+        },
+      } as StreamChunk);
+    }
+  } finally {
+    signal?.removeEventListener("abort", abortHandler);
+  }
 }
 
 async function sleep(milliseconds: number) {
@@ -190,7 +229,7 @@ async function customSendMessage(
         });
         break;
       case "stream text":
-        doFakeTextStreaming(instance as ChatInstance);
+        doFakeTextStreaming(instance as ChatInstance, requestOptions.signal);
         break;
       default:
         instance.messaging.addMessage({

--- a/examples/web-components/basic/src/customSendMessage.ts
+++ b/examples/web-components/basic/src/customSendMessage.ts
@@ -79,53 +79,92 @@ print(generate_lorem_ipsum(2))  # Generates 2 paragraphs of Lorem Ipsum text
 
 const WORD_DELAY = 40;
 
-async function doFakeTextStreaming(instance: ChatInstance) {
+async function doFakeTextStreaming(
+  instance: ChatInstance,
+  signal?: AbortSignal,
+) {
   const responseID = crypto.randomUUID();
   const words = TEXT.split(" ");
+  let isCanceled = false;
+  const timeouts: number[] = [];
 
-  words.forEach((word, index) => {
-    setTimeout(() => {
-      instance.messaging.addMessageChunk({
-        partial_item: {
-          response_type: MessageResponseTypes.TEXT,
-          text: `${word} `,
-          streaming_metadata: {
-            id: "1",
-          },
+  // Listen to abort signal (handles both stop button and restart/clear)
+  const abortHandler = () => {
+    isCanceled = true;
+    // Clear all pending timeouts
+    timeouts.forEach((timeoutId) => clearTimeout(timeoutId));
+  };
+  signal?.addEventListener("abort", abortHandler);
+
+  try {
+    words.forEach((word, index) => {
+      const timeoutId = setTimeout(() => {
+        if (!isCanceled) {
+          instance.messaging.addMessageChunk({
+            partial_item: {
+              response_type: MessageResponseTypes.TEXT,
+              text: `${word} `,
+              streaming_metadata: {
+                id: "1",
+                cancellable: true,
+              },
+            },
+            streaming_metadata: {
+              response_id: responseID,
+            },
+          });
+        }
+      }, index * WORD_DELAY);
+      timeouts.push(timeoutId as unknown as number);
+    });
+
+    await sleep(words.length * WORD_DELAY);
+
+    if (!isCanceled) {
+      const completeItem = {
+        response_type: MessageResponseTypes.TEXT,
+        text: `${TEXT}\n\nMore stuff on the end when adding as a complete item.`,
+        streaming_metadata: {
+          id: "1",
         },
+      };
+      instance.messaging.addMessageChunk({
+        complete_item: completeItem,
         streaming_metadata: {
           response_id: responseID,
         },
-      });
-    }, index * WORD_DELAY);
-  });
+      } as StreamChunk);
 
-  await sleep(words.length * WORD_DELAY);
+      const finalResponse = {
+        id: responseID,
+        output: {
+          generic: [completeItem],
+        },
+      };
 
-  const completeItem = {
-    response_type: MessageResponseTypes.TEXT,
-    text: `${TEXT}\n\nMore stuff on the end when adding as a complete item.`,
-    streaming_metadata: {
-      id: "1",
-    },
-  };
-  instance.messaging.addMessageChunk({
-    complete_item: completeItem,
-    streaming_metadata: {
-      response_id: responseID,
-    },
-  } as StreamChunk);
-
-  const finalResponse = {
-    id: responseID,
-    output: {
-      generic: [completeItem],
-    },
-  };
-
-  instance.messaging.addMessageChunk({
-    final_response: finalResponse,
-  } as StreamChunk);
+      instance.messaging.addMessageChunk({
+        final_response: finalResponse,
+      } as StreamChunk);
+    } else {
+      // Send stream_stopped marker
+      const completeItem = {
+        response_type: MessageResponseTypes.TEXT,
+        text: words.slice(0, Math.floor(words.length * 0.3)).join(" "),
+        streaming_metadata: {
+          id: "1",
+          stream_stopped: true,
+        },
+      };
+      instance.messaging.addMessageChunk({
+        complete_item: completeItem,
+        streaming_metadata: {
+          response_id: responseID,
+        },
+      } as StreamChunk);
+    }
+  } finally {
+    signal?.removeEventListener("abort", abortHandler);
+  }
 }
 
 async function sleep(milliseconds: number) {
@@ -208,7 +247,7 @@ async function customSendMessage(
         });
         break;
       case "stream text":
-        doFakeTextStreaming(instance as ChatInstance);
+        doFakeTextStreaming(instance as ChatInstance, requestOptions.signal);
         break;
       default:
         instance.messaging.addMessage({

--- a/examples/web-components/custom-element/src/customSendMessage.ts
+++ b/examples/web-components/custom-element/src/customSendMessage.ts
@@ -76,53 +76,92 @@ print(generate_lorem_ipsum(2))  # Generates 2 paragraphs of Lorem Ipsum text
 
 const WORD_DELAY = 40;
 
-async function doFakeTextStreaming(instance: ChatInstance) {
+async function doFakeTextStreaming(
+  instance: ChatInstance,
+  signal?: AbortSignal,
+) {
   const responseID = crypto.randomUUID();
   const words = TEXT.split(" ");
+  let isCanceled = false;
+  const timeouts: number[] = [];
 
-  words.forEach((word, index) => {
-    setTimeout(() => {
-      instance.messaging.addMessageChunk({
-        partial_item: {
-          response_type: MessageResponseTypes.TEXT,
-          text: `${word} `,
-          streaming_metadata: {
-            id: "1",
-          },
+  // Listen to abort signal (handles both stop button and restart/clear)
+  const abortHandler = () => {
+    isCanceled = true;
+    // Clear all pending timeouts
+    timeouts.forEach((timeoutId) => clearTimeout(timeoutId));
+  };
+  signal?.addEventListener("abort", abortHandler);
+
+  try {
+    words.forEach((word, index) => {
+      const timeoutId = setTimeout(() => {
+        if (!isCanceled) {
+          instance.messaging.addMessageChunk({
+            partial_item: {
+              response_type: MessageResponseTypes.TEXT,
+              text: `${word} `,
+              streaming_metadata: {
+                id: "1",
+                cancellable: true,
+              },
+            },
+            streaming_metadata: {
+              response_id: responseID,
+            },
+          });
+        }
+      }, index * WORD_DELAY);
+      timeouts.push(timeoutId as unknown as number);
+    });
+
+    await sleep(words.length * WORD_DELAY);
+
+    if (!isCanceled) {
+      const completeItem = {
+        response_type: MessageResponseTypes.TEXT,
+        text: `${TEXT}\n\nMore stuff on the end when adding as a complete item.`,
+        streaming_metadata: {
+          id: "1",
         },
+      };
+      instance.messaging.addMessageChunk({
+        complete_item: completeItem,
         streaming_metadata: {
           response_id: responseID,
         },
-      });
-    }, index * WORD_DELAY);
-  });
+      } as StreamChunk);
 
-  await sleep(words.length * WORD_DELAY);
+      const finalResponse = {
+        id: responseID,
+        output: {
+          generic: [completeItem],
+        },
+      };
 
-  const completeItem = {
-    response_type: MessageResponseTypes.TEXT,
-    text: `${TEXT}\n\nMore stuff on the end when adding as a complete item.`,
-    streaming_metadata: {
-      id: "1",
-    },
-  };
-  instance.messaging.addMessageChunk({
-    complete_item: completeItem,
-    streaming_metadata: {
-      response_id: responseID,
-    },
-  } as StreamChunk);
-
-  const finalResponse = {
-    id: responseID,
-    output: {
-      generic: [completeItem],
-    },
-  };
-
-  instance.messaging.addMessageChunk({
-    final_response: finalResponse,
-  } as StreamChunk);
+      instance.messaging.addMessageChunk({
+        final_response: finalResponse,
+      } as StreamChunk);
+    } else {
+      // Send stream_stopped marker
+      const completeItem = {
+        response_type: MessageResponseTypes.TEXT,
+        text: words.slice(0, Math.floor(words.length * 0.3)).join(" "),
+        streaming_metadata: {
+          id: "1",
+          stream_stopped: true,
+        },
+      };
+      instance.messaging.addMessageChunk({
+        complete_item: completeItem,
+        streaming_metadata: {
+          response_id: responseID,
+        },
+      } as StreamChunk);
+    }
+  } finally {
+    signal?.removeEventListener("abort", abortHandler);
+  }
 }
 
 async function sleep(milliseconds: number) {
@@ -162,7 +201,7 @@ async function customSendMessage(
         });
         break;
       case "stream text":
-        doFakeTextStreaming(instance as ChatInstance);
+        doFakeTextStreaming(instance as ChatInstance, requestOptions.signal);
         break;
       default:
         instance.messaging.addMessage({

--- a/examples/web-components/history/src/customSendMessage.ts
+++ b/examples/web-components/history/src/customSendMessage.ts
@@ -78,53 +78,92 @@ print(generate_lorem_ipsum(2))  # Generates 2 paragraphs of Lorem Ipsum text
 
 const WORD_DELAY = 40;
 
-async function doFakeTextStreaming(instance: ChatInstance) {
+async function doFakeTextStreaming(
+  instance: ChatInstance,
+  signal?: AbortSignal,
+) {
   const responseID = crypto.randomUUID();
   const words = TEXT.split(" ");
+  let isCanceled = false;
+  const timeouts: number[] = [];
 
-  words.forEach((word, index) => {
-    setTimeout(() => {
-      instance.messaging.addMessageChunk({
-        partial_item: {
-          response_type: MessageResponseTypes.TEXT,
-          text: `${word} `,
-          streaming_metadata: {
-            id: "1",
-          },
+  // Listen to abort signal (handles both stop button and restart/clear)
+  const abortHandler = () => {
+    isCanceled = true;
+    // Clear all pending timeouts
+    timeouts.forEach((timeoutId) => clearTimeout(timeoutId));
+  };
+  signal?.addEventListener("abort", abortHandler);
+
+  try {
+    words.forEach((word, index) => {
+      const timeoutId = setTimeout(() => {
+        if (!isCanceled) {
+          instance.messaging.addMessageChunk({
+            partial_item: {
+              response_type: MessageResponseTypes.TEXT,
+              text: `${word} `,
+              streaming_metadata: {
+                id: "1",
+                cancellable: true,
+              },
+            },
+            streaming_metadata: {
+              response_id: responseID,
+            },
+          });
+        }
+      }, index * WORD_DELAY);
+      timeouts.push(timeoutId as unknown as number);
+    });
+
+    await sleep(words.length * WORD_DELAY);
+
+    if (!isCanceled) {
+      const completeItem = {
+        response_type: MessageResponseTypes.TEXT,
+        text: `${TEXT}\n\nMore stuff on the end when adding as a complete item.`,
+        streaming_metadata: {
+          id: "1",
         },
+      };
+      instance.messaging.addMessageChunk({
+        complete_item: completeItem,
         streaming_metadata: {
           response_id: responseID,
         },
-      });
-    }, index * WORD_DELAY);
-  });
+      } as StreamChunk);
 
-  await sleep(words.length * WORD_DELAY);
+      const finalResponse = {
+        id: responseID,
+        output: {
+          generic: [completeItem],
+        },
+      };
 
-  const completeItem = {
-    response_type: MessageResponseTypes.TEXT,
-    text: `${TEXT}\n\nMore stuff on the end when adding as a complete item.`,
-    streaming_metadata: {
-      id: "1",
-    },
-  };
-  instance.messaging.addMessageChunk({
-    complete_item: completeItem,
-    streaming_metadata: {
-      response_id: responseID,
-    },
-  } as StreamChunk);
-
-  const finalResponse = {
-    id: responseID,
-    output: {
-      generic: [completeItem],
-    },
-  };
-
-  instance.messaging.addMessageChunk({
-    final_response: finalResponse,
-  } as StreamChunk);
+      instance.messaging.addMessageChunk({
+        final_response: finalResponse,
+      } as StreamChunk);
+    } else {
+      // Send stream_stopped marker
+      const completeItem = {
+        response_type: MessageResponseTypes.TEXT,
+        text: words.slice(0, Math.floor(words.length * 0.3)).join(" "),
+        streaming_metadata: {
+          id: "1",
+          stream_stopped: true,
+        },
+      };
+      instance.messaging.addMessageChunk({
+        complete_item: completeItem,
+        streaming_metadata: {
+          response_id: responseID,
+        },
+      } as StreamChunk);
+    }
+  } finally {
+    signal?.removeEventListener("abort", abortHandler);
+  }
 }
 
 async function sleep(milliseconds: number) {
@@ -192,7 +231,7 @@ async function customSendMessage(
         });
         break;
       case "stream text":
-        doFakeTextStreaming(instance as ChatInstance);
+        doFakeTextStreaming(instance as ChatInstance, requestOptions.signal);
         break;
       default:
         instance.messaging.addMessage({

--- a/packages/ai-chat-components/src/components/processing/__tests__/processing.test.ts
+++ b/packages/ai-chat-components/src/components/processing/__tests__/processing.test.ts
@@ -1,4 +1,4 @@
-// cspell:words CDSAIChatTileContainer aichat
+// cspell:words CDSAIChatProcessing aichat
 /*
  *  Copyright IBM Corp. 2025
  *
@@ -9,45 +9,52 @@
  */
 
 import { html, fixture, expect } from "@open-wc/testing";
-import "@carbon/web-components/es/components/tile/tile.js";
-import "@carbon/ai-chat-components/es/components/tile-container/index.js";
-import CDSAIChatTileContainer from "@carbon/ai-chat-components/es/components/tile-container/src/tile-container.js";
+import "@carbon/ai-chat-components/es/components/processing/index.js";
+import CDSAIChatProcessing from "@carbon/ai-chat-components/es/components/processing/src/processing.js";
 
 /**
  * This repository uses the @web/test-runner library for testing
  * Documentation on writing tests, plugins, and commands
  * here: https://modern-web.dev/docs/test-runner/overview/
  */
-describe("aichat tile", function () {
-  it("should render cds-aichat-tile-container in DOM", async () => {
-    const el = await fixture<CDSAIChatTileContainer>(
-      html`<cds-aichat-tile-container>
-        <cds-tile>tile</cds-tile>
-      </cds-aichat-tile-container>`,
+describe("aichat processing", function () {
+  it("should render cds-aichat-processing in DOM", async () => {
+    const el = await fixture<CDSAIChatProcessing>(
+      html`<cds-aichat-processing></cds-aichat-processing>`,
     );
 
-    await expect(el).dom.to.equalSnapshot();
+    expect(el).to.be.instanceOf(CDSAIChatProcessing);
+    expect(el.tagName.toLowerCase()).to.equal("cds-aichat-processing");
+    expect(el.shadowRoot?.querySelector("div[data-carbon-theme]")).to.exist;
   });
 
-  it("should place the light dom styles into the header", async () => {
-    await fixture<CDSAIChatTileContainer>(
-      html`<cds-aichat-tile-container>
-          <cds-tile>tile</cds-tile>
-        </cds-aichat-tile-container>
-        <cds-aichat-tile-container>
-          <cds-tile>tile</cds-tile>
-        </cds-aichat-tile-container>`,
+  it("should render with loop property", async () => {
+    const el = await fixture<CDSAIChatProcessing>(
+      html`<cds-aichat-processing loop></cds-aichat-processing>`,
     );
 
-    const styleId = "cds-aichat-tile-container-light-dom-styles";
-    const style = document.querySelectorAll(
-      `style#${styleId}`,
-    )[0] as HTMLStyleElement;
-    expect(style).to.exist;
-    expect(style?.textContent).to.include("cds-tile");
+    expect(el.loop).to.be.true;
+    const linearClass = el.shadowRoot?.querySelector(".linear");
+    expect(linearClass).to.exist;
+  });
 
-    // ensure the style is not duplicated
-    const styles = document.querySelectorAll(`style#${styleId}`);
-    expect(styles.length).to.equal(1);
+  it("should render with quickLoad property", async () => {
+    const el = await fixture<CDSAIChatProcessing>(
+      html`<cds-aichat-processing quickLoad></cds-aichat-processing>`,
+    );
+
+    expect(el.quickLoad).to.be.true;
+    const quickLoadClass = el.shadowRoot?.querySelector(".quick-load");
+    expect(quickLoadClass).to.exist;
+  });
+
+  it("should render with custom carbonTheme", async () => {
+    const el = await fixture<CDSAIChatProcessing>(
+      html`<cds-aichat-processing carbonTheme="g100"></cds-aichat-processing>`,
+    );
+
+    expect(el.carbonTheme).to.equal("g100");
+    const div = el.shadowRoot?.querySelector("div[data-carbon-theme]");
+    expect(div?.getAttribute("data-carbon-theme")).to.equal("g100");
   });
 });

--- a/packages/ai-chat/src/aiChatEntry.tsx
+++ b/packages/ai-chat/src/aiChatEntry.tsx
@@ -96,6 +96,7 @@ export {
 } from "./types/config/HomeScreenConfig";
 
 export {
+  CancellationReason,
   ChatInstanceMessaging,
   CustomSendMessageOptions,
 } from "./types/config/MessagingConfig";

--- a/packages/ai-chat/src/chat/components-legacy/input/Input.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/input/Input.tsx
@@ -507,10 +507,14 @@ function Input(props: InputProps, ref: Ref<InputFunctions>) {
                 label={input_stopResponse}
                 disabled={isStopStreamingButtonDisabled}
                 tooltipAlignment="top"
-                onClick={() => {
+                onClick={async () => {
                   const { store } = serviceManager;
                   store.dispatch(actions.setStopStreamingButtonDisabled(true));
-                  serviceManager.fire({ type: BusEventType.STOP_STREAMING });
+                  await serviceManager.fire({
+                    type: BusEventType.STOP_STREAMING,
+                  });
+                  // Also cancel the current message request to abort the signal
+                  serviceManager.messageService.cancelCurrentMessageRequest();
                 }}
               />
             )}

--- a/packages/ai-chat/src/chat/events/ChatActionsImpl.ts
+++ b/packages/ai-chat/src/chat/events/ChatActionsImpl.ts
@@ -1288,7 +1288,7 @@ class ChatActionsImpl {
   }
 
   /**
-   * Remove any record of the current session from the browser.
+   * Remove any record of the current session from the browser's SessionStorage.
    *
    * @param keepOpenState We can optionally just keep around if the chat is currently open or not.
    */

--- a/packages/ai-chat/src/serverEntry.ts
+++ b/packages/ai-chat/src/serverEntry.ts
@@ -101,6 +101,7 @@ export {
 } from "./types/config/HomeScreenConfig";
 
 export {
+  CancellationReason,
   ChatInstanceMessaging,
   CustomSendMessageOptions,
 } from "./types/config/MessagingConfig";

--- a/packages/ai-chat/src/types/config/MessagingConfig.ts
+++ b/packages/ai-chat/src/types/config/MessagingConfig.ts
@@ -10,6 +10,29 @@
 import { HistoryItem } from "../messaging/History";
 import type { MessageResponse, StreamChunk } from "../messaging/Messages";
 import { BusEventSend } from "../events/eventBusTypes";
+
+/**
+ * Reasons why a message request was cancelled via the abort signal.
+ *
+ * @category Messaging
+ */
+export enum CancellationReason {
+  /**
+   * User clicked the "stop streaming" button during message streaming.
+   */
+  STOP_STREAMING = "Stop streaming",
+
+  /**
+   * User restarted or cleared the conversation.
+   */
+  CONVERSATION_RESTARTED = "Conversation restarted",
+
+  /**
+   * Message request exceeded the configured timeout duration.
+   */
+  TIMEOUT = "Request timeout",
+}
+
 /**
  * Messaging actions for a chat instance.
  *

--- a/packages/ai-chat/src/types/instance/ChatInstance.ts
+++ b/packages/ai-chat/src/types/instance/ChatInstance.ts
@@ -245,7 +245,7 @@ interface ChatActions {
   serviceDesk: ChatInstanceServiceDeskActions;
 
   /**
-   * Remove any record of the current session from the browser.
+   * Remove any record of the current session from the browser's SessionStorage.
    *
    * @param keepOpenState If we are destroying the session to restart the chat this can be used to preserve if the web
    * chat is open.


### PR DESCRIPTION
Closes #564 

- Cancelling an in-flight message outside the timeout path was bubbling an error because we still rejected the pending promise instead of marking the request as cleanly cancelled.
- The “Stop streaming” button never triggered the abort signal, so downstream customSendMessage handlers has no way to stop work in a consistent way (only stop streaming BusEvent available).
- Added an explicit CancellationReason enum to document why a cancellation occurred and to make log/error handling consistent.
- Updated demo streaming helpers to accept the request options, listen for the abort signal, and pass it only to handlers that actually stream.

#### Testing / Reviewing

enter `text (stream)` into the demo site and complete the following operations each time you do it (before streaming is complete):

1. hit the stop stream button
2. restart the conversation
3. clear the conversation

In each case the message should stop streaming and with no error state
