### PR TITLE
fix: better handle nested inline html

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -34,6 +34,7 @@
     "@babel/preset-env": "^7.26.0",
     "@babel/preset-react": "^7.25.9",
     "@babel/preset-typescript": "^7.26.0",
+    "@carbon/ai-chat-utils": "0.0.0",
     "@playwright/test": "^1.54.1",
     "@types/node": "^24.0.14",
     "babel-loader": "^10.0.0",

--- a/demo/src/customSendMessage/constants.ts
+++ b/demo/src/customSendMessage/constants.ts
@@ -7,6 +7,17 @@
  *  @license
  */
 
+import {
+  BLOCKQUOTE,
+  CODE,
+  HTML,
+  MARKDOWN,
+  ORDERED_LIST,
+  TABLE,
+  TEXT,
+  UNORDERED_LIST,
+} from "@carbon/ai-chat-utils";
+
 const WELCOME_TEXT = `Welcome to this example of a custom back-end. This back-end is harded coded with responses to show a subset of the functionality of Carbon AI Chat.
 
 You can type **help** to see this message again.`;
@@ -14,154 +25,6 @@ You can type **help** to see this message again.`;
 const CHAIN_OF_THOUGHT_TEXT = `Carbon's versatile bonding properties have been analyzed through multiple chemical databases to present this comprehensive overview.`;
 
 const CHAIN_OF_THOUGHT_TEXT_STREAM = `Carbon's versatile bonding properties have been analyzed through multiple chemical databases to present this comprehensive overview. As this analysis streams in, various computational chemistry tools are querying molecular structures and periodic trends.`;
-
-const TABLE = `
-| Element      | Symbol | Atomic Number | Group | Period | Atomic Mass (u) | Electron Config | Bonding | Melting Point (°C) | Boiling Point (°C) |
-|--------------|--------|---------------|-------|--------|-----------------|-----------------|---------|--------------------|--------------------|
-| Carbon       | C      | 6             | 14    | 2      | 12.011          | [He] 2s² 2p²    | Covalent| 3550               | 4027               |
-| Silicon      | Si     | 14            | 14    | 3      | 28.085          | [Ne] 3s² 3p²    | Covalent| 1414               | 3265               |
-| Germanium    | Ge     | 32            | 14    | 4      | 72.630          | [Ar] 3d¹⁰ 4s² 4p²| Covalent| 938                | 2833               |
-| Tin          | Sn     | 50            | 14    | 5      | 118.710         | [Kr] 4d¹⁰ 5s² 5p²| Metallic| 232                | 2602               |
-| Lead         | Pb     | 82            | 14    | 6      | 207.200         | [Xe] 4f¹⁴ 5d¹⁰ 6s² 6p²| Metallic| 327          | 1749               |
-| Flerovium    | Fl     | 114           | 14    | 7      | 289             | [Rn] 5f¹⁴ 6d¹⁰ 7s² 7p²| Unknown | Unknown      | Unknown            |
-| Hydrogen     | H      | 1             | 1     | 1      | 1.008           | 1s¹             | Covalent| -259               | -253               |
-| Helium       | He     | 2             | 18    | 1      | 4.003           | 1s²             | Noble   | -272               | -269               |
-| Lithium      | Li     | 3             | 1     | 2      | 6.940           | [He] 2s¹        | Metallic| 180                | 1342               |
-| Beryllium    | Be     | 4             | 2     | 2      | 9.012           | [He] 2s²        | Metallic| 1287               | 2468               |
-| Boron        | B      | 5             | 13    | 2      | 10.810          | [He] 2s² 2p¹    | Covalent| 2075               | 4000               |
-| Nitrogen     | N      | 7             | 15    | 2      | 14.007          | [He] 2s² 2p³    | Covalent| -210               | -196               |
-| Oxygen       | O      | 8             | 16    | 2      | 15.999          | [He] 2s² 2p⁴    | Covalent| -218               | -183               |
-| Fluorine     | F      | 9             | 17    | 2      | 18.998          | [He] 2s² 2p⁵    | Covalent| -220               | -188               |
-| Neon         | Ne     | 10            | 18    | 2      | 20.180          | [He] 2s² 2p⁶    | Noble   | -249               | -246               |
-`;
-
-const UNORDERED_LIST = `
-- Carbon allotropes
-- Diamond
-- Graphite
-  - Graphene layers
-  - Hexagonal structure
-  - Electrical conductivity
-  - Thermal properties
-- Fullerenes
-- Carbon nanotubes
-- Amorphous carbon
-- Coal
-- Activated carbon
-`;
-
-const ORDERED_LIST = `
-1. Carbon bonding types
-  1. Single bonds (sp³)
-  2. Double bonds (sp²)
-2. Triple bonds (sp)
-3. Aromatic bonding
-4. Metallic carbides
-`;
-
-const TEXT = `Carbon is a **chemical element** with the *atomic number* 6 and symbol **C**. \`C + O₂ → CO₂\` represents one of carbon's most fundamental reactions.
-
-Carbon forms [covalent bonds](https://ibm.com) through electron sharing and creates [carbon chains](https://ibm.com){{target="_self"}} that are essential for organic molecules.
-
-`;
-
-const HEADERS = `
-# Header 1 sized header
-${TEXT}
-
-## Header 2 sized header
-${TEXT}
-
-### Header 3 sized header
-${TEXT}
-`;
-
-const CODE =
-  "\n```python\n" +
-  `import periodictable
-from rdkit import Chem
-
-def analyze_carbon_compounds(smiles_list):
-    # Analyze carbon-containing molecules
-    carbon = periodictable.C
-    results = []
-    
-    for smiles in smiles_list:
-        mol = Chem.MolFromSmiles(smiles)
-        if mol:
-            carbon_count = sum(1 for atom in mol.GetAtoms() if atom.GetSymbol() == 'C')
-            molecular_weight = Chem.rdMolDescriptors.CalcExactMolWt(mol)
-            results.append({
-                'smiles': smiles,
-                'carbon_atoms': carbon_count,
-                'molecular_weight': molecular_weight
-            })
-    
-    return results
-
-# Example usage - analyzing carbon compounds
-compounds = ['CCO', 'C6H6', 'CC(=O)O']  # Ethanol, Benzene, Acetic acid
-print(analyze_carbon_compounds(compounds))
-` +
-  "```";
-
-const BLOCKQUOTE = `
-> Carbon is the **fourth most abundant** element in the *observable universe* by mass after hydrogen, helium, and oxygen. \`C₆H₁₂O₆\` represents glucose, a fundamental carbon-based molecule for life. Carbon's unique tetravalent bonding capability enables complex molecular architectures.
->
-> The [carbon cycle](https://ibm.com) describes how carbon moves between Earth's atmosphere, oceans, and [living organisms](https://ibm.com){{target="_self"}} through photosynthesis and respiration. Carbon dating uses the radioactive isotope ¹⁴C to determine the age of organic materials. Diamond and graphite demonstrate carbon's structural versatility through different bonding arrangements.
- `;
-
-const MARKDOWN = `
-${TEXT}
----
-${HEADERS}
----
-${TABLE}
----
-${BLOCKQUOTE}
----
-${ORDERED_LIST}
----
-${UNORDERED_LIST}
----
-`;
-
-const HTML = `
-Here is some <b>Carbon</b> information peppered with HTML!
-
-<style>
-    .fun-fact { 
-        background-color: #e8f5e8; 
-        color: #161616;
-        border-inline-start: 4px solid #27ae60; 
-        padding: 10px; 
-        margin: 10px 0; 
-    }
-</style>
-<h2>Carbon <b>(C)</b> - The Element of Life</h2>
-
-<p><strong>Carbon</strong> is a <mark>non-metallic element</mark> with atomic number <strong>6</strong>. It's one of the most important elements on Earth because it forms the backbone of all organic molecules.</p>
-
-<div class="fun-fact">
-    <h4>Fun Fact</h4>
-    <p>Carbon can form more compounds than any other element except hydrogen. There are over <em>10 million</em> known carbon compounds!</p>
-</div>
-
-<blockquote>
-    <p>"We are made of <strong>star stuff</strong>. We are a way for the cosmos to know itself."</p>
-    <cite>— Carl Sagan (referring to carbon-based life)</cite>
-</blockquote>
-
-<h3>Why Carbon Matters</h3>
-<ol>
-    <li>Forms the basis of all <abbr title="deoxyribonucleic acid">DNA</abbr> and proteins</li>
-    <li>Essential for photosynthesis in plants</li>
-    <li>Key component in fossil fuels and climate change</li>
-    <li>Used in advanced materials like carbon nanotubes</li>
-</ol>
-
-<hr>
-<small><em>Carbon's unique ability to form four bonds makes it the perfect element for complex biological molecules.</em></small>`;
 
 const WORD_DELAY = 40;
 

--- a/demo/src/customSendMessage/doConversationalSearch.ts
+++ b/demo/src/customSendMessage/doConversationalSearch.ts
@@ -15,7 +15,7 @@ import {
   StreamChunk,
 } from "@carbon/ai-chat";
 
-import { sleep } from "../framework/utils";
+import { sleep } from "@carbon/ai-chat-utils";
 import { WORD_DELAY } from "./constants";
 
 const TEXT =

--- a/demo/src/customSendMessage/doText.ts
+++ b/demo/src/customSendMessage/doText.ts
@@ -19,7 +19,7 @@ import {
   UserType,
 } from "@carbon/ai-chat";
 
