### PR TITLE
fix: no accordion on empty cot

### DIFF
--- a/demo/src/customSendMessage/doText.ts
+++ b/demo/src/customSendMessage/doText.ts
@@ -81,6 +81,9 @@ const fullChainOfThought: ChainOfThoughtStep[] = [
     },
   },
   {
+    title: "Checking results",
+  },
+  {
     title: "Calculating carbon bond energies and molecular stability metrics",
     tool_name: "bond_analyzer",
     request: {

--- a/packages/ai-chat/src/chat/ai-chat-components/web-components/components/chainOfThought/src/chainOfThoughtElement.scss
+++ b/packages/ai-chat/src/chat/ai-chat-components/web-components/components/chainOfThought/src/chainOfThoughtElement.scss
@@ -139,6 +139,12 @@ button.#{$prefix}--chain-of-thought-button:focus-visible {
   }
 }
 
+.#{$prefix}--chain-of-thought-accordion-item-header-chevron[data-disabled] {
+  svg {
+    visibility: hidden;
+  }
+}
+
 .#{$prefix}--chain-of-thought-accordion-item {
   button.#{$prefix}--chain-of-thought-accordion-item-header {
     @include button.reset(true);
@@ -150,6 +156,10 @@ button.#{$prefix}--chain-of-thought-button:focus-visible {
 
     background: theme.$layer-accent-02;
     block-size: 2rem;
+  }
+
+  button.#{$prefix}--chain-of-thought-accordion-item-header[disabled] {
+    cursor: default;
   }
 
   button.#{$prefix}--chain-of-thought-accordion-item-header:focus,

--- a/packages/ai-chat/src/chat/ai-chat-components/web-components/components/chainOfThought/src/chainOfThoughtElement.template.ts
+++ b/packages/ai-chat/src/chat/ai-chat-components/web-components/components/chainOfThought/src/chainOfThoughtElement.template.ts
@@ -146,6 +146,7 @@ function accordionContent(customElementClass: ChainOfThoughtElement) {
     return html`${_steps.map((item, index) => {
       const stepNumber = index + 1;
       const content_id = `${_chainOfThoughtPanelID}-step-${stepNumber}-content`;
+      const disabled = !item.description && !item.request && !item.response;
       return html`<div class="${prefix}--chain-of-thought-accordion-item">
         <button
           class="${prefix}--chain-of-thought-accordion-item-header"
@@ -162,9 +163,11 @@ function accordionContent(customElementClass: ChainOfThoughtElement) {
           }}
           aria-expanded=${item.open}
           aria-controls=${content_id}
+          ?disabled=${disabled}
         >
           <span
             class="${prefix}--chain-of-thought-accordion-item-header-chevron"
+            ?data-disabled=${disabled}
             ?data-open=${item.open}
             >${iconLoader(ChevronRight16)}</span
           >


### PR DESCRIPTION
Closes #604 

If a chain of thought step is empty, no need to show an accordian

#### Testing / Reviewing

The "text with chain of thought" on the demo site now includes a step with no inner data and it should be shown with no accordion to open.
