### PR TITLE
chore: remove private field from components package

### DIFF
--- a/packages/ai-chat-components/package.json
+++ b/packages/ai-chat-components/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@carbon/ai-chat-components",
   "version": "0.2.1",
-  "private": true,
   "type": "module",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/ai-chat/package.json
+++ b/packages/ai-chat/package.json
@@ -8,7 +8,8 @@
   "module": "./dist/es/aiChatEntry.js",
   "types": "./dist/types/aiChatEntry.d.ts",
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "exports": {
     ".": {


### PR DESCRIPTION
This PR removes the `private` field from the `@carbon/ai-chat-components` package and sets `provenance` to true to the `@carbon/ai-chat` package. 