-import { sleep } from "../framework/utils";
+import { sleep } from "@carbon/ai-chat-utils";
 import {
   CHAIN_OF_THOUGHT_TEXT,
   CHAIN_OF_THOUGHT_TEXT_STREAM,

--- a/demo/src/customSendMessage/doUserDefined.ts
+++ b/demo/src/customSendMessage/doUserDefined.ts
@@ -14,7 +14,7 @@ import {
   StreamChunk,
 } from "@carbon/ai-chat";
 
-import { sleep } from "../framework/utils";
+import { sleep } from "@carbon/ai-chat-utils";
 
 const FAKE_DATA = `Some text that came from the server inside the user_defined object. Bacon ipsum dolor amet salami capicola chislic, meatball tail beef ham hock brisket cow ground round chuck. Turkey pork loin pastrami, ribeye jerky meatball drumstick kielbasa corned beef shankle picanha. Spare ribs leberkas hamburger strip steak beef ribs sirloin brisket capicola, sausage meatball drumstick ham swine alcatra. Pastrami filet mignon salami, flank short loin t-bone tenderloin ribeye brisket.`;
 

--- a/demo/src/framework/utils.ts
+++ b/demo/src/framework/utils.ts
@@ -16,12 +16,6 @@ import {
 import { customSendMessage } from "../customSendMessage/customSendMessage";
 import { KeyPairs, Settings } from "./types";
 
-async function sleep(milliseconds: number) {
-  await new Promise((resolve) => {
-    setTimeout(resolve, milliseconds);
-  });
-}
-
 function updateQueryParams(items: KeyPairs[]) {
   // Get the current URL's search params
   const urlParams = new URLSearchParams(window.location.search);
@@ -230,6 +224,5 @@ export {
   updateQueryParamsWithoutRefresh,
   updatePageTheme,
   getSettings,
-  sleep,
   asyncForEach,
 };

--- a/demo/src/mockServiceDesk/mockServiceDesk.ts
+++ b/demo/src/mockServiceDesk/mockServiceDesk.ts
@@ -30,7 +30,7 @@ import {
 
 import { v4 as uuid } from "uuid";
 
-import { sleep } from "../framework/utils";
+import { sleep } from "@carbon/ai-chat-utils";
 import { MARKDOWN } from "../customSendMessage/constants";
 
 /**

--- a/demo/tests/smoke.spec.ts
+++ b/demo/tests/smoke.spec.ts
@@ -48,9 +48,7 @@ test("smoke React", async ({ page }) => {
   await mainPanel.getByTestId(PageObjectId.INPUT).click();
   await mainPanel.getByTestId(PageObjectId.INPUT).fill("text");
   await mainPanel.getByTestId(PageObjectId.INPUT_SEND).click();
-  await expect(page.locator("#cds-aichat--message-3")).toContainText(
-    "Carbon is a",
-  );
+  await expect(page.locator("#cds-aichat--message-3")).toContainText("Carbon");
   await close.click();
 });
 
@@ -81,8 +79,6 @@ test("smoke web component", async ({ page }) => {
   await mainPanelWebComponent.getByTestId(PageObjectId.INPUT).click();
   await mainPanelWebComponent.getByTestId(PageObjectId.INPUT).fill("text");
   await mainPanelWebComponent.getByTestId(PageObjectId.INPUT_SEND).click();
-  await expect(page.locator("#cds-aichat--message-3")).toContainText(
-    "Carbon is a",
-  );
+  await expect(page.locator("#cds-aichat--message-3")).toContainText("Carbon");
   await close.click();
 });

--- a/demo/tests/utils.ts
+++ b/demo/tests/utils.ts
@@ -6,6 +6,7 @@
  */
 
 import { PageObjectId, ViewType } from "@carbon/ai-chat/server";
+import { sleep } from "@carbon/ai-chat-utils";
 import type { Page } from "@playwright/test";
 
 // Import types for window globals used in evaluated browser context.
@@ -133,6 +134,8 @@ export const waitForChatReady = async (
       timeout,
     });
   }
+
+  await sleep(200);
 };
 
 /**

--- a/examples/react/README.md
+++ b/examples/react/README.md
@@ -2,9 +2,24 @@
 
 This folder contains examples for specific functionality in React.
 
-| Example                             | Description                                                                 |
-| ----------------------------------- | --------------------------------------------------------------------------- |
-| [Basic](./basic/)                   | Example showing sending and receiving a message from a mock server.         |
-| [Custom Element](./custom-element/) | Example using ChatCustomElement for full-screen custom element integration. |
-| [History](./history/)               | Example showing message history loading with customLoadHistory.             |
-| [watsonx.ai](./watsonx/)            | Example showing sending and receiving a message from watsonx.ai.            |
+## Run Examples from the Monorepo Root
+
+Install dependencies once from the repository root:
+
+```bash
+npm install
+```
+
+Then start any React example directly from the root:
+
+```bash
+npm run start --workspace=<workspace-name>
+```
+
+| Example                             | Description                                                                 | Start command                                                             |
+| ----------------------------------- | --------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| [Basic](./basic/)                   | Example showing sending and receiving a message from a mock server.         | `npm run start --workspace=@carbon/ai-chat-examples-react-basic`          |
+| [Custom Element](./custom-element/) | Example using ChatCustomElement for full-screen custom element integration. | `npm run start --workspace=@carbon/ai-chat-examples-react-custom-element` |
+| [History](./history/)               | Example showing message history loading with customLoadHistory.             | `npm run start --workspace=@carbon/ai-chat-examples-react-history`        |
+| [watsonx.ai](./watsonx/)            | Example showing sending and receiving a message from watsonx.ai.            | `npm run start --workspace=@carbon/ai-chat-examples-react-watsonx`        |
+| [Watch state](./watch-state/)       | Example monitoring chat state changes.                                      | `npm run start --workspace=@carbon/ai-chat-examples-react-watch-state`    |

--- a/examples/react/basic/src/customSendMessage.ts
+++ b/examples/react/basic/src/customSendMessage.ts
@@ -14,6 +14,7 @@ import {
   MessageResponseTypes,
   StreamChunk,
 } from "@carbon/ai-chat";
+import { sleep } from "@carbon/ai-chat-utils";
 
 const WELCOME_TEXT = `Welcome to this example of a custom back-end. This back-end is mocked entirely on the client side. It does not show all potential functionality.
 
@@ -165,12 +166,6 @@ async function doFakeTextStreaming(
   } finally {
     signal?.removeEventListener("abort", abortHandler);
   }
-}
-
-async function sleep(milliseconds: number) {
-  await new Promise((resolve) => {
-    setTimeout(resolve, milliseconds);
-  });
 }
 
 async function customSendMessage(

--- a/examples/react/custom-element/src/customSendMessage.ts
+++ b/examples/react/custom-element/src/customSendMessage.ts
@@ -14,6 +14,7 @@ import {
   MessageResponseTypes,
   StreamChunk,
 } from "@carbon/ai-chat";
+import { sleep } from "@carbon/ai-chat-utils";
 
 const WELCOME_TEXT = `Welcome to this example of a custom back-end. This back-end is mocked entirely on the client side. It does not show all potential functionality.
 
@@ -162,12 +163,6 @@ async function doFakeTextStreaming(
   } finally {
     signal?.removeEventListener("abort", abortHandler);
   }
-}
-
-async function sleep(milliseconds: number) {
-  await new Promise((resolve) => {
-    setTimeout(resolve, milliseconds);
-  });
 }
 
 async function customSendMessage(

--- a/examples/react/history/src/customSendMessage.ts
+++ b/examples/react/history/src/customSendMessage.ts
@@ -14,6 +14,7 @@ import {
   MessageResponseTypes,
   StreamChunk,
 } from "@carbon/ai-chat";
+import { sleep } from "@carbon/ai-chat-utils";
 
 const WELCOME_TEXT = `Welcome to this example of a custom back-end. This back-end is mocked entirely on the client side. It does not show all potential functionality.
 
@@ -162,12 +163,6 @@ async function doFakeTextStreaming(
   } finally {
     signal?.removeEventListener("abort", abortHandler);
   }
-}
-
-async function sleep(milliseconds: number) {
-  await new Promise((resolve) => {
-    setTimeout(resolve, milliseconds);
-  });
 }
 
 async function customSendMessage(

--- a/examples/react/watsonx/README.md
+++ b/examples/react/watsonx/README.md
@@ -68,29 +68,19 @@ You can find the complete list of available models in your watsonx.ai project da
 
 ### Step 5: Install Dependencies
 
+From the repository root, install all workspace dependencies (run once after cloning):
+
 ```bash
 npm install
 ```
 
-### Step 6: Run the Application
+### Step 6: Run from the Monorepo Root
 
-Start both the proxy server and React development server:
-
-```bash
-npm run start
-```
-
-This command runs:
-
-- **Proxy server** on `http://localhost:3010` (handles IBM Cloud authentication)
-- **React app** on `http://localhost:3003` (the chat interface)
-
-Alternatively, you can run them separately:
+Install dependencies once and start this workspace directly from the repository root:
 
 ```bash
-# Terminal 1: Start the proxy server
-npm run start:server
-
-# Terminal 2: Start the React app
-npm start:client
+npm install
+npm run start --workspace=@carbon/ai-chat-examples-react-watsonx
 ```
+
+> The `start` script launches both the local proxy server and React development server for this example.

--- a/examples/web-components/README.md
+++ b/examples/web-components/README.md
@@ -2,9 +2,24 @@
 
 This folder contains examples for specific functionality using web components with Lit.
 
-| Example                             | Description                                                                         |
-| ----------------------------------- | ----------------------------------------------------------------------------------- |
-| [Basic](./basic/)                   | Example showing sending and receiving a message from a mock server.                 |
-| [Custom Element](./custom-element/) | Example using cds-aichat-custom-element for full-screen custom element integration. |
-| [History](./history/)               | Example showing message history loading with customLoadHistory.                     |
-| [watsonx.ai](./watsonx/)            | Example showing sending and receiving a message from watsonx.ai.                    |
+## Run Examples from the Monorepo Root
+
+Install dependencies once from the repository root:
+
+```bash
+npm install
+```
+
+Then start any web components example directly from the root:
+
+```bash
+npm run start --workspace=<workspace-name>
+```
+
+| Example                             | Description                                                                         | Start command                                                                      |
+| ----------------------------------- | ----------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| [Basic](./basic/)                   | Example showing sending and receiving a message from a mock server.                 | `npm run start --workspace=@carbon/ai-chat-examples-web-components-basic`          |
+| [Custom Element](./custom-element/) | Example using cds-aichat-custom-element for full-screen custom element integration. | `npm run start --workspace=@carbon/ai-chat-examples-web-components-custom-element` |
+| [History](./history/)               | Example showing message history loading with customLoadHistory.                     | `npm run start --workspace=@carbon/ai-chat-examples-web-components-history`        |
+| [watsonx.ai](./watsonx/)            | Example showing sending and receiving a message from watsonx.ai.                    | `npm run start --workspace=@carbon/ai-chat-examples-web-components-watsonx`        |
+| [Watch state](./watch-state/)       | Example monitoring chat state changes.                                              | `npm run start --workspace=@carbon/ai-chat-examples-web-components-watch-state`    |

--- a/examples/web-components/basic/src/customSendMessage.ts
+++ b/examples/web-components/basic/src/customSendMessage.ts
@@ -14,6 +14,7 @@ import {
   MessageResponseTypes,
   StreamChunk,
 } from "@carbon/ai-chat";
+import { sleep } from "@carbon/ai-chat-utils";
 
 const WELCOME_TEXT = `Welcome to this example of a custom back-end. This back-end is mocked entirely on the client side. It does not show all potential functionality.
 
@@ -165,12 +166,6 @@ async function doFakeTextStreaming(
   } finally {
     signal?.removeEventListener("abort", abortHandler);
   }
-}
-
-async function sleep(milliseconds: number) {
-  await new Promise((resolve) => {
-    setTimeout(resolve, milliseconds);
-  });
 }
 
 async function customSendMessage(

--- a/examples/web-components/custom-element/src/customSendMessage.ts
+++ b/examples/web-components/custom-element/src/customSendMessage.ts
@@ -14,6 +14,7 @@ import {
   MessageResponseTypes,
   StreamChunk,
 } from "@carbon/ai-chat";
+import { sleep } from "@carbon/ai-chat-utils";
 
 const WELCOME_TEXT = `Welcome to this example of a custom back-end. This back-end is mocked entirely on the client side. It does not show all potential functionality.
 
@@ -162,12 +163,6 @@ async function doFakeTextStreaming(
   } finally {
     signal?.removeEventListener("abort", abortHandler);
   }
-}
-
-async function sleep(milliseconds: number) {
-  await new Promise((resolve) => {
-    setTimeout(resolve, milliseconds);
-  });
 }
 
 async function customSendMessage(

--- a/examples/web-components/history/src/customSendMessage.ts
+++ b/examples/web-components/history/src/customSendMessage.ts
@@ -14,6 +14,7 @@ import {
   MessageResponseTypes,
   StreamChunk,
 } from "@carbon/ai-chat";
+import { sleep } from "@carbon/ai-chat-utils";
 
 const WELCOME_TEXT = `Welcome to this example of a custom back-end. This back-end is mocked entirely on the client side. It does not show all potential functionality.
 
@@ -164,12 +165,6 @@ async function doFakeTextStreaming(
   } finally {
     signal?.removeEventListener("abort", abortHandler);
   }
-}
-
-async function sleep(milliseconds: number) {
-  await new Promise((resolve) => {
-    setTimeout(resolve, milliseconds);
-  });
 }
 
 async function customSendMessage(

--- a/examples/web-components/watsonx/README.md
+++ b/examples/web-components/watsonx/README.md
@@ -69,29 +69,19 @@ You can find the complete list of available models in your watsonx.ai project da
 
 ### Step 5: Install Dependencies
 
+From the repository root, install all workspace dependencies (run once after cloning):
+
 ```bash
 npm install
 ```
 
-### Step 6: Run the Application
+### Step 6: Run from the Monorepo Root
 
-Start both the proxy server and web components development server:
-
-```bash
-npm run start
-```
-
-This command runs:
-
-- **Proxy server** on `http://localhost:3011` (handles IBM Cloud authentication)
-- **Web components app** on `http://localhost:3005` (the chat interface)
-
-Alternatively, you can run them separately:
+Install dependencies once and start this workspace directly from the repository root:
 
 ```bash
-# Terminal 1: Start the proxy server
-npm run start:server
-
-# Terminal 2: Start the web components app
-npm start:client
+npm install
+npm run start --workspace=@carbon/ai-chat-examples-web-components-watsonx
 ```
+
+> The `start` script launches both the local proxy server and web components development server for this example.

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,8 @@
         "examples/web-components/watch-state",
         "examples/web-components/watsonx",
         "packages/ai-chat",
-        "packages/ai-chat-components"
+        "packages/ai-chat-components",
+        "utils"
       ],
       "dependencies": {
         "@carbon/ai-chat": "^0.0.0"
@@ -81,6 +82,7 @@
         "@babel/preset-env": "^7.26.0",
         "@babel/preset-react": "^7.25.9",
         "@babel/preset-typescript": "^7.26.0",
+        "@carbon/ai-chat-utils": "0.0.0",
         "@playwright/test": "^1.54.1",
         "@types/node": "^24.0.14",
         "babel-loader": "^10.0.0",
@@ -138,6 +140,22 @@
       "license": "MIT",
       "dependencies": {
         "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "demo/node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
       },
       "engines": {
         "node": ">=10"
@@ -312,10 +330,33 @@
         "webpack-dev-server": "^5.1.0"
       }
     },
+    "examples/react/watsonx/node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "examples/react/watsonx/node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
     "examples/react/watsonx/node_modules/open": {
       "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
-      "integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -515,10 +556,33 @@
         "webpack-dev-server": "^5.1.0"
       }
     },
+    "examples/web-components/watsonx/node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "examples/web-components/watsonx/node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
     "examples/web-components/watsonx/node_modules/open": {
       "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/open/-/open-10.2.0.tgz",
-      "integrity": "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2582,6 +2646,22 @@
         "keyv": "^5.5.3"
       }
     },
+    "node_modules/@cacheable/memory/node_modules/@keyv/bigmap": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@keyv/bigmap/-/bigmap-1.1.0.tgz",
+      "integrity": "sha512-MX7XIUNwVRK+hjZcAbNJ0Z8DREo+Weu9vinBOjGU1thEi9F6vPhICzBbk4CCf3eEefKRz7n6TfZXwUFZTSgj8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hookified": "^1.12.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "keyv": "^5.5.3"
+      }
+    },
     "node_modules/@cacheable/memory/node_modules/keyv": {
       "version": "5.5.3",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.5.3.tgz",
@@ -2664,6 +2744,10 @@
       "resolved": "examples/web-components/watsonx",
       "link": true
     },
+    "node_modules/@carbon/ai-chat-utils": {
+      "resolved": "utils",
+      "link": true
+    },
     "node_modules/@carbon/colors": {
       "version": "11.42.0",
       "resolved": "https://registry.npmjs.org/@carbon/colors/-/colors-11.42.0.tgz",
@@ -2696,13 +2780,13 @@
       }
     },
     "node_modules/@carbon/icon-helpers": {
-      "version": "10.47.0",
-      "resolved": "https://registry.npmjs.org/@carbon/icon-helpers/-/icon-helpers-10.47.0.tgz",
-      "integrity": "sha512-vv2Wkuw7lYkYVKrn5ABzlZD+6ioAYwMuyKi2XPqYY3hrHYoL4CQUnuSFDhlj0DR2HHCB0L5MGRLxHLucx5cc7g==",
+      "version": "10.68.0",
+      "resolved": "https://registry.npmjs.org/@carbon/icon-helpers/-/icon-helpers-10.68.0.tgz",
+      "integrity": "sha512-fYor/Fs0RLtPMh2KRyPYR83JKoWbAmoQ7tCIW0QQcwYcIu82tvy7uT8vTNhda21w3uueOp70p6rYyY6vYjuRZA==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@ibm/telemetry-js": "^1.2.1"
+        "@ibm/telemetry-js": "^1.5.0"
       }
     },
     "node_modules/@carbon/icons": {
@@ -2728,16 +2812,6 @@
       },
       "peerDependencies": {
         "react": ">=16"
-      }
-    },
-    "node_modules/@carbon/icons-react/node_modules/@carbon/icon-helpers": {
-      "version": "10.68.0",
-      "resolved": "https://registry.npmjs.org/@carbon/icon-helpers/-/icon-helpers-10.68.0.tgz",
-      "integrity": "sha512-fYor/Fs0RLtPMh2KRyPYR83JKoWbAmoQ7tCIW0QQcwYcIu82tvy7uT8vTNhda21w3uueOp70p6rYyY6vYjuRZA==",
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@ibm/telemetry-js": "^1.5.0"
       }
     },
     "node_modules/@carbon/layout": {
@@ -2880,6 +2954,16 @@
         "lit": "^3.1.0",
         "lodash-es": "^4.17.21",
         "tslib": "^2.6.3"
+      }
+    },
+    "node_modules/@carbon/web-components/node_modules/@carbon/icon-helpers": {
+      "version": "10.47.0",
+      "resolved": "https://registry.npmjs.org/@carbon/icon-helpers/-/icon-helpers-10.47.0.tgz",
+      "integrity": "sha512-vv2Wkuw7lYkYVKrn5ABzlZD+6ioAYwMuyKi2XPqYY3hrHYoL4CQUnuSFDhlj0DR2HHCB0L5MGRLxHLucx5cc7g==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ibm/telemetry-js": "^1.2.1"
       }
     },
     "node_modules/@commitlint/cli": {
@@ -3265,6 +3349,28 @@
         "custom-elements-manifest": "cem.js"
       }
     },
+    "node_modules/@custom-elements-manifest/analyzer/node_modules/chokidar": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
+      "integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
     "node_modules/@custom-elements-manifest/analyzer/node_modules/comment-parser": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.2.4.tgz",
@@ -3273,6 +3379,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@custom-elements-manifest/analyzer/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/@custom-elements-manifest/analyzer/node_modules/globby": {
@@ -3294,6 +3413,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@custom-elements-manifest/analyzer/node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
       }
     },
     "node_modules/@custom-elements-manifest/analyzer/node_modules/slash": {
@@ -3377,9 +3509,9 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.5.0.tgz",
-      "integrity": "sha512-sbP8GzB1WDzacS8fgNPpHlp6C9VZe+SJP3F90W9rLemaQj2PzIuTEl1qDOYQf58YIpyjViI24y9aPWCjEzY2cg==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.6.0.tgz",
+      "integrity": "sha512-zq/ay+9fNIJJtJiZxdTnXS20PllcYMX3OE23ESc4HK/bdYu3cOWYVhsOhVnXALfU/uqJIxn5NBPd9z4v+SfoSg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3388,9 +3520,9 @@
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.5.0.tgz",
-      "integrity": "sha512-97/BJ3iXHww3djw6hYIfErCZFee7qCtrneuLa20UXFCOTCfBM2cvQHjWJ2EG0s0MtdNwInarqCTz35i4wWXHsQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.6.0.tgz",
+      "integrity": "sha512-obtUmAHTMjll499P+D9A3axeJFlhdjOWdKUNs/U6QIGT7V5RjcUW1xToAzjvmgTSQhDbYn/NwfTRoJcQ2rNBxA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4480,23 +4612,6 @@
         }
       }
     },
-    "node_modules/@inquirer/external-editor/node_modules/iconv-lite": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.0.tgz",
-      "integrity": "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
     "node_modules/@inquirer/figures": {
       "version": "1.0.14",
       "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.14.tgz",
@@ -4869,16 +4984,6 @@
         "sprintf-js": "~1.0.2"
       }
     },
-    "node_modules/@istanbuljs/load-nyc-config/node_modules/camelcase": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/find-up": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -5091,20 +5196,40 @@
         }
       }
     },
-    "node_modules/@jest/core/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+    "node_modules/@jest/core/node_modules/@jest/schemas": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "color-convert": "^2.0.1"
+        "@sinclair/typebox": "^0.27.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/core/node_modules/@sinclair/typebox": {
+      "version": "0.27.8",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
+      "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jest/core/node_modules/ansi-escapes": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.21.3"
       },
       "engines": {
         "node": ">=8"
       },
       "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@jest/core/node_modules/chalk": {
@@ -5123,6 +5248,44 @@
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
+    },
+    "node_modules/@jest/core/node_modules/chalk/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@jest/core/node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/core/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@jest/core/node_modules/slash": {
       "version": "3.0.0",
@@ -5145,6 +5308,19 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@jest/core/node_modules/type-fest": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@jest/diff-sequences": {
@@ -5321,6 +5497,19 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/@jest/reporters/node_modules/chalk/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@jest/reporters/node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -5360,6 +5549,22 @@
         "node": ">=10"
       }
     },
+    "node_modules/@jest/reporters/node_modules/jest-worker": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
+      "integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "jest-util": "^29.7.0",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
     "node_modules/@jest/reporters/node_modules/semver": {
       "version": "7.7.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
@@ -5383,30 +5588,17 @@
         "node": ">=8"
       }
     },
-    "node_modules/@jest/reporters/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/@jest/schemas": {
-      "version": "29.6.3",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
-      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+      "version": "30.0.5",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.5.tgz",
+      "integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@sinclair/typebox": "^0.27.8"
+        "@sinclair/typebox": "^0.34.0"
       },
       "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/@jest/source-map": {
@@ -5580,6 +5772,26 @@
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
+    },
+    "node_modules/@jest/types/node_modules/@jest/schemas": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.27.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/types/node_modules/@sinclair/typebox": {
+      "version": "0.27.8",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
+      "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@jest/types/node_modules/ansi-styles": {
       "version": "4.3.0",
@@ -5808,19 +6020,6 @@
         "tslib": "2"
       }
     },
-    "node_modules/@keyv/bigmap": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@keyv/bigmap/-/bigmap-1.0.3.tgz",
-      "integrity": "sha512-jUEkNlnE9tYzX2AIBeoSe1gVUvSOfIOQ5EFPL5Un8cFHGvjD9L/fxpxlS1tEivRLHgapO2RZJ3D93HYAa049pg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "hookified": "^1.12.1"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
     "node_modules/@keyv/serialize": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.1.tgz",
@@ -5947,43 +6146,6 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/@lerna/create/node_modules/execa": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-5.0.0.tgz",
-      "integrity": "sha512-ov6w/2LCiuyO4RLYGdpFGjkcs0wMTgGE8PrkTHikeUy5iJekXyPIKUjifk5CsE0pt7sMCrMZ3YNqoCj6idQOnQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cross-spawn": "^7.0.3",
-        "get-stream": "^6.0.0",
-        "human-signals": "^2.1.0",
-        "is-stream": "^2.0.0",
-        "merge-stream": "^2.0.0",
-        "npm-run-path": "^4.0.1",
-        "onetime": "^5.1.2",
-        "signal-exit": "^3.0.3",
-        "strip-final-newline": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/execa?sponsor=1"
-      }
-    },
-    "node_modules/@lerna/create/node_modules/get-stream": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.0.tgz",
-      "integrity": "sha512-A1B3Bh1UmL0bidM/YX2NsCOTnGJePL9rO/M+Mw3m9f2gUpfokS0hi5Eah0WSUEWZdZhIZtMjkIYS7mDfOqNHbg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/@lerna/create/node_modules/glob": {
       "version": "9.3.5",
       "resolved": "https://registry.npmjs.org/glob/-/glob-9.3.5.tgz",
@@ -6035,16 +6197,6 @@
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/@lerna/create/node_modules/is-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
-      "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/@lerna/create/node_modules/minimatch": {
       "version": "3.0.5",
@@ -7968,13 +8120,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.56.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.56.0.tgz",
-      "integrity": "sha512-Tzh95Twig7hUwwNe381/K3PggZBZblKUe2wv25oIpzWLr6Z0m4KgV1ZVIjnR6GM9ANEqjZD7XsZEa6JL/7YEgg==",
+      "version": "1.56.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.56.1.tgz",
+      "integrity": "sha512-vSMYtL/zOcFpvJCW71Q/OEGQb7KYBPAdKh35WNSkaZA75JlAO8ED8UN6GUNTm3drWomcbcqRPFqQbLae8yBTdg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.56.0"
+        "playwright": "1.56.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -8056,6 +8208,23 @@
       },
       "peerDependencies": {
         "postcss": "^8.0.9"
+      }
+    },
+    "node_modules/@pwrs/lit-css/node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
       }
     },
     "node_modules/@pwrs/lit-css/node_modules/cssnano": {
@@ -8164,6 +8333,65 @@
       "engines": {
         "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0",
         "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@pwrs/lit-css/node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/@pwrs/lit-css/node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/@pwrs/lit-css/node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/@pwrs/lit-css/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/@pwrs/lit-css/node_modules/lilconfig": {
@@ -8739,6 +8967,37 @@
         }
       }
     },
+    "node_modules/@rollup/plugin-commonjs/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rollup/plugin-commonjs/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/@rollup/plugin-json": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-json/-/plugin-json-6.1.0.tgz",
@@ -8880,10 +9139,23 @@
         }
       }
     },
+    "node_modules/@rollup/pluginutils/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.52.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.52.4.tgz",
-      "integrity": "sha512-BTm2qKNnWIQ5auf4deoetINJm2JzvihvGb9R6K/ETwKLql/Bb3Eg2H1FBp1gUb4YGbydMA3jcmQTR73q7J+GAA==",
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.52.5.tgz",
+      "integrity": "sha512-8c1vW4ocv3UOMp9K+gToY5zL2XiiVw3k7f1ksf4yO1FlDFQ1C2u72iACFnSOceJFsWskc2WZNqeRhFRPzv+wtQ==",
       "cpu": [
         "arm"
       ],
@@ -8895,9 +9167,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.52.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.52.4.tgz",
-      "integrity": "sha512-P9LDQiC5vpgGFgz7GSM6dKPCiqR3XYN1WwJKA4/BUVDjHpYsf3iBEmVz62uyq20NGYbiGPR5cNHI7T1HqxNs2w==",
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.52.5.tgz",
+      "integrity": "sha512-mQGfsIEFcu21mvqkEKKu2dYmtuSZOBMmAl5CFlPGLY94Vlcm+zWApK7F/eocsNzp8tKmbeBP8yXyAbx0XHsFNA==",
       "cpu": [
         "arm64"
       ],
@@ -8909,9 +9181,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.52.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.52.4.tgz",
-      "integrity": "sha512-QRWSW+bVccAvZF6cbNZBJwAehmvG9NwfWHwMy4GbWi/BQIA/laTIktebT2ipVjNncqE6GLPxOok5hsECgAxGZg==",
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.52.5.tgz",
+      "integrity": "sha512-takF3CR71mCAGA+v794QUZ0b6ZSrgJkArC+gUiG6LB6TQty9T0Mqh3m2ImRBOxS2IeYBo4lKWIieSvnEk2OQWA==",
       "cpu": [
         "arm64"
       ],
@@ -8923,9 +9195,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.52.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.52.4.tgz",
-      "integrity": "sha512-hZgP05pResAkRJxL1b+7yxCnXPGsXU0fG9Yfd6dUaoGk+FhdPKCJ5L1Sumyxn8kvw8Qi5PvQ8ulenUbRjzeCTw==",
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.52.5.tgz",
+      "integrity": "sha512-W901Pla8Ya95WpxDn//VF9K9u2JbocwV/v75TE0YIHNTbhqUTv9w4VuQ9MaWlNOkkEfFwkdNhXgcLqPSmHy0fA==",
       "cpu": [
         "x64"
       ],
@@ -8937,9 +9209,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.52.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.52.4.tgz",
-      "integrity": "sha512-xmc30VshuBNUd58Xk4TKAEcRZHaXlV+tCxIXELiE9sQuK3kG8ZFgSPi57UBJt8/ogfhAF5Oz4ZSUBN77weM+mQ==",
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.52.5.tgz",
+      "integrity": "sha512-QofO7i7JycsYOWxe0GFqhLmF6l1TqBswJMvICnRUjqCx8b47MTo46W8AoeQwiokAx3zVryVnxtBMcGcnX12LvA==",
       "cpu": [
         "arm64"
       ],
@@ -8951,9 +9223,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.52.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.52.4.tgz",
-      "integrity": "sha512-WdSLpZFjOEqNZGmHflxyifolwAiZmDQzuOzIq9L27ButpCVpD7KzTRtEG1I0wMPFyiyUdOO+4t8GvrnBLQSwpw==",
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.52.5.tgz",
+      "integrity": "sha512-jr21b/99ew8ujZubPo9skbrItHEIE50WdV86cdSoRkKtmWa+DDr6fu2c/xyRT0F/WazZpam6kk7IHBerSL7LDQ==",
       "cpu": [
         "x64"
       ],
@@ -8965,9 +9237,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.52.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.52.4.tgz",
-      "integrity": "sha512-xRiOu9Of1FZ4SxVbB0iEDXc4ddIcjCv2aj03dmW8UrZIW7aIQ9jVJdLBIhxBI+MaTnGAKyvMwPwQnoOEvP7FgQ==",
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.52.5.tgz",
+      "integrity": "sha512-PsNAbcyv9CcecAUagQefwX8fQn9LQ4nZkpDboBOttmyffnInRy8R8dSg6hxxl2Re5QhHBf6FYIDhIj5v982ATQ==",
       "cpu": [
         "arm"
       ],
@@ -8979,9 +9251,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.52.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.52.4.tgz",
-      "integrity": "sha512-FbhM2p9TJAmEIEhIgzR4soUcsW49e9veAQCziwbR+XWB2zqJ12b4i/+hel9yLiD8pLncDH4fKIPIbt5238341Q==",
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.52.5.tgz",
+      "integrity": "sha512-Fw4tysRutyQc/wwkmcyoqFtJhh0u31K+Q6jYjeicsGJJ7bbEq8LwPWV/w0cnzOqR2m694/Af6hpFayLJZkG2VQ==",
       "cpu": [
         "arm"
       ],
@@ -8993,9 +9265,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.52.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.52.4.tgz",
-      "integrity": "sha512-4n4gVwhPHR9q/g8lKCyz0yuaD0MvDf7dV4f9tHt0C73Mp8h38UCtSCSE6R9iBlTbXlmA8CjpsZoujhszefqueg==",
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.52.5.tgz",
+      "integrity": "sha512-a+3wVnAYdQClOTlyapKmyI6BLPAFYs0JM8HRpgYZQO02rMR09ZcV9LbQB+NL6sljzG38869YqThrRnfPMCDtZg==",
       "cpu": [
         "arm64"
       ],
@@ -9007,9 +9279,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.52.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.52.4.tgz",
-      "integrity": "sha512-u0n17nGA0nvi/11gcZKsjkLj1QIpAuPFQbR48Subo7SmZJnGxDpspyw2kbpuoQnyK+9pwf3pAoEXerJs/8Mi9g==",
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.52.5.tgz",
+      "integrity": "sha512-AvttBOMwO9Pcuuf7m9PkC1PUIKsfaAJ4AYhy944qeTJgQOqJYJ9oVl2nYgY7Rk0mkbsuOpCAYSs6wLYB2Xiw0Q==",
       "cpu": [
         "arm64"
       ],
@@ -9021,9 +9293,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.52.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.52.4.tgz",
-      "integrity": "sha512-0G2c2lpYtbTuXo8KEJkDkClE/+/2AFPdPAbmaHoE870foRFs4pBrDehilMcrSScrN/fB/1HTaWO4bqw+ewBzMQ==",
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.52.5.tgz",
+      "integrity": "sha512-DkDk8pmXQV2wVrF6oq5tONK6UHLz/XcEVow4JTTerdeV1uqPeHxwcg7aFsfnSm9L+OO8WJsWotKM2JJPMWrQtA==",
       "cpu": [
         "loong64"
       ],
@@ -9035,9 +9307,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.52.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.52.4.tgz",
-      "integrity": "sha512-teSACug1GyZHmPDv14VNbvZFX779UqWTsd7KtTM9JIZRDI5NUwYSIS30kzI8m06gOPB//jtpqlhmraQ68b5X2g==",
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.52.5.tgz",
+      "integrity": "sha512-W/b9ZN/U9+hPQVvlGwjzi+Wy4xdoH2I8EjaCkMvzpI7wJUs8sWJ03Rq96jRnHkSrcHTpQe8h5Tg3ZzUPGauvAw==",
       "cpu": [
         "ppc64"
       ],
@@ -9049,9 +9321,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.52.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.52.4.tgz",
-      "integrity": "sha512-/MOEW3aHjjs1p4Pw1Xk4+3egRevx8Ji9N6HUIA1Ifh8Q+cg9dremvFCUbOX2Zebz80BwJIgCBUemjqhU5XI5Eg==",
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.52.5.tgz",
+      "integrity": "sha512-sjQLr9BW7R/ZiXnQiWPkErNfLMkkWIoCz7YMn27HldKsADEKa5WYdobaa1hmN6slu9oWQbB6/jFpJ+P2IkVrmw==",
       "cpu": [
         "riscv64"
       ],
@@ -9063,9 +9335,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.52.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.52.4.tgz",
-      "integrity": "sha512-1HHmsRyh845QDpEWzOFtMCph5Ts+9+yllCrREuBR/vg2RogAQGGBRC8lDPrPOMnrdOJ+mt1WLMOC2Kao/UwcvA==",
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.52.5.tgz",
+      "integrity": "sha512-hq3jU/kGyjXWTvAh2awn8oHroCbrPm8JqM7RUpKjalIRWWXE01CQOf/tUNWNHjmbMHg/hmNCwc/Pz3k1T/j/Lg==",
       "cpu": [
         "riscv64"
       ],
@@ -9077,9 +9349,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.52.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.52.4.tgz",
-      "integrity": "sha512-seoeZp4L/6D1MUyjWkOMRU6/iLmCU2EjbMTyAG4oIOs1/I82Y5lTeaxW0KBfkUdHAWN7j25bpkt0rjnOgAcQcA==",
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.52.5.tgz",
+      "integrity": "sha512-gn8kHOrku8D4NGHMK1Y7NA7INQTRdVOntt1OCYypZPRt6skGbddska44K8iocdpxHTMMNui5oH4elPH4QOLrFQ==",
       "cpu": [
         "s390x"
       ],
@@ -9091,9 +9363,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.52.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.52.4.tgz",
-      "integrity": "sha512-Wi6AXf0k0L7E2gteNsNHUs7UMwCIhsCTs6+tqQ5GPwVRWMaflqGec4Sd8n6+FNFDw9vGcReqk2KzBDhCa1DLYg==",
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.52.5.tgz",
+      "integrity": "sha512-hXGLYpdhiNElzN770+H2nlx+jRog8TyynpTVzdlc6bndktjKWyZyiCsuDAlpd+j+W+WNqfcyAWz9HxxIGfZm1Q==",
       "cpu": [
         "x64"
       ],
@@ -9105,9 +9377,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.52.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.52.4.tgz",
-      "integrity": "sha512-dtBZYjDmCQ9hW+WgEkaffvRRCKm767wWhxsFW3Lw86VXz/uJRuD438/XvbZT//B96Vs8oTA8Q4A0AfHbrxP9zw==",
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.52.5.tgz",
+      "integrity": "sha512-arCGIcuNKjBoKAXD+y7XomR9gY6Mw7HnFBv5Rw7wQRvwYLR7gBAgV7Mb2QTyjXfTveBNFAtPt46/36vV9STLNg==",
       "cpu": [
         "x64"
       ],
@@ -9119,9 +9391,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.52.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.52.4.tgz",
-      "integrity": "sha512-1ox+GqgRWqaB1RnyZXL8PD6E5f7YyRUJYnCqKpNzxzP0TkaUh112NDrR9Tt+C8rJ4x5G9Mk8PQR3o7Ku2RKqKA==",
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.52.5.tgz",
+      "integrity": "sha512-QoFqB6+/9Rly/RiPjaomPLmR/13cgkIGfA40LHly9zcH1S0bN2HVFYk3a1eAyHQyjs3ZJYlXvIGtcCs5tko9Cw==",
       "cpu": [
         "arm64"
       ],
@@ -9133,9 +9405,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.52.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.52.4.tgz",
-      "integrity": "sha512-8GKr640PdFNXwzIE0IrkMWUNUomILLkfeHjXBi/nUvFlpZP+FA8BKGKpacjW6OUUHaNI6sUURxR2U2g78FOHWQ==",
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.52.5.tgz",
+      "integrity": "sha512-w0cDWVR6MlTstla1cIfOGyl8+qb93FlAVutcor14Gf5Md5ap5ySfQ7R9S/NjNaMLSFdUnKGEasmVnu3lCMqB7w==",
       "cpu": [
         "arm64"
       ],
@@ -9147,9 +9419,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.52.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.52.4.tgz",
-      "integrity": "sha512-AIy/jdJ7WtJ/F6EcfOb2GjR9UweO0n43jNObQMb6oGxkYTfLcnN7vYYpG+CN3lLxrQkzWnMOoNSHTW54pgbVxw==",
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.52.5.tgz",
+      "integrity": "sha512-Aufdpzp7DpOTULJCuvzqcItSGDH73pF3ko/f+ckJhxQyHtp67rHw3HMNxoIdDMUITJESNE6a8uh4Lo4SLouOUg==",
       "cpu": [
         "ia32"
       ],
@@ -9161,9 +9433,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.52.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.52.4.tgz",
-      "integrity": "sha512-UF9KfsH9yEam0UjTwAgdK0anlQ7c8/pWPU2yVjyWcF1I1thABt6WXE47cI71pGiZ8wGvxohBoLnxM04L/wj8mQ==",
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.52.5.tgz",
+      "integrity": "sha512-UGBUGPFp1vkj6p8wCRraqNhqwX/4kNQPS57BCFc8wYh0g94iVIW33wJtQAx3G7vrjjNtRaxiMUylM0ktp/TRSQ==",
       "cpu": [
         "x64"
       ],
@@ -9175,9 +9447,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.52.4",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.52.4.tgz",
-      "integrity": "sha512-bf9PtUa0u8IXDVxzRToFQKsNCRz9qLYfR/MpECxl4mRoWYjAeFjgxj1XdZr2M/GNVpT05p+LgQOHopYDlUu6/w==",
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.52.5.tgz",
+      "integrity": "sha512-TAcgQh2sSkykPRWLrdyy2AiceMckNf5loITqXxFI5VuQjS5tSuw3WlwdN8qv8vzjLAUTvYaH/mVjSFpbkFbpTg==",
       "cpu": [
         "x64"
       ],
@@ -9603,9 +9875,9 @@
       }
     },
     "node_modules/@sinclair/typebox": {
-      "version": "0.27.8",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
-      "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
+      "version": "0.34.41",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.41.tgz",
+      "integrity": "sha512-6gS8pZzSXdyRHTIqoqSVknxolr1kzfy4/CeDnrzsVz8TTIWUbOBr6gnzOmTYJ3eXQNh4IYHIGi5aIL7sOZ2G/g==",
       "dev": true,
       "license": "MIT"
     },
@@ -9888,9 +10160,9 @@
       }
     },
     "node_modules/@storybook/addon-a11y": {
-      "version": "9.1.12",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-a11y/-/addon-a11y-9.1.12.tgz",
-      "integrity": "sha512-K7Ssk9MXwjGVtxFRBRsqE1zhZXZJbEaya/4TaFcBxE2JJLd2myNEsU27m6xkiYda3Qgu5GfDSYqdwYCUaFPMWA==",
+      "version": "9.1.13",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-a11y/-/addon-a11y-9.1.13.tgz",
+      "integrity": "sha512-4enIl1h2XSZnFKUQJJoZbp1X40lzdj7f5JE15ZhU1al4z6hHWp7i2zD7ySyDpEbMypBCz1xnLvyiyw79m1fp7w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9902,20 +10174,20 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^9.1.12"
+        "storybook": "^9.1.13"
       }
     },
     "node_modules/@storybook/addon-docs": {
-      "version": "9.1.12",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-docs/-/addon-docs-9.1.12.tgz",
-      "integrity": "sha512-isHZvVgFLU2cBD+TbFY9Fu4fREoli/OoKGYterMI+/OQDzCAmoPs2i8HgCK8bwgrCnJKf8dS0uv28+6qBdZoZQ==",
+      "version": "9.1.13",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-docs/-/addon-docs-9.1.13.tgz",
+      "integrity": "sha512-V1nCo7bfC3kQ5VNVq0VDcHsIhQf507m+BxMA5SIYiwdJHljH2BXpW2fL3FFn9gv9Wp57AEEzhm+wh4zANaJgkg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@mdx-js/react": "^3.0.0",
-        "@storybook/csf-plugin": "9.1.12",
+        "@storybook/csf-plugin": "9.1.13",
         "@storybook/icons": "^1.4.0",
-        "@storybook/react-dom-shim": "9.1.12",
+        "@storybook/react-dom-shim": "9.1.13",
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "ts-dedent": "^2.0.0"
@@ -9925,13 +10197,13 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^9.1.12"
+        "storybook": "^9.1.13"
       }
     },
     "node_modules/@storybook/addon-links": {
-      "version": "9.1.12",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-links/-/addon-links-9.1.12.tgz",
-      "integrity": "sha512-g+QGw0Qdr+IVEuVO6CAt39QquHUCx6O1Ypo6RKjtl6gjsgRhpj7O4byzJ60yXQrk+LX70fP2f5z0S3YeAImvsg==",
+      "version": "9.1.13",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-links/-/addon-links-9.1.13.tgz",
+      "integrity": "sha512-wx33RA5PPRSepVAjR0hMFp2IXoPgjwNAHIP92aoi2QQFS3+NHlf1I4vXEPpHU6lc0WBwM43qvLSI0qTAyZd8Nw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9943,7 +10215,7 @@
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
-        "storybook": "^9.1.12"
+        "storybook": "^9.1.13"
       },
       "peerDependenciesMeta": {
         "react": {
@@ -9952,13 +10224,13 @@
       }
     },
     "node_modules/@storybook/builder-vite": {
-      "version": "9.1.12",
-      "resolved": "https://registry.npmjs.org/@storybook/builder-vite/-/builder-vite-9.1.12.tgz",
-      "integrity": "sha512-EYuMN4OXkRIa5K/JU23bRslHrG/3K6/LXIPLWZ5b2+T5qhW9JKW/wM98rRbqxPfU57ytlSwBFe2fUFREBAsvbA==",
+      "version": "9.1.13",
+      "resolved": "https://registry.npmjs.org/@storybook/builder-vite/-/builder-vite-9.1.13.tgz",
+      "integrity": "sha512-pmtIjU02ASJOZKdL8DoxWXJgZnpTDgD5WmMnjKJh9FaWmc2YiCW2Y6VRxPox96OM655jYHQe5+UIbk3Cwtwb4A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@storybook/csf-plugin": "9.1.12",
+        "@storybook/csf-plugin": "9.1.13",
         "ts-dedent": "^2.0.0"
       },
       "funding": {
@@ -9966,7 +10238,7 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^9.1.12",
+        "storybook": "^9.1.13",
         "vite": "^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
@@ -9981,9 +10253,9 @@
       }
     },
     "node_modules/@storybook/csf-plugin": {
-      "version": "9.1.12",
-      "resolved": "https://registry.npmjs.org/@storybook/csf-plugin/-/csf-plugin-9.1.12.tgz",
-      "integrity": "sha512-qfKQp13TP116GSzc5R30ScPFYwQzk3SWQEksv2IubEOk3TMfeuVHzfifRrfQ/mZyglxQ1uZlpOO5+4fe6dv2gw==",
+      "version": "9.1.13",
+      "resolved": "https://registry.npmjs.org/@storybook/csf-plugin/-/csf-plugin-9.1.13.tgz",
+      "integrity": "sha512-EMpzYuyt9FDcxxfBChWzfId50y8QMpdenviEQ8m+pa6c+ANx3pC5J6t7y0khD8TQu815sTy+nc6cc8PC45dPUA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9994,7 +10266,7 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^9.1.12"
+        "storybook": "^9.1.13"
       }
     },
     "node_modules/@storybook/global": {
@@ -10019,9 +10291,9 @@
       }
     },
     "node_modules/@storybook/react-dom-shim": {
-      "version": "9.1.12",
-      "resolved": "https://registry.npmjs.org/@storybook/react-dom-shim/-/react-dom-shim-9.1.12.tgz",
-      "integrity": "sha512-d6NHTvGUQb27xvKXLwSchhqrN43b8bdnegSZbgi+y/tddyTdEO1LPHBguGH7B7woA4VQuAs7WwiYiCm4lNqa7A==",
+      "version": "9.1.13",
+      "resolved": "https://registry.npmjs.org/@storybook/react-dom-shim/-/react-dom-shim-9.1.13.tgz",
+      "integrity": "sha512-/tMr9TmV3+98GEQO0S03k4gtKHGCpv9+k9Dmnv+TJK3TBz7QsaFEzMwe3gCgoTaebLACyVveDiZkWnCYAWB6NA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -10031,13 +10303,13 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta",
-        "storybook": "^9.1.12"
+        "storybook": "^9.1.13"
       }
     },
     "node_modules/@storybook/web-components": {
-      "version": "9.1.12",
-      "resolved": "https://registry.npmjs.org/@storybook/web-components/-/web-components-9.1.12.tgz",
-      "integrity": "sha512-Bj3zo3JE/T6GT83z7qnZugnxWdojaJ6YmQRj9Iq5l7F8vn63l25GQdFVuTt9gSfmIaak2tk9Gbc/ORz9EiUkzw==",
+      "version": "9.1.13",
+      "resolved": "https://registry.npmjs.org/@storybook/web-components/-/web-components-9.1.13.tgz",
+      "integrity": "sha512-fVPpD0WfBiAI65a3azyC/8CeFSF4iiRGNHmwjVOHBVEJ7fb53dFvSxbCq/i8j8xJesvBI9RbqSNWQxp4rK26tw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10054,18 +10326,18 @@
       },
       "peerDependencies": {
         "lit": "^2.0.0 || ^3.0.0",
-        "storybook": "^9.1.12"
+        "storybook": "^9.1.13"
       }
     },
     "node_modules/@storybook/web-components-vite": {
-      "version": "9.1.12",
-      "resolved": "https://registry.npmjs.org/@storybook/web-components-vite/-/web-components-vite-9.1.12.tgz",
-      "integrity": "sha512-SWz5ylKdbL90LeSC6gxCYZaJxJdOCyP9MMHL9+c1RKAZEEckifQBG70Az0z7Y5dD24Bfsyu3MVNRp9ReBSz82A==",
+      "version": "9.1.13",
+      "resolved": "https://registry.npmjs.org/@storybook/web-components-vite/-/web-components-vite-9.1.13.tgz",
+      "integrity": "sha512-mjdNzLzPEo1HHyDJbfdErxMGY5ctYL5hCy/qrRlxNfHTE/4nSMTfjuFhsMmmVmGBNVDiCLjTaJ/bhSYPkesugg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@storybook/builder-vite": "9.1.12",
-        "@storybook/web-components": "9.1.12"
+        "@storybook/builder-vite": "9.1.13",
+        "@storybook/web-components": "9.1.13"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -10075,7 +10347,7 @@
         "url": "https://opencollective.com/storybook"
       },
       "peerDependencies": {
-        "storybook": "^9.1.12"
+        "storybook": "^9.1.13"
       }
     },
     "node_modules/@swc/helpers": {
@@ -10584,19 +10856,6 @@
       }
     },
     "node_modules/@types/express-serve-static-core": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.0.tgz",
-      "integrity": "sha512-jnHMsrd0Mwa9Cf4IdOzbz543y4XJepXrbia2T4b6+spXC2We3t1y6K44D3mR8XMFSXMCf3/l7rCgddfx7UNVBA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "@types/qs": "*",
-        "@types/range-parser": "*",
-        "@types/send": "*"
-      }
-    },
-    "node_modules/@types/express/node_modules/@types/express-serve-static-core": {
       "version": "4.19.7",
       "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.7.tgz",
       "integrity": "sha512-FvPtiIf1LfhzsaIXhv/PHan/2FeQBbtBDtfX2QfvPxdUelMDEckK08SM6nqo1MIZY3RUlfA+HV8+hFUSio78qg==",
@@ -10709,6 +10968,48 @@
         "expect": "^29.0.0",
         "pretty-format": "^29.0.0"
       }
+    },
+    "node_modules/@types/jest/node_modules/@jest/schemas": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.27.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/@sinclair/typebox": {
+      "version": "0.27.8",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
+      "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/jest/node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/jsdom": {
       "version": "20.0.1",
@@ -10901,13 +11202,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.8.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.8.0.tgz",
-      "integrity": "sha512-5x08bUtU8hfboMTrJ7mEO4CpepS9yBwAqcL52y86SWNmbPX8LVbNs3EP4cNrIZgdjk2NAlP2ahNihozpoZIxSg==",
+      "version": "24.9.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.9.1.tgz",
+      "integrity": "sha512-QoiaXANRkSXK6p0Duvt56W208du4P9Uye9hWLWgGMDTEoKPhuenzNcC4vGUmrNkiOKTlIrBoyNQYNpSwfEZXSg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.14.0"
+        "undici-types": "~7.16.0"
       }
     },
     "node_modules/@types/node-forge": {
@@ -11067,9 +11368,9 @@
       }
     },
     "node_modules/@types/sinonjs__fake-timers": {
-      "version": "8.1.5",
-      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.5.tgz",
-      "integrity": "sha512-mQkU2jY8jJEF7YHjHvsQO8+3ughTL1mcnn96igfhONmR+fUPSKIkefQYpSe8bsly2Ep7oQbn/6VG5/9/0qcArQ==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-15.0.0.tgz",
+      "integrity": "sha512-lqKG4X0fO3aJF7Bz590vuCkFt/inbDyL7FXaVjPEYO+LogMZ2fwSDUiP7bJvdYHaCgCQGNOPxquzSrrnVH3fGw==",
       "dev": true,
       "license": "MIT"
     },
@@ -11129,9 +11430,9 @@
       }
     },
     "node_modules/@types/ws": {
-      "version": "7.4.7",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-7.4.7.tgz",
-      "integrity": "sha512-JQbbmxZTZehdc2iszGKs5oC3NFnjeay7mtAWrdt7qNtAVK0g19muApzAy4bm9byz79xa2ZnO/BOBC2R8RC5Lww==",
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11481,13 +11782,14 @@
       }
     },
     "node_modules/@vitest/expect/node_modules/@types/chai": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.2.tgz",
-      "integrity": "sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/deep-eql": "*"
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
       }
     },
     "node_modules/@vitest/mocker": {
@@ -11674,20 +11976,24 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@web/dev-server-core/node_modules/chokidar": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
-      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+    "node_modules/@web/dev-server-core/node_modules/@types/ws": {
+      "version": "7.4.7",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-7.4.7.tgz",
+      "integrity": "sha512-JQbbmxZTZehdc2iszGKs5oC3NFnjeay7mtAWrdt7qNtAVK0g19muApzAy4bm9byz79xa2ZnO/BOBC2R8RC5Lww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "readdirp": "^4.0.1"
-      },
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@web/dev-server-core/node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
-        "node": ">= 14.16.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
+        "node": ">=0.8"
       }
     },
     "node_modules/@web/dev-server-core/node_modules/lru-cache": {
@@ -11700,31 +12006,56 @@
         "node": ">=16.14"
       }
     },
-    "node_modules/@web/dev-server-core/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+    "node_modules/@web/dev-server-core/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
+        "node": ">= 0.6"
       }
     },
-    "node_modules/@web/dev-server-core/node_modules/readdirp": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
-      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+    "node_modules/@web/dev-server-core/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@web/dev-server-core/node_modules/parse5": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
+      "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@web/dev-server-core/node_modules/ws": {
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">= 14.18.0"
+        "node": ">=8.3.0"
       },
-      "funding": {
-        "type": "individual",
-        "url": "https://paulmillr.com/funding/"
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/@web/dev-server-esbuild": {
@@ -11743,6 +12074,13 @@
       "engines": {
         "node": ">=18.0.0"
       }
+    },
+    "node_modules/@web/dev-server-esbuild/node_modules/parse5": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
+      "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@web/dev-server-rollup": {
       "version": "0.6.4",
@@ -11787,6 +12125,13 @@
         }
       }
     },
+    "node_modules/@web/dev-server-rollup/node_modules/parse5": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
+      "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@web/dev-server/node_modules/@web/config-loader": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/@web/config-loader/-/config-loader-0.3.3.tgz",
@@ -11795,6 +12140,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@web/dev-server/node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@web/parse5-utils": {
@@ -11810,6 +12168,13 @@
       "engines": {
         "node": ">=18.0.0"
       }
+    },
+    "node_modules/@web/parse5-utils/node_modules/parse5": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
+      "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@web/test-runner": {
       "version": "0.19.0",
@@ -11912,20 +12277,49 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@web/test-runner-core/node_modules/chokidar": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
-      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+    "node_modules/@web/test-runner-core/node_modules/ansi-escapes": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "readdirp": "^4.0.1"
+        "type-fest": "^0.21.3"
       },
       "engines": {
-        "node": ">= 14.16.0"
+        "node": ">=8"
       },
       "funding": {
-        "url": "https://paulmillr.com/funding/"
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@web/test-runner-core/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@web/test-runner-core/node_modules/cli-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@web/test-runner-core/node_modules/globby": {
@@ -11949,31 +12343,47 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@web/test-runner-core/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+    "node_modules/@web/test-runner-core/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
+        "node": ">=8"
       }
     },
-    "node_modules/@web/test-runner-core/node_modules/readdirp": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
-      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+    "node_modules/@web/test-runner-core/node_modules/log-update": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-4.0.0.tgz",
+      "integrity": "sha512-9fkkDevMefjg0mmzWFBW8YkFP91OrizzkW3diF7CpG+S2EYdy4+TVfGwz1zeF8x7hCx1ovSPTOE9Ngib74qqUg==",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "ansi-escapes": "^4.3.0",
+        "cli-cursor": "^3.1.0",
+        "slice-ansi": "^4.0.0",
+        "wrap-ansi": "^6.2.0"
+      },
       "engines": {
-        "node": ">= 14.18.0"
+        "node": ">=10"
       },
       "funding": {
-        "type": "individual",
-        "url": "https://paulmillr.com/funding/"
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@web/test-runner-core/node_modules/restore-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@web/test-runner-core/node_modules/slash": {
@@ -11984,6 +12394,47 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@web/test-runner-core/node_modules/slice-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+      "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@web/test-runner-core/node_modules/source-map": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@web/test-runner-core/node_modules/type-fest": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@web/test-runner-coverage-v8": {
@@ -12011,19 +12462,6 @@
       "license": "ISC",
       "engines": {
         "node": ">=16.14"
-      }
-    },
-    "node_modules/@web/test-runner-coverage-v8/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/@web/test-runner-mocha": {
@@ -12064,6 +12502,19 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@web/test-runner/node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@web/test-runner/node_modules/globby": {
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
@@ -12093,6 +12544,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@web/test-runner/node_modules/source-map": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/@webassemblyjs/ast": {
@@ -12566,27 +13027,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/accepts/node_modules/mime-db": {
-      "version": "1.54.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
-      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/accepts/node_modules/mime-types": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
-      "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "^1.54.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -12780,29 +13220,16 @@
       }
     },
     "node_modules/ansi-escapes": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
-      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.1.1.tgz",
+      "integrity": "sha512-Zhl0ErHcSRUaVfGUeUdDuLgpkEo8KIFjB4Y9uAc46ScOpdDiU1Dbyplh7qWJeJ/ZHpbyMSM26+X3BySgnIz40Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "type-fest": "^0.21.3"
+        "environment": "^1.0.0"
       },
       "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/ansi-escapes/node_modules/type-fest": {
-      "version": "0.21.3",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
-      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
-      "dev": true,
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=10"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -12855,19 +13282,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/anymatch/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/aproba": {
@@ -13675,9 +14089,9 @@
       }
     },
     "node_modules/bare-url": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.3.0.tgz",
-      "integrity": "sha512-c+RCqMSZbkz97Mw1LWR0gcOqwK82oyYKfLoHJ8k13ybi1+I80ffdDzUy0TdAburdrR/kI0/VuN8YgEnJqX+Nyw==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.3.1.tgz",
+      "integrity": "sha512-v2yl0TnaZTdEnelkKtXZGnotiV6qATBlnNuUMrHl6v9Lmmrh9mw9RYyImPU7/4RahumSwQS1k2oKXcRfXcbjJw==",
       "dev": true,
       "license": "Apache-2.0",
       "optional": true,
@@ -13707,9 +14121,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.8.17",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.17.tgz",
-      "integrity": "sha512-j5zJcx6golJYTG6c05LUZ3Z8Gi+M62zRT/ycz4Xq4iCOdpcxwg7ngEYD4KA0eWZC7U17qh/Smq8bYbACJ0ipBA==",
+      "version": "2.8.19",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.19.tgz",
+      "integrity": "sha512-zoKGUdu6vb2jd3YOq0nnhEDQVbPcHhco3UImJrv5dSkvxTc2pl2WjOPsjZXDwPDSl5eghIMuY3R6J9NDKF3KcQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -13862,79 +14276,16 @@
         "node": ">=18"
       }
     },
-    "node_modules/body-parser/node_modules/media-typer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
-      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/body-parser/node_modules/mime-db": {
-      "version": "1.54.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
-      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/body-parser/node_modules/mime-types": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
-      "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "^1.54.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/body-parser/node_modules/raw-body": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.1.tgz",
-      "integrity": "sha512-9G8cA+tuMS75+6G/TzW8OtLzmBDMo8p1JRxN5AZ+LAp8uxGA8V8GZm4GQ4/N5QNQEnLmg6SS7wyuSmbKepiKqA==",
-      "license": "MIT",
-      "dependencies": {
-        "bytes": "3.1.2",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.7.0",
-        "unpipe": "1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
-    "node_modules/body-parser/node_modules/raw-body/node_modules/iconv-lite": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.0.tgz",
-      "integrity": "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==",
+    "node_modules/body-parser/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
       "engines": {
         "node": ">=0.10.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/body-parser/node_modules/type-is": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
-      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
-      "license": "MIT",
-      "dependencies": {
-        "content-type": "^1.0.5",
-        "media-typer": "^1.1.0",
-        "mime-types": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/bonjour-service": {
@@ -14362,17 +14713,40 @@
         "node": ">= 6.0.0"
       }
     },
+    "node_modules/cache-content-type/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cache-content-type/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/cacheable": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cacheable/-/cacheable-2.1.0.tgz",
-      "integrity": "sha512-zzL1BxdnqwD69JRT0dihnawAcLkBMwAH+hZSKjUzeBbPedVhk3qYPjRw9VOMYWwt5xRih5xd8S+3kEdGohZm/g==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/cacheable/-/cacheable-2.1.1.tgz",
+      "integrity": "sha512-LmF4AXiSNdiRbI2UjH8pAp9NIXxeQsTotpEaegPiDcnN0YPygDJDV3l/Urc0mL72JWdATEorKqIHEx55nDlONg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@cacheable/memoize": "^2.0.3",
         "@cacheable/memory": "^2.0.3",
         "@cacheable/utils": "^2.1.0",
-        "hookified": "^1.12.1",
+        "hookified": "^1.12.2",
         "keyv": "^5.5.3",
         "qified": "^0.5.0"
       }
@@ -14457,16 +14831,13 @@
       }
     },
     "node_modules/camelcase": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
-      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=6"
       }
     },
     "node_modules/camelcase-keys": {
@@ -14485,16 +14856,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/camelcase-keys/node_modules/camelcase": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/caniuse-api": {
@@ -14732,10 +15093,73 @@
         "url": "https://github.com/sponsors/fb55"
       }
     },
-    "node_modules/cheerio/node_modules/entities": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
-      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+    "node_modules/cheerio-select/node_modules/css-select": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/cheerio-select/node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/cheerio-select/node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/cheerio-select/node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/cheerio-select/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
       "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
@@ -14743,6 +15167,85 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/cheerio/node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/cheerio/node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/cheerio/node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/cheerio/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/cheerio/node_modules/htmlparser2": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
+      "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1",
+        "entities": "^4.4.0"
       }
     },
     "node_modules/cheerio/node_modules/parse5": {
@@ -14758,39 +15261,32 @@
         "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
-    "node_modules/chokidar": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
-      "integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
+    "node_modules/cheerio/node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "anymatch": "~3.1.2",
-        "braces": "~3.0.2",
-        "glob-parent": "~5.1.2",
-        "is-binary-path": "~2.1.0",
-        "is-glob": "~4.0.1",
-        "normalize-path": "~3.0.0",
-        "readdirp": "~3.6.0"
-      },
+      "license": "BSD-2-Clause",
       "engines": {
-        "node": ">= 8.10.0"
+        "node": ">=0.12"
       },
-      "optionalDependencies": {
-        "fsevents": "~2.3.2"
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
-    "node_modules/chokidar/node_modules/glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
-      "license": "ISC",
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "license": "MIT",
       "dependencies": {
-        "is-glob": "^4.0.1"
+        "readdirp": "^4.0.1"
       },
       "engines": {
-        "node": ">= 6"
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/chownr": {
@@ -14888,16 +15384,6 @@
         "node": ">= 10.0"
       }
     },
-    "node_modules/clean-css/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/clean-stack": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
@@ -14922,16 +15408,19 @@
       }
     },
     "node_modules/cli-cursor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
-      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "restore-cursor": "^3.1.0"
+        "restore-cursor": "^5.0.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/cli-spinners": {
@@ -15038,6 +15527,30 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/clipboardy/node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
     "node_modules/cliui": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
@@ -15085,9 +15598,9 @@
       }
     },
     "node_modules/clone": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -15158,6 +15671,82 @@
       },
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/co-body/node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/co-body/node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/co-body/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/co-body/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/co-body/node_modules/raw-body": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
+      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/co-body/node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/collect-v8-coverage": {
@@ -15449,16 +16038,6 @@
       "license": "ISC",
       "dependencies": {
         "source-map": "^0.6.1"
-      }
-    },
-    "node_modules/concat-with-sourcemaps/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/concurrently": {
@@ -16791,16 +17370,16 @@
       }
     },
     "node_modules/css-select": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
-      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.3.0.tgz",
+      "integrity": "sha512-wPpOYtnsVontu2mODhA19JrqWxNsfdatRKd64kmpRbQgh1KtItko5sTnEpPdpSaJszTOhEMlF/RPz28qj4HqhQ==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "boolbase": "^1.0.0",
-        "css-what": "^6.1.0",
-        "domhandler": "^5.0.2",
-        "domutils": "^3.0.1",
+        "css-what": "^6.0.1",
+        "domhandler": "^4.3.1",
+        "domutils": "^2.8.0",
         "nth-check": "^2.0.1"
       },
       "funding": {
@@ -17014,16 +17593,6 @@
       "integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==",
       "dev": true,
       "license": "CC0-1.0"
-    },
-    "node_modules/csso/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/cssom": {
       "version": "0.5.0",
@@ -17414,16 +17983,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/defaults/node_modules/clone": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/define-data-property": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
@@ -17443,16 +18002,13 @@
       }
     },
     "node_modules/define-lazy-prop": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
-      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
+      "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=8"
       }
     },
     "node_modules/define-properties": {
@@ -17721,6 +18277,16 @@
         "node": ">=16"
       }
     },
+    "node_modules/doiuse/node_modules/source-map": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/dom-accessibility-api": {
       "version": "0.5.16",
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
@@ -17740,15 +18306,15 @@
       }
     },
     "node_modules/dom-serializer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
-      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.4.1.tgz",
+      "integrity": "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.2",
-        "entities": "^4.2.0"
+        "domelementtype": "^2.0.1",
+        "domhandler": "^4.2.0",
+        "entities": "^2.0.0"
       },
       "funding": {
         "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
@@ -17782,13 +18348,13 @@
       }
     },
     "node_modules/domhandler": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
-      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
+      "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "domelementtype": "^2.3.0"
+        "domelementtype": "^2.2.0"
       },
       "engines": {
         "node": ">= 4"
@@ -17807,15 +18373,15 @@
       }
     },
     "node_modules/domutils": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
-      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
+      "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "dom-serializer": "^2.0.0",
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.3"
+        "dom-serializer": "^1.0.1",
+        "domelementtype": "^2.2.0",
+        "domhandler": "^4.2.0"
       },
       "funding": {
         "url": "https://github.com/fb55/domutils?sponsor=1"
@@ -17846,9 +18412,10 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "16.6.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
-      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "version": "16.4.7",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
+      "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
+      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -18040,6 +18607,20 @@
         "iconv-lite": "^0.6.2"
       }
     },
+    "node_modules/encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
@@ -18078,13 +18659,11 @@
       }
     },
     "node_modules/entities": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
-      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
+      "dev": true,
       "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=0.12"
-      },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
@@ -18442,17 +19021,6 @@
       },
       "optionalDependencies": {
         "source-map": "~0.6.1"
-      }
-    },
-    "node_modules/escodegen/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/eslint": {
@@ -19092,6 +19660,22 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/eslint/node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/eslint/node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -19237,9 +19821,9 @@
       }
     },
     "node_modules/execa": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
-      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.0.0.tgz",
+      "integrity": "sha512-ov6w/2LCiuyO4RLYGdpFGjkcs0wMTgGE8PrkTHikeUy5iJekXyPIKUjifk5CsE0pt7sMCrMZ3YNqoCj6idQOnQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -19333,50 +19917,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/express/node_modules/media-typer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
-      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/express/node_modules/mime-db": {
-      "version": "1.54.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
-      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/express/node_modules/mime-types": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
-      "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "^1.54.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/express/node_modules/type-is": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
-      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
-      "license": "MIT",
-      "dependencies": {
-        "content-type": "^1.0.5",
-        "media-typer": "^1.1.0",
-        "mime-types": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/extend": {
@@ -19558,24 +20098,6 @@
         "pend": "~1.2.0"
       }
     },
-    "node_modules/fdir": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "peerDependencies": {
-        "picomatch": "^3 || ^4"
-      },
-      "peerDependenciesMeta": {
-        "picomatch": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/figures": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
@@ -19687,6 +20209,39 @@
       "dependencies": {
         "common-path-prefix": "^3.0.0",
         "pkg-dir": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/find-cache-dir/node_modules/find-up": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-6.3.0.tgz",
+      "integrity": "sha512-v2ZsoEuVHYy8ZIlYqwPe/39Cy+cFDzp4dXPaxNvkEuouymu+2Jbz0PxpKarJHYJTmv2HWT3O382qY8l4jMWthw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^7.1.0",
+        "path-exists": "^5.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/find-cache-dir/node_modules/pkg-dir": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-7.0.0.tgz",
+      "integrity": "sha512-Ie9z/WINcxxLp27BKOCHGde4ITq9UklYKDzVo1nhk5sqGEXU3FpkwP5GM2voTGJkGd9B3Otl+Q4uwSOeSUtOBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "find-up": "^6.3.0"
       },
       "engines": {
         "node": ">=14.16"
@@ -19895,6 +20450,29 @@
         "node": ">= 6"
       }
     },
+    "node_modules/form-data/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -20004,9 +20582,9 @@
       "license": "ISC"
     },
     "node_modules/fsevents": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -20298,9 +20876,9 @@
       }
     },
     "node_modules/get-stream": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
-      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.0.tgz",
+      "integrity": "sha512-A1B3Bh1UmL0bidM/YX2NsCOTnGJePL9rO/M+Mw3m9f2gUpfokS0hi5Eah0WSUEWZdZhIZtMjkIYS7mDfOqNHbg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -20977,16 +21555,6 @@
         "uglify-js": "^3.1.4"
       }
     },
-    "node_modules/handlebars/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/hard-rejection": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/hard-rejection/-/hard-rejection-2.1.0.tgz",
@@ -21337,9 +21905,9 @@
       }
     },
     "node_modules/htmlparser2": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
-      "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
+      "integrity": "sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==",
       "dev": true,
       "funding": [
         "https://github.com/fb55/htmlparser2?sponsor=1",
@@ -21350,10 +21918,10 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.3",
-        "domutils": "^3.0.1",
-        "entities": "^4.4.0"
+        "domelementtype": "^2.0.1",
+        "domhandler": "^4.0.0",
+        "domutils": "^2.5.2",
+        "entities": "^2.0.0"
       }
     },
     "node_modules/http-assert": {
@@ -21507,19 +22075,6 @@
         }
       }
     },
-    "node_modules/http-proxy-middleware/node_modules/is-plain-obj": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-3.0.0.tgz",
-      "integrity": "sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/http-proxy/node_modules/eventemitter3": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
@@ -21578,15 +22133,19 @@
       }
     },
     "node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.0.tgz",
+      "integrity": "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==",
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
       "engines": {
         "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/icss-replace-symbols": {
@@ -21759,85 +22318,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/import-local/node_modules/find-up": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "locate-path": "^5.0.0",
-        "path-exists": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/import-local/node_modules/locate-path": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "p-locate": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/import-local/node_modules/p-limit": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "p-try": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/import-local/node_modules/p-locate": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "p-limit": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/import-local/node_modules/path-exists": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/import-local/node_modules/pkg-dir": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
-      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "find-up": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/import-meta-resolve": {
@@ -22167,28 +22647,11 @@
       }
     },
     "node_modules/is-buffer": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
-      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
       "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
+      "license": "MIT"
     },
     "node_modules/is-builtin-module": {
       "version": "3.2.1",
@@ -22284,16 +22747,16 @@
       }
     },
     "node_modules/is-docker": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
-      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
       "dev": true,
       "license": "MIT",
       "bin": {
         "is-docker": "cli.js"
       },
       "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+        "node": ">=8"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -22398,6 +22861,22 @@
       },
       "engines": {
         "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-inside-container/node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -22520,13 +22999,13 @@
       }
     },
     "node_modules/is-plain-obj": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
-      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-3.0.0.tgz",
+      "integrity": "sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=12"
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -22637,16 +23116,13 @@
       }
     },
     "node_modules/is-stream": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+      "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-string": {
@@ -22785,22 +23261,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/is-wsl/node_modules/is-docker": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
-      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "is-docker": "cli.js"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/isarray": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
@@ -22906,16 +23366,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/istanbul-lib-source-maps/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/istanbul-reports": {
@@ -23058,21 +23508,25 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/jest-circus/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+    "node_modules/jest-circus/node_modules/@jest/schemas": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "color-convert": "^2.0.1"
+        "@sinclair/typebox": "^0.27.8"
       },
       "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
+    },
+    "node_modules/jest-circus/node_modules/@sinclair/typebox": {
+      "version": "0.27.8",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
+      "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/jest-circus/node_modules/chalk": {
       "version": "4.1.2",
@@ -23090,6 +23544,44 @@
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
+    },
+    "node_modules/jest-circus/node_modules/chalk/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-circus/node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-circus/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/jest-circus/node_modules/slash": {
       "version": "3.0.0",
@@ -23240,21 +23732,25 @@
         }
       }
     },
-    "node_modules/jest-config/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+    "node_modules/jest-config/node_modules/@jest/schemas": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "color-convert": "^2.0.1"
+        "@sinclair/typebox": "^0.27.8"
       },
       "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
+    },
+    "node_modules/jest-config/node_modules/@sinclair/typebox": {
+      "version": "0.27.8",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
+      "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/jest-config/node_modules/chalk": {
       "version": "4.1.2",
@@ -23271,6 +23767,22 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/jest-config/node_modules/chalk/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/jest-config/node_modules/glob": {
@@ -23294,6 +23806,28 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/jest-config/node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-config/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/jest-config/node_modules/slash": {
       "version": "3.0.0",
@@ -23319,19 +23853,19 @@
       }
     },
     "node_modules/jest-diff": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
-      "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.2.0.tgz",
+      "integrity": "sha512-dQHFo3Pt4/NLlG5z4PxZ/3yZTZ1C7s9hveiOj+GCN+uT109NC2QgsoVZsVOAvbJ3RgKkvyLGXZV9+piDpWbm6A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "chalk": "^4.0.0",
-        "diff-sequences": "^29.6.3",
-        "jest-get-type": "^29.6.3",
-        "pretty-format": "^29.7.0"
+        "@jest/diff-sequences": "30.0.1",
+        "@jest/get-type": "30.1.0",
+        "chalk": "^4.1.2",
+        "pretty-format": "30.2.0"
       },
       "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/jest-diff/node_modules/ansi-styles": {
@@ -23410,21 +23944,25 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/jest-each/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+    "node_modules/jest-each/node_modules/@jest/schemas": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "color-convert": "^2.0.1"
+        "@sinclair/typebox": "^0.27.8"
       },
       "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
+    },
+    "node_modules/jest-each/node_modules/@sinclair/typebox": {
+      "version": "0.27.8",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
+      "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/jest-each/node_modules/chalk": {
       "version": "4.1.2",
@@ -23442,6 +23980,44 @@
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
+    },
+    "node_modules/jest-each/node_modules/chalk/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-each/node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-each/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/jest-each/node_modules/supports-color": {
       "version": "7.2.0",
@@ -23538,6 +24114,22 @@
         "fsevents": "^2.3.2"
       }
     },
+    "node_modules/jest-haste-map/node_modules/jest-worker": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
+      "integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "jest-util": "^29.7.0",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
     "node_modules/jest-leak-detector": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.7.0.tgz",
@@ -23551,6 +24143,48 @@
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
+    },
+    "node_modules/jest-leak-detector/node_modules/@jest/schemas": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.27.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-leak-detector/node_modules/@sinclair/typebox": {
+      "version": "0.27.8",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
+      "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jest-leak-detector/node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-leak-detector/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/jest-matcher-utils": {
       "version": "29.7.0",
@@ -23568,21 +24202,25 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/jest-matcher-utils/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+    "node_modules/jest-matcher-utils/node_modules/@jest/schemas": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "color-convert": "^2.0.1"
+        "@sinclair/typebox": "^0.27.8"
       },
       "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
+    },
+    "node_modules/jest-matcher-utils/node_modules/@sinclair/typebox": {
+      "version": "0.27.8",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
+      "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/jest-matcher-utils/node_modules/chalk": {
       "version": "4.1.2",
@@ -23600,6 +24238,60 @@
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
+    },
+    "node_modules/jest-matcher-utils/node_modules/chalk/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-matcher-utils/node_modules/jest-diff": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
+      "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "diff-sequences": "^29.6.3",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-matcher-utils/node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-matcher-utils/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/jest-matcher-utils/node_modules/supports-color": {
       "version": "7.2.0",
@@ -23635,21 +24327,25 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/jest-message-util/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+    "node_modules/jest-message-util/node_modules/@jest/schemas": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "color-convert": "^2.0.1"
+        "@sinclair/typebox": "^0.27.8"
       },
       "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
+    },
+    "node_modules/jest-message-util/node_modules/@sinclair/typebox": {
+      "version": "0.27.8",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
+      "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/jest-message-util/node_modules/chalk": {
       "version": "4.1.2",
@@ -23667,6 +24363,44 @@
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
+    },
+    "node_modules/jest-message-util/node_modules/chalk/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-message-util/node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-message-util/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/jest-message-util/node_modules/slash": {
       "version": "3.0.0",
@@ -23891,7 +24625,7 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/jest-runner/node_modules/supports-color": {
+    "node_modules/jest-runner/node_modules/chalk/node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
@@ -23902,6 +24636,33 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/jest-runner/node_modules/jest-worker": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
+      "integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "jest-util": "^29.7.0",
+        "merge-stream": "^2.0.0",
+        "supports-color": "^8.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-runner/node_modules/source-map-support": {
+      "version": "0.5.13",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
+      "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
       }
     },
     "node_modules/jest-runtime": {
@@ -24048,21 +24809,25 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/jest-snapshot/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+    "node_modules/jest-snapshot/node_modules/@jest/schemas": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "color-convert": "^2.0.1"
+        "@sinclair/typebox": "^0.27.8"
       },
       "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
+    },
+    "node_modules/jest-snapshot/node_modules/@sinclair/typebox": {
+      "version": "0.27.8",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
+      "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/jest-snapshot/node_modules/chalk": {
       "version": "4.1.2",
@@ -24080,6 +24845,60 @@
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
+    },
+    "node_modules/jest-snapshot/node_modules/chalk/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-snapshot/node_modules/jest-diff": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
+      "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "diff-sequences": "^29.6.3",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-snapshot/node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-snapshot/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/jest-snapshot/node_modules/semver": {
       "version": "7.7.3",
@@ -24158,19 +24977,6 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/jest-util/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/jest-util/node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -24202,20 +25008,37 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/jest-validate/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+    "node_modules/jest-validate/node_modules/@jest/schemas": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "color-convert": "^2.0.1"
+        "@sinclair/typebox": "^0.27.8"
       },
       "engines": {
-        "node": ">=8"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-validate/node_modules/@sinclair/typebox": {
+      "version": "0.27.8",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
+      "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jest-validate/node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       },
       "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/jest-validate/node_modules/chalk": {
@@ -24234,6 +25057,44 @@
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
+    },
+    "node_modules/jest-validate/node_modules/chalk/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-validate/node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-validate/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/jest-validate/node_modules/supports-color": {
       "version": "7.2.0",
@@ -24266,6 +25127,22 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-watcher/node_modules/ansi-escapes": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.21.3"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/jest-watcher/node_modules/ansi-styles": {
@@ -24314,20 +25191,32 @@
         "node": ">=8"
       }
     },
+    "node_modules/jest-watcher/node_modules/type-fest": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/jest-worker": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
-      "integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
+      "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
-        "jest-util": "^29.7.0",
         "merge-stream": "^2.0.0",
         "supports-color": "^8.0.0"
       },
       "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "node": ">= 10.13.0"
       }
     },
     "node_modules/jiti": {
@@ -24542,28 +25431,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/jsdom/node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -24773,9 +25640,9 @@
       "license": "MIT"
     },
     "node_modules/koa": {
-      "version": "2.16.2",
-      "resolved": "https://registry.npmjs.org/koa/-/koa-2.16.2.tgz",
-      "integrity": "sha512-+CCssgnrWKx9aI3OeZwroa/ckG4JICxvIFnSiOUyl2Uv+UTI+xIw0FfFrWS7cQFpoePpr9o8csss7KzsTzNL8Q==",
+      "version": "2.16.3",
+      "resolved": "https://registry.npmjs.org/koa/-/koa-2.16.3.tgz",
+      "integrity": "sha512-zPPuIt+ku1iCpFBRwseMcPYQ1cJL8l60rSmKeOuGfOXyE6YnTBmf2aEFNL2HQGrD0cPcLO/t+v9RTgC+fwEh/g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -24988,6 +25855,39 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/koa/node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/koa/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/koa/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/koa/node_modules/negotiator": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
@@ -25004,6 +25904,20 @@
       "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/koa/node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
       "engines": {
         "node": ">= 0.6"
       }
@@ -25131,26 +26045,6 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
-    "node_modules/lerna/node_modules/@jest/schemas": {
-      "version": "30.0.5",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.5.tgz",
-      "integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sinclair/typebox": "^0.34.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/lerna/node_modules/@sinclair/typebox": {
-      "version": "0.34.41",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.41.tgz",
-      "integrity": "sha512-6gS8pZzSXdyRHTIqoqSVknxolr1kzfy4/CeDnrzsVz8TTIWUbOBr6gnzOmTYJ3eXQNh4IYHIGi5aIL7sOZ2G/g==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/lerna/node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -25182,43 +26076,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/lerna/node_modules/execa": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-5.0.0.tgz",
-      "integrity": "sha512-ov6w/2LCiuyO4RLYGdpFGjkcs0wMTgGE8PrkTHikeUy5iJekXyPIKUjifk5CsE0pt7sMCrMZ3YNqoCj6idQOnQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cross-spawn": "^7.0.3",
-        "get-stream": "^6.0.0",
-        "human-signals": "^2.1.0",
-        "is-stream": "^2.0.0",
-        "merge-stream": "^2.0.0",
-        "npm-run-path": "^4.0.1",
-        "onetime": "^5.1.2",
-        "signal-exit": "^3.0.3",
-        "strip-final-newline": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/execa?sponsor=1"
-      }
-    },
-    "node_modules/lerna/node_modules/get-stream": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.0.tgz",
-      "integrity": "sha512-A1B3Bh1UmL0bidM/YX2NsCOTnGJePL9rO/M+Mw3m9f2gUpfokS0hi5Eah0WSUEWZdZhIZtMjkIYS7mDfOqNHbg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/lerna/node_modules/glob": {
@@ -25273,49 +26130,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/lerna/node_modules/is-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
-      "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/lerna/node_modules/jest-diff": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.2.0.tgz",
-      "integrity": "sha512-dQHFo3Pt4/NLlG5z4PxZ/3yZTZ1C7s9hveiOj+GCN+uT109NC2QgsoVZsVOAvbJ3RgKkvyLGXZV9+piDpWbm6A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/diff-sequences": "30.0.1",
-        "@jest/get-type": "30.1.0",
-        "chalk": "^4.1.2",
-        "pretty-format": "30.2.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/lerna/node_modules/jest-diff/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
     "node_modules/lerna/node_modules/minimatch": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.5.tgz",
@@ -25338,41 +26152,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/lerna/node_modules/pretty-format": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.2.0.tgz",
-      "integrity": "sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/schemas": "30.0.5",
-        "ansi-styles": "^5.2.0",
-        "react-is": "^18.3.1"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/lerna/node_modules/pretty-format/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/lerna/node_modules/react-is": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/lerna/node_modules/rimraf": {
       "version": "4.4.1",
@@ -25772,9 +26551,9 @@
       }
     },
     "node_modules/lint-staged": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-16.2.4.tgz",
-      "integrity": "sha512-Pkyr/wd90oAyXk98i/2KwfkIhoYQUMtss769FIT9hFM5ogYZwrk+GRE46yKXSg2ZGhcJ1p38Gf5gmI5Ohjg2yg==",
+      "version": "16.2.5",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-16.2.5.tgz",
+      "integrity": "sha512-o36wH3OX0jRWqDw5dOa8a8x6GXTKaLM+LvhRaucZxez0IxA+KNDUCiyjBfNgsMNmchwSX6urLSL7wShcUqAang==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -25797,9 +26576,9 @@
       }
     },
     "node_modules/listr2": {
-      "version": "9.0.4",
-      "resolved": "https://registry.npmjs.org/listr2/-/listr2-9.0.4.tgz",
-      "integrity": "sha512-1wd/kpAdKRLwv7/3OKC8zZ5U8e/fajCfWMxacUvB79S5nLrYGPtUI/8chMQhn3LQjsRVErTb9i1ECAwW0ZIHnQ==",
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-9.0.5.tgz",
+      "integrity": "sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -25812,22 +26591,6 @@
       },
       "engines": {
         "node": ">=20.0.0"
-      }
-    },
-    "node_modules/listr2/node_modules/ansi-escapes": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.1.1.tgz",
-      "integrity": "sha512-Zhl0ErHcSRUaVfGUeUdDuLgpkEo8KIFjB4Y9uAc46ScOpdDiU1Dbyplh7qWJeJ/ZHpbyMSM26+X3BySgnIz40Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "environment": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/listr2/node_modules/ansi-regex": {
@@ -25856,94 +26619,12 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/listr2/node_modules/cli-cursor": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
-      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "restore-cursor": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/listr2/node_modules/emoji-regex": {
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
       "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/listr2/node_modules/log-update": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz",
-      "integrity": "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-escapes": "^7.0.0",
-        "cli-cursor": "^5.0.0",
-        "slice-ansi": "^7.1.0",
-        "strip-ansi": "^7.1.0",
-        "wrap-ansi": "^9.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/listr2/node_modules/onetime": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
-      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mimic-function": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/listr2/node_modules/restore-cursor": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
-      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "onetime": "^7.0.0",
-        "signal-exit": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/listr2/node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
     },
     "node_modules/listr2/node_modules/string-width": {
       "version": "7.2.0",
@@ -26094,13 +26775,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/lit-analyzer/node_modules/parse5": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.0.tgz",
-      "integrity": "sha512-fxNG2sQjHvlVAYmzBZS9YlDp6PTSSDwa98vkD4QgVDDCAo84z5X1t5XyJQ62ImdLXx5NdIIfihey6xpum9/gRQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/lit-analyzer/node_modules/supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -26201,51 +26875,6 @@
       },
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/locate-path/node_modules/p-limit": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
-      "integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "yocto-queue": "^1.0.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/locate-path/node_modules/p-locate": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-6.0.0.tgz",
-      "integrity": "sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "p-limit": "^4.0.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/locate-path/node_modules/yocto-queue": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.1.tgz",
-      "integrity": "sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -26426,66 +27055,108 @@
       }
     },
     "node_modules/log-update": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/log-update/-/log-update-4.0.0.tgz",
-      "integrity": "sha512-9fkkDevMefjg0mmzWFBW8YkFP91OrizzkW3diF7CpG+S2EYdy4+TVfGwz1zeF8x7hCx1ovSPTOE9Ngib74qqUg==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz",
+      "integrity": "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ansi-escapes": "^4.3.0",
-        "cli-cursor": "^3.1.0",
-        "slice-ansi": "^4.0.0",
-        "wrap-ansi": "^6.2.0"
+        "ansi-escapes": "^7.0.0",
+        "cli-cursor": "^5.0.0",
+        "slice-ansi": "^7.1.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/log-update/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+    "node_modules/log-update/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/log-update/node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+    "node_modules/log-update/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
       "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
+      "license": "MIT"
     },
-    "node_modules/log-update/node_modules/slice-ansi": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
-      "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+    "node_modules/log-update/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "astral-regex": "^2.0.0",
-        "is-fullwidth-code-point": "^3.0.0"
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       },
       "funding": {
-        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/strip-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
+      "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/longest-streak": {
@@ -26784,16 +27455,16 @@
         "markdown-it": "bin/markdown-it.mjs"
       }
     },
-    "node_modules/markdown-it-attrs": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/markdown-it-attrs/-/markdown-it-attrs-4.3.1.tgz",
-      "integrity": "sha512-/ko6cba+H6gdZ0DOw7BbNMZtfuJTRp9g/IrGIuz8lYc/EfnmWRpaR3CFPnNbVz0LDvF8Gf1hFGPqrQqq7De0rg==",
-      "license": "MIT",
+    "node_modules/markdown-it/node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
       "engines": {
-        "node": ">=6"
+        "node": ">=0.12"
       },
-      "peerDependencies": {
-        "markdown-it": ">= 9.0.0"
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/markdown-table": {
@@ -26845,13 +27516,6 @@
         "crypt": "0.0.2",
         "is-buffer": "~1.1.6"
       }
-    },
-    "node_modules/md5/node_modules/is-buffer": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/mdast-util-find-and-replace": {
       "version": "3.0.2",
@@ -27080,13 +27744,12 @@
       "license": "MIT"
     },
     "node_modules/media-typer": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
-      "dev": true,
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
       "license": "MIT",
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 0.8"
       }
     },
     "node_modules/memfs": {
@@ -27791,19 +28454,6 @@
         "node": ">=8.6"
       }
     },
-    "node_modules/micromatch/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "devOptional": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/mime": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
@@ -27818,23 +28468,21 @@
       }
     },
     "node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
     },
     "node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
+      "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
       "license": "MIT",
       "dependencies": {
-        "mime-db": "1.52.0"
+        "mime-db": "^1.54.0"
       },
       "engines": {
         "node": ">= 0.6"
@@ -28548,9 +29196,9 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.25",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.25.tgz",
-      "integrity": "sha512-4auku8B/vw5psvTiiN9j1dAOsXvMoGqJuKJcR+dTdqiXEK20mMTk1UEo3HS16LeGQsVG6+qKTPM9u/qQ2LqATA==",
+      "version": "2.0.26",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.26.tgz",
+      "integrity": "sha512-S2M9YimhSjBSvYnlr5/+umAnPHE++ODwt5e2Ij6FoX45HA/s4vHdkDx1eax2pAPeAOqu4s9b7ppahsyEFdVqQA==",
       "dev": true,
       "license": "MIT"
     },
@@ -28950,26 +29598,6 @@
         }
       }
     },
-    "node_modules/nx/node_modules/@jest/schemas": {
-      "version": "30.0.5",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.5.tgz",
-      "integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@sinclair/typebox": "^0.34.0"
-      },
-      "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-      }
-    },
-    "node_modules/nx/node_modules/@sinclair/typebox": {
-      "version": "0.34.41",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.41.tgz",
-      "integrity": "sha512-6gS8pZzSXdyRHTIqoqSVknxolr1kzfy4/CeDnrzsVz8TTIWUbOBr6gnzOmTYJ3eXQNh4IYHIGi5aIL7sOZ2G/g==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/nx/node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -29013,33 +29641,17 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/nx/node_modules/dotenv": {
-      "version": "16.4.7",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
-      "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://dotenvx.com"
-      }
-    },
-    "node_modules/nx/node_modules/jest-diff": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.2.0.tgz",
-      "integrity": "sha512-dQHFo3Pt4/NLlG5z4PxZ/3yZTZ1C7s9hveiOj+GCN+uT109NC2QgsoVZsVOAvbJ3RgKkvyLGXZV9+piDpWbm6A==",
+    "node_modules/nx/node_modules/cli-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/diff-sequences": "30.0.1",
-        "@jest/get-type": "30.1.0",
-        "chalk": "^4.1.2",
-        "pretty-format": "30.2.0"
+        "restore-cursor": "^3.1.0"
       },
       "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+        "node": ">=8"
       }
     },
     "node_modules/nx/node_modules/minimatch": {
@@ -29058,40 +29670,19 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/nx/node_modules/pretty-format": {
-      "version": "30.2.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.2.0.tgz",
-      "integrity": "sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA==",
+    "node_modules/nx/node_modules/restore-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/schemas": "30.0.5",
-        "ansi-styles": "^5.2.0",
-        "react-is": "^18.3.1"
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
       },
       "engines": {
-        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+        "node": ">=8"
       }
-    },
-    "node_modules/nx/node_modules/pretty-format/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/nx/node_modules/react-is": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/nx/node_modules/semver": {
       "version": "7.7.3",
@@ -29343,32 +29934,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/open/node_modules/define-lazy-prop": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
-      "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/open/node_modules/is-docker": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
-      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "is-docker": "cli.js"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/opener": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
@@ -29452,6 +30017,33 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/ora/node_modules/cli-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ora/node_modules/restore-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ora/node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -29526,16 +30118,45 @@
       }
     },
     "node_modules/p-locate": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-6.0.0.tgz",
+      "integrity": "sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "p-limit": "^3.0.2"
+        "p-limit": "^4.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate/node_modules/p-limit": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
+      "integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^1.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate/node_modules/yocto-queue": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.1.tgz",
+      "integrity": "sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -30163,9 +30784,9 @@
       }
     },
     "node_modules/parse5": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
-      "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-5.1.0.tgz",
+      "integrity": "sha512-fxNG2sQjHvlVAYmzBZS9YlDp6PTSSDwa98vkD4QgVDDCAo84z5X1t5XyJQ62ImdLXx5NdIIfihey6xpum9/gRQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -30181,6 +30802,22 @@
       },
       "funding": {
         "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter/node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
       }
     },
     "node_modules/parse5-htmlparser2-tree-adapter/node_modules/entities": {
@@ -30344,13 +30981,13 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "dev": true,
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
-        "node": ">=12"
+        "node": ">=8.6"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
@@ -30393,46 +31030,92 @@
       }
     },
     "node_modules/pkg-dir": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-7.0.0.tgz",
-      "integrity": "sha512-Ie9z/WINcxxLp27BKOCHGde4ITq9UklYKDzVo1nhk5sqGEXU3FpkwP5GM2voTGJkGd9B3Otl+Q4uwSOeSUtOBA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "find-up": "^6.3.0"
+        "find-up": "^4.0.0"
       },
       "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=8"
       }
     },
     "node_modules/pkg-dir/node_modules/find-up": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-6.3.0.tgz",
-      "integrity": "sha512-v2ZsoEuVHYy8ZIlYqwPe/39Cy+cFDzp4dXPaxNvkEuouymu+2Jbz0PxpKarJHYJTmv2HWT3O382qY8l4jMWthw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "locate-path": "^7.1.0",
-        "path-exists": "^5.0.0"
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
       },
       "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+        "node": ">=8"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pkg-dir/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/playwright": {
-      "version": "1.56.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.56.0.tgz",
-      "integrity": "sha512-X5Q1b8lOdWIE4KAoHpW3SE8HvUB+ZZsUoN64ZhjnN8dOb1UpujxBtENGiZFE+9F/yhzJwYa+ca3u43FeLbboHA==",
+      "version": "1.56.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.56.1.tgz",
+      "integrity": "sha512-aFi5B0WovBHTEvpM3DzXTUaeN6eN0qWnTkKx4NQaH4Wvcmc153PdaY2UBdSYKaGYw+UyWXSVyxDUg5DoPEttjw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.56.0"
+        "playwright-core": "1.56.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -30445,9 +31128,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.56.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.56.0.tgz",
-      "integrity": "sha512-1SXl7pMfemAMSDn5rkPeZljxOCYAmQnYLBTExuh6E8USHXGSX3dx6lYZN/xPpTz1vimXmPA9CDnILvmJaB8aSQ==",
+      "version": "1.56.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.56.1.tgz",
+      "integrity": "sha512-hutraynyn31F+Bifme+Ps9Vq59hKuUCz7H1kDOcBs+2oGguKkWTU50bBWrtz34OUWmIwpBTWDxaRPXrIXkgvmQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -30455,21 +31138,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/playwright/node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/portfinder": {
@@ -31296,18 +31964,18 @@
       }
     },
     "node_modules/pretty-format": {
-      "version": "29.7.0",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
-      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "version": "30.2.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.2.0.tgz",
+      "integrity": "sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@jest/schemas": "^29.6.3",
-        "ansi-styles": "^5.0.0",
-        "react-is": "^18.0.0"
+        "@jest/schemas": "30.0.5",
+        "ansi-styles": "^5.2.0",
+        "react-is": "^18.3.1"
       },
       "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/pretty-format/node_modules/react-is": {
@@ -31570,28 +32238,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/puppeteer-core/node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/pure-rand": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
@@ -31610,13 +32256,13 @@
       "license": "MIT"
     },
     "node_modules/qified": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/qified/-/qified-0.5.0.tgz",
-      "integrity": "sha512-Zj6Q/Vc/SQ+Fzc87N90jJUzBzxD7MVQ2ZvGyMmYtnl2u1a07CejAhvtk4ZwASos+SiHKCAIylyGHJKIek75QBw==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/qified/-/qified-0.5.1.tgz",
+      "integrity": "sha512-+BtFN3dCP+IaFA6IYNOu/f/uK1B8xD2QWyOeCse0rjtAebBmkzgd2d1OAXi3ikAzJMIBSdzZDNZ3wZKEUDQs5w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "hookified": "^1.12.1"
+        "hookified": "^1.12.2"
       },
       "engines": {
         "node": ">=20"
@@ -31702,32 +32348,18 @@
       }
     },
     "node_modules/raw-body": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
-      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
-      "dev": true,
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.1.tgz",
+      "integrity": "sha512-9G8cA+tuMS75+6G/TzW8OtLzmBDMo8p1JRxN5AZ+LAp8uxGA8V8GZm4GQ4/N5QNQEnLmg6SS7wyuSmbKepiKqA==",
       "license": "MIT",
       "dependencies": {
         "bytes": "3.1.2",
         "http-errors": "2.0.0",
-        "iconv-lite": "0.4.24",
+        "iconv-lite": "0.7.0",
         "unpipe": "1.0.0"
       },
       "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/raw-body/node_modules/iconv-lite": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3"
-      },
-      "engines": {
-        "node": ">=0.10.0"
+        "node": ">= 0.10"
       }
     },
     "node_modules/rc": {
@@ -32226,29 +32858,16 @@
       }
     },
     "node_modules/readdirp": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "picomatch": "^2.2.1"
-      },
-      "engines": {
-        "node": ">=8.10.0"
-      }
-    },
-    "node_modules/readdirp/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
       "license": "MIT",
       "engines": {
-        "node": ">=8.6"
+        "node": ">= 14.18.0"
       },
       "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/recast": {
@@ -32279,16 +32898,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/recast/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/rechoir": {
@@ -32526,99 +33135,6 @@
         "strip-ansi": "^6.0.1"
       }
     },
-    "node_modules/renderkid/node_modules/css-select": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.3.0.tgz",
-      "integrity": "sha512-wPpOYtnsVontu2mODhA19JrqWxNsfdatRKd64kmpRbQgh1KtItko5sTnEpPdpSaJszTOhEMlF/RPz28qj4HqhQ==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "boolbase": "^1.0.0",
-        "css-what": "^6.0.1",
-        "domhandler": "^4.3.1",
-        "domutils": "^2.8.0",
-        "nth-check": "^2.0.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/fb55"
-      }
-    },
-    "node_modules/renderkid/node_modules/dom-serializer": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.4.1.tgz",
-      "integrity": "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "domelementtype": "^2.0.1",
-        "domhandler": "^4.2.0",
-        "entities": "^2.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
-      }
-    },
-    "node_modules/renderkid/node_modules/domhandler": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
-      "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "domelementtype": "^2.2.0"
-      },
-      "engines": {
-        "node": ">= 4"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domhandler?sponsor=1"
-      }
-    },
-    "node_modules/renderkid/node_modules/domutils": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
-      "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "dom-serializer": "^1.0.1",
-        "domelementtype": "^2.2.0",
-        "domhandler": "^4.2.0"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domutils?sponsor=1"
-      }
-    },
-    "node_modules/renderkid/node_modules/entities": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
-      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/renderkid/node_modules/htmlparser2": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
-      "integrity": "sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==",
-      "dev": true,
-      "funding": [
-        "https://github.com/fb55/htmlparser2?sponsor=1",
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fb55"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "domelementtype": "^2.0.1",
-        "domhandler": "^4.0.0",
-        "domutils": "^2.5.2",
-        "entities": "^2.0.0"
-      }
-    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -32656,13 +33172,13 @@
       "license": "MIT"
     },
     "node_modules/resolve": {
-      "version": "1.22.10",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
-      "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
+      "version": "1.22.11",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
+      "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "is-core-module": "^2.16.0",
+        "is-core-module": "^2.16.1",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       },
@@ -32784,17 +33300,49 @@
       }
     },
     "node_modules/restore-cursor": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
-      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "onetime": "^5.1.0",
-        "signal-exit": "^3.0.2"
+        "onetime": "^7.0.0",
+        "signal-exit": "^4.1.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/restore-cursor/node_modules/onetime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/restore-cursor/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/retry": {
@@ -32865,9 +33413,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.52.4",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.52.4.tgz",
-      "integrity": "sha512-CLEVl+MnPAiKh5pl4dEWSyMTpuflgNQiLGhMv8ezD5W/qP8AKvmYpCOKRRNOh7oRKnauBZ4SyeYkMS+1VSyKwQ==",
+      "version": "4.52.5",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.52.5.tgz",
+      "integrity": "sha512-3GuObel8h7Kqdjt0gxkEzaifHTqLVW56Y/bjN7PSQtkKr0w3V/QYSdt6QWYtd7A1xUtYQigtdUfgj1RvWVtorw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -32881,28 +33429,28 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.52.4",
-        "@rollup/rollup-android-arm64": "4.52.4",
-        "@rollup/rollup-darwin-arm64": "4.52.4",
-        "@rollup/rollup-darwin-x64": "4.52.4",
-        "@rollup/rollup-freebsd-arm64": "4.52.4",
-        "@rollup/rollup-freebsd-x64": "4.52.4",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.52.4",
-        "@rollup/rollup-linux-arm-musleabihf": "4.52.4",
-        "@rollup/rollup-linux-arm64-gnu": "4.52.4",
-        "@rollup/rollup-linux-arm64-musl": "4.52.4",
-        "@rollup/rollup-linux-loong64-gnu": "4.52.4",
-        "@rollup/rollup-linux-ppc64-gnu": "4.52.4",
-        "@rollup/rollup-linux-riscv64-gnu": "4.52.4",
-        "@rollup/rollup-linux-riscv64-musl": "4.52.4",
-        "@rollup/rollup-linux-s390x-gnu": "4.52.4",
-        "@rollup/rollup-linux-x64-gnu": "4.52.4",
-        "@rollup/rollup-linux-x64-musl": "4.52.4",
-        "@rollup/rollup-openharmony-arm64": "4.52.4",
-        "@rollup/rollup-win32-arm64-msvc": "4.52.4",
-        "@rollup/rollup-win32-ia32-msvc": "4.52.4",
-        "@rollup/rollup-win32-x64-gnu": "4.52.4",
-        "@rollup/rollup-win32-x64-msvc": "4.52.4",
+        "@rollup/rollup-android-arm-eabi": "4.52.5",
+        "@rollup/rollup-android-arm64": "4.52.5",
+        "@rollup/rollup-darwin-arm64": "4.52.5",
+        "@rollup/rollup-darwin-x64": "4.52.5",
+        "@rollup/rollup-freebsd-arm64": "4.52.5",
+        "@rollup/rollup-freebsd-x64": "4.52.5",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.52.5",
+        "@rollup/rollup-linux-arm-musleabihf": "4.52.5",
+        "@rollup/rollup-linux-arm64-gnu": "4.52.5",
+        "@rollup/rollup-linux-arm64-musl": "4.52.5",
+        "@rollup/rollup-linux-loong64-gnu": "4.52.5",
+        "@rollup/rollup-linux-ppc64-gnu": "4.52.5",
+        "@rollup/rollup-linux-riscv64-gnu": "4.52.5",
+        "@rollup/rollup-linux-riscv64-musl": "4.52.5",
+        "@rollup/rollup-linux-s390x-gnu": "4.52.5",
+        "@rollup/rollup-linux-x64-gnu": "4.52.5",
+        "@rollup/rollup-linux-x64-musl": "4.52.5",
+        "@rollup/rollup-openharmony-arm64": "4.52.5",
+        "@rollup/rollup-win32-arm64-msvc": "4.52.5",
+        "@rollup/rollup-win32-ia32-msvc": "4.52.5",
+        "@rollup/rollup-win32-x64-gnu": "4.52.5",
+        "@rollup/rollup-win32-x64-msvc": "4.52.5",
         "fsevents": "~2.3.2"
       }
     },
@@ -33043,6 +33591,29 @@
         "rollup": {
           "optional": true
         }
+      }
+    },
+    "node_modules/rollup-plugin-visualizer/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/rollup-plugin-visualizer/node_modules/source-map": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/rollup-pluginutils": {
@@ -33264,34 +33835,6 @@
         "@parcel/watcher": "^2.4.1"
       }
     },
-    "node_modules/sass/node_modules/chokidar": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
-      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
-      "license": "MIT",
-      "dependencies": {
-        "readdirp": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 14.16.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/sass/node_modules/readdirp": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
-      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14.18.0"
-      },
-      "funding": {
-        "type": "individual",
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/sax": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
@@ -33389,27 +33932,6 @@
       },
       "engines": {
         "node": ">= 18"
-      }
-    },
-    "node_modules/send/node_modules/mime-db": {
-      "version": "1.54.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
-      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/send/node_modules/mime-types": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
-      "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "^1.54.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/serialize-javascript": {
@@ -33599,6 +34121,29 @@
       "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/serve-index/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/serve-index/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/serve-index/node_modules/ms": {
       "version": "2.0.0",
@@ -34059,13 +34604,13 @@
       }
     },
     "node_modules/source-map": {
-      "version": "0.7.6",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
-      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
-        "node": ">= 12"
+        "node": ">=0.10.0"
       }
     },
     "node_modules/source-map-js": {
@@ -34078,24 +34623,14 @@
       }
     },
     "node_modules/source-map-support": {
-      "version": "0.5.13",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
-      "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
-      }
-    },
-    "node_modules/source-map-support/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/sourcemap-codec": {
@@ -34283,9 +34818,9 @@
       }
     },
     "node_modules/storybook": {
-      "version": "9.1.12",
-      "resolved": "https://registry.npmjs.org/storybook/-/storybook-9.1.12.tgz",
-      "integrity": "sha512-JJkpcmELR8N3uM03OG7Oyi5FiCsfZAjArNANw5aR4L2NFt8vErOi3XA7AgIF7gCyPeDWAmK1NV0IlF3OZnRTtQ==",
+      "version": "9.1.13",
+      "resolved": "https://registry.npmjs.org/storybook/-/storybook-9.1.13.tgz",
+      "integrity": "sha512-G3KZ36EVzXyHds72B/qtWiJnhUpM0xOUeYlDcO9DSHL1bDTv15cW4+upBl+mcBZrDvU838cn7Bv4GpF+O5MCfw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -34329,28 +34864,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/storybook/node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
       }
     },
     "node_modules/stream-shift": {
@@ -35217,23 +35730,6 @@
         "node": ">= 10"
       }
     },
-    "node_modules/svgo/node_modules/css-select": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.3.0.tgz",
-      "integrity": "sha512-wPpOYtnsVontu2mODhA19JrqWxNsfdatRKd64kmpRbQgh1KtItko5sTnEpPdpSaJszTOhEMlF/RPz28qj4HqhQ==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "boolbase": "^1.0.0",
-        "css-what": "^6.0.1",
-        "domhandler": "^4.3.1",
-        "domutils": "^2.8.0",
-        "nth-check": "^2.0.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/fb55"
-      }
-    },
     "node_modules/svgo/node_modules/css-tree": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz",
@@ -35248,78 +35744,12 @@
         "node": ">=8.0.0"
       }
     },
-    "node_modules/svgo/node_modules/dom-serializer": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.4.1.tgz",
-      "integrity": "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "domelementtype": "^2.0.1",
-        "domhandler": "^4.2.0",
-        "entities": "^2.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
-      }
-    },
-    "node_modules/svgo/node_modules/domhandler": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
-      "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "domelementtype": "^2.2.0"
-      },
-      "engines": {
-        "node": ">= 4"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domhandler?sponsor=1"
-      }
-    },
-    "node_modules/svgo/node_modules/domutils": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
-      "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "dom-serializer": "^1.0.1",
-        "domelementtype": "^2.2.0",
-        "domhandler": "^4.2.0"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domutils?sponsor=1"
-      }
-    },
-    "node_modules/svgo/node_modules/entities": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
-      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
     "node_modules/svgo/node_modules/mdn-data": {
       "version": "2.0.14",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
       "integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow==",
       "dev": true,
       "license": "CC0-1.0"
-    },
-    "node_modules/svgo/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/swiper": {
       "version": "11.2.10",
@@ -35654,48 +36084,12 @@
         }
       }
     },
-    "node_modules/terser-webpack-plugin/node_modules/jest-worker": {
-      "version": "27.5.1",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-27.5.1.tgz",
-      "integrity": "sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "merge-stream": "^2.0.0",
-        "supports-color": "^8.0.0"
-      },
-      "engines": {
-        "node": ">= 10.13.0"
-      }
-    },
     "node_modules/terser/node_modules/commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/terser/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/terser/node_modules/source-map-support": {
-      "version": "0.5.21",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
-      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
-      }
     },
     "node_modules/test-exclude": {
       "version": "6.0.0",
@@ -35877,6 +36271,37 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/tinyrainbow": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
@@ -36012,6 +36437,30 @@
       "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/transform-ast/node_modules/is-buffer": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/transform-ast/node_modules/magic-string": {
       "version": "0.23.2",
@@ -36247,6 +36696,16 @@
         "node": ">=10"
       }
     },
+    "node_modules/ts-loader/node_modules/source-map": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/ts-loader/node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -36362,6 +36821,22 @@
         "fsevents": "~2.3.3"
       }
     },
+    "node_modules/tsx/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/tuf-js": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/tuf-js/-/tuf-js-3.1.0.tgz",
@@ -36461,14 +36936,14 @@
       }
     },
     "node_modules/type-is": {
-      "version": "1.6.18",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
-      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
-      "dev": true,
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
       "license": "MIT",
       "dependencies": {
-        "media-typer": "0.3.0",
-        "mime-types": "~2.1.24"
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
       },
       "engines": {
         "node": ">= 0.6"
@@ -36718,9 +37193,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.14.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.14.0.tgz",
-      "integrity": "sha512-QQiYxHuyZ9gQUIrmPo3IA+hUl4KYk8uSA7cHrcKd/l3p1OTpZcM0Tbp9x7FAtXdAYhlasd60ncPpgu6ihG6TOA==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "dev": true,
       "license": "MIT"
     },
@@ -36801,6 +37276,19 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/unified/node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/unique-filename": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-4.0.0.tgz",
@@ -36872,9 +37360,9 @@
       }
     },
     "node_modules/unist-util-visit-parents": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.1.tgz",
-      "integrity": "sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -37133,9 +37621,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.1.10",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.10.tgz",
-      "integrity": "sha512-CmuvUBzVJ/e3HGxhg6cYk88NGgTnBoOo7ogtfJJ0fefUWAxN/WDSUa50o+oVBxuIhO8FoEZW0j2eW7sfjs5EtA==",
+      "version": "7.1.11",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.11.tgz",
+      "integrity": "sha512-uzcxnSDVjAopEUjljkWh8EIrg6tlzrjFUfMcR1EVsRDGwf/ccef0qQPRyOrROwhrTDaApueq+ja+KLPlzR/zdg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -37205,6 +37693,52 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vite/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/vite/node_modules/tinyglobby": {
@@ -37501,6 +38035,27 @@
         "node": ">= 10"
       }
     },
+    "node_modules/webpack-bundle-analyzer/node_modules/ws": {
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/webpack-cli": {
       "version": "5.1.4",
       "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-5.1.4.tgz",
@@ -37587,29 +38142,6 @@
         }
       }
     },
-    "node_modules/webpack-dev-middleware/node_modules/mime-db": {
-      "version": "1.54.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
-      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/webpack-dev-middleware/node_modules/mime-types": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
-      "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "^1.54.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/webpack-dev-server": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.2.tgz",
@@ -37666,29 +38198,6 @@
         "webpack-cli": {
           "optional": true
         }
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/@types/express-serve-static-core": {
-      "version": "4.19.7",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.7.tgz",
-      "integrity": "sha512-FvPtiIf1LfhzsaIXhv/PHan/2FeQBbtBDtfX2QfvPxdUelMDEckK08SM6nqo1MIZY3RUlfA+HV8+hFUSio78qg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "@types/qs": "*",
-        "@types/range-parser": "*",
-        "@types/send": "*"
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/@types/ws": {
-      "version": "8.18.1",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
-      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
       }
     },
     "node_modules/webpack-dev-server/node_modules/accepts": {
@@ -37802,6 +38311,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/webpack-dev-server/node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/webpack-dev-server/node_modules/express": {
       "version": "4.21.2",
       "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
@@ -37914,6 +38436,16 @@
         "node": ">= 10"
       }
     },
+    "node_modules/webpack-dev-server/node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/webpack-dev-server/node_modules/merge-descriptors": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
@@ -37922,6 +38454,29 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/webpack-dev-server/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/webpack-dev-server/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/webpack-dev-server/node_modules/negotiator": {
@@ -37974,6 +38529,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/webpack-dev-server/node_modules/raw-body": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
+      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/webpack-dev-server/node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
       }
     },
     "node_modules/webpack-dev-server/node_modules/send": {
@@ -38037,26 +38621,18 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/webpack-dev-server/node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+    "node_modules/webpack-dev-server/node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
       "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
+        "node": ">= 0.6"
       }
     },
     "node_modules/webpack-merge": {
@@ -38122,6 +38698,29 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/webpack/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/webpack/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/websocket-driver": {
       "version": "0.7.4",
       "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
@@ -38158,6 +38757,19 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/whatwg-mimetype": {
@@ -38591,16 +39203,17 @@
       }
     },
     "node_modules/ws": {
-      "version": "7.5.10",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=8.3.0"
+        "node": ">=10.0.0"
       },
       "peerDependencies": {
         "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
+        "utf-8-validate": ">=5.0.2"
       },
       "peerDependenciesMeta": {
         "bufferutil": {
@@ -38814,7 +39427,6 @@
         "intl-messageformat": "^10.7.15",
         "lodash-es": "^4.17.0",
         "markdown-it": "^14.1.0",
-        "markdown-it-attrs": "^4.1.6",
         "react-intl": "^7.1.6",
         "react-player": "2.15.1",
         "swiper": "^11.1.1",
@@ -38822,10 +39434,12 @@
         "use-sync-external-store": "^1.2.0"
       },
       "devDependencies": {
+        "@carbon/ai-chat-utils": "0.0.0",
         "@carbon/icons": "^11.53.0",
         "@carbon/styles": "^1.88.0",
         "@carbon/themes": "^11.58.0",
         "@carbon/web-components": "^2.40.1",
+        "@open-wc/testing": "4.0.0",
         "@rollup/plugin-babel": "^6.0.4",
         "@rollup/plugin-commonjs": "^28.0.6",
         "@rollup/plugin-json": "^6.1.0",
@@ -38843,6 +39457,9 @@
         "@types/node": "^24.0.12",
         "@types/react": "^19.2.1",
         "@types/react-dom": "^19.2.1",
+        "@web/dev-server-esbuild": "1.0.4",
+        "@web/test-runner": "0.19.0",
+        "@web/test-runner-playwright": "^0.11.0",
         "autoprefixer": "^10.4.21",
         "babel-jest": "^29.7.0",
         "concurrently": "^9.2.0",
@@ -38852,6 +39469,7 @@
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
         "lit": "^3.1.0",
+        "playwright": "^1.48.1",
         "postcss": "^8.4.41",
         "postcss-discard-comments": "^7.0.4",
         "react": "^19.0.0",
@@ -38867,7 +39485,8 @@
         "ts-lit-plugin": "^2.0.2",
         "tsx": "^4.19.3",
         "typedoc": "^0.28.0",
-        "wait-on": "^9.0.1"
+        "wait-on": "^9.0.1",
+        "web-dev-server-plugin-lit-css": "^4.0.0"
       },
       "peerDependencies": {
         "@carbon/icons": ">=11.53.0 <12.0.0",
@@ -38935,8 +39554,6 @@
     },
     "packages/ai-chat-components/node_modules/glob": {
       "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-11.0.3.tgz",
-      "integrity": "sha512-2Nim7dha1KVkaiF4q6Dj+ngPPMdfvLJEOpZk/jKiUAkqKebpGAWQXAq9z1xu9HKu5lWfqw/FASuccEjyznjPaA==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -38959,8 +39576,6 @@
     },
     "packages/ai-chat-components/node_modules/jackspeak": {
       "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.1.1.tgz",
-      "integrity": "sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -38975,8 +39590,6 @@
     },
     "packages/ai-chat-components/node_modules/lru-cache": {
       "version": "11.2.2",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.2.tgz",
-      "integrity": "sha512-F9ODfyqML2coTIsQpSkRHnLSZMtkU8Q+mSfcaIyKwy58u+8k5nvAYeiNhsyMARvzNcXJ9QfWVrcPsC9e9rAxtg==",
       "dev": true,
       "license": "ISC",
       "engines": {
@@ -38985,8 +39598,6 @@
     },
     "packages/ai-chat-components/node_modules/minimatch": {
       "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.3.tgz",
-      "integrity": "sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -39001,8 +39612,6 @@
     },
     "packages/ai-chat-components/node_modules/path-scurry": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.0.tgz",
-      "integrity": "sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -39018,8 +39627,6 @@
     },
     "packages/ai-chat-components/node_modules/rimraf": {
       "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.0.1.tgz",
-      "integrity": "sha512-9dkvaxAsk/xNXSJzMgFqqMCuFgt2+KsOFek3TMLfo8NCPfWpBmqwyNn5Y+NX56QUYfCtsyhF3ayiboEoUmJk/A==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -39038,8 +39645,6 @@
     },
     "packages/ai-chat/node_modules/postcss-discard-comments": {
       "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-7.0.4.tgz",
-      "integrity": "sha512-6tCUoql/ipWwKtVP/xYiFf1U9QgJ0PUvxN7pTcsQ8Ns3Fnwq1pU5D5s1MhT/XySeLq6GXNvn37U46Ded0TckWg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -39051,6 +39656,11 @@
       "peerDependencies": {
         "postcss": "^8.4.32"
       }
+    },
+    "utils": {
+      "name": "@carbon/ai-chat-utils",
+      "version": "0.0.0",
+      "license": "Apache-2.0"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "examples/web-components/watch-state",
     "examples/web-components/watsonx",
     "packages/ai-chat",
-    "packages/ai-chat-components"
+    "packages/ai-chat-components",
+    "utils"
   ],
   "scripts": {
     "aiChat:build": "lerna run build --stream --scope @carbon/ai-chat-components --scope @carbon/ai-chat --scope @carbon/ai-chat-examples-demo",

--- a/packages/ai-chat/jest.config.cjs
+++ b/packages/ai-chat/jest.config.cjs
@@ -27,9 +27,8 @@ module.exports = {
     "^.+\\.(css|scss)$": ["<rootDir>/tests/transforms/cssTransform.cjs"],
   },
   moduleNameMapper: {
+    "^(\\.\\.?/.+)\\.js$": "$1",
     "\\.(css|less|scss|sass)$": "<rootDir>/tests/transforms/cssTransform.cjs",
-    "^../../../codeElement/cds-aichat-code$": "<rootDir>/src/chat/web-components/components/codeElement/cds-aichat-code.ts",
-    "^../../../table/cds-aichat-table$": "<rootDir>/src/chat/web-components/components/table/cds-aichat-table.ts",
   },
   transformIgnorePatterns: [
     "node_modules/(?!(@lit|lit|lit-html|lit-element|@carbon|lodash-es|@floating-ui|uuid|csv-stringify|compute-scroll-into-view|@ibm|classnames|tabbable|react-player|swiper|dayjs|dompurify|focus-trap-react|highlight.js|intl-messageformat|markdown-it|react-intl)/)",

--- a/packages/ai-chat/package.json
+++ b/packages/ai-chat/package.json
@@ -83,6 +83,8 @@
     "@types/node": "^24.0.12",
     "@types/react": "^19.2.1",
     "@types/react-dom": "^19.2.1",
+    "@carbon/ai-chat-utils": "0.0.0",
+    "@open-wc/testing": "4.0.0",
     "autoprefixer": "^10.4.21",
     "babel-jest": "^29.7.0",
     "concurrently": "^9.2.0",
@@ -107,7 +109,12 @@
     "ts-lit-plugin": "^2.0.2",
     "tsx": "^4.19.3",
     "typedoc": "^0.28.0",
-    "wait-on": "^9.0.1"
+    "wait-on": "^9.0.1",
+    "@web/dev-server-esbuild": "1.0.4",
+    "@web/test-runner": "0.19.0",
+    "@web/test-runner-playwright": "^0.11.0",
+    "playwright": "^1.48.1",
+    "web-dev-server-plugin-lit-css": "^4.0.0"
   },
   "peerDependencies": {
     "@carbon/icons": ">=11.53.0 <12.0.0",
@@ -131,7 +138,6 @@
     "intl-messageformat": "^10.7.15",
     "lodash-es": "^4.17.0",
     "markdown-it": "^14.1.0",
-    "markdown-it-attrs": "^4.1.6",
     "react-intl": "^7.1.6",
     "react-player": "2.15.1",
     "swiper": "^11.1.1",
@@ -143,7 +149,9 @@
     "postinstall": "ibmtelemetry --config=telemetry.yml",
     "start": "concurrently \"rollup -c ./tasks/rollup.aichat.js --watch\" \"typedoc --watch\" \"serve dist/docs/carbon-tsdocs -l 5001 --no-port-switching\" \"wait-on dist/docs/carbon-tsdocs/index.html && open http://localhost:5001\"",
     "telemetry:config": "npx -y @ibm/telemetry-js-config-generator generate --id ef967584-5788-47d4-b9c2-a60da7ad901d --endpoint https://www-api.ibm.com/ibm-telemetry/v1/metrics --files ./src --wc",
-    "test": "jest"
+    "test": "npm run test:jest && npm run test:web",
+    "test:jest": "jest",
+    "test:web": "web-test-runner --config ./web-test-runner.config.js"
   },
   "repository": {
     "type": "git",

--- a/packages/ai-chat/src/chat/ai-chat-components/web-components/components/markdownText/src/MarkdownElement.ts
+++ b/packages/ai-chat/src/chat/ai-chat-components/web-components/components/markdownText/src/MarkdownElement.ts
@@ -12,70 +12,55 @@ import { property, state } from "lit/decorators.js";
 import throttle from "lodash-es/throttle.js";
 
 import { LocalizationOptions } from "../../../../../../types/localization/LocalizationOptions";
-import {
-  TokenTree,
-  renderTokenTree,
-  markdownToTokenTree,
-} from "./markdownProcessor";
+import { markdownToTokenTree, TokenTree } from "./markdownTokenTree";
+import { renderTokenTree } from "./markdownRenderer";
 import { consoleError, consoleLog } from "../../../../../utils/miscUtils";
 
 class MarkdownElement extends LitElement {
-  @property({ type: Boolean })
+  @property({ type: Boolean, attribute: "debug" })
   debug = false;
 
-  @property({ type: String })
-  set markdown(newMarkdown: string) {
-    if (newMarkdown !== this.fullText) {
-      const old = this.fullText;
-      this.fullText = newMarkdown ?? "";
-      this.requestUpdate("markdown", old);
-      if (this.debug) {
-        consoleLog("markdown prop updated");
-      }
-      this.scheduleTokenParse();
-    }
-  }
-  get markdown(): string {
-    return this.fullText;
-  }
+  @property({ type: String, attribute: "markdown" })
+  markdown = "";
 
-  @property({ type: Boolean })
+  @property({ type: Boolean, attribute: "sanitize-html" })
   sanitizeHTML = false;
 
-  @property({ type: Boolean })
-  shouldRemoveHTMLBeforeMarkdownConversion = false;
+  @property({ type: Boolean, attribute: "remove-html" })
+  removeHTML = false;
 
-  @property({ type: Boolean })
+  @property({ type: Boolean, attribute: "streaming" })
   streaming = false;
 
-  @property({ type: Object })
+  @property({ type: Object, attribute: false })
   localization?: LocalizationOptions;
 
-  @property({ type: Boolean })
+  @property({ type: Boolean, attribute: "dark" })
   dark = false;
 
-  private fullText = "";
-
-  protected updated(changedProperties: PropertyValues) {
-    super.updated(changedProperties);
-
-    // Only schedule token parse if markdown content changed
-    if (changedProperties.has("markdown")) {
-      this.scheduleTokenParse();
-    }
-
-    // Re-render if dark mode, localization, or other rendering properties changed
-    if (
-      changedProperties.has("dark") ||
-      changedProperties.has("localization") ||
-      changedProperties.has("streaming")
-    ) {
-      this.scheduleRender();
-    }
-  }
+  private needsReparse = false;
+  // Tracks the latest asynchronous rendering work so callers waiting on
+  // `updateComplete` know when throttled updates are done.
+  private renderTask: Promise<void> | null = null;
 
   protected willUpdate(changed: PropertyValues<this>) {
-    if (changed.has("sanitizeHTML") || changed.has("streaming")) {
+    if (changed.has("markdown") || changed.has("removeHTML")) {
+      // Properties that affect token tree structure require full reparse
+      // - markdown: the source content changed
+      // - removeHTML: changes which parser is used (html: true vs false)
+      this.needsReparse = true;
+      this.scheduleRender();
+    } else if (
+      // Properties that only affect rendering can skip reparsing
+      // - sanitizeHTML: applies DOMPurify during render, doesn't change tokens
+      // - dark: changes theme classes in rendered output
+      // - localization: changes translated strings in rendered output
+      // - streaming: affects loading states in rendered output
+      changed.has("sanitizeHTML") ||
+      changed.has("dark") ||
+      changed.has("localization") ||
+      changed.has("streaming")
+    ) {
       this.scheduleRender();
     }
   }
@@ -105,21 +90,31 @@ class MarkdownElement extends LitElement {
   renderedContent: TemplateResult | null = null;
 
   /**
-   * Throttled function that parses markdown text into a token tree and renders it.
-   * Called when the markdown content changes. Handles both parsing and rendering
-   * to avoid duplicate work when content updates.
+   * Throttled function that updates the rendered content.
+   * If needsReparse is true, parses markdown into a token tree first.
+   * Otherwise, just re-renders the existing token tree with current settings.
    */
-  private scheduleTokenParse = throttle(async () => {
-    if (this.debug) {
-      consoleLog("Parsing markdown", this.fullText);
-    }
+  private renderMarkdown = async () => {
     try {
-      this.tokenTree = markdownToTokenTree(
-        this.fullText,
-        this.tokenTree,
-        !this.shouldRemoveHTMLBeforeMarkdownConversion,
-      );
+      if (this.needsReparse) {
+        if (this.debug) {
+          consoleLog("Parsing markdown", this.markdown);
+        }
+        // First, we take the markdown we were given and use the markdown-it parser to turn is into a tree we can
+        // transform into Lit components and compare smartly to avoid re-renders of components that were already
+        // rendered when the markdown is updated (likely by streaming, but possibly by an edit somewhere in the
+        // middle). It takes the current tokenTree as an argument for quick diffing to avoid re-creating parts
+        // of the tree.
+        this.tokenTree = markdownToTokenTree(
+          this.markdown,
+          this.tokenTree,
+          !this.removeHTML,
+        );
+        this.needsReparse = false;
+      }
 
+      // Next we take that tree and transform it into Lit content to be rendered into the template.
+      // this.renderedContent is what is rendered in the template directly.
       this.renderedContent = renderTokenTree(this.tokenTree, {
         sanitize: this.sanitizeHTML,
         streaming: this.streaming,
@@ -133,21 +128,46 @@ class MarkdownElement extends LitElement {
     } catch (error) {
       consoleError("Failed to parse markdown", error);
     }
-  }, 100);
+  };
 
-  /**
-   * Throttled function that re-renders the existing token tree with current settings.
-   * Called when only rendering options change (like sanitizeHTML) without needing
-   * to re-parse the markdown content.
-   */
-  private scheduleRender = throttle(async () => {
-    this.renderedContent = renderTokenTree(this.tokenTree, {
-      sanitize: this.sanitizeHTML,
-      streaming: this.streaming,
-      localization: this.localization,
-      dark: this.dark,
+  private scheduleRender = throttle(() => {
+    // Lit's getter/setter pipeline can schedule multiple renders quickly.
+    // We capture the active render promise so we can report completion later.
+    const task = this.renderMarkdown();
+    const trackedTask = task.finally(() => {
+      if (this.renderTask === trackedTask) {
+        this.renderTask = null;
+      }
     });
-  }, 50);
+
+    this.renderTask = trackedTask;
+    return trackedTask;
+  }, 150);
+
+  protected async getUpdateComplete(): Promise<boolean> {
+    // `updateComplete` is Lit's public hook for consumers/tests to await
+    // all pending work. Because we throttle renders, the base implementation
+    // might resolve before the throttled callback runs. Overriding this
+    // method lets us flush the throttle and await the render promise so
+    // callers can reliably wait for `renderedContent` to update.
+    const result = await super.getUpdateComplete();
+
+    const flushResult = (
+      this.scheduleRender as {
+        flush?: () => Promise<void> | void;
+      }
+    ).flush?.();
+
+    if (flushResult instanceof Promise) {
+      await flushResult;
+    }
+
+    if (this.renderTask) {
+      await this.renderTask;
+    }
+
+    return result;
+  }
 }
 
 export default MarkdownElement;

--- a/packages/ai-chat/src/chat/ai-chat-components/web-components/components/markdownText/src/__tests__/smoke.test.ts
+++ b/packages/ai-chat/src/chat/ai-chat-components/web-components/components/markdownText/src/__tests__/smoke.test.ts
@@ -1,0 +1,179 @@
+/*
+ *  Copyright IBM Corp. 2025
+ *
+ *  This source code is licensed under the Apache-2.0 license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ *  @license
+ */
+
+import { expect, fixture, html } from "@open-wc/testing";
+import { TEXT } from "@carbon/ai-chat-utils";
+import CDSChatMarkdownElement from "../../cds-aichat-markdown-text";
+const MARKDOWN_ELEMENT_TAG = "cds-aichat-markdown-text";
+
+const registeredConstructor = customElements.get(MARKDOWN_ELEMENT_TAG);
+
+if (!registeredConstructor) {
+  throw new Error("cds-aichat-markdown-text was not registered");
+}
+
+const MarkdownElementConstructor =
+  (registeredConstructor as typeof CDSChatMarkdownElement) ??
+  CDSChatMarkdownElement;
+
+type MarkdownElementInstance = InstanceType<typeof MarkdownElementConstructor>;
+
+describe("cds-aichat-markdown-text smoke test", () => {
+  it("renders markdown when text content is provided", async () => {
+    const el = await fixture<MarkdownElementInstance>(
+      html`<cds-aichat-markdown-text></cds-aichat-markdown-text>`,
+    );
+
+    el.setAttribute("markdown", TEXT);
+
+    await el.updateComplete;
+
+    const root = el.shadowRoot;
+    expect(root).to.not.equal(null);
+    const textContent = (root?.textContent ?? "").replace(/\s+/g, " ");
+    expect(textContent).to.include("Carbon");
+    expect(textContent).to.include("chemical element");
+  });
+
+  it("strips inline html when HTML removal attribute is set", async () => {
+    const el = await fixture<MarkdownElementInstance>(
+      html`<cds-aichat-markdown-text
+        markdown=${TEXT}
+        remove-html
+      ></cds-aichat-markdown-text>`,
+    );
+
+    await el.updateComplete;
+
+    const root = el.shadowRoot;
+    if (!root) {
+      throw new Error("Expected shadow root to exist");
+    }
+    expect(root.innerHTML).to.not.include("<svg");
+  });
+
+  it("removes svg click handler when sanitize-html is enabled", async () => {
+    const originalOpen = window.open;
+    let openUrl: string | null = null;
+    const mockOpen: typeof window.open = (
+      input?: string | URL,
+      _target?: string,
+      _features?: string,
+      _replace?: boolean,
+    ) => {
+      if (!input) {
+        openUrl = null;
+        return null;
+      }
+      openUrl = typeof input === "string" ? input : input.href;
+      return null;
+    };
+    window.open = mockOpen;
+
+    try {
+      const unsafeEl = await fixture<MarkdownElementInstance>(
+        html`<cds-aichat-markdown-text
+          markdown=${TEXT}
+        ></cds-aichat-markdown-text>`,
+      );
+      await unsafeEl.updateComplete;
+
+      const unsafeSvg = unsafeEl.shadowRoot?.querySelector("svg");
+      if (!unsafeSvg) {
+        throw new Error("Expected SVG element to exist");
+      }
+      expect(unsafeSvg.getAttribute("onclick") ?? "").to.include("window.open");
+      unsafeSvg.dispatchEvent(
+        new MouseEvent("click", { bubbles: true, composed: true }),
+      );
+
+      expect(openUrl).to.equal("https://carbondesignsystem.com");
+
+      openUrl = null;
+
+      const safeEl = await fixture<MarkdownElementInstance>(
+        html`<cds-aichat-markdown-text
+          markdown=${TEXT}
+          sanitize-html
+        ></cds-aichat-markdown-text>`,
+      );
+      await safeEl.updateComplete;
+
+      const safeSvg = safeEl.shadowRoot?.querySelector("svg");
+      expect(safeSvg).to.not.equal(null);
+      if (!safeSvg) {
+        throw new Error("Expected sanitized SVG element to exist");
+      }
+      expect(safeSvg.getAttribute("onclick")).to.equal(null);
+      safeSvg.dispatchEvent(
+        new MouseEvent("click", { bubbles: true, composed: true }),
+      );
+
+      expect(openUrl).to.equal(null);
+    } finally {
+      window.open = originalOpen;
+    }
+  });
+
+  it("preserves svg nesting with defs and title as children", async () => {
+    const el = await fixture<MarkdownElementInstance>(
+      html`<cds-aichat-markdown-text
+        markdown=${TEXT}
+      ></cds-aichat-markdown-text>`,
+    );
+
+    await el.updateComplete;
+
+    const root = el.shadowRoot;
+    if (!root) {
+      throw new Error("Expected shadow root to exist");
+    }
+
+    const svg = root.querySelector("svg");
+    expect(svg, "Expected inline SVG element").to.not.equal(null);
+
+    const defs = svg?.querySelector("defs") ?? null;
+    const title = svg?.querySelector("title") ?? null;
+
+    expect(defs, "Expected <defs> child inside SVG").to.not.equal(null);
+    expect(title, "Expected <title> child inside SVG").to.not.equal(null);
+
+    if (defs) {
+      expect(defs.parentElement, "defs should be nested under svg").to.equal(
+        svg,
+      );
+    }
+    if (title) {
+      expect(title.parentElement, "title should be nested under svg").to.equal(
+        svg,
+      );
+    }
+  });
+
+  it("correctly adds defined attributes to links", async () => {
+    const el = await fixture<MarkdownElementInstance>(
+      html`<cds-aichat-markdown-text
+        markdown=${TEXT}
+      ></cds-aichat-markdown-text>`,
+    );
+
+    await el.updateComplete;
+
+    const root = el.shadowRoot;
+    if (!root) {
+      throw new Error("Expected shadow root to exist");
+    }
+
+    const link = root.querySelector('a[target="_self"]');
+    expect(link).to.not.equal(null);
+    if (!link) {
+      throw new Error(`Link did not get target="_self" applied`);
+    }
+  });
+});

--- a/packages/ai-chat/src/chat/ai-chat-components/web-components/components/markdownText/src/markdownTokenTree.ts
+++ b/packages/ai-chat/src/chat/ai-chat-components/web-components/components/markdownText/src/markdownTokenTree.ts
@@ -1,0 +1,202 @@
+/*
+ *  Copyright IBM Corp. 2025
+ *
+ *  This source code is licensed under the Apache-2.0 license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ *  @license
+ */
+
+import MarkdownIt, { Token } from "markdown-it";
+
+import { markdownItAttrs } from "./plugins/markdownItAttrs";
+import { markdownItHighlight } from "./plugins/markdownItHighlight";
+
+/**
+ * Represents a node in the token tree structure.
+ */
+export interface TokenTree {
+  /** Unique identifier for this node, used for efficient diffing */
+  key: string;
+  /** The original markdown-it token data */
+  token: Partial<Token>;
+  /** Child nodes for nested content */
+  children: TokenTree[];
+}
+
+/**
+ * Pre-configured markdown-it instance that allows HTML content.
+ */
+const htmlMarkdown = new MarkdownIt({
+  html: true,
+  breaks: true,
+  linkify: true,
+})
+  .use(markdownItAttrs, {
+    leftDelimiter: "{{",
+    rightDelimiter: "}}",
+    allowedAttributes: ["target", "rel", "class", "id"],
+  })
+  .use(markdownItHighlight);
+
+/**
+ * Pre-configured markdown-it instance that strips HTML content.
+ * Same features as htmlMarkdown but with HTML disabled for security.
+ */
+const noHtmlMarkdown = new MarkdownIt({
+  html: false,
+  breaks: true,
+  linkify: true,
+})
+  .use(markdownItAttrs, {
+    leftDelimiter: "{{",
+    rightDelimiter: "}}",
+    allowedAttributes: ["target", "rel", "class", "id"],
+  })
+  .use(markdownItHighlight);
+
+/**
+ * Parses markdown text into a flat array of markdown-it tokens.
+ */
+export function markdownToMarkdownItTokens(
+  fullText: string,
+  allowHtml = true,
+): Token[] {
+  return allowHtml
+    ? htmlMarkdown.parse(fullText, {})
+    : noHtmlMarkdown.parse(fullText, {});
+}
+
+/**
+ * Generates a unique string key for a markdown-it token.
+ *
+ * The key combines the token type, HTML tag, and source position to create
+ * a stable identifier that can be used by Lit's repeat() directive for
+ * efficient DOM updates.
+ */
+function generateKey(token: Token): string {
+  const map = token.map ? token.map.join("-") : "";
+  return `${token.type}:${token.tag}:${map}`;
+}
+
+/**
+ * Converts a flat list of markdown-it tokens into a tree.
+ */
+export function buildTokenTree(tokens: Token[]): TokenTree {
+  // Create the root node that will contain all top-level content
+  const root: TokenTree = {
+    key: "root",
+    token: {
+      type: "root",
+      tag: "",
+      nesting: 0,
+      level: 0,
+      content: "",
+      attrs: null,
+      children: null,
+      markup: "",
+      block: true,
+      hidden: false,
+      map: null,
+      info: "",
+      meta: null,
+    },
+    children: [],
+  };
+
+  // Stack tracks the current nesting context while building the tree
+  const stack: TokenTree[] = [root];
+
+  tokens.forEach((token) => {
+    // Create a new node for this token
+    const node: TokenTree = {
+      key: generateKey(token),
+      token,
+      children: [],
+    };
+
+    // Handle inline tokens that contain their own child tokens
+    // (e.g., a paragraph containing bold, italic, and text tokens)
+    if (token.type === "inline" && token.children?.length) {
+      node.children = buildTokenTree(token.children).children;
+    }
+
+    const current = stack[stack.length - 1];
+
+    if (token.nesting === 1) {
+      // Opening tag: add node to current container and descend into it
+      current.children.push(node);
+      stack.push(node);
+    } else if (token.nesting === -1) {
+      // Closing tag: exit current container
+      stack.pop();
+    } else {
+      // Self-contained token: add to current container
+      current.children.push(node);
+    }
+  });
+
+  return root;
+}
+
+/**
+ * Compares two TokenTree structures and creates a new tree that reuses
+ * unchanged nodes from the old tree.
+ *
+ * This optimization is crucial for performance when content is being streamed
+ * or updated incrementally.
+ */
+export function diffTokenTree(
+  oldTree: TokenTree | undefined,
+  newTree: TokenTree,
+): TokenTree {
+  // If keys don't match, the entire subtree changed - use new tree
+  if (!oldTree || oldTree.key !== newTree.key) {
+    return newTree;
+  }
+
+  // Keys match so create merged tree reusing unchanged children
+  const merged: TokenTree = {
+    key: newTree.key,
+    token: newTree.token,
+    children: [],
+  };
+
+  // Create lookup map of old children by key for efficient comparison
+  const oldChildrenByKey = new Map(
+    oldTree.children.map((child) => [child.key, child]),
+  );
+
+  // Process each new child, reusing old ones where possible
+  newTree.children.forEach((newChild) => {
+    const oldChild = oldChildrenByKey.get(newChild.key);
+
+    if (oldChild) {
+      // Recursively diff matching children
+      merged.children.push(diffTokenTree(oldChild, newChild));
+    } else {
+      // Use new child as-is
+      merged.children.push(newChild);
+    }
+  });
+
+  return merged;
+}
+
+/**
+ * Converts markdown into a tree with keys on it for Lit.
+ */
+export function markdownToTokenTree(
+  markdown: string,
+  lastTree?: TokenTree,
+  allowHtml = true,
+): TokenTree {
+  // Parse markdown into flat token array
+  const tokens = markdownToMarkdownItTokens(markdown, allowHtml);
+
+  // Build hierarchical tree structure
+  const tree = buildTokenTree(tokens);
+
+  // Optimize by reusing unchanged parts of previous tree
+  return diffTokenTree(lastTree, tree);
+}

--- a/packages/ai-chat/src/chat/ai-chat-components/web-components/components/markdownText/src/plugins/markdownItAttrs.ts
+++ b/packages/ai-chat/src/chat/ai-chat-components/web-components/components/markdownText/src/plugins/markdownItAttrs.ts
@@ -1,0 +1,134 @@
+/*
+ *  Copyright IBM Corp. 2025
+ *
+ *  This source code is licensed under the Apache-2.0 license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ *  @license
+ */
+
+/*
+ *  This file is based on markdown-it-attrs by Arve Seljebu
+ *  Original repository: https://github.com/arve0/markdown-it-attrs
+ *
+ *  The MIT License (MIT)
+ *
+ *  Copyright (c) Arve Seljebu <arve.seljebu@gmail.com> (arve0.github.io)
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ *
+ *  ---
+ *
+ *  This file has been rewritten to be fully ESM-compliant and TypeScript-compatible
+ *  for use in Carbon AI Chat.
+ */
+
+import type MarkdownIt from "markdown-it";
+import type StateCore from "markdown-it/lib/rules_core/state_core.mjs";
+import type { MarkdownItAttrsOptions } from "./markdownItAttrs/types.js";
+import { test } from "./markdownItAttrs/core.js";
+import { createPatterns } from "./markdownItAttrs/patterns/index.js";
+
+const defaultOptions: Required<MarkdownItAttrsOptions> = {
+  leftDelimiter: "{",
+  rightDelimiter: "}",
+  allowedAttributes: [],
+};
+
+/**
+ * Markdown-it plugin that adds support for applying attributes to markdown elements using curly brace syntax.
+ */
+export function markdownItAttrs(
+  md: MarkdownIt,
+  options_?: MarkdownItAttrsOptions,
+): void {
+  const options: Required<MarkdownItAttrsOptions> = Object.assign(
+    {},
+    defaultOptions,
+    options_,
+  );
+
+  // Create an array of pattern matchers that detect and transform different markdown
+  // elements with attribute syntax (e.g., {.class #id key=val}). Each pattern defines
+  // rules for matching specific token sequences and transforming them by extracting
+  // and applying the attributes. Different patterns are needed because attributes appear
+  // in different positions for different elements:
+  //   - Links: attributes after closing: [text](url){target="_blank"}
+  //   - Inline elements: attributes after closing: **bold**{.class}
+  //   - Code blocks: attributes at end of info string: ```js{.highlight}
+  //   - Tables: attributes in paragraph after table_close
+  //   - Lists: attributes on softbreak or at item end
+  // Each pattern knows where to look for attributes and which token to apply them to.
+  const patterns = createPatterns(options);
+
+  /**
+   * Core processing function that walks through all tokens in the markdown document
+   * and applies attribute transformations when patterns match.
+   */
+  function curlyAttrs(state: StateCore): void {
+    const tokens = state.tokens;
+
+    // Iterate through each token in the document
+    for (let tokenIndex = 0; tokenIndex < tokens.length; tokenIndex++) {
+      // Test each pattern against the current token position
+      for (
+        let patternIndex = 0;
+        patternIndex < patterns.length;
+        patternIndex++
+      ) {
+        const pattern = patterns[patternIndex];
+        let childIndex: number | null = null;
+
+        // Check if all tests in the pattern match
+        const patternMatches = pattern.tests.every((rule) => {
+          const result = test(tokens, tokenIndex, rule);
+          if (result.j !== null) {
+            childIndex = result.j; // Store child token index if matched within children
+          }
+          return result.match;
+        });
+
+        // If pattern matched, apply the transformation
+        if (patternMatches) {
+          try {
+            pattern.transform(tokens, tokenIndex, childIndex ?? undefined);
+
+            // For inline patterns, re-check the same position since tokens may have changed
+            if (
+              pattern.name === "inline attributes" ||
+              pattern.name === "inline nesting 0"
+            ) {
+              patternIndex--;
+            }
+          } catch (error) {
+            console.error(
+              `markdown-it-attrs: Error in pattern '${pattern.name}': ${(error as Error).message}`,
+            );
+            console.error((error as Error).stack);
+          }
+        }
+      }
+    }
+  }
+
+  // Register the curlyAttrs function to run before linkify in the markdown-it processing pipeline
+  md.core.ruler.before("linkify", "curly_attributes", curlyAttrs);
+}
+
+export default markdownItAttrs;

--- a/packages/ai-chat/src/chat/ai-chat-components/web-components/components/markdownText/src/plugins/markdownItAttrs/core.ts
+++ b/packages/ai-chat/src/chat/ai-chat-components/web-components/components/markdownText/src/plugins/markdownItAttrs/core.ts
@@ -1,0 +1,433 @@
+/*
+ *  Copyright IBM Corp. 2025
+ *
+ *  This source code is licensed under the Apache-2.0 license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ *  @license
+ */
+
+import type { Token } from "markdown-it";
+import type {
+  MarkdownItAttrsOptions,
+  AttributePair,
+  DetectingStrRule,
+  DetectingRule,
+  MatchedResult,
+} from "./types.js";
+import {
+  escapeRegExp,
+  get,
+  last,
+  isArrayOfObjects,
+  isArrayOfFunctions,
+} from "./utils.js";
+
+/**
+ * Parses attribute strings in the format {.class #id key=val} and returns an array of attribute key-value pairs.
+ */
+export function getAttrs(
+  str: string,
+  start: number,
+  options: Required<MarkdownItAttrsOptions>,
+): AttributePair[] {
+  const allowedKeyChars = /[^\t\n\f />"'=]/;
+  const pairSeparator = " ";
+  const keySeparator = "=";
+  const classChar = ".";
+  const idChar = "#";
+
+  const attrs: AttributePair[] = [];
+  let key = "";
+  let value = "";
+  let parsingKey = true;
+  let valueInsideQuotes = false;
+
+  // Iterate through the string starting after the left delimiter
+  for (
+    let characterIndex = start + options.leftDelimiter.length;
+    characterIndex < str.length;
+    characterIndex++
+  ) {
+    // Check if we've reached the right delimiter (end of attributes)
+    if (
+      str.slice(
+        characterIndex,
+        characterIndex + options.rightDelimiter.length,
+      ) === options.rightDelimiter
+    ) {
+      if (key !== "") {
+        attrs.push([key, value]);
+      }
+      break;
+    }
+    const char_ = str.charAt(characterIndex);
+
+    // Switch from parsing key to parsing value when we hit '='
+    if (char_ === keySeparator && parsingKey) {
+      parsingKey = false;
+      continue;
+    }
+
+    // Handle class shorthand syntax: .classname or ..css-module
+    if (char_ === classChar && key === "") {
+      if (str.charAt(characterIndex + 1) === classChar) {
+        key = "css-module";
+        characterIndex += 1;
+      } else {
+        key = "class";
+      }
+      parsingKey = false;
+      continue;
+    }
+
+    // Handle id shorthand syntax: #idname
+    if (char_ === idChar && key === "") {
+      key = "id";
+      parsingKey = false;
+      continue;
+    }
+
+    // Handle opening quote for attribute values
+    if (char_ === '"' && value === "" && !valueInsideQuotes) {
+      valueInsideQuotes = true;
+      continue;
+    }
+    // Handle closing quote for attribute values
+    if (char_ === '"' && valueInsideQuotes) {
+      valueInsideQuotes = false;
+      continue;
+    }
+
+    // Space separates attribute pairs (unless inside quotes)
+    if (char_ === pairSeparator && !valueInsideQuotes) {
+      if (key === "") {
+        continue;
+      }
+      attrs.push([key, value]);
+      key = "";
+      value = "";
+      parsingKey = true;
+      continue;
+    }
+
+    // Skip invalid characters in key names
+    if (parsingKey && char_.search(allowedKeyChars) === -1) {
+      continue;
+    }
+
+    // Append character to either key or value
+    if (parsingKey) {
+      key += char_;
+      continue;
+    }
+    value += char_;
+  }
+
+  // Filter attributes based on allowedAttributes option
+  if (options.allowedAttributes && options.allowedAttributes.length) {
+    return attrs.filter((attrPair) => {
+      const attr = attrPair[0];
+      return options.allowedAttributes.some((allowedAttribute) =>
+        allowedAttribute instanceof RegExp
+          ? allowedAttribute.test(attr)
+          : attr === allowedAttribute,
+      );
+    });
+  }
+  return attrs;
+}
+
+/**
+ * Applies an array of attribute pairs to a token, handling special cases for class and css-module attributes.
+ */
+export function addAttrs(attrs: AttributePair[], token: Token): Token {
+  for (
+    let attributeIndex = 0;
+    attributeIndex < attrs.length;
+    attributeIndex += 1
+  ) {
+    const key = attrs[attributeIndex][0];
+    if (key === "class") {
+      token.attrJoin("class", attrs[attributeIndex][1]);
+    } else if (key === "css-module") {
+      token.attrJoin("css-module", attrs[attributeIndex][1]);
+    } else {
+      token.attrPush(attrs[attributeIndex]);
+    }
+  }
+  return token;
+}
+
+/**
+ * Creates a function that tests whether a string contains attribute delimiters at a specified position (start, end, or only).
+ */
+export function hasDelimiters(
+  where: "start" | "end" | "only",
+  options: Required<MarkdownItAttrsOptions>,
+): DetectingStrRule {
+  if (!where) {
+    throw new Error(
+      'Parameter `where` not passed. Should be "start", "end" or "only".',
+    );
+  }
+
+  return function (str: string): boolean {
+    // Minimum length needed: { + at least one char + }
+    const minCurlyLength =
+      options.leftDelimiter.length + 1 + options.rightDelimiter.length;
+    if (!str || typeof str !== "string" || str.length < minCurlyLength) {
+      return false;
+    }
+
+    // Class/ID syntax requires an extra character (.class or #id)
+    function validCurlyLength(curly: string): boolean {
+      const isClass = curly.charAt(options.leftDelimiter.length) === ".";
+      const isId = curly.charAt(options.leftDelimiter.length) === "#";
+      return isClass || isId
+        ? curly.length >= minCurlyLength + 1
+        : curly.length >= minCurlyLength;
+    }
+
+    let start: number, end: number, slice: string, nextChar: string;
+    const rightDelimiterMinimumShift =
+      minCurlyLength - options.rightDelimiter.length;
+
+    switch (where) {
+      case "start":
+        // Check if delimiters are at the start of the string
+        slice = str.slice(0, options.leftDelimiter.length);
+        start = slice === options.leftDelimiter ? 0 : -1;
+        end =
+          start === -1
+            ? -1
+            : str.indexOf(options.rightDelimiter, rightDelimiterMinimumShift);
+        // Ensure the character after closing delimiter isn't part of the delimiter itself
+        nextChar = str.charAt(end + options.rightDelimiter.length);
+        if (nextChar && options.rightDelimiter.indexOf(nextChar) !== -1) {
+          end = -1;
+        }
+        break;
+
+      case "end":
+        // Check if delimiters are at the end of the string
+        start = str.lastIndexOf(options.leftDelimiter);
+        end =
+          start === -1
+            ? -1
+            : str.indexOf(
+                options.rightDelimiter,
+                start + rightDelimiterMinimumShift,
+              );
+        // Verify the closing delimiter is actually at the string's end
+        end = end === str.length - options.rightDelimiter.length ? end : -1;
+        break;
+
+      case "only":
+        // Check if the entire string is delimiters with content inside
+        slice = str.slice(0, options.leftDelimiter.length);
+        start = slice === options.leftDelimiter ? 0 : -1;
+        slice = str.slice(str.length - options.rightDelimiter.length);
+        end =
+          slice === options.rightDelimiter
+            ? str.length - options.rightDelimiter.length
+            : -1;
+        break;
+
+      default:
+        throw new Error(
+          `Unexpected case ${where}, expected 'start', 'end' or 'only'`,
+        );
+    }
+
+    // Valid if we found both delimiters and the content between them is valid
+    return (
+      start !== -1 &&
+      end !== -1 &&
+      validCurlyLength(
+        str.substring(start, end + options.rightDelimiter.length),
+      )
+    );
+  };
+}
+
+/**
+ * Removes attribute delimiters and their contents from the end of a string.
+ */
+export function removeDelimiter(
+  str: string,
+  options: Required<MarkdownItAttrsOptions>,
+): string {
+  const start = escapeRegExp(options.leftDelimiter);
+  const end = escapeRegExp(options.rightDelimiter);
+
+  const curly = new RegExp(
+    "[ \\n]?" + start + "[^" + start + end + "]+" + end + "$",
+  );
+  const pos = str.search(curly);
+
+  return pos !== -1 ? str.slice(0, pos) : str;
+}
+
+/**
+ * Finds the matching opening token for a given closing token by searching backwards through the token array.
+ */
+export function getMatchingOpeningToken(
+  tokens: Token[],
+  closingTokenIndex: number,
+): Token | false {
+  if (tokens[closingTokenIndex].type === "softbreak") {
+    return false;
+  }
+  if (tokens[closingTokenIndex].nesting === 0) {
+    return tokens[closingTokenIndex];
+  }
+
+  const targetLevel = tokens[closingTokenIndex].level;
+  const expectedType = tokens[closingTokenIndex].type.replace(
+    "_close",
+    "_open",
+  );
+
+  for (let searchIndex = closingTokenIndex; searchIndex >= 0; searchIndex--) {
+    if (
+      tokens[searchIndex].type === expectedType &&
+      tokens[searchIndex].level === targetLevel
+    ) {
+      return tokens[searchIndex];
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Tests whether a token at a given index matches a detecting rule, recursively checking nested rules.
+ */
+export function test(
+  tokens: Token[],
+  baseIndex: number,
+  rule: DetectingRule,
+): MatchedResult {
+  const result: MatchedResult = {
+    match: false,
+    j: null,
+  };
+
+  // Calculate the actual token index using shift (relative) or position (absolute)
+  const targetIndex =
+    rule.shift !== undefined ? baseIndex + rule.shift : rule.position;
+
+  // Negative indices are invalid when using shift
+  if (
+    rule.shift !== undefined &&
+    targetIndex !== undefined &&
+    targetIndex < 0
+  ) {
+    return result;
+  }
+
+  // Get the token at the calculated index
+  const token = get(tokens, targetIndex ?? 0);
+
+  if (token === undefined) {
+    return result;
+  }
+
+  // Test each property in the detecting rule
+  for (const key of Object.keys(rule)) {
+    // Skip internal position markers
+    if (key === "shift" || key === "position") {
+      continue;
+    }
+
+    // Token must have the property being tested
+    if ((token as unknown as Record<string, unknown>)[key] === undefined) {
+      return result;
+    }
+
+    // Special handling for children array matching
+    if (key === "children" && isArrayOfObjects(rule.children)) {
+      if (!token.children || token.children.length === 0) {
+        return result;
+      }
+      let match: boolean;
+      const childTests = rule.children;
+      const children = token.children;
+
+      // If all child tests use absolute positions, test those specific positions
+      if (childTests.every((childRule) => childRule.position !== undefined)) {
+        match = childTests.every(
+          (childRule) =>
+            test(children, childRule.position as number, childRule).match,
+        );
+        if (match) {
+          // Calculate the actual index (handling negative positions)
+          const childPosition = last(childTests).position as number;
+          result.j =
+            childPosition >= 0
+              ? childPosition
+              : children.length + childPosition;
+        }
+      } else {
+        // Otherwise, scan through all children to find a matching sequence
+        match = false;
+        for (let childIndex = 0; childIndex < children.length; childIndex++) {
+          match = childTests.every(
+            (childRule) => test(children, childIndex, childRule).match,
+          );
+          if (match) {
+            result.j = childIndex;
+            break;
+          }
+        }
+      }
+
+      if (match === false) {
+        return result;
+      }
+
+      continue;
+    }
+
+    // Get the values to compare
+    const ruleValue = (rule as Record<string, unknown>)[key];
+    const tokenValue = (token as unknown as Record<string, unknown>)[key];
+
+    // Match based on the type of the test value
+    switch (typeof ruleValue) {
+      case "boolean":
+      case "number":
+      case "string":
+        // Direct value comparison
+        if (tokenValue !== ruleValue) {
+          return result;
+        }
+        break;
+      case "function":
+        // Function predicate test
+        if (!(ruleValue as (arg: unknown) => boolean)(tokenValue)) {
+          return result;
+        }
+        break;
+      case "object":
+        // Array of function predicates (all must pass)
+        if (isArrayOfFunctions(ruleValue)) {
+          const allPass = ruleValue.every((predicate) => predicate(tokenValue));
+          if (allPass === false) {
+            return result;
+          }
+          break;
+        }
+      // fall through for objects !== arrays of functions
+      default:
+        throw new Error(
+          `Unknown type of pattern test (key: ${key}). Test should be of type boolean, number, string, function or array of functions.`,
+        );
+    }
+  }
+
+  // All tests passed
+  result.match = true;
+  return result;
+}

--- a/packages/ai-chat/src/chat/ai-chat-components/web-components/components/markdownText/src/plugins/markdownItAttrs/patterns/blocks.ts
+++ b/packages/ai-chat/src/chat/ai-chat-components/web-components/components/markdownText/src/plugins/markdownItAttrs/patterns/blocks.ts
@@ -1,0 +1,60 @@
+/*
+ *  Copyright IBM Corp. 2025
+ *
+ *  This source code is licensed under the Apache-2.0 license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ *  @license
+ */
+
+import type { MarkdownItAttrsOptions, CurlyAttrsPattern } from "../types.js";
+import { getAttrs, addAttrs } from "../core.js";
+import { escapeRegExp } from "../utils.js";
+
+/**
+ * Pattern for horizontal rules with attributes.
+ * Example: --- {.class}
+ */
+export function createHorizontalRulePattern(
+  options: Required<MarkdownItAttrsOptions>,
+): CurlyAttrsPattern {
+  const __hr = new RegExp(
+    "^ {0,3}[-*_]{3,} ?" +
+      escapeRegExp(options.leftDelimiter) +
+      "[^" +
+      escapeRegExp(options.rightDelimiter) +
+      "]",
+  );
+
+  return {
+    name: "horizontal rule",
+    tests: [
+      {
+        shift: 0,
+        type: "paragraph_open",
+      },
+      {
+        shift: 1,
+        type: "inline",
+        children: (arr: unknown[]) => arr.length === 1,
+        content: (str: string) => str.match(__hr) !== null,
+      },
+      {
+        shift: 2,
+        type: "paragraph_close",
+      },
+    ],
+    transform: (tokens, tokenIndex) => {
+      const token = tokens[tokenIndex];
+      token.type = "hr";
+      token.tag = "hr";
+      token.nesting = 0;
+      const content = tokens[tokenIndex + 1].content;
+      const attrStart = content.lastIndexOf(options.leftDelimiter);
+      const attrs = getAttrs(content, attrStart, options);
+      addAttrs(attrs, token);
+      token.markup = content;
+      tokens.splice(tokenIndex + 1, 2);
+    },
+  };
+}

--- a/packages/ai-chat/src/chat/ai-chat-components/web-components/components/markdownText/src/plugins/markdownItAttrs/patterns/code.ts
+++ b/packages/ai-chat/src/chat/ai-chat-components/web-components/components/markdownText/src/plugins/markdownItAttrs/patterns/code.ts
@@ -1,0 +1,37 @@
+/*
+ *  Copyright IBM Corp. 2025
+ *
+ *  This source code is licensed under the Apache-2.0 license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ *  @license
+ */
+
+import type { MarkdownItAttrsOptions, CurlyAttrsPattern } from "../types.js";
+import { getAttrs, addAttrs, hasDelimiters, removeDelimiter } from "../core.js";
+
+/**
+ * Pattern for fenced code blocks with attributes.
+ * Example: ```js {.highlight}
+ */
+export function createFencedCodeBlockPattern(
+  options: Required<MarkdownItAttrsOptions>,
+): CurlyAttrsPattern {
+  return {
+    name: "fenced code blocks",
+    tests: [
+      {
+        shift: 0,
+        block: true,
+        info: hasDelimiters("end", options),
+      },
+    ],
+    transform: (tokens, tokenIndex) => {
+      const token = tokens[tokenIndex];
+      const attrStart = token.info.lastIndexOf(options.leftDelimiter);
+      const attrs = getAttrs(token.info, attrStart, options);
+      addAttrs(attrs, token);
+      token.info = removeDelimiter(token.info, options);
+    },
+  };
+}

--- a/packages/ai-chat/src/chat/ai-chat-components/web-components/components/markdownText/src/plugins/markdownItAttrs/patterns/index.ts
+++ b/packages/ai-chat/src/chat/ai-chat-components/web-components/components/markdownText/src/plugins/markdownItAttrs/patterns/index.ts
@@ -1,0 +1,73 @@
+/*
+ *  Copyright IBM Corp. 2025
+ *
+ *  This source code is licensed under the Apache-2.0 license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ *  @license
+ */
+
+import type { MarkdownItAttrsOptions, CurlyAttrsPattern } from "../types.js";
+import { createFencedCodeBlockPattern } from "./code.js";
+import {
+  createInlineNesting0Pattern,
+  createInlineAttributesPattern,
+  createSoftbreakCurlyPattern,
+  createEndOfBlockPattern,
+} from "./inline.js";
+import {
+  createTablePattern,
+  createTableTheadMetadataPattern,
+  createTableTbodyCalculatePattern,
+} from "./tables.js";
+import {
+  createListSoftbreakPattern,
+  createListDoubleSoftbreakPattern,
+  createListItemEndPattern,
+} from "./lists.js";
+import { createHorizontalRulePattern } from "./blocks.js";
+
+/**
+ * Creates an array of patterns used to detect and transform markdown tokens with attribute syntax.
+ */
+export function createPatterns(
+  options: Required<MarkdownItAttrsOptions>,
+): CurlyAttrsPattern[] {
+  return [
+    // Fenced code blocks: ```js {.highlight}
+    createFencedCodeBlockPattern(options),
+
+    // Inline elements with nesting 0: ![alt](img.jpg){.class} or `code`{.class}
+    createInlineNesting0Pattern(options),
+
+    // Tables with attributes
+    createTablePattern(options),
+
+    // Table header metadata calculation (used for colspan/rowspan)
+    createTableTheadMetadataPattern(),
+
+    // Table body calculation for handling colspan/rowspan
+    createTableTbodyCalculatePattern(),
+
+    // Inline attributes on emphasized/strong text: **bold**{.class}
+    createInlineAttributesPattern(options),
+
+    // List items with attributes after softbreak
+    createListSoftbreakPattern(options),
+
+    // Lists with double softbreak before attributes
+    createListDoubleSoftbreakPattern(options),
+
+    // List items with attributes at the end
+    createListItemEndPattern(options),
+
+    // Softbreak followed by attributes at start of line
+    createSoftbreakCurlyPattern(options),
+
+    // Horizontal rules with attributes: --- {.class}
+    createHorizontalRulePattern(options),
+
+    // Attributes at the end of a block
+    createEndOfBlockPattern(options),
+  ];
+}

--- a/packages/ai-chat/src/chat/ai-chat-components/web-components/components/markdownText/src/plugins/markdownItAttrs/patterns/inline.ts
+++ b/packages/ai-chat/src/chat/ai-chat-components/web-components/components/markdownText/src/plugins/markdownItAttrs/patterns/inline.ts
@@ -1,0 +1,240 @@
+/*
+ *  Copyright IBM Corp. 2025
+ *
+ *  This source code is licensed under the Apache-2.0 license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ *  @license
+ */
+
+import type { MarkdownItAttrsOptions, CurlyAttrsPattern } from "../types.js";
+import {
+  getAttrs,
+  addAttrs,
+  hasDelimiters,
+  getMatchingOpeningToken,
+} from "../core.js";
+import { last } from "../utils.js";
+
+/**
+ * Pattern for inline elements with nesting level 0 (images, inline code).
+ * Example: ![alt](img.jpg){.class} or `code`{.class}
+ */
+export function createInlineNesting0Pattern(
+  options: Required<MarkdownItAttrsOptions>,
+): CurlyAttrsPattern {
+  return {
+    name: "inline nesting 0",
+    tests: [
+      {
+        shift: 0,
+        type: "inline",
+        children: [
+          {
+            shift: -1,
+            type: (str: string) => str === "image" || str === "code_inline",
+          },
+          {
+            shift: 0,
+            type: "text",
+            content: hasDelimiters("start", options),
+          },
+        ],
+      },
+    ],
+    transform: (tokens, tokenIndex, childIndex) => {
+      if (
+        childIndex === null ||
+        childIndex === undefined ||
+        !tokens[tokenIndex].children
+      ) {
+        return;
+      }
+      const children = tokens[tokenIndex].children;
+      const token = children[childIndex];
+      const endChar = token.content.indexOf(options.rightDelimiter);
+      const attrToken = children[childIndex - 1];
+      const attrs = getAttrs(token.content, 0, options);
+      addAttrs(attrs, attrToken);
+      if (token.content.length === endChar + options.rightDelimiter.length) {
+        children.splice(childIndex, 1);
+      } else {
+        token.content = token.content.slice(
+          endChar + options.rightDelimiter.length,
+        );
+      }
+    },
+  };
+}
+
+/**
+ * Pattern for inline attributes on emphasized/strong text.
+ * Example: **bold**{.class}
+ */
+export function createInlineAttributesPattern(
+  options: Required<MarkdownItAttrsOptions>,
+): CurlyAttrsPattern {
+  return {
+    name: "inline attributes",
+    tests: [
+      {
+        shift: 0,
+        type: "inline",
+        children: [
+          {
+            shift: -1,
+            nesting: -1,
+          },
+          {
+            shift: 0,
+            type: "text",
+            content: hasDelimiters("start", options),
+          },
+        ],
+      },
+    ],
+    transform: (tokens, tokenIndex, childIndex) => {
+      if (
+        childIndex === null ||
+        childIndex === undefined ||
+        !tokens[tokenIndex].children
+      ) {
+        return;
+      }
+      const children = tokens[tokenIndex].children;
+      const token = children[childIndex];
+      const content = token.content;
+      const attrs = getAttrs(content, 0, options);
+      const openingToken = getMatchingOpeningToken(children, childIndex - 1);
+      if (!openingToken) {
+        return;
+      }
+      addAttrs(attrs, openingToken);
+      token.content = content.slice(
+        content.indexOf(options.rightDelimiter) + options.rightDelimiter.length,
+      );
+    },
+  };
+}
+
+/**
+ * Pattern for softbreak followed by attributes at start of line.
+ */
+export function createSoftbreakCurlyPattern(
+  options: Required<MarkdownItAttrsOptions>,
+): CurlyAttrsPattern {
+  return {
+    name: "\n{.a} softbreak then curly in start",
+    tests: [
+      {
+        shift: 0,
+        type: "inline",
+        children: [
+          {
+            position: -2,
+            type: "softbreak",
+          },
+          {
+            position: -1,
+            type: "text",
+            content: hasDelimiters("only", options),
+          },
+        ],
+      },
+    ],
+    transform: (tokens, tokenIndex, childIndex) => {
+      if (
+        childIndex === null ||
+        childIndex === undefined ||
+        !tokens[tokenIndex].children
+      ) {
+        return;
+      }
+      const children = tokens[tokenIndex].children;
+      const token = children[childIndex];
+      const attrs = getAttrs(token.content, 0, options);
+      // Find the next closing token
+      let closingTokenIndex = tokenIndex + 1;
+      while (
+        tokens[closingTokenIndex + 1] &&
+        tokens[closingTokenIndex + 1].nesting === -1
+      ) {
+        closingTokenIndex++;
+      }
+      // Find its matching opening token and apply attributes
+      const openingToken = getMatchingOpeningToken(tokens, closingTokenIndex);
+      if (!openingToken) {
+        return;
+      }
+      addAttrs(attrs, openingToken);
+      // Remove the softbreak and attributes from children
+      tokens[tokenIndex].children = children.slice(0, -2);
+    },
+  };
+}
+
+/**
+ * Pattern for attributes at the end of a block.
+ */
+export function createEndOfBlockPattern(
+  options: Required<MarkdownItAttrsOptions>,
+): CurlyAttrsPattern {
+  return {
+    name: "end of block",
+    tests: [
+      {
+        shift: 0,
+        type: "inline",
+        children: [
+          {
+            position: -1,
+            content: hasDelimiters("end", options),
+            type: (t: string) => t !== "code_inline" && t !== "math_inline",
+          },
+        ],
+      },
+    ],
+    transform: (tokens, tokenIndex, childIndex) => {
+      if (
+        childIndex === null ||
+        childIndex === undefined ||
+        !tokens[tokenIndex].children
+      ) {
+        return;
+      }
+      const children = tokens[tokenIndex].children;
+      const token = children[childIndex];
+      const content = token.content;
+      // Extract attributes from the end of content
+      const attrs = getAttrs(
+        content,
+        content.lastIndexOf(options.leftDelimiter),
+        options,
+      );
+      // Find the next closing token
+      let closingTokenIndex = tokenIndex + 1;
+      do {
+        if (
+          tokens[closingTokenIndex] &&
+          tokens[closingTokenIndex].nesting === -1
+        ) {
+          break;
+        }
+      } while (closingTokenIndex++ < tokens.length);
+      // Find its matching opening token
+      const openingToken = getMatchingOpeningToken(tokens, closingTokenIndex);
+      if (!openingToken) {
+        return;
+      }
+      addAttrs(attrs, openingToken);
+      // Remove attributes from content, trimming trailing space if present
+      const trimmed = content.slice(
+        0,
+        content.lastIndexOf(options.leftDelimiter),
+      );
+      const trimmedChars = trimmed.split("");
+      token.content =
+        last(trimmedChars) !== " " ? trimmed : trimmed.slice(0, -1);
+    },
+  };
+}

--- a/packages/ai-chat/src/chat/ai-chat-components/web-components/components/markdownText/src/plugins/markdownItAttrs/patterns/lists.ts
+++ b/packages/ai-chat/src/chat/ai-chat-components/web-components/components/markdownText/src/plugins/markdownItAttrs/patterns/lists.ts
@@ -1,0 +1,175 @@
+/*
+ *  Copyright IBM Corp. 2025
+ *
+ *  This source code is licensed under the Apache-2.0 license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ *  @license
+ */
+
+import type { MarkdownItAttrsOptions, CurlyAttrsPattern } from "../types.js";
+import {
+  getAttrs,
+  addAttrs,
+  hasDelimiters,
+  getMatchingOpeningToken,
+} from "../core.js";
+import { last } from "../utils.js";
+
+/**
+ * Pattern for list items with attributes after softbreak.
+ */
+export function createListSoftbreakPattern(
+  options: Required<MarkdownItAttrsOptions>,
+): CurlyAttrsPattern {
+  return {
+    name: "list softbreak",
+    tests: [
+      {
+        shift: -2,
+        type: "list_item_open",
+      },
+      {
+        shift: 0,
+        type: "inline",
+        children: [
+          {
+            position: -2,
+            type: "softbreak",
+          },
+          {
+            position: -1,
+            type: "text",
+            content: hasDelimiters("only", options),
+          },
+        ],
+      },
+    ],
+    transform: (tokens, tokenIndex, childIndex) => {
+      if (
+        childIndex === null ||
+        childIndex === undefined ||
+        !tokens[tokenIndex].children
+      ) {
+        return;
+      }
+      const children = tokens[tokenIndex].children;
+      const token = children[childIndex];
+      const content = token.content;
+      const attrs = getAttrs(content, 0, options);
+      // Find the list open token by walking backwards
+      let listOpenIndex = tokenIndex - 2;
+      while (
+        tokens[listOpenIndex - 1] &&
+        tokens[listOpenIndex - 1].type !== "ordered_list_open" &&
+        tokens[listOpenIndex - 1].type !== "bullet_list_open"
+      ) {
+        listOpenIndex--;
+      }
+      // Apply attributes to the list
+      addAttrs(attrs, tokens[listOpenIndex - 1]);
+      tokens[tokenIndex].children = children.slice(0, -2);
+    },
+  };
+}
+
+/**
+ * Pattern for lists with double softbreak before attributes.
+ */
+export function createListDoubleSoftbreakPattern(
+  options: Required<MarkdownItAttrsOptions>,
+): CurlyAttrsPattern {
+  return {
+    name: "list double softbreak",
+    tests: [
+      {
+        shift: 0,
+        type: (str: string) =>
+          str === "bullet_list_close" || str === "ordered_list_close",
+      },
+      {
+        shift: 1,
+        type: "paragraph_open",
+      },
+      {
+        shift: 2,
+        type: "inline",
+        content: hasDelimiters("only", options),
+        children: (arr: unknown[]) => arr.length === 1,
+      },
+      {
+        shift: 3,
+        type: "paragraph_close",
+      },
+    ],
+    transform: (tokens, tokenIndex) => {
+      const token = tokens[tokenIndex + 2];
+      const content = token.content;
+      const attrs = getAttrs(content, 0, options);
+      // Find the matching list open token
+      const openingToken = getMatchingOpeningToken(tokens, tokenIndex);
+      if (!openingToken) {
+        return;
+      }
+      addAttrs(attrs, openingToken);
+      // Remove the paragraph containing the attributes
+      tokens.splice(tokenIndex + 1, 3);
+    },
+  };
+}
+
+/**
+ * Pattern for list items with attributes at the end.
+ */
+export function createListItemEndPattern(
+  options: Required<MarkdownItAttrsOptions>,
+): CurlyAttrsPattern {
+  return {
+    name: "list item end",
+    tests: [
+      {
+        shift: -2,
+        type: "list_item_open",
+      },
+      {
+        shift: 0,
+        type: "inline",
+        children: [
+          {
+            position: -1,
+            type: "text",
+            content: hasDelimiters("end", options),
+          },
+        ],
+      },
+    ],
+    transform: (tokens, tokenIndex, childIndex) => {
+      if (
+        childIndex === null ||
+        childIndex === undefined ||
+        !tokens[tokenIndex].children
+      ) {
+        return;
+      }
+      const children = tokens[tokenIndex].children;
+      const token = children[childIndex];
+      const content = token.content;
+      // Extract attributes from the end of the content
+      const attrs = getAttrs(
+        content,
+        content.lastIndexOf(options.leftDelimiter),
+        options,
+      );
+      // Apply to list item
+      addAttrs(attrs, tokens[tokenIndex - 2]);
+      // Remove attributes from content, trimming trailing space if present
+      const trimmed = content.slice(
+        0,
+        content.lastIndexOf(options.leftDelimiter),
+      );
+      const trimmedChars = trimmed.split("");
+      token.content =
+        last(trimmedChars) !== " " ? trimmed : trimmed.slice(0, -1);
+    },
+  };
+}

--- a/packages/ai-chat/src/chat/ai-chat-components/web-components/components/markdownText/src/plugins/markdownItAttrs/patterns/tables.ts
+++ b/packages/ai-chat/src/chat/ai-chat-components/web-components/components/markdownText/src/plugins/markdownItAttrs/patterns/tables.ts
@@ -1,0 +1,269 @@
+/*
+ *  Copyright IBM Corp. 2025
+ *
+ *  This source code is licensed under the Apache-2.0 license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ *  @license
+ */
+
+import type { MarkdownItAttrsOptions, CurlyAttrsPattern } from "../types.js";
+import {
+  getAttrs,
+  addAttrs,
+  hasDelimiters,
+  getMatchingOpeningToken,
+} from "../core.js";
+import { hidden } from "../utils.js";
+
+/**
+ * Pattern for table attributes.
+ */
+export function createTablePattern(
+  options: Required<MarkdownItAttrsOptions>,
+): CurlyAttrsPattern {
+  return {
+    name: "tables",
+    tests: [
+      {
+        shift: 0,
+        type: "table_close",
+      },
+      {
+        shift: 1,
+        type: "paragraph_open",
+      },
+      {
+        shift: 2,
+        type: "inline",
+        content: hasDelimiters("only", options),
+      },
+    ],
+    transform: (tokens, tokenIndex) => {
+      const token = tokens[tokenIndex + 2];
+      const tableOpen = getMatchingOpeningToken(tokens, tokenIndex);
+      if (!tableOpen) {
+        return;
+      }
+      const attrs = getAttrs(token.content, 0, options);
+      addAttrs(attrs, tableOpen);
+      tokens.splice(tokenIndex + 1, 3);
+    },
+  };
+}
+
+/**
+ * Pattern for table header metadata calculation (used for colspan/rowspan).
+ */
+export function createTableTheadMetadataPattern(): CurlyAttrsPattern {
+  return {
+    name: "tables thead metadata",
+    tests: [
+      {
+        shift: 0,
+        type: "tr_close",
+      },
+      {
+        shift: 1,
+        type: "thead_close",
+      },
+      {
+        shift: 2,
+        type: "tbody_open",
+      },
+    ],
+    transform: (tokens, tokenIndex) => {
+      // Find the matching opening tr token
+      const trOpen = getMatchingOpeningToken(tokens, tokenIndex);
+      if (!trOpen) {
+        return;
+      }
+      const thToken = tokens[tokenIndex - 1];
+      let columnCount = 0;
+      let currentIndex = tokenIndex;
+
+      // Count the number of columns by walking backwards through table headers
+      while (--currentIndex) {
+        if (tokens[currentIndex] === trOpen) {
+          // Store column count in metadata for use in tbody calculations
+          tokens[currentIndex - 1].meta = Object.assign(
+            {},
+            tokens[currentIndex + 2].meta,
+            {
+              colsnum: columnCount,
+            },
+          );
+          break;
+        }
+        columnCount +=
+          ((tokens[currentIndex].level === thToken.level &&
+          tokens[currentIndex].type === thToken.type
+            ? 1
+            : 0) as number) >> 0;
+      }
+      // Also store column count in tbody metadata
+      tokens[tokenIndex + 2].meta = Object.assign(
+        {},
+        tokens[tokenIndex + 2].meta,
+        {
+          colsnum: columnCount,
+        },
+      );
+    },
+  };
+}
+
+/**
+ * Pattern for table body calculation for handling colspan/rowspan.
+ */
+export function createTableTbodyCalculatePattern(): CurlyAttrsPattern {
+  return {
+    name: "tables tbody calculate",
+    tests: [
+      {
+        shift: 0,
+        type: "tbody_close",
+        hidden: false,
+      },
+    ],
+    transform: (tokens, tokenIndex) => {
+      // Find the tbody_open token
+      let tbodyOpenIndex = tokenIndex - 2;
+      while (
+        tbodyOpenIndex > 0 &&
+        "tbody_open" !== tokens[--tbodyOpenIndex].type
+      ) {
+        // Continue searching backwards
+      }
+
+      // Get the calculated column count from metadata
+      const totalColumns =
+        (tokens[tbodyOpenIndex].meta as { colsnum?: number })?.colsnum ?? 0;
+      if (totalColumns < 2) {
+        return;
+      }
+
+      const targetLevel = tokens[tokenIndex].level + 2;
+      // Process each token in the table body
+      for (
+        let currentTokenIndex = tbodyOpenIndex;
+        currentTokenIndex < tokenIndex;
+        currentTokenIndex++
+      ) {
+        if (tokens[currentTokenIndex].level > targetLevel) {
+          continue;
+        }
+
+        const token = tokens[currentTokenIndex];
+        const rowspan = token.hidden
+          ? 0
+          : Number(token.attrGet("rowspan")) || 0;
+        const colspan = token.hidden
+          ? 0
+          : Number(token.attrGet("colspan")) || 0;
+
+        // Handle rowspan > 1: update metadata for affected rows
+        if (rowspan > 1) {
+          let availableColumns = totalColumns - (colspan > 0 ? colspan : 1);
+          for (
+            let searchIndex = currentTokenIndex, remainingRows = rowspan;
+            searchIndex < tokenIndex && remainingRows > 1;
+            searchIndex++
+          ) {
+            if ("tr_open" == tokens[searchIndex].type) {
+              tokens[searchIndex].meta = Object.assign(
+                {},
+                tokens[searchIndex].meta,
+              );
+              if (
+                tokens[searchIndex].meta &&
+                (tokens[searchIndex].meta as { colsnum?: number }).colsnum
+              ) {
+                availableColumns -= 1;
+              }
+              (tokens[searchIndex].meta as { colsnum: number }).colsnum =
+                availableColumns;
+              remainingRows--;
+            }
+          }
+        }
+
+        // Hide cells that exceed the column count in a row
+        if (
+          "tr_open" == token.type &&
+          token.meta &&
+          (token.meta as { colsnum?: number }).colsnum
+        ) {
+          const maxColumns = (token.meta as { colsnum: number }).colsnum;
+          for (
+            let searchIndex = currentTokenIndex, cellCount = 0;
+            searchIndex < tokenIndex;
+            searchIndex++
+          ) {
+            if ("td_open" == tokens[searchIndex].type) {
+              cellCount += 1;
+            } else if ("tr_close" == tokens[searchIndex].type) {
+              break;
+            }
+            // Hide cells beyond the maximum column count
+            if (cellCount > maxColumns) {
+              tokens[searchIndex].hidden || hidden(tokens[searchIndex]);
+            }
+          }
+        }
+
+        // Handle colspan > 1: adjust colspan value and hide excess cells
+        if (colspan > 1) {
+          const cellIndices: number[] = [];
+          let rowEndIndex = currentTokenIndex + 3;
+          let columnsInRow = totalColumns;
+
+          for (
+            let searchIndex = currentTokenIndex;
+            searchIndex > tbodyOpenIndex;
+            searchIndex--
+          ) {
+            if ("tr_open" == tokens[searchIndex].type) {
+              columnsInRow =
+                (tokens[searchIndex].meta as { colsnum?: number })?.colsnum ??
+                columnsInRow;
+              break;
+            } else if ("td_open" === tokens[searchIndex].type) {
+              cellIndices.unshift(searchIndex);
+            }
+          }
+
+          for (
+            let searchIndex = currentTokenIndex + 2;
+            searchIndex < tokenIndex;
+            searchIndex++
+          ) {
+            if ("tr_close" == tokens[searchIndex].type) {
+              rowEndIndex = searchIndex;
+              break;
+            } else if ("td_open" == tokens[searchIndex].type) {
+              cellIndices.push(searchIndex);
+            }
+          }
+
+          const cellOffset = cellIndices.indexOf(currentTokenIndex);
+          let actualColspan = columnsInRow - cellOffset;
+          actualColspan = actualColspan > colspan ? colspan : actualColspan;
+          if (colspan > actualColspan) {
+            token.attrSet("colspan", actualColspan + "");
+          }
+
+          for (
+            let hideIndex = cellIndices.slice(
+              columnsInRow + 1 - totalColumns - actualColspan,
+            )[0];
+            hideIndex < rowEndIndex;
+            hideIndex++
+          ) {
+            tokens[hideIndex].hidden || hidden(tokens[hideIndex]);
+          }
+        }
+      }
+    },
+  };
+}

--- a/packages/ai-chat/src/chat/ai-chat-components/web-components/components/markdownText/src/plugins/markdownItAttrs/types.ts
+++ b/packages/ai-chat/src/chat/ai-chat-components/web-components/components/markdownText/src/plugins/markdownItAttrs/types.ts
@@ -1,0 +1,49 @@
+/*
+ *  Copyright IBM Corp. 2025
+ *
+ *  This source code is licensed under the Apache-2.0 license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ *  @license
+ */
+
+import type { Token } from "markdown-it";
+
+export interface MarkdownItAttrsOptions {
+  leftDelimiter?: string;
+  rightDelimiter?: string;
+  allowedAttributes?: (string | RegExp)[];
+}
+
+export type AttributePair = [string, string];
+
+export type DetectingStrRule = (str: string) => boolean;
+
+export interface DetectingRule {
+  shift?: number;
+  position?: number;
+  type?: string | DetectingStrRule;
+  tag?: string | DetectingStrRule;
+  children?: DetectingRule[] | ((arr: unknown[]) => boolean);
+  content?: string | DetectingStrRule;
+  markup?: string | DetectingStrRule;
+  info?: string | DetectingStrRule;
+  nesting?: number;
+  level?: number;
+  block?: boolean;
+  hidden?: boolean;
+  attrs?: AttributePair[];
+  map?: [number, number][];
+  meta?: unknown;
+}
+
+export interface CurlyAttrsPattern {
+  name: string;
+  tests: DetectingRule[];
+  transform: (tokens: Token[], i: number, j?: number) => void;
+}
+
+export interface MatchedResult {
+  match: boolean;
+  j: number | null;
+}

--- a/packages/ai-chat/src/chat/ai-chat-components/web-components/components/markdownText/src/plugins/markdownItAttrs/utils.ts
+++ b/packages/ai-chat/src/chat/ai-chat-components/web-components/components/markdownText/src/plugins/markdownItAttrs/utils.ts
@@ -1,0 +1,68 @@
+/*
+ *  Copyright IBM Corp. 2025
+ *
+ *  This source code is licensed under the Apache-2.0 license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ *  @license
+ */
+
+import type { Token } from "markdown-it";
+
+/**
+ * Escapes special regex characters in a string for use in regular expressions.
+ */
+export function escapeRegExp(s: string): string {
+  return s.replace(/[-/\\^$*+?.()|[\]{}]/g, "\\$&");
+}
+
+/**
+ * Gets an element from an array, supporting negative indices for accessing from the end.
+ */
+export function get<T>(arr: T[], n: number): T | undefined {
+  return n >= 0 ? arr[n] : arr[arr.length + n];
+}
+
+/**
+ * Returns the last element of an array, or an empty object if the array is empty.
+ */
+export function last<T>(arr: T[]): T {
+  return arr.slice(-1)[0] || ({} as T);
+}
+
+/**
+ * Type guard to check if a value is a non-empty array of objects.
+ */
+export function isArrayOfObjects(
+  arr: unknown,
+): arr is Record<string, unknown>[] {
+  return (
+    Array.isArray(arr) &&
+    arr.length > 0 &&
+    arr.every((i) => typeof i === "object")
+  );
+}
+
+/**
+ * Type guard to check if a value is a non-empty array of functions.
+ */
+export function isArrayOfFunctions(
+  arr: unknown,
+): arr is ((arg: unknown) => boolean)[] {
+  return (
+    Array.isArray(arr) &&
+    arr.length > 0 &&
+    arr.every((i) => typeof i === "function")
+  );
+}
+
+/**
+ * Recursively hides a token and all its children by setting their hidden flag and clearing content.
+ */
+export function hidden(token: Token): void {
+  token.hidden = true;
+  token.children?.forEach((t) => {
+    t.content = "";
+    hidden(t);
+  });
+}

--- a/packages/ai-chat/src/chat/ai-chat-components/web-components/components/markdownText/src/utils/htmlInlineHelpers.ts
+++ b/packages/ai-chat/src/chat/ai-chat-components/web-components/components/markdownText/src/utils/htmlInlineHelpers.ts
@@ -1,0 +1,245 @@
+/*
+ *  Copyright IBM Corp. 2025
+ *
+ *  This source code is licensed under the Apache-2.0 license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ *  @license
+ */
+
+import type { TokenTree } from "../markdownTokenTree";
+
+// HTML elements that never ship closing tags; treat them as self-closing so the stack logic does not wait for </tag>.
+const SELF_CLOSING_HTML_TAGS = new Set<string>([
+  "area",
+  "base",
+  "br",
+  "col",
+  "embed",
+  "hr",
+  "img",
+  "input",
+  "link",
+  "meta",
+  "param",
+  "source",
+  "track",
+  "wbr",
+]);
+
+// Token types we can safely glue into the combined HTML chunk. Anything else (e.g., emphasis markers) should abort
+// the merge to avoid damaging markdown.
+const INLINE_HTML_ALLOWED_TOKEN_TYPES = new Set<string>([
+  "html_inline",
+  "text",
+  "softbreak",
+  "hardbreak",
+  "code_inline",
+  "entity",
+  "link_open",
+  "link_close",
+]);
+
+type HtmlInlineTag =
+  | { kind: "opening"; tagName: string; selfClosing: boolean }
+  | { kind: "closing"; tagName: string };
+
+// Minimal tag parser that ignores comments/entities (e.g., <!-- ... -->) and reports whether a tag opens, closes, or
+// self-closes a given element.
+function parseHtmlInlineTag(content: string | undefined): HtmlInlineTag | null {
+  const trimmed = (content ?? "").trim();
+
+  if (!trimmed.startsWith("<") || !trimmed.endsWith(">")) {
+    // Not bracketed like "<...>"; definitely not a tag token.
+    return null;
+  }
+
+  if (trimmed.startsWith("</")) {
+    // Closing tag: extract the element name. Reject malformed endings.
+    const closingMatch = trimmed.match(/^<\/\s*([A-Za-z][\w:-]*)\s*>$/);
+    if (!closingMatch) {
+      return null;
+    }
+    return { kind: "closing", tagName: closingMatch[1].toLowerCase() };
+  }
+
+  // Skip comments/doctype/instruction fragments; they cannot help balance nesting.
+  if (
+    trimmed.startsWith("<!") ||
+    trimmed.startsWith("<?") ||
+    trimmed.startsWith("<%")
+  ) {
+    return null;
+  }
+
+  // Opening tag: grab the element name even if attributes trail after it.
+  const openingMatch = trimmed.match(/^<\s*([A-Za-z][\w:-]*)\b[\s\S]*>$/);
+  if (!openingMatch) {
+    return null;
+  }
+
+  const tagName = openingMatch[1].toLowerCase();
+  // Treat `<tag/>` and the HTML void elements as self-contained so they do not
+  // add entries to the stack.
+  const selfClosing =
+    trimmed.endsWith("/>") || SELF_CLOSING_HTML_TAGS.has(tagName);
+
+  return { kind: "opening", tagName, selfClosing };
+}
+
+// Collapses runs of html_inline tokens (possibly interleaved with text) into a
+// single token so the browser does not auto-close the first tag mid-render.
+export function combineConsecutiveHtmlInline(
+  children: TokenTree[],
+): TokenTree[] {
+  if (children.length < 2) {
+    return children;
+  }
+
+  const combinedChildren: TokenTree[] = [];
+  let didCombine = false;
+
+  for (let index = 0; index < children.length; index++) {
+    const startNode = children[index];
+
+    if (startNode.token.type !== "html_inline") {
+      combinedChildren.push(startNode);
+      continue;
+    }
+
+    const openingTag = parseHtmlInlineTag(startNode.token.content);
+    if (
+      !openingTag ||
+      openingTag.kind !== "opening" ||
+      openingTag.selfClosing
+    ) {
+      combinedChildren.push(startNode);
+      continue;
+    }
+
+    const stack: string[] = [openingTag.tagName]; // Track nested openings we must close.
+    const chunkTokens: TokenTree[] = [startNode]; // Collect tokens to merge if the stack clears.
+    let content = startNode.token.content ?? "";
+    let endIndex = index;
+    let success = false;
+
+    for (let lookahead = index + 1; lookahead < children.length; lookahead++) {
+      const candidate = children[lookahead];
+      const tokenType = candidate.token.type ?? "";
+
+      if (!INLINE_HTML_ALLOWED_TOKEN_TYPES.has(tokenType)) {
+        // Encountered formatting/inline constructs we do not know how to merge.
+        break;
+      }
+
+      if (tokenType === "html_inline") {
+        const parsed = parseHtmlInlineTag(candidate.token.content);
+        if (!parsed) {
+          // Malformed tag; abandon the merge.
+          break;
+        }
+
+        chunkTokens.push(candidate);
+        content += candidate.token.content ?? "";
+
+        if (parsed.kind === "opening") {
+          if (!parsed.selfClosing) {
+            // Push nested openers so we wait for their matching closers too.
+            stack.push(parsed.tagName);
+          }
+        } else {
+          const expected = stack[stack.length - 1];
+          if (expected !== parsed.tagName) {
+            // Mismatched closing tag; bail before corrupting structure.
+            break;
+          }
+
+          stack.pop();
+          endIndex = lookahead;
+
+          if (stack.length === 0) {
+            // All openings matched; we can fuse the run.
+            success = true;
+            break;
+          }
+        }
+
+        continue;
+      }
+
+      // Non-tag inline content (text, code, breaks, links) is safe to append.
+      chunkTokens.push(candidate);
+      content += serializeInlineToken(candidate);
+    }
+
+    if (!success) {
+      return combinedChildren;
+    }
+
+    if (stack.length === 0 && endIndex > index) {
+      combinedChildren.push({
+        key: chunkTokens.map((token) => token.key).join("|"),
+        token: {
+          ...startNode.token,
+          content,
+        },
+        children: [],
+      });
+      index = endIndex; // Skip over tokens we already collapsed.
+      didCombine = true;
+      continue;
+    }
+
+    combinedChildren.push(startNode);
+  }
+
+  return didCombine ? combinedChildren : children;
+}
+
+function serializeInlineToken(tokenTree: TokenTree): string {
+  const token = tokenTree.token;
+  const type = token.type ?? "";
+
+  if (
+    type === "text" ||
+    type === "code_inline" ||
+    type === "softbreak" ||
+    type === "hardbreak" ||
+    type === "entity" ||
+    type === "html_inline"
+  ) {
+    return token.content ?? "";
+  }
+
+  if (type === "link_open") {
+    const attrs = (token.attrs ?? []) as Array<
+      [string, string | null | undefined]
+    >;
+    const attrString = attrs
+      .map(([name, value]) => {
+        if (!name) {
+          return "";
+        }
+        if (value === undefined || value === null) {
+          return name;
+        }
+        const escaped = String(value).replace(/"/g, "&quot;");
+        return `${name}="${escaped}"`;
+      })
+      .filter(Boolean)
+      .join(" ");
+
+    const childContent = (tokenTree.children ?? [])
+      .map((child) => serializeInlineToken(child))
+      .join("");
+
+    const openTag = attrString.length ? `<a ${attrString}>` : "<a>";
+    return `${openTag}${childContent}</a>`;
+  }
+
+  if (type === "link_close") {
+    return "";
+  }
+
+  return token.content ?? "";
+}

--- a/packages/ai-chat/src/chat/ai-chat-components/web-components/components/markdownText/src/utils/tableTokenHelpers.ts
+++ b/packages/ai-chat/src/chat/ai-chat-components/web-components/components/markdownText/src/utils/tableTokenHelpers.ts
@@ -1,0 +1,100 @@
+/*
+ *  Copyright IBM Corp. 2025
+ *
+ *  This source code is licensed under the Apache-2.0 license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ *  @license
+ */
+
+import type { TokenTree } from "../markdownTokenTree";
+
+// Static constants to provide the table component when we are just showing the skeleton.
+export const EMPTY_HEADERS: string[] = [];
+export const EMPTY_TABLE_ROWS: { cells: string[] }[] = [];
+
+// Default localization functions for table pagination
+export const DEFAULT_PAGINATION_SUPPLEMENTAL_TEXT = ({
+  count,
+}: {
+  count: number;
+}) => `${count} items`;
+export const DEFAULT_PAGINATION_STATUS_TEXT = ({
+  start,
+  end,
+  count,
+}: {
+  start: number;
+  end: number;
+  count: number;
+}) => `${start}–${end} of ${count} items`;
+
+/**
+ * Extracts tabular data from a table TokenTree node.
+ *
+ * Converts the hierarchical markdown table structure into the flat
+ * header/rows format expected by the cds-aichat-table component.
+ */
+export function extractTableData(tableNode: TokenTree): {
+  headers: string[];
+  rows: string[][];
+} {
+  const headers: string[] = [];
+  const rows: string[][] = [];
+
+  for (const child of tableNode.children) {
+    if (child.token.tag === "thead") {
+      // Extract column headers
+      for (const theadChild of child.children) {
+        if (theadChild.token.tag === "tr") {
+          for (const thChild of theadChild.children) {
+            if (thChild.token.tag === "th") {
+              headers.push(extractTextContent(thChild));
+            }
+          }
+        }
+      }
+    } else if (child.token.tag === "tbody") {
+      // Extract data rows
+      for (const tbodyChild of child.children) {
+        if (tbodyChild.token.tag === "tr") {
+          const row: string[] = [];
+          for (const tdChild of tbodyChild.children) {
+            if (tdChild.token.tag === "td") {
+              row.push(extractTextContent(tdChild));
+            }
+          }
+          rows.push(row);
+        }
+      }
+    }
+  }
+
+  return { headers, rows };
+}
+
+/**
+ * Recursively extracts plain text content from a TokenTree node.
+ *
+ * This is used for table cells and other contexts where we need the
+ * text content without HTML formatting.
+ */
+export function extractTextContent(node: TokenTree): string {
+  // Handle direct text tokens
+  if (node.token.type === "text") {
+    return node.token.content;
+  }
+
+  // Handle inline code
+  if (node.token.type === "code_inline") {
+    return node.token.content;
+  }
+
+  // Recursively extract text from child nodes
+  let text = "";
+  for (const child of node.children) {
+    text += extractTextContent(child);
+  }
+
+  return text;
+}

--- a/packages/ai-chat/src/chat/components-legacy/MessageTypeComponent.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/MessageTypeComponent.tsx
@@ -209,7 +209,7 @@ function MessageTypeComponent(props: MessageTypeComponentProps) {
           <div role="heading" aria-level={2}>
             <RichText
               text={userText}
-              shouldRemoveHTMLBeforeMarkdownConversion
+              removeHTML
               overrideSanitize={true}
             ></RichText>
           </div>
@@ -378,7 +378,7 @@ function MessageTypeComponent(props: MessageTypeComponentProps) {
         disableUserInputs={disableUserInputs || !isMessageForInput}
         requestInputFocus={requestInputFocus}
         serviceManager={serviceManager}
-        shouldRemoveHTMLBeforeMarkdownConversion={withHumanAgent}
+        removeHTML={withHumanAgent}
       />
     );
   }

--- a/packages/ai-chat/src/chat/components-legacy/responseTypes/error/InlineError.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/responseTypes/error/InlineError.tsx
@@ -22,7 +22,7 @@ export function InlineError({ text }: { text?: string }) {
       </div>
       <div className="cds-aichat--inline-error--text">
         <RichText
-          shouldRemoveHTMLBeforeMarkdownConversion
+          removeHTML
           text={text || languagePack.errors_generalContent}
         />
       </div>

--- a/packages/ai-chat/src/chat/components-legacy/responseTypes/options/OptionComponent.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/responseTypes/options/OptionComponent.tsx
@@ -59,7 +59,7 @@ interface OptionProps extends HasServiceManager, HasLanguagePack {
    * Indicates if HTML should be removed from text before converting Markdown to HTML.
    * This is used to sanitize data coming from a human agent.
    */
-  shouldRemoveHTMLBeforeMarkdownConversion?: boolean;
+  removeHTML?: boolean;
 }
 
 class OptionComponent extends Component<OptionProps> {
@@ -113,7 +113,7 @@ class OptionComponent extends Component<OptionProps> {
       languagePack,
       disableUserInputs,
       serviceManager,
-      shouldRemoveHTMLBeforeMarkdownConversion,
+      removeHTML,
     } = this.props;
     const { options, title, description, preference } = localMessage.item;
     const { optionSelected } = localMessage.ui_state;
@@ -124,9 +124,7 @@ class OptionComponent extends Component<OptionProps> {
         <Metablock
           title={title}
           description={description}
-          shouldRemoveHTMLBeforeMarkdownConversion={
-            shouldRemoveHTMLBeforeMarkdownConversion
-          }
+          removeHTML={removeHTML}
         />
         <div className="cds-aichat--button-holder">
           <ul>
@@ -164,9 +162,7 @@ class OptionComponent extends Component<OptionProps> {
         disableUserInputs={disableUserInputs}
         onChange={this.onSelectChange}
         value={optionSelected}
-        shouldRemoveHTMLBeforeMarkdownConversion={
-          shouldRemoveHTMLBeforeMarkdownConversion
-        }
+        removeHTML={removeHTML}
       />
     );
   }

--- a/packages/ai-chat/src/chat/components-legacy/responseTypes/options/SelectComponent.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/responseTypes/options/SelectComponent.tsx
@@ -46,7 +46,7 @@ interface SelectProps extends HasLanguagePack, HasServiceManager {
    * Indicates if HTML should be removed from text before converting Markdown to HTML.
    * This is used to sanitize data coming from a human agent.
    */
-  shouldRemoveHTMLBeforeMarkdownConversion?: boolean;
+  removeHTML?: boolean;
 }
 
 function SelectComponent(props: SelectProps) {
@@ -58,7 +58,7 @@ function SelectComponent(props: SelectProps) {
     languagePack,
     disableUserInputs,
     serviceManager,
-    shouldRemoveHTMLBeforeMarkdownConversion,
+    removeHTML,
   } = props;
 
   const [isBeingOpened, setIsBeingOpened] = useState(false);
@@ -116,9 +116,7 @@ function SelectComponent(props: SelectProps) {
         title={title}
         description={description}
         id={`cds-aichat--select-uuid-${id}-label`}
-        shouldRemoveHTMLBeforeMarkdownConversion={
-          shouldRemoveHTMLBeforeMarkdownConversion
-        }
+        removeHTML={removeHTML}
       />
       <div
         className={cx("cds-aichat--select-holder", {

--- a/packages/ai-chat/src/chat/components-legacy/responseTypes/util/Description.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/responseTypes/util/Description.tsx
@@ -19,22 +19,17 @@ interface DescriptionProps extends HasClassName {
    * Indicates if HTML should be removed from text before converting Markdown to HTML.
    * This is used to sanitize data coming from a human agent.
    */
-  shouldRemoveHTMLBeforeMarkdownConversion?: boolean;
+  removeHTML?: boolean;
 }
 
 export default function Description({
   className,
   text,
-  shouldRemoveHTMLBeforeMarkdownConversion = false,
+  removeHTML = false,
 }: DescriptionProps) {
   return (
     <div className={`cds-aichat--description ${className}`}>
-      <RichText
-        text={text}
-        shouldRemoveHTMLBeforeMarkdownConversion={
-          shouldRemoveHTMLBeforeMarkdownConversion
-        }
-      />
+      <RichText text={text} removeHTML={removeHTML} />
     </div>
   );
 }

--- a/packages/ai-chat/src/chat/components-legacy/responseTypes/util/Metablock.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/responseTypes/util/Metablock.tsx
@@ -20,14 +20,14 @@ interface MetablockProps {
    * Indicates if HTML should be removed from text before converting Markdown to HTML.
    * This is used to sanitize data coming from a human agent.
    */
-  shouldRemoveHTMLBeforeMarkdownConversion?: boolean;
+  removeHTML?: boolean;
 }
 
 export default function Metablock({
   title = null,
   description = null,
   id = null,
-  shouldRemoveHTMLBeforeMarkdownConversion = false,
+  removeHTML = false,
 }: MetablockProps) {
   return title || description ? (
     <div className="cds-aichat--received--metablock" id={id}>
@@ -35,18 +35,14 @@ export default function Metablock({
         <Description
           className="cds-aichat--received--metablock-content cds-aichat--metablock__title"
           text={title}
-          shouldRemoveHTMLBeforeMarkdownConversion={
-            shouldRemoveHTMLBeforeMarkdownConversion
-          }
+          removeHTML={removeHTML}
         />
       )}
       {description && (
         <Description
           className="cds-aichat--received--metablock-content cds-aichat--metablock__description"
           text={description}
-          shouldRemoveHTMLBeforeMarkdownConversion={
-            shouldRemoveHTMLBeforeMarkdownConversion
-          }
+          removeHTML={removeHTML}
         />
       )}
     </div>

--- a/packages/ai-chat/src/chat/components-legacy/responseTypes/util/RichText.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/responseTypes/util/RichText.tsx
@@ -29,7 +29,7 @@ interface RichTextProps {
    * Indicates if HTML should be removed from text before converting Markdown to HTML.
    * This is used to sanitize data coming from a human agent.
    */
-  shouldRemoveHTMLBeforeMarkdownConversion?: boolean;
+  removeHTML?: boolean;
 
   /**
    * If defined, this value indicates if this component should override the default sanitization setting.
@@ -50,12 +50,7 @@ interface RichTextProps {
  * Warning: This should only be used with trusted text. Do NOT use this with text that was entered by the end-user.
  */
 function RichText(props: RichTextProps) {
-  const {
-    text,
-    shouldRemoveHTMLBeforeMarkdownConversion,
-    overrideSanitize,
-    streaming,
-  } = props;
+  const { text, removeHTML, overrideSanitize, streaming } = props;
 
   let doSanitize = useShouldSanitizeHTML();
   if (overrideSanitize !== undefined) {
@@ -140,9 +135,7 @@ function RichText(props: RichTextProps) {
       streaming={streaming}
       localization={localization}
       dark={isDarkTheme}
-      shouldRemoveHTMLBeforeMarkdownConversion={
-        shouldRemoveHTMLBeforeMarkdownConversion
-      }
+      removeHTML={removeHTML}
     />
   );
 }
@@ -150,9 +143,7 @@ function RichText(props: RichTextProps) {
 const RichTextExport = React.memo(RichText, (prevProps, nextProps) => {
   // Custom comparison to prevent re-render when only streaming changes but content is the same
   const textEqual = prevProps.text === nextProps.text;
-  const htmlConversionEqual =
-    prevProps.shouldRemoveHTMLBeforeMarkdownConversion ===
-    nextProps.shouldRemoveHTMLBeforeMarkdownConversion;
+  const htmlConversionEqual = prevProps.removeHTML === nextProps.removeHTML;
   const sanitizeEqual =
     prevProps.overrideSanitize === nextProps.overrideSanitize;
 

--- a/packages/ai-chat/src/chat/components-legacy/responseTypes/util/StreamingRichText.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/responseTypes/util/StreamingRichText.tsx
@@ -64,7 +64,7 @@ function StreamingRichText(props: StreamingRichTextProps) {
     <>
       <RichText
         text={textToUse}
-        shouldRemoveHTMLBeforeMarkdownConversion={removeHTML}
+        removeHTML={removeHTML}
         streaming={streamingState && !streamingState.isDone}
       />
       {isStreamingError && (

--- a/packages/ai-chat/src/chat/utils/lang/promiseUtils.ts
+++ b/packages/ai-chat/src/chat/utils/lang/promiseUtils.ts
@@ -11,16 +11,8 @@
  * Miscellaneous utils for dealing with promises.
  */
 
-/**
- * This is an async function that will simply wait for the given amount of time.
- *
- * @param milliseconds The amount of time in milliseconds to wait.
- */
-async function sleep(milliseconds: number) {
-  await new Promise((resolve) => {
-    setTimeout(resolve, milliseconds);
-  });
-}
+// Re-export shared helpers sourced from @carbon/ai-chat-utils to avoid duplication.
+export { sleep } from "@carbon/ai-chat-utils";
 
 /**
  * This function returns a Promise that will be resolved if the provided Promise has resolved within the duration
@@ -48,4 +40,4 @@ function resolveOrTimeout<T>(
   return Promise.race([promise, timeout]);
 }
 
-export { sleep, resolveOrTimeout };
+export { resolveOrTimeout };

--- a/packages/ai-chat/web-test-runner.config.js
+++ b/packages/ai-chat/web-test-runner.config.js
@@ -1,0 +1,49 @@
+/*
+ *  Copyright IBM Corp. 2025
+ *
+ *  This source code is licensed under the Apache-2.0 license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ *  @license
+ */
+
+import { esbuildPlugin } from "@web/dev-server-esbuild";
+import { playwrightLauncher } from "@web/test-runner-playwright";
+
+export default {
+  files: ["src/**/*.test.ts"],
+  nodeResolve: true,
+  plugins: [
+    {
+      name: "stub-scss",
+      resolveMimeType(context) {
+        if (context.path.endsWith(".scss")) {
+          return "js";
+        }
+        return undefined;
+      },
+      transform(context) {
+        if (context.path.endsWith(".scss")) {
+          return 'export default "";';
+        }
+        return undefined;
+      },
+    },
+    esbuildPlugin({
+      ts: true,
+      json: true,
+      tsconfig: "tsconfig.json",
+      tsconfigRaw: {
+        compilerOptions: {
+          experimentalDecorators: true,
+          useDefineForClassFields: false,
+        },
+      },
+    }),
+  ],
+  browsers: [
+    playwrightLauncher({ product: "chromium" }),
+    playwrightLauncher({ product: "firefox" }),
+    playwrightLauncher({ product: "webkit" }),
+  ],
+};

--- a/utils/index.d.ts
+++ b/utils/index.d.ts
@@ -1,0 +1,19 @@
+/*
+ *  Copyright IBM Corp. 2025
+ *
+ *  This source code is licensed under the Apache-2.0 license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ *  @license
+ */
+
+export declare const TABLE: string;
+export declare const UNORDERED_LIST: string;
+export declare const ORDERED_LIST: string;
+export declare const TEXT: string;
+export declare const HEADERS: string;
+export declare const CODE: string;
+export declare const BLOCKQUOTE: string;
+export declare const MARKDOWN: string;
+export declare const HTML: string;
+export declare function sleep(milliseconds: number): Promise<void>;

--- a/utils/package.json
+++ b/utils/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@carbon/ai-chat-utils",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Shared utilities and sample content for Carbon AI Chat demos, tests, and examples.",
+  "license": "Apache-2.0",
+  "type": "module",
+  "main": "./src/index.js",
+  "types": "./index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./src/index.js",
+      "default": "./src/index.js",
+      "types": "./index.d.ts"
+    }
+  },
+  "sideEffects": false,
+  "files": [
+    "src",
+    "index.d.ts"
+  ]
+}

--- a/utils/src/index.js
+++ b/utils/src/index.js
@@ -1,0 +1,189 @@
+/*
+ *  Copyright IBM Corp. 2025
+ *
+ *  This source code is licensed under the Apache-2.0 license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ *  @license
+ */
+
+async function sleep(milliseconds) {
+  await new Promise((resolve) => {
+    setTimeout(resolve, milliseconds);
+  });
+}
+
+const TABLE = `
+| Element      | Symbol | Atomic Number | Group | Period | Atomic Mass (u) | Electron Config | Bonding | Melting Point (°C) | Boiling Point (°C) |
+|--------------|--------|---------------|-------|--------|-----------------|-----------------|---------|--------------------|--------------------|
+| Carbon       | C      | 6             | 14    | 2      | 12.011          | [He] 2s² 2p²    | Covalent| 3550               | 4027               |
+| Silicon      | Si     | 14            | 14    | 3      | 28.085          | [Ne] 3s² 3p²    | Covalent| 1414               | 3265               |
+| Germanium    | Ge     | 32            | 14    | 4      | 72.630          | [Ar] 3d¹⁰ 4s² 4p²| Covalent| 938                | 2833               |
+| Tin          | Sn     | 50            | 14    | 5      | 118.710         | [Kr] 4d¹⁰ 5s² 5p²| Metallic| 232                | 2602               |
+| Lead         | Pb     | 82            | 14    | 6      | 207.200         | [Xe] 4f¹⁴ 5d¹⁰ 6s² 6p²| Metallic| 327          | 1749               |
+| Flerovium    | Fl     | 114           | 14    | 7      | 289             | [Rn] 5f¹⁴ 6d¹⁰ 7s² 7p²| Unknown | Unknown      | Unknown            |
+| Hydrogen     | H      | 1             | 1     | 1      | 1.008           | 1s¹             | Covalent| -259               | -253               |
+| Helium       | He     | 2             | 18    | 1      | 4.003           | 1s²             | Noble   | -272               | -269               |
+| Lithium      | Li     | 3             | 1     | 2      | 6.940           | [He] 2s¹        | Metallic| 180                | 1342               |
+| Beryllium    | Be     | 4             | 2     | 2      | 9.012           | [He] 2s²        | Metallic| 1287               | 2468               |
+| Boron        | B      | 5             | 13    | 2      | 10.810          | [He] 2s² 2p¹    | Covalent| 2075               | 4000               |
+| Nitrogen     | N      | 7             | 15    | 2      | 14.007          | [He] 2s² 2p³    | Covalent| -210               | -196               |
+| Oxygen       | O      | 8             | 16    | 2      | 15.999          | [He] 2s² 2p⁴    | Covalent| -218               | -183               |
+| Fluorine     | F      | 9             | 17    | 2      | 18.998          | [He] 2s² 2p⁵    | Covalent| -220               | -188               |
+| Neon         | Ne     | 10            | 18    | 2      | 20.180          | [He] 2s² 2p⁶    | Noble   | -249               | -246               |
+`;
+
+const UNORDERED_LIST = `
+- Carbon allotropes
+- Diamond
+- Graphite
+  - Graphene layers
+  - Hexagonal structure
+  - Electrical conductivity
+  - Thermal properties
+- Fullerenes
+- Carbon nanotubes
+- Amorphous carbon
+- Coal
+- Activated carbon
+`;
+
+const ORDERED_LIST = `
+1. Carbon bonding types
+  1. Single bonds (sp³)
+  2. Double bonds (sp²)
+2. Triple bonds (sp)
+3. Aromatic bonding
+4. Metallic carbides
+`;
+
+const TEXT = `Carbon <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 32 32" onclick="window.open('https://carbondesignsystem.com', '_blank')"><defs><style>.cls-1{fill:none;}</style></defs><title>If you click on this icon, it will go to https://carbondesignsystem.com. This is here to test "shouldSanitizeHTML". If true, the click shouldn't work!</title><path d="M13.5,30.8149a1.0011,1.0011,0,0,1-.4927-.13l-8.5-4.815A1,1,0,0,1,4,25V15a1,1,0,0,1,.5073-.87l8.5-4.815a1.0013,1.0013,0,0,1,.9854,0l8.5,4.815A1,1,0,0,1,23,15V25a1,1,0,0,1-.5073.87l-8.5,4.815A1.0011,1.0011,0,0,1,13.5,30.8149ZM6,24.417l7.5,4.2485L21,24.417V15.583l-7.5-4.2485L6,15.583Z"/><path d="M28,17H26V7.583L18.5,3.3345,10.4927,7.87,9.5073,6.13l8.5-4.815a1.0013,1.0013,0,0,1,.9854,0l8.5,4.815A1,1,0,0,1,28,7Z"/><rect class="cls-1" width="32" height="32" transform="translate(32 32) rotate(180)"/></svg> is a **chemical element** with the *atomic number* 6 and symbol **C**. \`C + O₂ → CO₂\` represents one of carbon's most fundamental reactions.
+
+Carbon forms [covalent bonds](https://ibm.com) through electron sharing and creates [carbon chains](https://ibm.com){{target="_self"}} that are essential for organic molecules.
+`;
+
+const HEADERS = `
+# Header 1 sized header
+${TEXT}
+
+## Header 2 sized header
+${TEXT}
+
+### Header 3 sized header
+${TEXT}
+`;
+
+const CODE =
+  "\n```python\n" +
+  `import periodictable
+from rdkit import Chem
+
+def analyze_carbon_compounds(smiles_list):
+    # Analyze carbon-containing molecules
+    carbon = periodictable.C
+    results = []
+    
+    for smiles in smiles_list:
+        mol = Chem.MolFromSmiles(smiles)
+        if mol:
+            carbon_count = sum(1 for atom in mol.GetAtoms() if atom.GetSymbol() == 'C')
+            molecular_weight = Chem.rdMolDescriptors.CalcExactMolWt(mol)
+            results.append({
+                'smiles': smiles,
+                'carbon_atoms': carbon_count,
+                'molecular_weight': molecular_weight
+            })
+    
+    return results
+
+# Example usage - analyzing carbon compounds
+compounds = ['CCO', 'C6H6', 'CC(=O)O']  # Ethanol, Benzene, Acetic acid
+print(analyze_carbon_compounds(compounds))
+` +
+  "```";
+
+const BLOCKQUOTE = `
+> Carbon is the **fourth most abundant** element in the *observable universe* by mass after hydrogen, helium, and oxygen. \`C₆H₁₂O₆\` represents glucose, a fundamental carbon-based molecule for life. Carbon's unique tetravalent bonding capability enables complex molecular architectures.
+>
+> The [carbon cycle](https://ibm.com) describes how carbon moves between Earth's atmosphere, oceans, and [living organisms](https://ibm.com){{target="_self"}} through photosynthesis and respiration. Carbon dating uses the radioactive isotope ¹⁴C to determine the age of organic materials. Diamond and graphite demonstrate carbon's structural versatility through different bonding arrangements.
+ `;
+
+const MARKDOWN = `
+${TEXT}
+---
+${HEADERS}
+---
+${TABLE}
+---
+${BLOCKQUOTE}
+---
+${ORDERED_LIST}
+---
+${UNORDERED_LIST}
+---
+`;
+
+const HTML = `
+Here is some <b>Carbon</b> information peppered with HTML!
+
+<style>
+    .fun-fact { 
+        background-color: #e8f5e8; 
+        color: #161616;
+        border-inline-start: 4px solid #27ae60; 
+        padding: 10px; 
+        margin: 10px 0; 
+    }
+</style>
+<h2>Carbon <b>(C)</b> - The Element of Life</h2>
+
+<p><strong>Carbon</strong> is a <mark>non-metallic element</mark> with atomic number <strong>6</strong>. It's one of the most important elements on Earth because it forms the backbone of all organic molecules.</p>
+
+<div class="fun-fact">
+    <h4>Fun Fact</h4>
+    <p>Carbon can form more compounds than any other element except hydrogen. There are over <em>10 million</em> known carbon compounds!</p>
+</div>
+
+<p>Inline visualization: 
+    <span class="inline-carbon-diagram" role="img" aria-label="Carbon atom with bonds">
+        <svg width="96" height="32" viewBox="0 0 96 32" xmlns="http://www.w3.org/2000/svg">
+            <g fill="none" stroke="#0f62fe" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <circle cx="16" cy="16" r="6"></circle>
+                <circle cx="48" cy="16" r="6"></circle>
+                <circle cx="80" cy="16" r="6"></circle>
+                <path d="M22 16 L42 16"></path>
+                <path d="M54 16 L74 16"></path>
+            </g>
+        </svg>
+    </span>
+    shows a simplified bonding chain rendered entirely with inline HTML.
+</p>
+
+<blockquote>
+    <p>"We are made of <strong>star stuff</strong>. We are a way for the cosmos to know itself."</p>
+    <cite>— Carl Sagan (referring to carbon-based life)</cite>
+</blockquote>
+
+<h3>Why Carbon Matters</h3>
+<ol>
+    <li>Forms the basis of all <abbr title="deoxyribonucleic acid">DNA</abbr> and proteins</li>
+    <li>Essential for photosynthesis in plants</li>
+    <li>Key component in fossil fuels and climate change</li>
+    <li>Used in advanced materials like carbon nanotubes</li>
+</ol>
+
+<hr>
+<small><em>Carbon's unique ability to form four bonds makes it the perfect element for complex biological molecules.</em></small>`;
+
+export {
+  BLOCKQUOTE,
+  CODE,
+  HEADERS,
+  HTML,
+  MARKDOWN,
+  ORDERED_LIST,
+  sleep,
+  TABLE,
+  TEXT,
+  UNORDERED_LIST,
+};


### PR DESCRIPTION
Closes #567 

So this "small bug fix" ended up pulling the string a bit.

When we get a block of html, markdown-it will return that whole block as a token. If its inline it will return the opening and closing tags, and any inner content (including more open and closing tags) as different items in the tree. When that happens, we can't just render the tokens as we get them, because the browser will do things like auto-close the opened tags. Instead we have to gather up everything until we get the closing tag passed back before we render.

This lead to a bit of refactoring of the markdownParser code because the file was getting too big to follow so I broke it up into multiple logical chunks.

Then, I wanted to add some tests. But, I didn't want to write Jest tests since we are just going to be moving this into `@carbon/ai-chat-components` in the coming sprints. So I brought in web-test-runner temporarily into `@carbon/ai-chat`. This pulled another string where our markdown-it plugin to handle attributes is cjs only and when I looked to see if that was going to change at some point, noted that the plugin seemed abandoned. So, I did a refactor of it to be ejs and brought it into the repo. I wouldn't feel the need to review that code TOO deeply compared to the markdown parsing changes. 

Now there are automated tests for some of the markdown behavior, specifically the bug I just fixed and around attributes. The rest of the test additions will come when we move to the other workspace.

Testing instructions:

Make sure the inline SVG in the text response type of the "carbon" icon renders correctly.
Make sure that "carbon chains" link still links to self instead of blank
