### PR TITLE
fix(option): pass in label to ensure response come back with label value

### DIFF
--- a/packages/ai-chat/src/chat/components-legacy/responseTypes/options/SelectComponent.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/responseTypes/options/SelectComponent.tsx
@@ -85,7 +85,7 @@ function SelectComponent(props: SelectProps) {
     }
   };
 
-  const handleBeingSelected = (e: SelectionEvent) => {
+  const handleSelected = (e: SelectionEvent) => {
     const label = e.detail.item.textContent;
     const text = e.detail.item.value;
 
@@ -135,7 +135,7 @@ function SelectComponent(props: SelectProps) {
           disabled={disableUserInputs}
           onToggled={handleToggle}
           onKeyDown={handleKeyDown}
-          onBeingSelected={handleBeingSelected}
+          onSelected={handleSelected}
         >
           {options.map((option) => (
             <DropdownItem

--- a/packages/ai-chat/src/chat/components/carbon/Dropdown.tsx
+++ b/packages/ai-chat/src/chat/components/carbon/Dropdown.tsx
@@ -18,7 +18,7 @@ const Dropdown = createComponent({
   tagName: "cds-dropdown",
   elementClass: CarbonDropdownElement,
   events: {
-    onBeingSelected: "cds-dropdown-beingselected",
+    onSelected: "cds-dropdown-selected",
     onToggled: "cds-dropdown-toggled",
   },
   react: React,


### PR DESCRIPTION
Closes #641

When using the options message response type, when user selects an option - the label should be returned to the UI instead  of the value. The select component was also displaying the `value` as the dropdown option instead of the `label`. 

This PR ensures we pass in the `label` of the selected item and also flips the `value` and `label` content so they are displayed properly in the dropdown. Also changed the trigger event to after an options item has been selected so the dropdown value has time to be set with the selected value.


https://github.com/user-attachments/assets/937305ea-93f7-43aa-95c8-e39cd144dfff



#### Changelog

**Changed**

- pull in the `e.detail.item.textContent` value to pass in as the `label` of the selected item - previously we were passing in the value as both the `value` and `label` 
- flip the value and label display in the dropdown 
- change selected event to `onSelect` instead of `onBeingSelected` so that the parent dropdown component value is set with the selected item value first before the `onChange` event handler, that passes the selected value and disables the dropdown, is triggered

#### Testing / Reviewing

You can test with the `examples/react/basic` test app by adding to the `customSendMessage` file the following code and running the test app, typing in "options" in the input field.

```
const options = [
  {
    label: 'option label 1',
    value: 'value 1',
  },
  {
    label: 'option label 2',
    value: 'value 2',
  },
  {
    label: 'option label 3',
    value: 'value 3',
  },
  {
    label: 'option label 4',
    value: 'value 4',
  },
  {
    label: 'option label 5',
    value: 'value 5',
  },
  {
    label: 'option label 6',
    value: 'value 6',
  },
];

....

async function customSendMessage(
....
case 'options':
        instance.messaging.addMessage({
          output: {
            generic: [
              {
                response_type: MessageResponseTypes.OPTION,
                title: 'select something',
                options: options.map((x) => ({
                  label: x.label,
                  value: {
                    input: {
                      text: x.value,
                    },
                  },
                })),
              },
            ],
          },
        });
        break;
 ```
