### PR TITLE
feat: hide send button when stop button is rendered

### DIFF
--- a/packages/ai-chat/src/chat/components-legacy/input/Input.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/input/Input.tsx
@@ -510,7 +510,7 @@ function Input(props: InputProps, ref: Ref<InputFunctions>) {
               <StopStreamingButton
                 label={input_stopResponse}
                 disabled={isStopStreamingButtonDisabled}
-                tooltipAlignment="top"
+                tooltipAlignment={isRTL ? "top-left" : "top-right"}
                 onClick={async () => {
                   const { store } = serviceManager;
                   store.dispatch(actions.setStopStreamingButtonDisabled(true));


### PR DESCRIPTION
Closes #632 

this pr conditionally renders send button based on `isStopStreamingButtonVisible` prop.
and also focuses the input on stop button interaction.

#### Changelog

**Changed**

- hides send button if `isStopStreamingButtonVisible` is true
- focus input field on stop button interaction

#### Testing / Reviewing
Try to interact with input field and try an asynchronous response type.
the send button is not rendered. and only user action available is to stop the response

This behavior can be compared with other popular chat applications

https://github.com/user-attachments/assets/eb98cba4-8f16-4a35-a462-0f157a4ff2dd


