### PR TITLE
fix: add type versions in package.json

### DIFF
--- a/packages/ai-chat/package.json
+++ b/packages/ai-chat/package.json
@@ -35,6 +35,15 @@
     "./dist/es/": "./dist/es/",
     "./dist/es-custom/": "./dist/es-custom/"
   },
+  "typesVersions": {
+    "*": {
+      "es": ["dist/types/aiChatEntry.d.ts"],
+      "es-custom": ["dist/types/aiChatEntry.d.ts"],
+      "server": ["dist/types/serverEntry.d.ts"],
+      "web-components/cds-aichat-container": ["dist/types/aiChatEntry.d.ts"],
+      "web-components/cds-aichat-custom-element": ["dist/types/aiChatEntry.d.ts"]
+    }
+  },
   "files": [
     "dist/es",
     "dist/es-custom",


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon-ai-chat/issues/557

[Test stackblitz application](https://stackblitz.com/edit/stackblitz-starters-jpvkeqwc?file=package.json,src%2Fmain.ts) still failing to get the type declarations from the latest release candidate. 

This PR adds the subpaths we want to expose and map types through `typesVersions` in the `package.json`.

#### Changelog

**New**

- `typeVersions` field in `package.json` to map the types to the subpaths

#### Testing / Reviewing

Pull the stackblitz example and add the `typeVersions` changes from this PR to the `node_modules/@carbon/ai-chat/package.json` from within the example. Run the example and notice it works without erroring out.
