### PR TITLE
fix: preact comp

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
         "cross-env": "^7.0.3",
         "eslint": "^8.53.0",
         "eslint-config-carbon": "3.10.0",
+        "eslint-plugin-import": "^2.32.0",
         "gitignore-to-glob": "^0.3.0",
         "globby": "^15.0.0",
         "husky": "^9.1.7",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "cross-env": "^7.0.3",
     "eslint": "^8.53.0",
     "eslint-config-carbon": "3.10.0",
+    "eslint-plugin-import": "^2.32.0",
     "gitignore-to-glob": "^0.3.0",
     "globby": "^15.0.0",
     "husky": "^9.1.7",
@@ -129,7 +130,9 @@
     "extends": [
       "eslint-config-carbon"
     ],
+    "plugins": ["import"],
     "rules": {
+      "import/no-named-as-default-member": "error",
       "jsdoc/check-tag-names": [
         "error",
         {

--- a/packages/ai-chat-components/package.json
+++ b/packages/ai-chat-components/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@carbon/ai-chat-components",
   "version": "0.2.1",
-  "private": true,
   "type": "module",
   "license": "Apache-2.0",
   "repository": {
@@ -10,8 +9,7 @@
     "directory": "packages/ai-chat"
   },
   "publishConfig": {
-    "access": "public",
-    "provenance": true
+    "access": "public"
   },
   "exports": {
     "./es/*": "./es/*",

--- a/packages/ai-chat/src/chat/ChatAppEntry.tsx
+++ b/packages/ai-chat/src/chat/ChatAppEntry.tsx
@@ -8,7 +8,13 @@
  */
 
 import isEqual from "lodash-es/isEqual.js";
-import React, { useEffect, useRef, useState } from "react";
+import React, {
+  Dispatch,
+  SetStateAction,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 import { StoreProvider } from "./providers/StoreProvider";
 
 import { ServiceManager } from "./services/ServiceManager";
@@ -60,7 +66,7 @@ interface AppProps {
   renderWriteableElements?: RenderWriteableElementResponse;
   container: HTMLElement;
   element?: HTMLElement;
-  setParentInstance?: React.Dispatch<React.SetStateAction<ChatInstance>>;
+  setParentInstance?: Dispatch<SetStateAction<ChatInstance>>;
   chatWrapper?: HTMLElement;
   serviceDeskFactory?: (
     parameters: ServiceDeskFactoryParameters,

--- a/packages/ai-chat/src/chat/ai-chat-components/react/components/UserDefinedResponsePortalsContainer.tsx
+++ b/packages/ai-chat/src/chat/ai-chat-components/react/components/UserDefinedResponsePortalsContainer.tsx
@@ -7,8 +7,8 @@
  *  @license
  */
 
-import React, { ReactNode, useRef } from "react";
-import ReactDOM from "react-dom";
+import React, { memo, ReactNode, useRef } from "react";
+import { createPortal } from "react-dom";
 
 import { ChatInstance } from "../../../../types/instance/ChatInstance";
 import {
@@ -111,10 +111,10 @@ function UserDefinedResponseComponentPortal({
   hostElement: HTMLElement;
   children: ReactNode;
 }) {
-  return ReactDOM.createPortal(children, hostElement);
+  return createPortal(children, hostElement);
 }
 
-const UserDefinedResponsePortalsContainerExport = React.memo(
+const UserDefinedResponsePortalsContainerExport = memo(
   UserDefinedResponsePortalsContainer,
 );
 export { UserDefinedResponsePortalsContainerExport as UserDefinedResponsePortalsContainer };

--- a/packages/ai-chat/src/chat/ai-chat-components/react/components/WriteableElementsPortalsContainer.tsx
+++ b/packages/ai-chat/src/chat/ai-chat-components/react/components/WriteableElementsPortalsContainer.tsx
@@ -7,8 +7,8 @@
  *  @license
  */
 
-import React, { ReactNode } from "react";
-import ReactDOM from "react-dom";
+import React, { memo, ReactNode } from "react";
+import { createPortal } from "react-dom";
 
 import {
   ChatInstance,
@@ -75,10 +75,10 @@ function WriteableElementsComponentPortal({
   hostElement: HTMLElement;
   children: ReactNode;
 }) {
-  return ReactDOM.createPortal(children, hostElement);
+  return createPortal(children, hostElement);
 }
 
-const WriteableElementsPortalsContainerExport = React.memo(
+const WriteableElementsPortalsContainerExport = memo(
   WriteableElementsPortalsContainer,
 );
 export { WriteableElementsPortalsContainerExport as WriteableElementsPortalsContainer };

--- a/packages/ai-chat/src/chat/components-legacy/AssistantChat.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/AssistantChat.tsx
@@ -7,7 +7,7 @@
  *  @license
  */
 
-import React, { Component, RefObject } from "react";
+import React, { Component, createRef, ErrorInfo, RefObject } from "react";
 import { injectIntl } from "react-intl";
 
 import MessagesComponent, { MessagesComponentClass } from "./MessagesComponent";
@@ -74,9 +74,8 @@ class AssistantChat extends Component<ChatInterfaceProps, ChatInterfaceState> {
     hasCaughtError: false,
   };
 
-  private inputRef: RefObject<InputFunctions | null> = React.createRef();
-  private messagesRef: RefObject<MessagesComponentClass | null> =
-    React.createRef();
+  private inputRef: RefObject<InputFunctions | null> = createRef();
+  private messagesRef: RefObject<MessagesComponentClass | null> = createRef();
   private messagesToArray = createUnmappingMemoizer<LocalMessageItem>();
 
   async scrollOnHydrationComplete() {
@@ -110,7 +109,7 @@ class AssistantChat extends Component<ChatInterfaceProps, ChatInterfaceState> {
     }
   }
 
-  componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
     this.props.serviceManager.actions.errorOccurred(
       createDidCatchErrorData("AssistantChat", error, errorInfo),
     );

--- a/packages/ai-chat/src/chat/components-legacy/Avatar.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/Avatar.tsx
@@ -13,7 +13,7 @@
  * Light and dark versions of the watsonx logo sourced from https://ibm.ent.box.com/s/ptn44fwqwbfu2i83poh4tk21a1lun3yn/folder/222574830530
  */
 
-import React from "react";
+import React, { memo } from "react";
 
 import { uuid } from "../utils/lang/uuid";
 import { CarbonTheme } from "../../types/config/PublicConfig";
@@ -232,6 +232,6 @@ function Avatar({ theme }: AvatarProps) {
   );
 }
 
-const AvatarExport = React.memo(Avatar);
+const AvatarExport = memo(Avatar);
 
 export { AvatarExport as Avatar };

--- a/packages/ai-chat/src/chat/components-legacy/BasePanelComponent.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/BasePanelComponent.tsx
@@ -14,6 +14,8 @@ import React, {
   useRef,
   useEffect,
   useState,
+  forwardRef,
+  memo,
 } from "react";
 import { useSelector } from "../hooks/useSelector";
 
@@ -160,8 +162,6 @@ function BasePanelComponent(
   );
 }
 
-const BasePanelComponentExport = React.memo(
-  React.forwardRef(BasePanelComponent),
-);
+const BasePanelComponentExport = memo(forwardRef(BasePanelComponent));
 
 export { BasePanelComponentExport as BasePanelComponent };

--- a/packages/ai-chat/src/chat/components-legacy/BodyWithFooterComponent.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/BodyWithFooterComponent.tsx
@@ -7,7 +7,7 @@
  *  @license
  */
 
-import React from "react";
+import React, { ReactNode } from "react";
 import { useSelector } from "../hooks/useSelector";
 
 import { useLanguagePack } from "../hooks/useLanguagePack";
@@ -34,7 +34,7 @@ interface BodyWithFooterComponentProps extends HasRequestFocus {
   /**
    * Function to render message components
    */
-  renderMessageComponent: (props: MessageTypeComponentProps) => React.ReactNode;
+  renderMessageComponent: (props: MessageTypeComponentProps) => ReactNode;
 }
 
 /**

--- a/packages/ai-chat/src/chat/components-legacy/CatastrophicError.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/CatastrophicError.tsx
@@ -14,7 +14,7 @@ import ChatButton, {
   CHAT_BUTTON_SIZE,
 } from "../components/carbon/ChatButton";
 import cx from "classnames";
-import React from "react";
+import React, { memo } from "react";
 import { useIntl } from "react-intl";
 import { useSelector } from "../hooks/useSelector";
 
@@ -124,7 +124,7 @@ function CatastrophicError({
   );
 }
 
-const CatastrophicErrorExport = React.memo(CatastrophicError);
+const CatastrophicErrorExport = memo(CatastrophicError);
 
 export { CatastrophicErrorExport as CatastrophicError };
 

--- a/packages/ai-chat/src/chat/components-legacy/LatestWelcomeNodes.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/LatestWelcomeNodes.tsx
@@ -12,7 +12,7 @@
  * her to do what she likes. The element is stored in the serviceManager and set in Chat.ts.
  */
 
-import React from "react";
+import React, { memo } from "react";
 
 import { WriteableElementName } from "../../types/instance/ChatInstance";
 import { useServiceManager } from "../hooks/useServiceManager";
@@ -40,4 +40,4 @@ function LatestWelcomeNodes({ children }: LatestWelcomeNodesProps) {
   );
 }
 
-export default React.memo(LatestWelcomeNodes);
+export default memo(LatestWelcomeNodes);

--- a/packages/ai-chat/src/chat/components-legacy/MessageComponent.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/MessageComponent.tsx
@@ -13,7 +13,12 @@ import Headset32 from "@carbon/icons/es/headset/32.js";
 import { carbonIconToReact } from "../utils/carbonIcon";
 import Loading from "../components/carbon/Loading";
 import cx from "classnames";
-import React, { KeyboardEvent, PureComponent } from "react";
+import React, {
+  createRef,
+  ErrorInfo,
+  KeyboardEvent,
+  PureComponent,
+} from "react";
 import { FormattedMessage, injectIntl } from "react-intl";
 
 import { nodeToText } from "./aria/AriaAnnouncerComponent";
@@ -216,17 +221,17 @@ class MessageComponent extends PureComponent<
   /**
    * A reference to the root element in this component.
    */
-  public ref = React.createRef<HTMLDivElement>();
+  public ref = createRef<HTMLDivElement>();
 
   /**
    * A reference to the pure message element in this component.
    */
-  public messageRef = React.createRef<HTMLDivElement>();
+  public messageRef = createRef<HTMLDivElement>();
 
   /**
    * A reference to the focus handle element in this component.
    */
-  public focusHandleRef = React.createRef<HTMLDivElement>();
+  public focusHandleRef = createRef<HTMLDivElement>();
 
   /**
    * Returns the value of the local message for the component.
@@ -259,7 +264,7 @@ class MessageComponent extends PureComponent<
       : null;
   }
 
-  componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
     this.props.serviceManager.actions.errorOccurred(
       createDidCatchErrorData("Message", error, errorInfo),
     );

--- a/packages/ai-chat/src/chat/components-legacy/MessagesComponent.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/MessagesComponent.tsx
@@ -11,7 +11,13 @@
 
 import cx from "classnames";
 import throttle from "lodash-es/throttle.js";
-import React, { Fragment, PureComponent, ReactNode } from "react";
+import React, {
+  createRef,
+  forwardRef,
+  Fragment,
+  PureComponent,
+  ReactNode,
+} from "react";
 import { useSelector } from "../hooks/useSelector";
 import DownToBottom16 from "@carbon/icons/es/down-to-bottom/16.js";
 import { HumanAgentBannerContainer } from "./humanAgent/HumanAgentBannerContainer";
@@ -149,17 +155,17 @@ class MessagesComponent extends PureComponent<MessagesProps, MessagesState> {
   /**
    * A ref to the scrollable container that contains the messages.
    */
-  public messagesContainerWithScrollingRef = React.createRef<HTMLDivElement>();
+  public messagesContainerWithScrollingRef = createRef<HTMLDivElement>();
 
   /**
    * A ref to the element that acts as a handle for scrolling.
    */
-  public scrollHandleRef = React.createRef<HTMLButtonElement>();
+  public scrollHandleRef = createRef<HTMLButtonElement>();
 
   /**
    * A ref to the element that acts as a handle for scrolling.
    */
-  public agentBannerRef = React.createRef<HasRequestFocus>();
+  public agentBannerRef = createRef<HasRequestFocus>();
 
   /**
    * This is the previous value of the offset height of the scrollable element when the last scroll event was fired.
@@ -1046,15 +1052,20 @@ function debugAutoScroll(message: string, ...args: any[]) {
 }
 
 // Functional wrapper to supply AppState via hooks
-const MessagesStateInjector = React.forwardRef<
-  MessagesComponent,
-  MessagesOwnProps
->((props, ref) => {
-  const state = useSelector<AppState, AppState>((s) => s);
-  return (
-    <MessagesComponent ref={ref} {...(props as MessagesOwnProps)} {...state} />
-  );
-});
+const MessagesStateInjector = forwardRef<MessagesComponent, MessagesOwnProps>(
+  (props, ref) => {
+    const state = useSelector<AppState, AppState>((s) => s);
+    return (
+      <MessagesComponent
+        ref={ref}
+        {...(props as MessagesOwnProps)}
+        {...state}
+      />
+    );
+  },
+);
+
+MessagesStateInjector.displayName = "MessagesComponent";
 
 export default withServiceManager(MessagesStateInjector);
 

--- a/packages/ai-chat/src/chat/components-legacy/ModalPortal.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/ModalPortal.tsx
@@ -7,8 +7,8 @@
  *  @license
  */
 
-import React, { Component, type JSX } from "react";
-import ReactDOM from "react-dom";
+import { Component, ContextType, type JSX } from "react";
+import { createPortal } from "react-dom";
 
 import { ModalPortalRootContext } from "../contexts/ModalPortalRootContext";
 
@@ -39,7 +39,7 @@ interface ModalPortalState {
 class ModalPortal extends Component<ModalPortalProps, ModalPortalState> {
   // Specify the context type and redefine the context property so it's got the right type.
   static contextType = ModalPortalRootContext;
-  declare context: React.ContextType<typeof ModalPortalRootContext>;
+  declare context: ContextType<typeof ModalPortalRootContext>;
 
   /**
    * Default state.
@@ -87,7 +87,7 @@ class ModalPortal extends Component<ModalPortalProps, ModalPortalState> {
       return null;
     }
 
-    return ReactDOM.createPortal(this.props.children, this.modalElement);
+    return createPortal(this.props.children, this.modalElement);
   }
 }
 

--- a/packages/ai-chat/src/chat/components-legacy/OverlayPanel.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/OverlayPanel.tsx
@@ -12,7 +12,7 @@
  */
 
 import cx from "classnames";
-import React, { PureComponent } from "react";
+import React, { AnimationEvent, PureComponent } from "react";
 
 import { HasServiceManager } from "../hocs/withServiceManager";
 import {
@@ -202,9 +202,7 @@ class OverlayPanel extends PureComponent<OverlayPanelProps, OverlayPanelState> {
     }
   }
 
-  private handleAnimationStart = (
-    event: React.AnimationEvent<HTMLDivElement>,
-  ) => {
+  private handleAnimationStart = (event: AnimationEvent<HTMLDivElement>) => {
     if (event.target !== event.currentTarget) {
       return;
     }
@@ -213,7 +211,7 @@ class OverlayPanel extends PureComponent<OverlayPanelProps, OverlayPanelState> {
   };
 
   private handleAnimationLifecycleEnd = (
-    event: React.AnimationEvent<HTMLDivElement>,
+    event: AnimationEvent<HTMLDivElement>,
   ) => {
     if (event.target !== event.currentTarget) {
       return;

--- a/packages/ai-chat/src/chat/components-legacy/WriteableElement.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/WriteableElement.tsx
@@ -13,7 +13,7 @@
  * own custom elements below it.
  */
 
-import React from "react";
+import React, { memo } from "react";
 
 import { HasClassName } from "../../types/utilities/HasClassName";
 
@@ -39,4 +39,4 @@ function WriteableElement({ slotName, id, className }: WriteableElementProps) {
   );
 }
 
-export default React.memo(WriteableElement);
+export default memo(WriteableElement);

--- a/packages/ai-chat/src/chat/components-legacy/aria/AriaAnnouncerComponent.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/aria/AriaAnnouncerComponent.tsx
@@ -7,7 +7,7 @@
  *  @license
  */
 
-import React from "react";
+import React, { createRef, PureComponent } from "react";
 
 import { AnnounceMessage } from "../../../types/state/AppState";
 import HasIntl from "../../../types/utilities/HasIntl";
@@ -56,16 +56,16 @@ const ANNOUNCE_NODE_EXCLUDE_ATTRIBUTE = "data-cds-aichat-exclude-node-read";
  * the content without some sort of delay before it's cleared (even waiting a tick isn't enough). In addition, a second
  * element will make sure the SR will read a new message even if it has the same content as a previous message.
  */
-class AriaAnnouncerComponent extends React.PureComponent<HasIntl> {
+class AriaAnnouncerComponent extends PureComponent<HasIntl> {
   /**
    * The first element into which the messages will be added.
    */
-  private ref1 = React.createRef<HTMLDivElement>();
+  private ref1 = createRef<HTMLDivElement>();
 
   /**
    * The second element into which the messages will be added.
    */
-  private ref2 = React.createRef<HTMLDivElement>();
+  private ref2 = createRef<HTMLDivElement>();
 
   /**
    * Indicates which of the two elements should next to be used to announce a new message.

--- a/packages/ai-chat/src/chat/components-legacy/aria/AriaLiveMessage.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/aria/AriaLiveMessage.tsx
@@ -7,7 +7,7 @@
  *  @license
  */
 
-import React, { useContext, useEffect } from "react";
+import React, { memo, useContext, useEffect } from "react";
 
 import { AriaAnnouncerContext } from "../../contexts/AriaAnnouncerContext";
 
@@ -31,5 +31,5 @@ function AriaLiveMessage(props: AriaLiveMessageProps) {
   return <div />;
 }
 
-const AriaLiveMessageExport = React.memo(AriaLiveMessage);
+const AriaLiveMessageExport = memo(AriaLiveMessage);
 export { AriaLiveMessageExport as AriaLiveMessage };

--- a/packages/ai-chat/src/chat/components-legacy/header/AssistantHeader.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/header/AssistantHeader.tsx
@@ -11,6 +11,7 @@ import Home16 from "@carbon/icons/es/home/16.js";
 import { carbonIconToReact } from "../../utils/carbonIcon";
 import React, {
   forwardRef,
+  memo,
   RefObject,
   useCallback,
   useImperativeHandle,
@@ -154,5 +155,5 @@ function AssistantHeader(
   );
 }
 
-const AssistantHeaderExport = React.memo(forwardRef(AssistantHeader));
+const AssistantHeaderExport = memo(forwardRef(AssistantHeader));
 export { AssistantHeaderExport as AssistantHeader };

--- a/packages/ai-chat/src/chat/components-legacy/header/Header.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/header/Header.tsx
@@ -25,6 +25,8 @@ import { POPOVER_ALIGNMENT } from "@carbon/web-components/es/components/popover/
 import cx from "classnames";
 import React, {
   forwardRef,
+  memo,
+  ReactNode,
   Ref,
   RefObject,
   useContext,
@@ -120,7 +122,7 @@ interface HeaderProps {
   /**
    * The contents/icon to display for the "back" button.
    */
-  backContent?: React.ReactNode;
+  backContent?: ReactNode;
 
   /**
    * The list of items to display in the overflow menu.
@@ -185,7 +187,7 @@ function Header(props: HeaderProps, ref: Ref<HasRequestFocus>) {
   const useHideCloseButton = header?.hideMinimizeButton || hideCloseButton;
 
   // The icon to use for the close button.
-  let closeIcon: React.ReactNode;
+  let closeIcon: ReactNode;
   let closeReverseIcon = false;
   let closeIsReversible = true;
   const minimizeButtonIconType = header?.minimizeButtonIconType;
@@ -470,5 +472,5 @@ function HeaderButton({
   );
 }
 
-const HeaderExport = React.memo(forwardRef(Header));
+const HeaderExport = memo(forwardRef(Header));
 export { HeaderExport as Header };

--- a/packages/ai-chat/src/chat/components-legacy/header/SimpleHeader.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/header/SimpleHeader.tsx
@@ -7,7 +7,13 @@
  *  @license
  */
 
-import React, { forwardRef, Ref, useImperativeHandle, useRef } from "react";
+import React, {
+  forwardRef,
+  memo,
+  Ref,
+  useImperativeHandle,
+  useRef,
+} from "react";
 
 import { HasRequestFocus } from "../../../types/utilities/HasRequestFocus";
 import { Header } from "./Header";
@@ -52,5 +58,5 @@ function SimpleHeader(props: SimpleHeaderProps, ref: Ref<HasRequestFocus>) {
   );
 }
 
-const SimpleHeaderExport = React.memo(forwardRef(SimpleHeader));
+const SimpleHeaderExport = memo(forwardRef(SimpleHeader));
 export { SimpleHeaderExport as SimpleHeader };

--- a/packages/ai-chat/src/chat/components-legacy/homeScreen/HomeScreen.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/homeScreen/HomeScreen.tsx
@@ -14,7 +14,7 @@ import ChatButton, {
 import ArrowRight16 from "@carbon/icons/es/arrow--right/16.js";
 import { carbonIconToReact } from "../../utils/carbonIcon";
 import cx from "classnames";
-import React, { RefObject } from "react";
+import React, { memo, RefObject } from "react";
 import { useSelector } from "../../hooks/useSelector";
 
 import { useLanguagePack } from "../../hooks/useLanguagePack";
@@ -226,6 +226,6 @@ function HomeScreenComponent({
   );
 }
 
-const HomeScreenExport = React.memo(HomeScreenComponent);
+const HomeScreenExport = memo(HomeScreenComponent);
 
 export { HomeScreenExport as HomeScreen };

--- a/packages/ai-chat/src/chat/components-legacy/homeScreen/HomeScreenHeader.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/homeScreen/HomeScreenHeader.tsx
@@ -9,6 +9,7 @@
 
 import React, {
   forwardRef,
+  memo,
   Ref,
   useCallback,
   useImperativeHandle,
@@ -83,5 +84,5 @@ function HomeScreenHeader(
   );
 }
 
-const HomeScreenHeaderExport = React.memo(forwardRef(HomeScreenHeader));
+const HomeScreenHeaderExport = memo(forwardRef(HomeScreenHeader));
 export { HomeScreenHeaderExport as HomeScreenHeader };

--- a/packages/ai-chat/src/chat/components-legacy/humanAgent/HumanAgentBanner.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/humanAgent/HumanAgentBanner.tsx
@@ -14,6 +14,7 @@ import CDSButton from "@carbon/web-components/es/components/button/button.js";
 import cx from "classnames";
 import React, {
   forwardRef,
+  memo,
   RefObject,
   useImperativeHandle,
   useRef,
@@ -157,5 +158,5 @@ function HumanAgentBanner(
   );
 }
 
-const HumanAgentBannerExport = React.memo(forwardRef(HumanAgentBanner));
+const HumanAgentBannerExport = memo(forwardRef(HumanAgentBanner));
 export { HumanAgentBannerExport as HumanAgentBanner };

--- a/packages/ai-chat/src/chat/components-legacy/humanAgent/HumanAgentBannerContainer.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/humanAgent/HumanAgentBannerContainer.tsx
@@ -7,7 +7,7 @@
  *  @license
  */
 
-import React from "react";
+import React, { RefObject } from "react";
 import { useSelector } from "../../hooks/useSelector";
 import { shallowEqual } from "../../store/appStore";
 
@@ -20,7 +20,7 @@ interface HumanAgentBannerContainerProps {
   /**
    * A ref to the banner.
    */
-  bannerRef: React.RefObject<HasRequestFocus | null>;
+  bannerRef: RefObject<HasRequestFocus | null>;
 
   /**
    * The callback that is called when the user clicks the "end chat" or "cancel" button.

--- a/packages/ai-chat/src/chat/components-legacy/input/Input.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/input/Input.tsx
@@ -20,6 +20,7 @@ import React, {
   ChangeEvent,
   forwardRef,
   KeyboardEvent,
+  memo,
   Ref,
   UIEvent,
   useImperativeHandle,
@@ -548,5 +549,5 @@ function Input(props: InputProps, ref: Ref<InputFunctions>) {
   );
 }
 
-const InputExport = React.memo(forwardRef(Input));
+const InputExport = memo(forwardRef(Input));
 export { InputExport as Input, InputFunctions };

--- a/packages/ai-chat/src/chat/components-legacy/launcher/LauncherDesktopContainer.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/launcher/LauncherDesktopContainer.tsx
@@ -19,6 +19,7 @@ import React, {
   useEffect,
   useRef,
   useState,
+  KeyboardEvent,
 } from "react";
 import { useIntl } from "react-intl";
 import { useSelector } from "../../hooks/useSelector";
@@ -411,7 +412,7 @@ const LauncherDesktopContainer = (props: LauncherDesktopContainerProps) => {
   }, [requestFocus, serviceManager.store]);
 
   const handleTagKeyDown = useCallback(
-    (event: React.KeyboardEvent<HTMLElement>) => {
+    (event: KeyboardEvent<HTMLElement>) => {
       if (event.key === "Enter" || event.key === " ") {
         event.preventDefault();
         onMinimize();

--- a/packages/ai-chat/src/chat/components-legacy/main/MainWindow.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/main/MainWindow.tsx
@@ -9,7 +9,14 @@
 
 import cx from "classnames";
 import FocusTrap from "focus-trap-react";
-import React, { Component, MutableRefObject, RefObject } from "react";
+import React, {
+  Component,
+  createRef,
+  ErrorInfo,
+  forwardRef,
+  MutableRefObject,
+  RefObject,
+} from "react";
 import { useSelector } from "../../hooks/useSelector";
 
 import AssistantChat, { ChatClass } from "../AssistantChat";
@@ -152,56 +159,52 @@ class MainWindow
   /**
    * A React ref to the "cds-aichat--main-window" element.
    */
-  private mainWindowRef = React.createRef<HTMLDivElement>();
+  private mainWindowRef = createRef<HTMLDivElement>();
 
   /**
    * A React ref to the "cds-aichat--widget" element.
    */
-  private containerRef = React.createRef<HTMLDivElement>();
+  private containerRef = createRef<HTMLDivElement>();
 
   /**
    * A React ref to the bot {@link Chat} component.
    */
-  private botChatRef: RefObject<ChatClass | null> = React.createRef();
+  private botChatRef: RefObject<ChatClass | null> = createRef();
 
   /**
    * A React ref to the bot {@link Input} component.
    */
-  private homeScreenInputRef: RefObject<InputFunctions | null> =
-    React.createRef();
+  private homeScreenInputRef: RefObject<InputFunctions | null> = createRef();
 
   /**
    * A React ref to the bot {@link Disclaimer} component.
    */
-  private disclaimerRef: RefObject<CDSButton | null> = React.createRef();
+  private disclaimerRef: RefObject<CDSButton | null> = createRef();
 
   /**
    * A React ref to the animation container element.
    */
-  private animationContainerRef: RefObject<HTMLDivElement | null> =
-    React.createRef();
+  private animationContainerRef: RefObject<HTMLDivElement | null> = createRef();
 
   /**
    * A React ref to the {@link IFramePanel} component.
    */
-  private iframePanelRef: RefObject<HasRequestFocus | null> = React.createRef();
+  private iframePanelRef: RefObject<HasRequestFocus | null> = createRef();
 
   /**
    * A React ref to the {@link ViewSourcePanel}.
    */
-  private viewSourcePanelRef: RefObject<HasRequestFocus | null> =
-    React.createRef();
+  private viewSourcePanelRef: RefObject<HasRequestFocus | null> = createRef();
 
   /**
    * A React ref to the {@link CustomPanel}.
    */
-  private customPanelRef: RefObject<HasRequestFocus | null> = React.createRef();
+  private customPanelRef: RefObject<HasRequestFocus | null> = createRef();
 
   /**
    * A React ref to the response panel component.
    */
-  private responsePanelRef: RefObject<HasRequestFocus | null> =
-    React.createRef();
+  private responsePanelRef: RefObject<HasRequestFocus | null> = createRef();
 
   /**
    * The observer used to monitor for changes in the main window size.
@@ -351,7 +354,7 @@ class MainWindow
     }
   }
 
-  componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
     this.props.serviceManager.actions.errorOccurred(
       createDidCatchErrorData("MainWindow", error, errorInfo, true),
     );
@@ -1071,12 +1074,15 @@ class MainWindow
 }
 
 // Functional wrapper to supply AppState via hooks
-const MainWindowStateInjector = React.forwardRef<
-  MainWindow,
-  MainWindowOwnProps
->((props, ref) => {
-  const state = useSelector<AppState, AppState>((s) => s);
-  return <MainWindow {...(props as MainWindowOwnProps)} {...state} ref={ref} />;
-});
+const MainWindowStateInjector = forwardRef<MainWindow, MainWindowOwnProps>(
+  (props, ref) => {
+    const state = useSelector<AppState, AppState>((s) => s);
+    return (
+      <MainWindow {...(props as MainWindowOwnProps)} {...state} ref={ref} />
+    );
+  },
+);
+
+MainWindowStateInjector.displayName = "MainWindow";
 
 export default withServiceManager(MainWindowStateInjector);

--- a/packages/ai-chat/src/chat/components-legacy/panels/BodyAndFooterPanelComponent.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/panels/BodyAndFooterPanelComponent.tsx
@@ -8,7 +8,14 @@
  */
 
 import cx from "classnames";
-import React, { forwardRef, Ref, useRef } from "react";
+import React, {
+  forwardRef,
+  memo,
+  ReactNode,
+  Ref,
+  useImperativeHandle,
+  useRef,
+} from "react";
 import { useSelector } from "../../hooks/useSelector";
 
 import { useLanguagePack } from "../../hooks/useLanguagePack";
@@ -109,7 +116,7 @@ interface BodyAndFooterPanelComponentProps
   /**
    * Function to render message components
    */
-  renderMessageComponent: (props: MessageTypeComponentProps) => React.ReactNode;
+  renderMessageComponent: (props: MessageTypeComponentProps) => ReactNode;
 
   /**
    * Controls whether to show the AI label in the header. When undefined, falls back to global config.
@@ -166,7 +173,7 @@ function BodyAndFooterPanelComponent(
   const basePanelRef = useRef<HasRequestFocus>(null);
 
   // Expose the BasePanelComponent's requestFocus method through the forwarded ref
-  React.useImperativeHandle(ref, () => ({
+  useImperativeHandle(ref, () => ({
     requestFocus: () => {
       if (basePanelRef.current) {
         return basePanelRef.current.requestFocus();
@@ -217,7 +224,7 @@ function BodyAndFooterPanelComponent(
   );
 }
 
-const BodyAndFooterPanelComponentExport = React.memo(
+const BodyAndFooterPanelComponentExport = memo(
   forwardRef(BodyAndFooterPanelComponent),
 );
 

--- a/packages/ai-chat/src/chat/components-legacy/panels/CustomPanel.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/panels/CustomPanel.tsx
@@ -7,7 +7,15 @@
  *  @license
  */
 
-import React, { forwardRef, Ref, useCallback, useEffect, useRef } from "react";
+import React, {
+  forwardRef,
+  memo,
+  Ref,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useRef,
+} from "react";
 import { useSelector } from "../../hooks/useSelector";
 
 import { BusEventType } from "../../../types/events/eventBusTypes";
@@ -106,7 +114,7 @@ function CustomPanel(props: CustomPanelProps, ref: Ref<HasRequestFocus>) {
   }, [ariaAnnouncer, hidePanelHeader, isOpen, prevIsOpen, title]);
 
   // Expose the BasePanelComponent's requestFocus method through the forwarded ref
-  React.useImperativeHandle(ref, () => ({
+  useImperativeHandle(ref, () => ({
     requestFocus: () => {
       if (basePanelRef.current) {
         return basePanelRef.current.requestFocus();
@@ -212,6 +220,6 @@ function checkAllowClose(viewChanging: boolean) {
   }
 }
 
-const CustomPanelExport = React.memo(forwardRef(CustomPanel));
+const CustomPanelExport = memo(forwardRef(CustomPanel));
 
 export { CustomPanelExport as CustomPanel };

--- a/packages/ai-chat/src/chat/components-legacy/responseTypes/audio/AudioComponent.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/responseTypes/audio/AudioComponent.tsx
@@ -7,7 +7,7 @@
  *  @license
  */
 
-import React from "react";
+import React, { memo } from "react";
 
 import { MediaPlayer, MediaPlayerContentConfig } from "../util/MediaPlayer";
 import { MessageResponseTypes } from "../../../../types/messaging/Messages";
@@ -34,6 +34,6 @@ function AudioComponent({ source, ...props }: AudioComponentProps) {
   );
 }
 
-const AudioComponentExport = React.memo(AudioComponent);
+const AudioComponentExport = memo(AudioComponent);
 
 export { AudioComponentConfig, AudioComponentExport as AudioComponent };

--- a/packages/ai-chat/src/chat/components-legacy/responseTypes/card/CardItemComponent.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/responseTypes/card/CardItemComponent.tsx
@@ -9,7 +9,7 @@
 
 import Tile from "../../../components/carbon/Tile";
 import cx from "classnames";
-import React from "react";
+import React, { memo, ReactNode } from "react";
 
 import { HasRequestFocus } from "../../../../types/utilities/HasRequestFocus";
 import { LocalMessageItem } from "../../../../types/messaging/LocalMessageItem";
@@ -38,7 +38,7 @@ interface CardItemComponentProps extends HasRequestFocus {
   /**
    * Function to render message components
    */
-  renderMessageComponent: (props: MessageTypeComponentProps) => React.ReactNode;
+  renderMessageComponent: (props: MessageTypeComponentProps) => ReactNode;
 }
 
 /**
@@ -67,6 +67,6 @@ function CardItemComponent(props: CardItemComponentProps) {
   );
 }
 
-const CardComponentExport = React.memo(CardItemComponent);
+const CardComponentExport = memo(CardItemComponent);
 
 export { CardComponentExport as CardItemComponent };

--- a/packages/ai-chat/src/chat/components-legacy/responseTypes/carousel/Carousel.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/responseTypes/carousel/Carousel.tsx
@@ -19,6 +19,8 @@ import React, {
   ReactElement,
   useState,
   Suspense,
+  lazy,
+  Children,
 } from "react";
 import { useIntl } from "react-intl";
 import { useSelector } from "../../../hooks/useSelector";
@@ -43,7 +45,7 @@ interface SwiperCarouselProps {
 }
 
 // Create a component that uses lazy-loaded Swiper
-const SwiperCarousel = React.lazy(async () => {
+const SwiperCarousel = lazy(async () => {
   const [{ Swiper: SwiperComponent, SwiperSlide }, { A11y, Navigation }] =
     await Promise.all([import("swiper/react"), import("swiper/modules")]);
 
@@ -78,7 +80,7 @@ const SwiperCarousel = React.lazy(async () => {
         slidesOffsetAfter={16}
         rewind
       >
-        {React.Children.map(children, (child) => (
+        {Children.map(children, (child) => (
           <SwiperSlide
             key={child.key}
             className={`cds-aichat--carousel-container__slide--${chatWidthBreakpoint}`}
@@ -140,7 +142,7 @@ function Carousel({
     onSlideChange?.(activeIndex);
   }
 
-  const totalSlideCount = React.Children.count(children);
+  const totalSlideCount = Children.count(children);
   const currentLabel = intl.formatMessage(
     { id: "components_swiper_currentLabel" },
     { currentSlideNumber, totalSlideCount },

--- a/packages/ai-chat/src/chat/components-legacy/responseTypes/carousel/CarouselItemComponent.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/responseTypes/carousel/CarouselItemComponent.tsx
@@ -7,7 +7,7 @@
  *  @license
  */
 
-import React, { Suspense } from "react";
+import React, { ReactNode, Suspense } from "react";
 import { useSelector } from "../../../hooks/useSelector";
 
 import { AppState } from "../../../../types/state/AppState";
@@ -34,7 +34,7 @@ interface CarouselItemComponentProps extends HasRequestFocus {
   /**
    * Function to render message components
    */
-  renderMessageComponent: (props: any) => React.ReactNode;
+  renderMessageComponent: (props: any) => ReactNode;
 }
 
 function CarouselItemComponent(props: CarouselItemComponentProps) {

--- a/packages/ai-chat/src/chat/components-legacy/responseTypes/conversationalSearch/ConversationalSearchText.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/responseTypes/conversationalSearch/ConversationalSearchText.tsx
@@ -10,7 +10,7 @@
 import ChevronDown16 from "@carbon/icons/es/chevron--down/16.js";
 import ChevronUp16 from "@carbon/icons/es/chevron--up/16.js";
 
-import React, { useEffect, useState } from "react";
+import React, { memo, useEffect, useState } from "react";
 
 import { LocalMessageItem } from "../../../../types/messaging/LocalMessageItem";
 import {
@@ -156,7 +156,7 @@ function insertHighlightMarkdown(
   return processedText;
 }
 
-const ConversationalSearchTextExport = React.memo(ConversationalSearchText);
+const ConversationalSearchTextExport = memo(ConversationalSearchText);
 
 export {
   ConversationalSearchTextExport as ConversationalSearchText,

--- a/packages/ai-chat/src/chat/components-legacy/responseTypes/custom/UserDefinedResponse.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/responseTypes/custom/UserDefinedResponse.tsx
@@ -14,7 +14,7 @@
  * service manager. This component attaches that host element in to the React tree.
  */
 
-import React from "react";
+import React, { memo } from "react";
 
 import { HasServiceManager } from "../../../hocs/withServiceManager";
 import { useCallbackOnChange } from "../../../hooks/useCallbackOnChange";
@@ -69,4 +69,4 @@ function UserDefinedResponse(props: UserDefinedResponseProps) {
   );
 }
 
-export default React.memo(UserDefinedResponse);
+export default memo(UserDefinedResponse);

--- a/packages/ai-chat/src/chat/components-legacy/responseTypes/datePicker/DatePickerComponent.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/responseTypes/datePicker/DatePickerComponent.tsx
@@ -17,7 +17,7 @@ import {
 import { DATE_PICKER_INPUT_KIND } from "@carbon/web-components/es/components/date-picker/defs.js";
 import dayjs from "dayjs";
 import { BaseOptions } from "flatpickr/dist/types/options";
-import React, { useCallback, useRef, useState } from "react";
+import React, { memo, useCallback, useRef, useState } from "react";
 import { useIntl } from "react-intl";
 import { useSelector } from "../../../hooks/useSelector";
 
@@ -281,6 +281,6 @@ function getFlatpickrDateFormat(format: string) {
   throw Error(`The provided format ${format} is invalid.`);
 }
 
-const DatePickerComponentExport = React.memo(DatePickerComponent);
+const DatePickerComponentExport = memo(DatePickerComponent);
 
 export { DatePickerComponentExport as DatePickerComponent };

--- a/packages/ai-chat/src/chat/components-legacy/responseTypes/grid/GridItemCell.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/responseTypes/grid/GridItemCell.tsx
@@ -7,7 +7,7 @@
  *  @license
  */
 
-import React, { useLayoutEffect, useRef } from "react";
+import React, { Fragment, ReactNode, useLayoutEffect, useRef } from "react";
 import { useSelector } from "../../../hooks/useSelector";
 import { useLanguagePack } from "../../../hooks/useLanguagePack";
 import { useServiceManager } from "../../../hooks/useServiceManager";
@@ -46,7 +46,7 @@ function GridItemCell({
   isPixelValue: boolean | string;
   localMessageItem: LocalMessageItem<GridItem>;
   originalMessage: MessageResponse;
-  renderMessageComponent: (props: MessageTypeComponentProps) => React.ReactNode;
+  renderMessageComponent: (props: MessageTypeComponentProps) => ReactNode;
   rowIndex: number;
 }) {
   const serviceManager = useServiceManager();
@@ -95,7 +95,7 @@ function GridItemCell({
       {cell.map((localMessageItemID, itemIndex) => {
         const message = allMessageItemsByID[localMessageItemID];
         return (
-          <React.Fragment key={`item-${rowIndex}-${columnIndex}-${itemIndex}`}>
+          <Fragment key={`item-${rowIndex}-${columnIndex}-${itemIndex}`}>
             {renderMessageComponent({
               message,
               originalMessage,
@@ -111,7 +111,7 @@ function GridItemCell({
               allowNewFeedback: false,
               showChainOfThought: false,
             })}
-          </React.Fragment>
+          </Fragment>
         );
       })}
     </div>

--- a/packages/ai-chat/src/chat/components-legacy/responseTypes/grid/GridItemComponent.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/responseTypes/grid/GridItemComponent.tsx
@@ -8,7 +8,7 @@
  */
 
 import cx from "classnames";
-import React from "react";
+import React, { memo, ReactNode } from "react";
 import { LocalMessageItem } from "../../../../types/messaging/LocalMessageItem";
 import {
   GridItem,
@@ -33,7 +33,7 @@ function GridItemComponent({
 }: {
   localMessageItem: LocalMessageItem<GridItem>;
   originalMessage: MessageResponse;
-  renderMessageComponent: (props: MessageTypeComponentProps) => React.ReactNode;
+  renderMessageComponent: (props: MessageTypeComponentProps) => ReactNode;
 }) {
   const { columns, max_width } = localMessageItem.item;
 
@@ -84,6 +84,6 @@ function GridItemComponent({
   );
 }
 
-const GridItemComponentExport = React.memo(GridItemComponent);
+const GridItemComponentExport = memo(GridItemComponent);
 
 export { GridItemComponentExport as GridItemComponent };

--- a/packages/ai-chat/src/chat/components-legacy/responseTypes/humanAgent/RealConnectToHumanAgent.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/responseTypes/humanAgent/RealConnectToHumanAgent.tsx
@@ -133,11 +133,11 @@ function RealConnectToHumanAgent(props: RealConnectToHumanAgentProps) {
     languagePack.default_agent_availableMessage;
 
   let ButtonIcon: (props: any) => ReactNode | Promise<ReactNode>; // CarbonIconType is not exported, currently.
-  // let ButtonIcon: React.FC<CarbonIconProps>;
+  // let ButtonIcon: FC<CarbonIconProps>;
   let buttonText: string;
   let showDisabled: boolean =
     disableUserInputs || agentDisplayState.isConnectingOrConnected;
-  let messageToUser: React.ReactNode = textFromMessage;
+  let messageToUser: ReactNode = textFromMessage;
 
   if (localMessage.ui_state.id === activeLocalMessageID) {
     // This card is the active card in a chat that has been started.

--- a/packages/ai-chat/src/chat/components-legacy/responseTypes/iframe/IFramePanel.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/responseTypes/iframe/IFramePanel.tsx
@@ -7,7 +7,7 @@
  *  @license
  */
 
-import React, { forwardRef, Ref } from "react";
+import React, { forwardRef, memo, Ref } from "react";
 import { useSelector } from "../../../hooks/useSelector";
 
 import { useLanguagePack } from "../../../hooks/useLanguagePack";
@@ -68,7 +68,7 @@ function IFramePanelComponent(
   );
 }
 
-const IFramePanelExport = React.memo(forwardRef(IFramePanelComponent));
+const IFramePanelExport = memo(forwardRef(IFramePanelComponent));
 
 export { IFramePanelExport as IFramePanel };
 

--- a/packages/ai-chat/src/chat/components-legacy/responseTypes/iframe/IFramePreviewCard.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/responseTypes/iframe/IFramePreviewCard.tsx
@@ -9,7 +9,7 @@
 
 import ArrowRight16 from "@carbon/icons/es/arrow--right/16.js";
 import { carbonIconToReact } from "../../../utils/carbonIcon";
-import React from "react";
+import React, { memo } from "react";
 import { useIntl } from "react-intl";
 import { useSelector } from "../../../hooks/useSelector";
 
@@ -89,6 +89,6 @@ function IFramePreviewCardComponent({
   );
 }
 
-const IFramePreviewCardExport = React.memo(IFramePreviewCardComponent);
+const IFramePreviewCardExport = memo(IFramePreviewCardComponent);
 
 export { IFramePreviewCardExport as IFramePreviewCard };

--- a/packages/ai-chat/src/chat/components-legacy/responseTypes/image/Image.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/responseTypes/image/Image.tsx
@@ -11,7 +11,16 @@ import Tile from "../../../components/carbon/Tile";
 import cx from "classnames";
 import AISkeletonPlaceholder from "../../../components/carbon/AISkeletonPlaceholder";
 import SkeletonPlaceholder from "../../../components/carbon/SkeletonPlaceholder";
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import React, {
+  Dispatch,
+  ElementType,
+  memo,
+  SetStateAction,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 
 import { useAriaAnnouncer } from "../../../hooks/useAriaAnnouncer";
 import { HasClassName } from "../../../../types/utilities/HasClassName";
@@ -41,7 +50,7 @@ interface ImageProps extends HasNeedsAnnouncement, HasClassName {
   /**
    * The svg icon to render in the button.
    */
-  renderIcon?: React.ElementType;
+  renderIcon?: ElementType;
 
   /**
    * This will prevent the inline error from rendering when the image fails to load. This only works if there is
@@ -155,8 +164,8 @@ function Image(props: ImageProps) {
 interface ImageOnlyProps extends Partial<ImageProps> {
   isLoaded: boolean;
   isError: boolean;
-  setIsLoaded: React.Dispatch<React.SetStateAction<boolean>>;
-  setIsError: React.Dispatch<React.SetStateAction<boolean>>;
+  setIsLoaded: Dispatch<SetStateAction<boolean>>;
+  setIsError: Dispatch<SetStateAction<boolean>>;
 }
 
 function ImageOnly({
@@ -233,6 +242,6 @@ function ImageOnly({
   );
 }
 
-const ImageExport = React.memo(Image);
+const ImageExport = memo(Image);
 
 export { ImageProps, ImageExport as Image };

--- a/packages/ai-chat/src/chat/components-legacy/responseTypes/options/SelectComponent.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/responseTypes/options/SelectComponent.tsx
@@ -9,7 +9,7 @@
 
 import { Dropdown, DropdownItem } from "../../../components/carbon/Dropdown";
 import cx from "classnames";
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useRef, useState, KeyboardEvent } from "react";
 
 import { HasServiceManager } from "../../../hocs/withServiceManager";
 import { useCounter } from "../../../hooks/useCounter";
@@ -79,7 +79,7 @@ function SelectComponent(props: SelectProps) {
     });
   };
 
-  const handleKeyDown = (e: React.KeyboardEvent) => {
+  const handleKeyDown = (e: KeyboardEvent) => {
     if (e.key === "ArrowUp" || e.key === "ArrowDown") {
       e.preventDefault();
     }

--- a/packages/ai-chat/src/chat/components-legacy/responseTypes/table/TableContainer.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/responseTypes/table/TableContainer.tsx
@@ -7,7 +7,7 @@
  *  @license
  */
 
-import React, { Suspense, useMemo } from "react";
+import React, { memo, Suspense, useMemo } from "react";
 import { useIntl } from "react-intl";
 import { useSelector } from "../../../hooks/useSelector";
 
@@ -104,5 +104,5 @@ function TableContainer(props: TableContainerProps) {
   );
 }
 
-const TableContainerExport = React.memo(TableContainer);
+const TableContainerExport = memo(TableContainer);
 export default TableContainerExport;

--- a/packages/ai-chat/src/chat/components-legacy/responseTypes/text/TextArea.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/responseTypes/text/TextArea.tsx
@@ -22,6 +22,8 @@
 import cx from "classnames";
 import React, {
   ChangeEvent,
+  createRef,
+  Fragment,
   KeyboardEventHandler,
   PureComponent,
   ReactEventHandler,
@@ -130,14 +132,13 @@ class TextArea extends PureComponent<TextAreaProps> {
   /**
    * A React ref to the TextArea component.
    */
-  private textAreaRef: RefObject<HTMLTextAreaElement | null> =
-    React.createRef();
+  private textAreaRef: RefObject<HTMLTextAreaElement | null> = createRef();
 
   /**
    * A React ref to the sizer component.
    * Used to calculate the required height for the textarea content and determine when scrolling is needed.
    */
-  private sizerRef: RefObject<HTMLDivElement | null> = React.createRef();
+  private sizerRef: RefObject<HTMLDivElement | null> = createRef();
 
   /**
    * Returns the HTML element.
@@ -272,10 +273,10 @@ class TextArea extends PureComponent<TextAreaProps> {
             {(value || placeholder || " ")
               .split("\n")
               .map((line, index, array) => (
-                <React.Fragment key={index}>
+                <Fragment key={index}>
                   {line || "\u00A0"}
                   {index < array.length - 1 && <br />}
-                </React.Fragment>
+                </Fragment>
               ))}
           </div>
         )}

--- a/packages/ai-chat/src/chat/components-legacy/responseTypes/util/BodyMessageComponents.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/responseTypes/util/BodyMessageComponents.tsx
@@ -8,7 +8,7 @@
  */
 
 import cx from "classnames";
-import React from "react";
+import React, { memo, ReactNode } from "react";
 import { useSelector } from "../../../hooks/useSelector";
 
 import { AppState } from "../../../../types/state/AppState";
@@ -21,7 +21,7 @@ interface BodyMessageComponentsProps extends MessageTypeComponentProps {
       message: any;
       isNestedMessageItem: boolean;
     },
-  ) => React.ReactNode;
+  ) => ReactNode;
 }
 
 /**
@@ -102,6 +102,6 @@ function isFullWidthResponseType(responseType: string) {
   }
 }
 
-const BodyMessageTypeComponentsExport = React.memo(BodyMessageComponents);
+const BodyMessageTypeComponentsExport = memo(BodyMessageComponents);
 
 export { BodyMessageTypeComponentsExport as BodyMessageComponents };

--- a/packages/ai-chat/src/chat/components-legacy/responseTypes/util/FooterButtonComponents.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/responseTypes/util/FooterButtonComponents.tsx
@@ -8,7 +8,7 @@
  */
 
 import cx from "classnames";
-import React from "react";
+import React, { Fragment, ReactNode } from "react";
 import { useSelector } from "../../../hooks/useSelector";
 
 import { AppState } from "../../../../types/state/AppState";
@@ -19,7 +19,7 @@ interface FooterButtonComponentsProps extends MessageTypeComponentProps {
     props: MessageTypeComponentProps & {
       isNestedMessageItem: boolean;
     },
-  ) => React.ReactNode;
+  ) => ReactNode;
 }
 
 /**
@@ -34,13 +34,13 @@ function FooterButtonComponents(props: FooterButtonComponentsProps) {
     props.message.ui_state.footerLocalMessageItemIDs?.map((nestedMessageID) => {
       const nestedLocalMessage = allMessageItemsByID[nestedMessageID];
       return (
-        <React.Fragment key={nestedMessageID}>
+        <Fragment key={nestedMessageID}>
           {props.renderMessageComponent({
             ...props,
             message: nestedLocalMessage,
             isNestedMessageItem: true,
           })}
-        </React.Fragment>
+        </Fragment>
       );
     });
   const totalButtons = buttonComponents?.length ?? 0;

--- a/packages/ai-chat/src/chat/components-legacy/responseTypes/util/MediaPlayer.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/responseTypes/util/MediaPlayer.tsx
@@ -12,6 +12,9 @@ import { carbonIconToReact } from "../../../utils/carbonIcon";
 import Tile from "../../../components/carbon/Tile";
 import cx from "classnames";
 import React, {
+  lazy,
+  LazyExoticComponent,
+  memo,
   Suspense,
   useCallback,
   useEffect,
@@ -37,7 +40,7 @@ import type ReactPlayer from "react-player";
 
 // https://reactjs.org/docs/code-splitting.html#reactlazy
 // Special handling for react-player due to CJS/ESM confusion
-const ReactPlayerComponent = React.lazy(() =>
+const ReactPlayerComponent = lazy(() =>
   import("react-player/lazy/index.js").then((mod: any) => {
     // react-player 2.x is old and is confused in their cjs vs mjs usage.
     // mod might be:
@@ -50,7 +53,7 @@ const ReactPlayerComponent = React.lazy(() =>
     }
     return { default: exported };
   }),
-) as React.LazyExoticComponent<typeof ReactPlayer>;
+) as LazyExoticComponent<typeof ReactPlayer>;
 
 /**
  * The parent interface for the different media player types (audio, video) which holds the common properties between
@@ -311,6 +314,6 @@ function MediaPlayerComponent({
   );
 }
 
-const MediaPlayerExport = React.memo(MediaPlayerComponent);
+const MediaPlayerExport = memo(MediaPlayerComponent);
 
 export { MediaPlayerContentConfig, MediaPlayerExport as MediaPlayer };

--- a/packages/ai-chat/src/chat/components-legacy/responseTypes/util/RichText.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/responseTypes/util/RichText.tsx
@@ -7,7 +7,7 @@
  *  @license
  */
 
-import React, { useMemo } from "react";
+import React, { memo, useMemo } from "react";
 import { useIntl } from "react-intl";
 import { useSelector } from "../../../hooks/useSelector";
 
@@ -147,7 +147,7 @@ function RichText(props: RichTextProps) {
   );
 }
 
-const RichTextExport = React.memo(RichText, (prevProps, nextProps) => {
+const RichTextExport = memo(RichText, (prevProps, nextProps) => {
   // Custom comparison to prevent re-render when only streaming changes but content is the same
   const textEqual = prevProps.text === nextProps.text;
   const htmlConversionEqual =

--- a/packages/ai-chat/src/chat/components-legacy/responseTypes/util/SearchResultBody.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/responseTypes/util/SearchResultBody.tsx
@@ -7,7 +7,7 @@
  *  @license
  */
 
-import React from "react";
+import React, { JSX, memo } from "react";
 
 import {
   convertPossibleStringifiedArrayToFirstString,
@@ -33,7 +33,7 @@ function SearchResultBodyWithCitationHighlighted({
   relatedSearchResult,
   citationItem,
 }: SearchResultBodyWithCitationProps) {
-  const elementsArray: React.JSX.Element[] = [];
+  const elementsArray: JSX.Element[] = [];
   let searchString;
   let citationString;
 
@@ -94,7 +94,7 @@ function SearchResultBodyWithCitationHighlighted({
   return [<span key="citation-string">{citationString}</span>];
 }
 
-const SearchResultBodyWithCitationHighlightedExport = React.memo(
+const SearchResultBodyWithCitationHighlightedExport = memo(
   SearchResultBodyWithCitationHighlighted,
 );
 

--- a/packages/ai-chat/src/chat/components-legacy/responseTypes/util/citations/CitationCard.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/responseTypes/util/citations/CitationCard.tsx
@@ -9,7 +9,7 @@
 
 import Tile from "../../../../components/carbon/Tile";
 import cx from "classnames";
-import React from "react";
+import React, { memo } from "react";
 import { CitationCardContent, CitationType } from "./CitationCardContent";
 import { ExpandToPanelCard } from "./ExpandToPanelCard";
 import {
@@ -83,6 +83,6 @@ function CitationCard({
   );
 }
 
-const CitationCardExport = React.memo(CitationCard);
+const CitationCardExport = memo(CitationCard);
 
 export { CitationCardExport as CitationCard };

--- a/packages/ai-chat/src/chat/components-legacy/responseTypes/util/citations/CitationCardContent.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/responseTypes/util/citations/CitationCardContent.tsx
@@ -10,7 +10,12 @@
 import Link16 from "@carbon/icons/es/link/16.js";
 import Maximize16 from "@carbon/icons/es/maximize/16.js";
 import { carbonIconToReact } from "../../../../utils/carbonIcon";
-import React, { useLayoutEffect, useRef } from "react";
+import React, {
+  Dispatch,
+  SetStateAction,
+  useLayoutEffect,
+  useRef,
+} from "react";
 
 import { useLanguagePack } from "../../../../hooks/useLanguagePack";
 import { useWindowSize } from "../../../../hooks/useWindowSize";
@@ -77,7 +82,7 @@ interface CitationCardContentProps
    * If the citation type is EXPAND_IF_NEEDED this is defined and is used to tell the parent component if it should render
    * this content inside a clickable tile or a non-clickable tile after it has measured itself.
    */
-  setIsExpandable?: React.Dispatch<React.SetStateAction<boolean>>;
+  setIsExpandable?: Dispatch<SetStateAction<boolean>>;
 }
 
 function CitationCardContent({

--- a/packages/ai-chat/src/chat/components-legacy/responseTypes/video/VideoComponent.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/responseTypes/video/VideoComponent.tsx
@@ -7,7 +7,7 @@
  *  @license
  */
 
-import React from "react";
+import React, { memo } from "react";
 
 import { HasBaseHeight } from "../../../../types/utilities/HasBaseHeight";
 import { MediaPlayer, MediaPlayerContentConfig } from "../util/MediaPlayer";
@@ -21,6 +21,6 @@ function VideoComponent({ ...props }: VideoComponentProps) {
   return <MediaPlayer type={MessageResponseTypes.VIDEO} {...props} />;
 }
 
-const VideoComponentExport = React.memo(VideoComponent);
+const VideoComponentExport = memo(VideoComponent);
 
 export { VideoComponentConfig, VideoComponentExport as VideoComponent };

--- a/packages/ai-chat/src/chat/components-legacy/util/IconHolder.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/util/IconHolder.tsx
@@ -7,10 +7,10 @@
  *  @license
  */
 
-import React from "react";
+import React, { ReactNode } from "react";
 
 interface IconCircleProps {
-  icon: React.ReactNode;
+  icon: ReactNode;
 }
 
 function IconHolder(props: IconCircleProps) {

--- a/packages/ai-chat/src/chat/components-legacy/util/ImageWithFallback.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/util/ImageWithFallback.tsx
@@ -7,7 +7,7 @@
  *  @license
  */
 
-import React, { useEffect, useState } from "react";
+import React, { ReactNode, useEffect, useState } from "react";
 
 interface ImageWithFallbackProps {
   /**
@@ -23,7 +23,7 @@ interface ImageWithFallbackProps {
   /**
    * The render prop to call when the image fails to load.
    */
-  fallback: React.ReactNode;
+  fallback: ReactNode;
 }
 
 function ImageWithFallback(props: ImageWithFallbackProps) {

--- a/packages/ai-chat/src/chat/components-legacy/util/VisuallyHidden.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/util/VisuallyHidden.tsx
@@ -12,13 +12,10 @@
  * that the item is present in the DOM and is visible to screen readers but it is not visible to sighted users.
  */
 
-import React from "react";
+import React, { forwardRef, HTMLAttributes, Ref } from "react";
 
-const VisuallyHidden = React.forwardRef(
-  (
-    props: React.HTMLAttributes<HTMLDivElement>,
-    ref: React.Ref<HTMLDivElement>,
-  ) => {
+const VisuallyHidden = forwardRef(
+  (props: HTMLAttributes<HTMLDivElement>, ref: Ref<HTMLDivElement>) => {
     return (
       <div
         ref={ref}

--- a/packages/ai-chat/src/chat/components/carbon/InlineNotification.tsx
+++ b/packages/ai-chat/src/chat/components/carbon/InlineNotification.tsx
@@ -8,7 +8,7 @@
  */
 
 import { createComponent } from "@lit/react";
-import React from "react";
+import React, { ForwardRefExoticComponent, HTMLAttributes } from "react";
 
 // Export the actual class for the component that will *directly* be wrapped with React.
 import CarbonInlineNotificationElement from "@carbon/web-components/es/components/notification/inline-notification.js";
@@ -17,8 +17,8 @@ const InlineNotification = createComponent({
   tagName: "cds-inline-notification",
   elementClass: CarbonInlineNotificationElement,
   react: React,
-}) as React.ForwardRefExoticComponent<
-  React.HTMLAttributes<HTMLElement> & {
+}) as ForwardRefExoticComponent<
+  HTMLAttributes<HTMLElement> & {
     kind?: string;
     lowContrast?: boolean;
     hideCloseButton?: boolean;

--- a/packages/ai-chat/src/chat/contexts/AriaAnnouncerContext.ts
+++ b/packages/ai-chat/src/chat/contexts/AriaAnnouncerContext.ts
@@ -7,7 +7,7 @@
  *  @license
  */
 
-import React from "react";
+import { createContext } from "react";
 
 import { AnnounceMessage } from "../../types/state/AppState";
 
@@ -25,7 +25,6 @@ type AriaAnnouncerFunctionType = (
   value: Node | AnnounceMessage | string,
 ) => void;
 
-const AriaAnnouncerContext =
-  React.createContext<AriaAnnouncerFunctionType>(null);
+const AriaAnnouncerContext = createContext<AriaAnnouncerFunctionType>(null);
 
 export { AriaAnnouncerContext, AriaAnnouncerFunctionType };

--- a/packages/ai-chat/src/chat/contexts/HideComponentContext.tsx
+++ b/packages/ai-chat/src/chat/contexts/HideComponentContext.tsx
@@ -7,13 +7,13 @@
  *  @license
  */
 
-import React from "react";
+import { createContext } from "react";
 
 /**
  * This file contains the context used by the {@link HideComponent} which is used to indicate if the component is
  * hidden or not. The value in the context is a boolean that is true if the component is hidden.
  */
 
-const HideComponentContext = React.createContext<boolean>(false);
+const HideComponentContext = createContext<boolean>(false);
 
 export { HideComponentContext };

--- a/packages/ai-chat/src/chat/contexts/LanguagePackContext.tsx
+++ b/packages/ai-chat/src/chat/contexts/LanguagePackContext.tsx
@@ -7,7 +7,7 @@
  *  @license
  */
 
-import React from "react";
+import { createContext } from "react";
 import { LanguagePack } from "../../types/config/PublicConfig";
 
 /**
@@ -15,6 +15,6 @@ import { LanguagePack } from "../../types/config/PublicConfig";
  * {@link LanguagePack}.
  */
 
-const LanguagePackContext = React.createContext<LanguagePack>(null);
+const LanguagePackContext = createContext<LanguagePack>(null);
 
 export { LanguagePackContext };

--- a/packages/ai-chat/src/chat/contexts/ModalPortalRootContext.tsx
+++ b/packages/ai-chat/src/chat/contexts/ModalPortalRootContext.tsx
@@ -7,7 +7,7 @@
  *  @license
  */
 
-import React from "react";
+import { createContext } from "react";
 
 /**
  * This context provides access to the portal root element that acts as the host element for instances of
@@ -15,6 +15,6 @@ import React from "react";
  * functionality.
  */
 
-const ModalPortalRootContext = React.createContext<Element>(null);
+const ModalPortalRootContext = createContext<Element>(null);
 
 export { ModalPortalRootContext };

--- a/packages/ai-chat/src/chat/contexts/ServiceManagerContext.tsx
+++ b/packages/ai-chat/src/chat/contexts/ServiceManagerContext.tsx
@@ -7,7 +7,7 @@
  *  @license
  */
 
-import React from "react";
+import { createContext } from "react";
 
 import { ServiceManager } from "../services/ServiceManager";
 
@@ -16,6 +16,6 @@ import { ServiceManager } from "../services/ServiceManager";
  * {@link ServiceManager}.
  */
 
-const ServiceManagerContext = React.createContext<ServiceManager>(null);
+const ServiceManagerContext = createContext<ServiceManager>(null);
 
 export { ServiceManagerContext };

--- a/packages/ai-chat/src/chat/contexts/StoreContext.tsx
+++ b/packages/ai-chat/src/chat/contexts/StoreContext.tsx
@@ -18,12 +18,11 @@
  * - react-redux: https://github.com/reduxjs/react-redux (License: https://github.com/reduxjs/react-redux/blob/master/LICENSE.md)
  */
 
-import React from "react";
+import { createContext } from "react";
 import type { AppStore, UnknownAction } from "../store/appStore";
 
-const StoreContext = React.createContext<AppStore<
-  unknown,
-  UnknownAction
-> | null>(null);
+const StoreContext = createContext<AppStore<unknown, UnknownAction> | null>(
+  null,
+);
 
 export { StoreContext };

--- a/packages/ai-chat/src/chat/contexts/WindowSizeContext.tsx
+++ b/packages/ai-chat/src/chat/contexts/WindowSizeContext.tsx
@@ -7,7 +7,7 @@
  *  @license
  */
 
-import React from "react";
+import { createContext } from "react";
 
 import { Dimension } from "../../types/utilities/Dimension";
 
@@ -15,6 +15,6 @@ import { Dimension } from "../../types/utilities/Dimension";
  * This context provides access to the current window size and is updated as the window size changes.
  */
 
-const WindowSizeContext = React.createContext<Dimension>(null);
+const WindowSizeContext = createContext<Dimension>(null);
 
 export { WindowSizeContext };

--- a/packages/ai-chat/src/chat/hocs/withAriaAnnouncer.tsx
+++ b/packages/ai-chat/src/chat/hocs/withAriaAnnouncer.tsx
@@ -11,7 +11,7 @@
  * This is a high order component that will inject a {@link AriaAnnouncerFunctionType} in to a component.
  */
 
-import React, { useContext } from "react";
+import React, { ComponentType, forwardRef, useContext } from "react";
 
 import {
   AriaAnnouncerContext,
@@ -29,14 +29,14 @@ interface HasAriaAnnouncer {
 }
 
 function withAriaAnnouncer<P extends HasAriaAnnouncer>(
-  Component: React.ComponentType<P>,
+  Component: ComponentType<P>,
 ) {
   // Drop the injected prop from the outer API
   type OuterProps = Omit<P, "ariaAnnouncer">;
 
   // Tell forwardRef: “I forward a ref of type unknown,
   // and I expect props = OuterProps”
-  const Wrapped = React.forwardRef<unknown, OuterProps>((props, ref) => {
+  const Wrapped = forwardRef<unknown, OuterProps>((props, ref) => {
     const ariaAnnouncer = useContext(AriaAnnouncerContext);
     return (
       <Component

--- a/packages/ai-chat/src/chat/hocs/withServiceManager.tsx
+++ b/packages/ai-chat/src/chat/hocs/withServiceManager.tsx
@@ -11,7 +11,7 @@
  * This is a high order component that will inject a {@link ServiceManager} in to a component.
  */
 
-import React, { useContext } from "react";
+import React, { ComponentType, forwardRef, useContext } from "react";
 
 import { ServiceManagerContext } from "../contexts/ServiceManagerContext";
 import { ServiceManager } from "../services/ServiceManager";
@@ -27,13 +27,13 @@ interface HasServiceManager {
 }
 
 function withServiceManager<P extends HasServiceManager>(
-  Component: React.ComponentType<P>,
+  Component: ComponentType<P>,
 ) {
   // 1. OuterProps = everything in P except serviceManager
   type OuterProps = Omit<P, "serviceManager">;
 
   // 2. Tell forwardRef what ref type (here unknown) and what props (OuterProps) look like
-  const Wrapped = React.forwardRef<unknown, OuterProps>((props, ref) => {
+  const Wrapped = forwardRef<unknown, OuterProps>((props, ref) => {
     const serviceManager = useContext(ServiceManagerContext);
     return (
       <Component

--- a/packages/ai-chat/src/chat/hooks/useSelector.tsx
+++ b/packages/ai-chat/src/chat/hooks/useSelector.tsx
@@ -14,17 +14,10 @@
  * For object/array outputs, pass `shallowEqual` or a custom comparator.
  */
 
-import React, { useCallback, useRef } from "react";
-import { useSyncExternalStore as useSyncExternalStoreShim } from "use-sync-external-store/shim";
+import { useCallback, useRef } from "react";
 import { useStore } from "./useStore";
 
-/** Choose the right `useSyncExternalStore` (React 17 uses the shim). */
-const useSyncExternalStore: typeof React.useSyncExternalStore =
-  (
-    React as unknown as {
-      useSyncExternalStore?: typeof React.useSyncExternalStore;
-    }
-  ).useSyncExternalStore ?? useSyncExternalStoreShim;
+import { useSyncExternalStore } from "use-sync-external-store/shim";
 
 /**
  * Select a slice and subscribe to changes.

--- a/packages/ai-chat/src/chat/store/README.md
+++ b/packages/ai-chat/src/chat/store/README.md
@@ -19,6 +19,7 @@ const isLoading = useSelector((s: AppState) => s.botMessageState.isLoading);
 Dispatch actions:
 
 ```tsx
+import React, { forwardRef } from "react";
 import { useDispatch } from "../../hooks/useDispatch";
 import actions from "../store/actions";
 
@@ -29,13 +30,12 @@ dispatch(actions.addIsLoadingCounter(1));
 Class components: wrap with a functional injector and pass props.
 
 ```tsx
-const MainWindowStateInjector = React.forwardRef<
-  MainWindow,
-  MainWindowOwnProps
->((props, ref) => {
-  const state = useSelector<AppState, AppState>((s) => s);
-  return <MainWindow {...props} {...state} ref={ref} />;
-});
+const MainWindowStateInjector = forwardRef<MainWindow, MainWindowOwnProps>(
+  (props, ref) => {
+    const state = useSelector<AppState, AppState>((s) => s);
+    return <MainWindow {...props} {...state} ref={ref} />;
+  },
+);
 ```
 
 ## References (MIT)

--- a/packages/ai-chat/src/chat/utils/carbonIcon.ts
+++ b/packages/ai-chat/src/chat/utils/carbonIcon.ts
@@ -11,7 +11,7 @@
  * Creates a React component from a Carbon icon object
  */
 
-import { createElement, FunctionComponent } from "react";
+import { createElement, FunctionComponent, SVGProps } from "react";
 
 type CarbonIcon = {
   elem: "svg";
@@ -28,7 +28,7 @@ type CarbonIcon = {
   }>;
 };
 
-export type CarbonIconProps = React.SVGProps<SVGSVGElement> & {
+export type CarbonIconProps = SVGProps<SVGSVGElement> & {
   slot?: string;
   [key: string]: unknown;
 };

--- a/packages/ai-chat/src/chat/utils/chatBoot.ts
+++ b/packages/ai-chat/src/chat/utils/chatBoot.ts
@@ -8,7 +8,6 @@
  */
 
 import dayjs from "dayjs";
-import type React from "react";
 import LocalizedFormat from "dayjs/plugin/localizedFormat.js";
 import merge from "lodash-es/merge.js";
 import isEqual from "lodash-es/isEqual.js";
@@ -31,6 +30,7 @@ import {
 import { VIEW_STATE_ALL_CLOSED } from "../store/reducerUtils";
 import { PublicConfig } from "../../types/config/PublicConfig";
 import { ChatInstance } from "../../types/instance/ChatInstance";
+import { Dispatch, SetStateAction } from "react";
 
 /**
  * Default values applied to the provided `PublicConfig` before boot. This keeps
@@ -160,8 +160,8 @@ export async function performInitialViewChange(serviceManager: ServiceManager) {
  */
 export function attachUserDefinedResponseHandlers(
   webChatInstance: ChatInstance,
-  setBySlot: React.Dispatch<
-    React.SetStateAction<{
+  setBySlot: Dispatch<
+    SetStateAction<{
       [key: string]: {
         fullMessage?: any;
         messageItem?: any;

--- a/packages/ai-chat/src/react/ChatContainer.tsx
+++ b/packages/ai-chat/src/react/ChatContainer.tsx
@@ -10,6 +10,7 @@
 import { createComponent } from "@lit/react";
 import { css, LitElement, PropertyValues } from "lit";
 import React, {
+  memo,
   useCallback,
   useEffect,
   useMemo,
@@ -56,7 +57,7 @@ class ChatContainerReact extends LitElement {
 }
 
 // Wrap the custom element as a React component
-const ReactChatContainer = React.memo(
+const ReactChatContainer = memo(
   createComponent({
     tagName: "cds-aichat-react",
     elementClass: ChatContainerReact,

--- a/packages/ai-chat/src/types/utilities/HasChildren.d.ts
+++ b/packages/ai-chat/src/types/utilities/HasChildren.d.ts
@@ -7,7 +7,7 @@
  *  @license
  */
 
-import React from "react";
+import { ReactNode } from "react";
 
 /**
  * Represents an item that has an optional className.
@@ -17,7 +17,7 @@ interface HasChildren {
   /**
    * The class name to add to the component.
    */
-  children?: React.ReactNode;
+  children?: ReactNode;
 }
 
 export { HasChildren };


### PR DESCRIPTION
React was getting treeshaken away in preact builds. This PR adds an eslint rule that prevents us from doing:

```
import React from "react";

React.foo()
```

and instead forces

```
import { foo } from "react";

foo()
```

and then ran the `--fix` command that created 60000 changes.

Waiting to here from the user if a canary version with this change works before adding in PR.