### PR TITLE
chore(release): v1.1.0-rc.0

### DIFF
--- a/.github/workflows/release-base.yml
+++ b/.github/workflows/release-base.yml
@@ -82,24 +82,24 @@ jobs:
       - name: Publish full minor release (ie. v1.x.0)
         if: github.event.inputs.type == 'full minor release'
         run: |
-          npx lerna publish minor --conventional-graduate --no-git-tag-version ${{ env.PUBLISH }} ${{ env.FORCE }}
+          npx lerna publish minor --conventional-graduate ${{ env.PUBLISH }} ${{ env.FORCE }}
 
       - name: Publish first minor RC (ie. v1.x.0-rc.0)
         if: github.event.inputs.type == 'first minor rc'
         run: |
-          npx lerna publish preminor --conventional-prerelease --no-git-tag-version --preid rc --pre-dist-tag next ${{ env.PUBLISH }} ${{ env.FORCE }}
+          npx lerna publish preminor --conventional-prerelease --preid rc --pre-dist-tag next ${{ env.PUBLISH }} ${{ env.FORCE }}
 
       - name: Publish full patch release (ie. v1.0.x)
         if: github.event.inputs.type == 'full patch release'
         run: |
-          npx lerna publish patch --conventional-graduate --no-git-tag-version ${{ env.PUBLISH }} ${{ env.FORCE }}
+          npx lerna publish patch --conventional-graduate ${{ env.PUBLISH }} ${{ env.FORCE }}
 
       - name: Publish first patch RC (ie. v1.0.x-rc.0)
         if: github.event.inputs.type == 'first patch rc'
         run: |
-          npx lerna publish prepatch --conventional-prerelease --no-git-tag-version --preid rc --pre-dist-tag next ${{ env.PUBLISH }} ${{ env.FORCE }}
+          npx lerna publish prepatch --conventional-prerelease --preid rc --pre-dist-tag next ${{ env.PUBLISH }} ${{ env.FORCE }}
 
       - name: Publish subsequent RC (ie. v1.0.0-rc.x)
         if: github.event.inputs.type == 'subsequent rc'
         run: |
-          npx lerna publish prerelease --conventional-prerelease --no-git-tag-version --preid rc --pre-dist-tag next ${{ env.PUBLISH }} ${{ env.FORCE }}
+          npx lerna publish prerelease --conventional-prerelease --preid rc --pre-dist-tag next ${{ env.PUBLISH }} ${{ env.FORCE }}

