### PR TITLE
fix: demo launcher

### DIFF
--- a/demo/src/framework/demo-layout-switcher.ts
+++ b/demo/src/framework/demo-layout-switcher.ts
@@ -37,12 +37,12 @@ export class DemoLayoutSwitcher extends LitElement {
       title-text="Layout"
       @cds-dropdown-selected=${this.dropdownSelected}
     >
-      <cds-dropdown-item value="float">Float</cds-dropdown-item>
-      <cds-dropdown-item value="sidebar">Sidebar</cds-dropdown-item>
       <cds-dropdown-item value="fullscreen">Fullscreen</cds-dropdown-item>
       <cds-dropdown-item value="fullscreen-no-gutter"
         >Full w/hasContentMaxWidth: false</cds-dropdown-item
       >
+      <cds-dropdown-item value="sidebar">Sidebar</cds-dropdown-item>
+      <cds-dropdown-item value="float">Float</cds-dropdown-item>
     </cds-dropdown>`;
   }
 }

--- a/demo/src/framework/utils.ts
+++ b/demo/src/framework/utils.ts
@@ -99,7 +99,7 @@ function getSettings() {
 
   const defaultSettings: Settings = {
     framework: "react",
-    layout: "float",
+    layout: "fullscreen",
     writeableElements: "false",
     direction: "default",
     ...settings,
@@ -129,6 +129,7 @@ function getSettings() {
           hasContentMaxWidth: undefined,
           corners: CornersType.SQUARE,
         },
+        launcher: { isOn: true },
         openChatByDefault: undefined,
       };
       delete defaultConfig.header?.minimizeButtonIconType;
@@ -170,6 +171,7 @@ function getSettings() {
           showFrame: false,
           hasContentMaxWidth: undefined,
         },
+        launcher: { isOn: true },
         openChatByDefault: true,
       };
       delete defaultConfig.header?.minimizeButtonIconType;
@@ -188,6 +190,7 @@ function getSettings() {
           hasContentMaxWidth: false,
           corners: CornersType.SQUARE,
         },
+        launcher: { isOn: true },
         openChatByDefault: true,
       };
       delete defaultConfig.header?.minimizeButtonIconType;

--- a/demo/tests/smoke.spec.ts
+++ b/demo/tests/smoke.spec.ts
@@ -5,7 +5,7 @@
  *  LICENSE file in the root directory of this source tree.
  */
 
-import { PageObjectId } from "@carbon/ai-chat/server";
+import { PageObjectId, ViewType } from "@carbon/ai-chat/server";
 import { test, expect } from "@playwright/test";
 
 // Import types for window.setChatConfig without emitting runtime code
@@ -18,6 +18,20 @@ test.beforeEach(async ({ page }) => {
 
   // Navigate to demo page first to get chatInstance
   await page.goto("/");
+
+  // Wait for page to fully load and web component to initialize
+  await page.waitForLoadState("domcontentloaded");
+
+  // Wait for the chatInstance to be available on window
+  await page.waitForFunction(() => Boolean(window.chatInstance), {
+    timeout: 10000,
+  });
+
+  await page.evaluate(() => {
+    if (window.chatInstance) {
+      window.chatInstance.changeView("launcher" as ViewType);
+    }
+  });
 });
 
 // Clear session between all tests to ensure clean state


### PR DESCRIPTION
when going to sidebar view, we were losing launcher setting when we switch back. Also went ahead and made the default for the demo site the full screen view.

#### Testing / Reviewing

Switch to sidebar view. Notice there is no launcher. Switch to fullscreen and/or float, note that launcher comes back when chat is closed.
