### PR TITLE
fix(ai-label): add AI label and remove extra spacing

### DIFF
--- a/packages/ai-chat/src/chat/components-legacy/header/Header.scss
+++ b/packages/ai-chat/src/chat/components-legacy/header/Header.scss
@@ -1,6 +1,6 @@
-/* 
+/*
  *  Copyright IBM Corp. 2025
- *  
+ *
  *  This source code is licensed under the Apache-2.0 license found in the
  *  LICENSE file in the root directory of this source tree.
  */
@@ -58,6 +58,12 @@
 
 .cds-aichat--header__center-container:first-child {
   margin: 0 layout.$spacing-05;
+}
+
+.cds-aichat--header__slug-label {
+  color: theme.$text-secondary;
+  padding-block-end: layout.$spacing-04;
+  @include type.type-style("body-compact-01");
 }
 
 .cds-aichat--header__slug-title {

--- a/packages/ai-chat/src/chat/components-legacy/header/Header.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/header/Header.tsx
@@ -343,9 +343,16 @@ function Header(props: HeaderProps, ref: Ref<HasRequestFocus>) {
               }
             >
               <div slot="body-text">
-                <h4 className="cds-aichat--header__slug-title">
-                  {languagePack.ai_slug_title}
-                </h4>
+                {languagePack.ai_slug_label && (
+                  <p className="cds-aichat--header__slug-label">
+                    {languagePack.ai_slug_label}
+                  </p>
+                )}
+                {languagePack.ai_slug_title && (
+                  <h4 className="cds-aichat--header__slug-title">
+                    {languagePack.ai_slug_title}
+                  </h4>
+                )}
                 <div className="cds-aichat--header__slug-description">
                   <div>{languagePack.ai_slug_description}</div>
                   {!isHidden && (

--- a/packages/ai-chat/src/chat/languages/en.json
+++ b/packages/ai-chat/src/chat/languages/en.json
@@ -1,4 +1,5 @@
 {
+  "ai_slug_label": "AI explained",
   "ai_slug_title": "Powered by IBM watsonx",
   "ai_slug_description": "IBM watsonx is powered by the latest AI models to intelligently process conversations and provide help whenever and wherever you may need it.",
   "components_overflow_ariaLabel": "Open and close list of options",


### PR DESCRIPTION
Closes #499 

This PR adds a `ai_slug_label` to the AI Label content and adds checks to the `ai_slug_label` and `ai_slug_title` to prevent additional padding being added when user opts not to use either of those strings.
<img height="300" alt="Screenshot 2025-10-31 at 2 53 34 PM" src="https://github.com/user-attachments/assets/f7735144-d6de-46f2-8d79-d11601d68f13" />

<img height="300" alt="Screenshot 2025-10-31 at 2 38 16 PM" src="https://github.com/user-attachments/assets/ff98b2b2-bc60-4c96-9c4c-4e4708b49deb" />


#### Changelog

**New**

- add styles and section for `cds-aichat--header__slug-label` in the `Header.tsx`
- add `ai_slug_label` to the languagePack

**Changed**

- add check for label and title and do not render if user decides not to pass in those strings, otherwise padding is associated with both strings.

#### Testing / Reviewing

Go to demo deploy preview and see the `AI explained` label is there in the AI Label

Run the demo locally and set the strings to `null`

```
<ChatContainer
      {...config}
      onBeforeRender={onBeforeRender}
      strings={{
        ai_slug_label: null,
        ai_slug_title: null,
        ai_slug_description: null,
      }}
      renderUserDefinedResponse={renderUserDefinedResponse}
      renderWriteableElements={renderWriteableElements}
      serviceDeskFactory={serviceDeskFactory}
    />
    ```
    
 and set "show writable elements" to true under "Page Settings" dropdown. You should see the padding from the top and sides is uniform
