### PR TITLE
fix: html parsing

### DIFF
--- a/demo/src/customSendMessage/constants.ts
+++ b/demo/src/customSendMessage/constants.ts
@@ -127,6 +127,8 @@ ${UNORDERED_LIST}
 `;
 
 const HTML = `
+Here is some <b>Carbon</b> information peppered with HTML!
+
 <style>
     .fun-fact { 
         background-color: #e8f5e8; 

--- a/packages/ai-chat/src/chat/ai-chat-components/web-components/components/markdownText/src/markdownProcessor.ts
+++ b/packages/ai-chat/src/chat/ai-chat-components/web-components/components/markdownText/src/markdownProcessor.ts
@@ -358,54 +358,57 @@ function extractTextContent(node: TokenTree): string {
 }
 
 /**
- * Fixes broken standalone HTML tags like <b>bold</b>.
- *
- * Problem: markdown-it splits '<b>bold</b>' into 3 tokens: [<b>, bold, </b>]
- * These render as separate Lit template parts: html`${<b>}${bold}${</b>}`
- * Lit processes each ${} independently, creating: <b></b>bold</b>
- *
- * Solution: Combine matching tokens into single template part: html`${<b>bold</b>}`
- *
- * Only handles exact pattern: html_inline + text + html_inline with matching tags.
+ * Attempts to merge inline HTML sequences like `<b>bold</b>` that markdown-it splits
+ * into three separate tokens (`<b>`, text, `</b>`). Rendering those tokens individually
+ * causes the browser to immediately close the opening tag, which moves the text outside
+ * the intended element. We detect those sequences and collapse them into a single
+ * html_inline token so Lit renders the full element at once.
  */
-function tryToCombineConsecutiveHtmlInline(
-  children: TokenTree[],
-): string | null {
-  // Only handle the exact pattern: html_inline + text + html_inline
-  if (children.length !== 3) {
-    return null;
+function combineConsecutiveHtmlInline(children: TokenTree[]): TokenTree[] {
+  if (children.length < 3) {
+    return children;
   }
 
-  const [first, second, third] = children;
+  const combinedChildren: TokenTree[] = [];
+  let didCombine = false;
 
-  // Check if we have the exact pattern
-  if (
-    first.token.type === "html_inline" &&
-    second.token.type === "text" &&
-    third.token.type === "html_inline"
-  ) {
-    const openingTag = first.token.content || "";
-    const textContent = second.token.content || "";
-    const closingTag = third.token.content || "";
+  for (let index = 0; index < children.length; index++) {
+    const first = children[index];
+    const second = children[index + 1];
+    const third = children[index + 2];
 
-    // Verify opening tag pattern: <tagname> or <tagname attr="value">
-    const openingMatch = openingTag.match(/^<([a-zA-Z][a-zA-Z0-9]*)[^>]*>$/);
-    if (!openingMatch) {
-      return null;
+    if (
+      second &&
+      third &&
+      first.token.type === "html_inline" &&
+      second.token.type === "text" &&
+      third.token.type === "html_inline"
+    ) {
+      const openingTag = first.token.content || "";
+      const textContent = second.token.content || "";
+      const closingTag = third.token.content || "";
+
+      // Verify opening tag pattern: <tagname> or <tagname attr="value">
+      const openingMatch = openingTag.match(/^<([a-zA-Z][a-zA-Z0-9]*)[^>]*>$/);
+      if (openingMatch && closingTag === `</${openingMatch[1]}>`) {
+        combinedChildren.push({
+          key: `${first.key}|${second.key}|${third.key}`,
+          token: {
+            ...first.token,
+            content: openingTag + textContent + closingTag,
+          },
+          children: [],
+        });
+        index += 2;
+        didCombine = true;
+        continue;
+      }
     }
 
-    const tagName = openingMatch[1];
-
-    // Verify closing tag matches: </tagname>
-    if (closingTag !== `</${tagName}>`) {
-      return null;
-    }
-
-    // Combine into complete HTML element
-    return openingTag + textContent + closingTag;
+    combinedChildren.push(first);
   }
 
-  return null;
+  return didCombine ? combinedChildren : children;
 }
 
 /**
@@ -496,39 +499,32 @@ function renderTokenTree(
     // Optimization: single text child doesn't need repeat wrapper
     content = html`${children[0].token.content}`;
   } else {
-    // Check if we have a simple case of consecutive html_inline + text + html_inline
-    // that forms a complete HTML element (e.g., <b>bold</b>)
-    const combinedContent = tryToCombineConsecutiveHtmlInline(children);
+    const normalizedChildren = combineConsecutiveHtmlInline(children);
 
-    if (combinedContent) {
-      // Render the combined HTML content directly
-      content = html`${unsafeHTML(combinedContent)}`;
-    } else {
-      // Multiple or complex children: use repeat for stable keying
-      content = html`${repeat(
-        children,
-        (c, index) => {
-          // Generate stable key that doesn't depend on line positions
-          // This prevents unnecessary re-renders during streaming
-          const stableKey = `${index}:${c.token.type}:${c.token.tag}`;
+    // Multiple or complex children: use repeat for stable keying
+    content = html`${repeat(
+      normalizedChildren,
+      (c, index) => {
+        // Generate stable key that doesn't depend on line positions
+        // This prevents unnecessary re-renders during streaming
+        const stableKey = `${index}:${c.token.type}:${c.token.tag}`;
 
-          if (c.token.type?.includes("table")) {
-            return `table-${stableKey}`;
-          }
+        if (c.token.type?.includes("table")) {
+          return `table-${stableKey}`;
+        }
 
-          return `stable-${stableKey}`;
-        },
-        (c, index) =>
-          renderTokenTree(c, {
-            ...options,
-            context: {
-              ...childContext,
-              parentChildren: children,
-              currentIndex: index,
-            },
-          }),
-      )}`;
-    }
+        return `stable-${stableKey}`;
+      },
+      (c, index) =>
+        renderTokenTree(c, {
+          ...options,
+          context: {
+            ...childContext,
+            parentChildren: normalizedChildren,
+            currentIndex: index,
+          },
+        }),
+    )}`;
   }
 
   // Handle tokens without HTML tags (just return content)


### PR DESCRIPTION
closes #567 

So when we get markdown we parse it with markdown-it. This gives us a tree of all the content. When markdown-it comes across inline html, it creates a token for the opening tag, a token for any inner text, and then a token to close it. Our problem is that unless we combing all those tokens into one token before we render that Lit can "helpfully" auto close the first html token. Which can lead to the following:

```
hello <b></b>bold.
```

instead of 

```
hello <b>bold</b>
```

as the `<b>` gets auto closed and then the trailing `</b>` just gets removed because it doesn't close anything.

We had logic in here to try to fix that already, but it was too strict in its checking and was only working if the first token received was an html tag, not if it occurred somewhere in the middle.

Added a block that starts with plain text at the begining of the "HTML" response in the dropdown of the demo site for testing.