### PR TITLE
fix: add disclaimer accepted event

### DIFF
--- a/packages/ai-chat/src/chat/components-legacy/main/MainWindow.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/main/MainWindow.tsx
@@ -56,6 +56,7 @@ import {
 import { consoleError, createDidCatchErrorData } from "../../utils/miscUtils";
 import { MainWindowFunctions } from "./MainWindowFunctions";
 import {
+  BusEventType,
   MainWindowCloseReason,
   MessageSendSource,
 } from "../../../types/events/eventBusTypes";
@@ -547,6 +548,9 @@ class MainWindow
    */
   onAcceptDisclaimer = () => {
     this.props.serviceManager.store.dispatch(actions.acceptDisclaimer());
+    this.props.serviceManager.fire({
+      type: BusEventType.DISCLAIMER_ACCEPTED,
+    });
   };
 
   /**

--- a/packages/ai-chat/src/types/events/eventBusTypes.ts
+++ b/packages/ai-chat/src/types/events/eventBusTypes.ts
@@ -186,6 +186,11 @@ export enum BusEventType {
    * This includes changes to viewState, showUnreadIndicator, and other persisted state.
    */
   STATE_CHANGE = "state:change",
+
+  /**
+   * Fired if the disclaimer is accepted.
+   */
+  DISCLAIMER_ACCEPTED = "disclaimerAccepted",
 }
 
 /**


### PR DESCRIPTION
Closes #611 

Now fires an event when folks accept the disclaimer so people can save that state

#### Testing / Reviewing

On the demo site, search for `instance.on({ type: BusEventType.FEEDBACK, handler: feedbackHandler });` throw in a `instance.on({ type: BusEventType.DISCLAIMER_ACCEPTED, handler: () => console.log('Disclaimer accepted')});` there and then accept the disclaimer from the demo site and check the console