--- a/demo/package.json
+++ b/demo/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@carbon/ai-chat-examples-demo",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.1.0-rc.0",
   "type": "module",
   "description": "A demo and testing framework using @carbon/ai-chat as a React component.",
   "scripts": {
@@ -13,7 +13,7 @@
   "license": "Apache-2.0",
   "browserslist": "> 0.5%, last 2 versions, not dead",
   "dependencies": {
-    "@carbon/ai-chat": "^1.0.0",
+    "@carbon/ai-chat": "^1.1.0-rc.0",
     "@carbon/icons": "^11.53.0",
     "@carbon/react": "^1.68.0",
     "@carbon/web-components": "^2.40.1",

--- a/examples/react/basic/package.json
+++ b/examples/react/basic/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@carbon/ai-chat-examples-react-basic",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.1.0-rc.0",
   "type": "module",
   "description": "A basic example using @carbon/ai-chat as a React component.",
   "scripts": {
@@ -13,7 +13,7 @@
   "license": "Apache-2.0",
   "browserslist": "> 0.5%, last 2 versions, not dead",
   "dependencies": {
-    "@carbon/ai-chat": "^1.0.0",
+    "@carbon/ai-chat": "^1.1.0-rc.0",
     "@carbon/icons": "^11.53.0",
     "@carbon/web-components": "^2.40.1",
     "lit": "^3.1.0",

--- a/examples/react/custom-element/package.json
+++ b/examples/react/custom-element/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@carbon/ai-chat-examples-react-custom-element",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.1.0-rc.0",
   "type": "module",
   "description": "Example using ChatCustomElement for full-screen custom element integration.",
   "scripts": {
@@ -12,7 +12,7 @@
   "license": "Apache-2.0",
   "browserslist": "> 0.5%, last 2 versions, not dead",
   "dependencies": {
-    "@carbon/ai-chat": "^1.0.0",
+    "@carbon/ai-chat": "^1.1.0-rc.0",
     "@carbon/icons": "^11.53.0",
     "@carbon/react": "^1.68.0",
     "@carbon/web-components": "^2.40.1",

--- a/examples/react/history/package.json
+++ b/examples/react/history/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@carbon/ai-chat-examples-react-history",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.1.0-rc.0",
   "type": "module",
   "description": "Example showing message history loading with customLoadHistory.",
   "scripts": {
@@ -12,7 +12,7 @@
   "license": "Apache-2.0",
   "browserslist": "> 0.5%, last 2 versions, not dead",
   "dependencies": {
-    "@carbon/ai-chat": "^1.0.0",
+    "@carbon/ai-chat": "^1.1.0-rc.0",
     "@carbon/icons": "^11.53.0",
     "@carbon/react": "^1.68.0",
     "@carbon/web-components": "^2.40.1",

--- a/examples/react/watch-state/package.json
+++ b/examples/react/watch-state/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@carbon/ai-chat-examples-react-watch-state",
   "private": true,
-  "version": "0.2.1",
+  "version": "0.3.0-rc.0",
   "type": "module",
   "description": "An example showing how to watch ChatInstance state changes in a React application.",
   "scripts": {
@@ -12,7 +12,7 @@
   "license": "Apache-2.0",
   "browserslist": "> 0.5%, last 2 versions, not dead",
   "dependencies": {
-    "@carbon/ai-chat": "^1.0.0-rc.1",
+    "@carbon/ai-chat": "^1.1.0-rc.0",
     "@carbon/icons": "^11.53.0",
     "@carbon/web-components": "^2.39.1",
     "react": "^19.0.0",

--- a/examples/react/watsonx/package.json
+++ b/examples/react/watsonx/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@carbon/ai-chat-examples-react-watsonx",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.1.0-rc.0",
   "type": "module",
   "description": "A basic example using @carbon/ai-chat as a React component connected to watsonx.ai.",
   "scripts": {
@@ -14,7 +14,7 @@
   "license": "Apache-2.0",
   "browserslist": "> 0.5%, last 2 versions, not dead",
   "dependencies": {
-    "@carbon/ai-chat": "^1.0.0",
+    "@carbon/ai-chat": "^1.1.0-rc.0",
     "@carbon/icons": "^11.53.0",
     "@carbon/web-components": "^2.40.1",
     "@microsoft/fetch-event-source": "^2.0.1",

--- a/examples/web-components/basic/package.json
+++ b/examples/web-components/basic/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carbon/ai-chat-examples-web-components-basic",
-  "version": "1.0.0",
+  "version": "1.1.0-rc.0",
   "private": true,
   "type": "module",
   "description": "A basic example using @carbon/ai-chat as a web component.",
@@ -13,7 +13,7 @@
   "license": "Apache-2.0",
   "browserslist": "> 0.5%, last 2 versions, not dead",
   "dependencies": {
-    "@carbon/ai-chat": "^1.0.0",
+    "@carbon/ai-chat": "^1.1.0-rc.0",
     "@carbon/icons": "^11.53.0",
     "@carbon/web-components": "^2.40.1",
     "lit": "^3.1.0",

--- a/examples/web-components/custom-element/package.json
+++ b/examples/web-components/custom-element/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carbon/ai-chat-examples-web-components-custom-element",
-  "version": "1.0.0",
+  "version": "1.1.0-rc.0",
   "private": true,
   "type": "module",
   "description": "A basic example using @carbon/ai-chat as a web component.",
@@ -12,7 +12,7 @@
   "license": "Apache-2.0",
   "browserslist": "> 0.5%, last 2 versions, not dead",
   "dependencies": {
-    "@carbon/ai-chat": "^1.0.0",
+    "@carbon/ai-chat": "^1.1.0-rc.0",
     "@carbon/icons": "^11.53.0",
     "@carbon/react": "^1.68.0",
     "@carbon/web-components": "^2.40.1",

--- a/examples/web-components/history/package.json
+++ b/examples/web-components/history/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carbon/ai-chat-examples-web-components-history",
-  "version": "1.0.0",
+  "version": "1.1.0-rc.0",
   "private": true,
   "type": "module",
   "description": "Example showing message history loading with customLoadHistory.",
@@ -12,7 +12,7 @@
   "license": "Apache-2.0",
   "browserslist": "> 0.5%, last 2 versions, not dead",
   "dependencies": {
-    "@carbon/ai-chat": "^1.0.0",
+    "@carbon/ai-chat": "^1.1.0-rc.0",
     "@carbon/icons": "^11.53.0",
     "@carbon/react": "^1.68.0",
     "@carbon/web-components": "^2.40.1",

--- a/examples/web-components/watch-state/package.json
+++ b/examples/web-components/watch-state/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carbon/ai-chat-examples-web-components-watch-state",
-  "version": "0.2.1",
+  "version": "0.3.0-rc.0",
   "private": true,
   "type": "module",
   "description": "An example showing how to watch ChatInstance state changes as a web component.",
@@ -12,7 +12,7 @@
   "license": "Apache-2.0",
   "browserslist": "> 0.5%, last 2 versions, not dead",
   "dependencies": {
-    "@carbon/ai-chat": "^1.0.0-rc.1",
+    "@carbon/ai-chat": "^1.1.0-rc.0",
     "@carbon/icons": "^11.53.0",
     "@carbon/web-components": "^2.39.1",
     "react": "^19.0.0",

--- a/examples/web-components/watsonx/package.json
+++ b/examples/web-components/watsonx/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carbon/ai-chat-examples-web-components-watsonx",
-  "version": "1.0.0",
+  "version": "1.1.0-rc.0",
   "private": true,
   "type": "module",
   "description": "A basic example using @carbon/ai-chat as a web component connected to watsonx.ai.",
@@ -14,7 +14,7 @@
   "license": "Apache-2.0",
   "browserslist": "> 0.5%, last 2 versions, not dead",
   "dependencies": {
-    "@carbon/ai-chat": "^1.0.0",
+    "@carbon/ai-chat": "^1.1.0-rc.0",
     "@carbon/icons": "^11.53.0",
     "@carbon/web-components": "^2.40.1",
     "@microsoft/fetch-event-source": "^2.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,10 +57,10 @@
     },
     "demo": {
       "name": "@carbon/ai-chat-examples-demo",
-      "version": "1.0.0",
+      "version": "1.1.0-rc.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@carbon/ai-chat": "^1.0.0",
+        "@carbon/ai-chat": "^1.1.0-rc.0",
         "@carbon/icons": "^11.53.0",
         "@carbon/react": "^1.68.0",
         "@carbon/web-components": "^2.40.1",
@@ -158,10 +158,10 @@
     },
     "examples/react/basic": {
       "name": "@carbon/ai-chat-examples-react-basic",
-      "version": "1.0.0",
+      "version": "1.1.0-rc.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@carbon/ai-chat": "^1.0.0",
+        "@carbon/ai-chat": "^1.1.0-rc.0",
         "@carbon/icons": "^11.53.0",
         "@carbon/web-components": "^2.40.1",
         "lit": "^3.1.0",
@@ -189,10 +189,10 @@
     },
     "examples/react/custom-element": {
       "name": "@carbon/ai-chat-examples-react-custom-element",
-      "version": "1.0.0",
+      "version": "1.1.0-rc.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@carbon/ai-chat": "^1.0.0",
+        "@carbon/ai-chat": "^1.1.0-rc.0",
         "@carbon/icons": "^11.53.0",
         "@carbon/react": "^1.68.0",
         "@carbon/web-components": "^2.40.1",
@@ -220,10 +220,10 @@
     },
     "examples/react/history": {
       "name": "@carbon/ai-chat-examples-react-history",
-      "version": "1.0.0",
+      "version": "1.1.0-rc.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@carbon/ai-chat": "^1.0.0",
+        "@carbon/ai-chat": "^1.1.0-rc.0",
         "@carbon/icons": "^11.53.0",
         "@carbon/react": "^1.68.0",
         "@carbon/web-components": "^2.40.1",
@@ -251,10 +251,10 @@
     },
     "examples/react/watch-state": {
       "name": "@carbon/ai-chat-examples-react-watch-state",
-      "version": "0.2.1",
+      "version": "0.3.0-rc.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@carbon/ai-chat": "^1.0.0-rc.1",
+        "@carbon/ai-chat": "^1.1.0-rc.0",
         "@carbon/icons": "^11.53.0",
         "@carbon/web-components": "^2.39.1",
         "react": "^19.0.0",
@@ -279,10 +279,10 @@
     },
     "examples/react/watsonx": {
       "name": "@carbon/ai-chat-examples-react-watsonx",
-      "version": "1.0.0",
+      "version": "1.1.0-rc.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@carbon/ai-chat": "^1.0.0",
+        "@carbon/ai-chat": "^1.1.0-rc.0",
         "@carbon/icons": "^11.53.0",
         "@carbon/web-components": "^2.40.1",
         "@microsoft/fetch-event-source": "^2.0.1",
@@ -333,10 +333,10 @@
     },
     "examples/web-components/basic": {
       "name": "@carbon/ai-chat-examples-web-components-basic",
-      "version": "1.0.0",
+      "version": "1.1.0-rc.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@carbon/ai-chat": "^1.0.0",
+        "@carbon/ai-chat": "^1.1.0-rc.0",
         "@carbon/icons": "^11.53.0",
         "@carbon/web-components": "^2.40.1",
         "lit": "^3.1.0",
@@ -370,10 +370,10 @@
     },
     "examples/web-components/custom-element": {
       "name": "@carbon/ai-chat-examples-web-components-custom-element",
-      "version": "1.0.0",
+      "version": "1.1.0-rc.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@carbon/ai-chat": "^1.0.0",
+        "@carbon/ai-chat": "^1.1.0-rc.0",
         "@carbon/icons": "^11.53.0",
         "@carbon/react": "^1.68.0",
         "@carbon/web-components": "^2.40.1",
@@ -406,10 +406,10 @@
     },
     "examples/web-components/history": {
       "name": "@carbon/ai-chat-examples-web-components-history",
-      "version": "1.0.0",
+      "version": "1.1.0-rc.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@carbon/ai-chat": "^1.0.0",
+        "@carbon/ai-chat": "^1.1.0-rc.0",
         "@carbon/icons": "^11.53.0",
         "@carbon/react": "^1.68.0",
         "@carbon/web-components": "^2.40.1",
@@ -442,10 +442,10 @@
     },
     "examples/web-components/watch-state": {
       "name": "@carbon/ai-chat-examples-web-components-watch-state",
-      "version": "0.2.1",
+      "version": "0.3.0-rc.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@carbon/ai-chat": "^1.0.0-rc.1",
+        "@carbon/ai-chat": "^1.1.0-rc.0",
         "@carbon/icons": "^11.53.0",
         "@carbon/web-components": "^2.39.1",
         "react": "^19.0.0",
@@ -476,10 +476,10 @@
     },
     "examples/web-components/watsonx": {
       "name": "@carbon/ai-chat-examples-web-components-watsonx",
-      "version": "1.0.0",
+      "version": "1.1.0-rc.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@carbon/ai-chat": "^1.0.0",
+        "@carbon/ai-chat": "^1.1.0-rc.0",
         "@carbon/icons": "^11.53.0",
         "@carbon/web-components": "^2.40.1",
         "@microsoft/fetch-event-source": "^2.0.1",
@@ -38796,11 +38796,11 @@
     },
     "packages/ai-chat": {
       "name": "@carbon/ai-chat",
-      "version": "1.0.0",
+      "version": "1.1.0-rc.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@carbon/ai-chat-components": "^0.2.1",
+        "@carbon/ai-chat-components": "^0.3.0-rc.0",
         "@ibm/telemetry-js": "^1.10.2",
         "@lit/react": "^1.0.6",
         "classnames": "^2.5.0",
@@ -38879,7 +38879,7 @@
     },
     "packages/ai-chat-components": {
       "name": "@carbon/ai-chat-components",
-      "version": "0.2.1",
+      "version": "0.3.0-rc.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/packages/ai-chat-components/package.json
+++ b/packages/ai-chat-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carbon/ai-chat-components",
-  "version": "0.2.1",
+  "version": "0.3.0-rc.0",
   "type": "module",
   "license": "Apache-2.0",
   "repository": {

--- a/packages/ai-chat/package.json
+++ b/packages/ai-chat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@carbon/ai-chat",
-  "version": "1.0.0",
+  "version": "1.1.0-rc.0",
   "description": "Be sure to review the [chat documentation](https://chat.carbondesignsystem.com/tag/latest/docs/documents/Overview.html).",
   "author": "IBM Corp",
   "license": "Apache-2.0",
@@ -108,7 +108,7 @@
     "react-dom": ">=17.0.0 <20.0.0"
   },
   "dependencies": {
-    "@carbon/ai-chat-components": "^0.2.1",
+    "@carbon/ai-chat-components": "^0.3.0-rc.0",
     "@ibm/telemetry-js": "^1.10.2",
     "@lit/react": "^1.0.6",
     "classnames": "^2.5.0",


### PR DESCRIPTION
Automated release PR for v1.1.0-rc.0

Tried to adjust release workflow to not push git tags for every single package, but that caused lerna to not push up the version bump commit. So this PR removes that `--no-git-tag-version` flag.

  **Checklist**
  - [x] Verify package version bumps are accurate
  - [x] Verify CI passes as expected