### PR TITLE
feat(table): remove table style overrides

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -16,7 +16,7 @@
     "@carbon/ai-chat": "^1.2.0-rc.1",
     "@carbon/icons": "^11.53.0",
     "@carbon/react": "^1.68.0",
-    "@carbon/web-components": "^2.40.1",
+    "@carbon/web-components": "^2.42.0",
     "lit": "^3.1.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/examples/react/basic/package.json
+++ b/examples/react/basic/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@carbon/ai-chat": "^1.2.0-rc.1",
     "@carbon/icons": "^11.53.0",
-    "@carbon/web-components": "^2.40.1",
+    "@carbon/web-components": "^2.42.0",
     "lit": "^3.1.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/examples/react/custom-element/package.json
+++ b/examples/react/custom-element/package.json
@@ -15,7 +15,7 @@
     "@carbon/ai-chat": "^1.2.0-rc.1",
     "@carbon/icons": "^11.53.0",
     "@carbon/react": "^1.68.0",
-    "@carbon/web-components": "^2.40.1",
+    "@carbon/web-components": "^2.42.0",
     "lit": "^3.1.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/examples/react/history/package.json
+++ b/examples/react/history/package.json
@@ -15,7 +15,7 @@
     "@carbon/ai-chat": "^1.2.0-rc.1",
     "@carbon/icons": "^11.53.0",
     "@carbon/react": "^1.68.0",
-    "@carbon/web-components": "^2.40.1",
+    "@carbon/web-components": "^2.42.0",
     "lit": "^3.1.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/examples/react/watsonx/package.json
+++ b/examples/react/watsonx/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@carbon/ai-chat": "^1.2.0-rc.1",
     "@carbon/icons": "^11.53.0",
-    "@carbon/web-components": "^2.40.1",
+    "@carbon/web-components": "^2.42.0",
     "@microsoft/fetch-event-source": "^2.0.1",
     "cors": "^2.8.5",
     "dotenv": "^16.6.1",

--- a/examples/web-components/basic/package.json
+++ b/examples/web-components/basic/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@carbon/ai-chat": "^1.2.0-rc.1",
     "@carbon/icons": "^11.53.0",
-    "@carbon/web-components": "^2.40.1",
+    "@carbon/web-components": "^2.42.0",
     "lit": "^3.1.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/examples/web-components/custom-element/package.json
+++ b/examples/web-components/custom-element/package.json
@@ -15,7 +15,7 @@
     "@carbon/ai-chat": "^1.2.0-rc.1",
     "@carbon/icons": "^11.53.0",
     "@carbon/react": "^1.68.0",
-    "@carbon/web-components": "^2.40.1",
+    "@carbon/web-components": "^2.42.0",
     "lit": "^3.1.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/examples/web-components/history/package.json
+++ b/examples/web-components/history/package.json
@@ -15,7 +15,7 @@
     "@carbon/ai-chat": "^1.2.0-rc.1",
     "@carbon/icons": "^11.53.0",
     "@carbon/react": "^1.68.0",
-    "@carbon/web-components": "^2.40.1",
+    "@carbon/web-components": "^2.42.0",
     "lit": "^3.1.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/examples/web-components/watsonx/package.json
+++ b/examples/web-components/watsonx/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@carbon/ai-chat": "^1.2.0-rc.1",
     "@carbon/icons": "^11.53.0",
-    "@carbon/web-components": "^2.40.1",
+    "@carbon/web-components": "^2.42.0",
     "@microsoft/fetch-event-source": "^2.0.1",
     "concurrently": "^9.2.0",
     "cors": "^2.8.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -66,7 +66,7 @@
         "@carbon/ai-chat": "^1.2.0-rc.1",
         "@carbon/icons": "^11.53.0",
         "@carbon/react": "^1.68.0",
-        "@carbon/web-components": "^2.40.1",
+        "@carbon/web-components": "^2.42.0",
         "lit": "^3.1.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -223,7 +223,7 @@
       "dependencies": {
         "@carbon/ai-chat": "^1.2.0-rc.1",
         "@carbon/icons": "^11.53.0",
-        "@carbon/web-components": "^2.40.1",
+        "@carbon/web-components": "^2.42.0",
         "lit": "^3.1.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -274,7 +274,7 @@
         "@carbon/ai-chat": "^1.2.0-rc.1",
         "@carbon/icons": "^11.53.0",
         "@carbon/react": "^1.68.0",
-        "@carbon/web-components": "^2.40.1",
+        "@carbon/web-components": "^2.42.0",
         "lit": "^3.1.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
@@ -324,7 +324,7 @@
         "@carbon/ai-chat": "^1.2.0-rc.1",
         "@carbon/icons": "^11.53.0",
         "@carbon/react": "^1.68.0",
-        "@carbon/web-components": "^2.40.1",
+        "@carbon/web-components": "^2.42.0",
         "lit": "^3.1.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
@@ -497,7 +497,7 @@
       "dependencies": {
         "@carbon/ai-chat": "^1.2.0-rc.1",
         "@carbon/icons": "^11.53.0",
-        "@carbon/web-components": "^2.40.1",
+        "@carbon/web-components": "^2.42.0",
         "@microsoft/fetch-event-source": "^2.0.1",
         "cors": "^2.8.5",
         "dotenv": "^16.6.1",
@@ -551,7 +551,7 @@
       "dependencies": {
         "@carbon/ai-chat": "^1.2.0-rc.1",
         "@carbon/icons": "^11.53.0",
-        "@carbon/web-components": "^2.40.1",
+        "@carbon/web-components": "^2.42.0",
         "lit": "^3.1.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -608,7 +608,7 @@
         "@carbon/ai-chat": "^1.2.0-rc.1",
         "@carbon/icons": "^11.53.0",
         "@carbon/react": "^1.68.0",
-        "@carbon/web-components": "^2.40.1",
+        "@carbon/web-components": "^2.42.0",
         "lit": "^3.1.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
@@ -663,7 +663,7 @@
         "@carbon/ai-chat": "^1.2.0-rc.1",
         "@carbon/icons": "^11.53.0",
         "@carbon/react": "^1.68.0",
-        "@carbon/web-components": "^2.40.1",
+        "@carbon/web-components": "^2.42.0",
         "lit": "^3.1.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
@@ -770,7 +770,7 @@
       "dependencies": {
         "@carbon/ai-chat": "^1.2.0-rc.1",
         "@carbon/icons": "^11.53.0",
-        "@carbon/web-components": "^2.40.1",
+        "@carbon/web-components": "^2.42.0",
         "@microsoft/fetch-event-source": "^2.0.1",
         "concurrently": "^9.2.0",
         "cors": "^2.8.5",
@@ -41655,7 +41655,7 @@
         "@carbon/icons": "^11.53.0",
         "@carbon/styles": "^1.88.0",
         "@carbon/themes": "^11.58.0",
-        "@carbon/web-components": "^2.40.1",
+        "@carbon/web-components": "^2.42.0",
         "@open-wc/testing": "4.0.0",
         "@rollup/plugin-babel": "^6.0.4",
         "@rollup/plugin-commonjs": "^29.0.0",
@@ -41700,7 +41700,7 @@
         "wait-on": "^9.0.1"
       },
       "peerDependencies": {
-        "@carbon/web-components": ">=2.40.1 <3.0.0",
+        "@carbon/web-components": ">=2.42.0 <3.0.0",
         "react": ">=17.0.0 <20.0.0",
         "react-dom": ">=17.0.0 <20.0.0"
       }
@@ -41714,7 +41714,7 @@
         "@carbon/icon-helpers": "^10.47.0",
         "@carbon/icons": "^11.53.0",
         "@carbon/styles": "^1.39.0",
-        "@carbon/web-components": "^2.40.1",
+        "@carbon/web-components": "^2.42.0",
         "@codemirror/language": "^6.11.3",
         "@codemirror/language-data": "^6.5.1",
         "@codemirror/state": "^6.5.2",

--- a/packages/ai-chat-components/package.json
+++ b/packages/ai-chat-components/package.json
@@ -45,7 +45,7 @@
     "@carbon/icon-helpers": "^10.47.0",
     "@carbon/icons": "^11.53.0",
     "@carbon/styles": "^1.39.0",
-    "@carbon/web-components": "^2.40.1",
+    "@carbon/web-components": "^2.42.0",
     "@codemirror/language": "^6.11.3",
     "@codemirror/language-data": "^6.5.1",
     "@codemirror/state": "^6.5.2",

--- a/packages/ai-chat-components/src/components/table/src/cds-aichat-table.ts
+++ b/packages/ai-chat-components/src/components/table/src/cds-aichat-table.ts
@@ -10,7 +10,6 @@
 import { type CDSTableRow } from "@carbon/web-components";
 import { TemplateResult, LitElement, PropertyValues, html } from "lit";
 import { property, state } from "lit/decorators.js";
-import { debounce } from "lodash-es";
 import { carbonElement } from "../../../globals/decorators";
 import { tableTemplate } from "./table.template";
 import { tablePaginationTemplate } from "./table-pagination.template";
@@ -200,76 +199,15 @@ class TableElement extends LitElement {
 
   static styles = styles;
 
-  private _parentResizeObserver?: ResizeObserver;
-
-  /**
-   * Called when the element is added to the DOM.
-   * Sets up the ResizeObserver to monitor parent element width changes.
-   */
-  connectedCallback() {
-    super.connectedCallback();
-    this._setupParentResizeObserver();
-  }
-
-  /**
-   * Called when the element is removed from the DOM.
-   * Cleans up the ResizeObserver to prevent memory leaks.
-   */
-  disconnectedCallback() {
-    super.disconnectedCallback();
-    this._cleanupParentResizeObserver();
-  }
-
   /**
    * Called after the element's DOM has been updated for the first time.
-   * Initializes the table page size and sets up width-based calculations.
+   * Initializes the table page size.
    *
    * @param _changedProperties - Map of properties that changed during the update
    */
   protected firstUpdated(_changedProperties: PropertyValues): void {
     this._setPageSize();
-    this._updateParentWidthCSSProperty(); // Initial width setting
-  }
-
-  /**
-   * Sets up a ResizeObserver to monitor the parent element's width changes.
-   * Updates the CSS custom property `--cds-chat-table-width` when the parent resizes.
-   * Uses debouncing to limit the frequency of updates to improve performance.
-   *
-   * @private
-   */
-  private _setupParentResizeObserver() {
-    if (typeof ResizeObserver !== "undefined" && this.parentElement) {
-      this._parentResizeObserver = new ResizeObserver(
-        debounce((entries) => {
-          for (const entry of entries) {
-            // Use the element's offsetWidth instead of contentRect.width for custom elements
-            const elementWidth = (entry.target as HTMLElement).offsetWidth;
-
-            if (elementWidth > 0) {
-              this.style.setProperty(
-                "--cds-aichat-table-width",
-                `${elementWidth}px`,
-              );
-            }
-          }
-        }, 100), // 100ms debounce for parent resize events
-      );
-      this._parentResizeObserver.observe(this.parentElement);
-    }
-  }
-
-  /**
-   * Cleans up the ResizeObserver to prevent memory leaks.
-   * Should be called when the component is disconnected from the DOM.
-   *
-   * @private
-   */
-  private _cleanupParentResizeObserver() {
-    if (this._parentResizeObserver) {
-      this._parentResizeObserver.disconnect();
-      this._parentResizeObserver = undefined;
-    }
+    this._updateDefaultPageSize(); // Initial width setting
   }
 
   /**
@@ -279,7 +217,7 @@ class TableElement extends LitElement {
    *
    * @private
    */
-  private _updateParentWidthCSSProperty() {
+  private _updateDefaultPageSize() {
     if (this.parentElement) {
       let parentWidth = this.parentElement.offsetWidth;
 
@@ -288,19 +226,15 @@ class TableElement extends LitElement {
         parentWidth = PAGE_SIZE_WIDTH_THRESHOLD - 1;
       }
 
-      if (parentWidth > 0) {
-        this.style.setProperty("--cds-aichat-table-width", `${parentWidth}px`);
+      // Calculate default page size based on the width we just measured
+      // Only set it once, don't recalculate on resize
+      if (parentWidth > 0 && this._defaultPageSize === 5) {
+        this._defaultPageSize =
+          parentWidth > PAGE_SIZE_WIDTH_THRESHOLD ? 10 : 5;
 
-        // Calculate default page size based on the width we just measured
-        // Only set it once, don't recalculate on resize
-        if (this._defaultPageSize === 5) {
-          this._defaultPageSize =
-            parentWidth > PAGE_SIZE_WIDTH_THRESHOLD ? 10 : 5;
-
-          // Update _currentPageSize if it's still at the initial value
-          if (this._currentPageSize === 5) {
-            this._currentPageSize = this._defaultPageSize;
-          }
+        // Update _currentPageSize if it's still at the initial value
+        if (this._currentPageSize === 5) {
+          this._currentPageSize = this._defaultPageSize;
         }
       }
     }

--- a/packages/ai-chat-components/src/components/table/src/table-pagination.template.ts
+++ b/packages/ai-chat-components/src/components/table/src/table-pagination.template.ts
@@ -68,15 +68,6 @@ function tablePaginationTemplate(props: TablePaginationProps) {
     (pageSize) => pageSize < totalRows,
   );
 
-  // TODO TABLE: This component is quite wide. Because of the shadow DOM we can't select it's contents to hide items
-  // with css, nor can we extend this class to manipulate it's styles because of Carbon's use of :host(cds-pagination)
-  // within their styles. There is however a smaller variation of this component
-  // (https://carbondesignsystem.com/components/pagination/usage/#responsive-behavior) but it's only used at a specific
-  // breakpoint, when the viewport is narrow (i.e. a mobile device). A Carbon enhancement request has been made to
-  // expose a prop that can be used to enable this smaller variation
-  // (https://github.com/carbon-design-system/carbon/issues/17564). When that enhancement is done, and we can
-  // dynamically enable a narrow form factor of this pagination component, then we could use the same css trick we used
-  // for the header to make the pagination component sticky (if the carbon component doesn't already do it for us).
   return html`<cds-pagination
     page-size=${currentPageSize}
     page=${currentPageNumber}

--- a/packages/ai-chat-components/src/components/table/src/table.scss
+++ b/packages/ai-chat-components/src/components/table/src/table.scss
@@ -1,85 +1,12 @@
-/* 
+/*
  *  Copyright IBM Corp. 2025
- *  
+ *
  *  This source code is licensed under the Apache-2.0 license found in the
  *  LICENSE file in the root directory of this source tree.
  */
 
-@use "@carbon/layout";
-@use "@carbon/styles/scss/theme";
-@use "@carbon/themes/scss/themes";
-
-// TODO TABLE: The below sticky header workaround should be removed when Carbon adds out of the box functionality for
-// this (re this issue: https://github.com/carbon-design-system/carbon/issues/17735). When the sticky header workaround
-// is removed we'll need to experiment with the overflow behavior here. Carbon's React example has a fixed width with no
-// overflow on the container and our implementation currently has an overflow at the (React) container level. It looks
-// like setting display: block with overflow-x: auto on any section of the table will allow allow just that specific
-// section to scroll (some info on that behavior:
-// https://stackoverflow.com/questions/17365582/displayblock-overflowauto-how-do-they-work). However it's unclear what
-// side effects could occur from overriding settings like display: table. Once Carbon's issue has been addressed we can
-// take a second look here and decide how we want to handle overflowing in the table.
-
-// Style the header components so that they will be sticky when the table body scrolls. Use a variable for the width of
-// the header that is equal to the width of the web component container, this way the header fits the container and
-// doesn't have any overflow. In an ideal world we could use this same technique on the pagination footer. However that
-// component currently has too much content for our smaller widths, and would have an overflow of it's own if we tried
-// to fix it to the container width. For now it's better to just have one scroll bar and let the footer scroll with the
-// table body.
-cds-table-header-title,
-cds-table-header-description,
-cds-table-toolbar {
-  position: sticky;
-  inline-size: var(--cds-aichat-table-width, auto);
-  inset-inline-start: 0;
-}
-
-// The title and description have a parent div around them with padding (cds--data-table-header) that causes the title
-// and description to scroll horizontally even when those items have a fixed width (equal to their container size). If
-// this was a React component we could just override the css, however because the container div that is setting this
-// padding is in a shadow DOM, we can't select the div to override the styles. In order to remove this scroll the
-// padding needs to be offset from the parent div using this negative margin "hack". Then the padding can be reapplied
-// to the component we control so the title is properly indented but doesn't scroll.
-cds-table-header-title,
-cds-table-header-description {
-  padding: 0 layout.$spacing-05;
-  inline-size: calc(
-    var(--cds-aichat-table-width, auto) - layout.$spacing-05 -
-      layout.$spacing-05
-  );
-  margin-inline: -#{layout.$spacing-05};
-}
-
-cds-table-header-description {
-  margin-block-end: -#{layout.$spacing-03};
-}
-
-:dir(rtl) cds-table-header-title,
-:dir(rtl) cds-table-header-description,
-:dir(rtl) cds-table-toolbar {
-  right: 0;
-  left: unset;
-}
-
-// Both table and pagination will be placed in the same grid column,
-// ensuring they have the same width that expands to fit the wider element.
-cds-pagination,
-cds-table {
-  grid-column: 1;
-  inline-size: 100%;
-}
-
-.cds-ai-chat-table-container {
+// prevent the table columns from being squished in narrow widths
+cds-table::part(inner-container) {
   display: grid;
   grid-template-columns: minmax(max-content, 1fr);
-  inline-size: 100%;
-  overflow-x: auto;
-}
-
-// Apply Carbon themes to the table container
-.cds-ai-chat-table-container.cds--white {
-  @include theme.theme(themes.$white);
-}
-
-.cds-ai-chat-table-container.cds--g90 {
-  @include theme.theme(themes.$g90);
 }

--- a/packages/ai-chat/package.json
+++ b/packages/ai-chat/package.json
@@ -75,7 +75,7 @@
     "@carbon/icons": "^11.53.0",
     "@carbon/styles": "^1.88.0",
     "@carbon/themes": "^11.58.0",
-    "@carbon/web-components": "^2.40.1",
+    "@carbon/web-components": "^2.42.0",
     "@open-wc/testing": "4.0.0",
     "@rollup/plugin-babel": "^6.0.4",
     "@rollup/plugin-commonjs": "^29.0.0",
@@ -120,7 +120,7 @@
     "wait-on": "^9.0.1"
   },
   "peerDependencies": {
-    "@carbon/web-components": ">=2.40.1 <3.0.0",
+    "@carbon/web-components": ">=2.42.0 <3.0.0",
     "react": ">=17.0.0 <20.0.0",
     "react-dom": ">=17.0.0 <20.0.0"
   },


### PR DESCRIPTION
Closes #528 

Remove style overrides that were in place to adjust the table and pagination components to be narrow width friendly now that the core table and pagination components can handle the narrow width view.

#### Changelog

**Changed**

- bump up `@carbon/web-components` package version to pull in the latest with the table style changes 

**Removed**

- most of the table styling
- the logic in the table component that handles the width of the pagination and table

#### Testing / Reviewing

Go to the demo deploy preview and select the `table` option. See that the table is rendered correctly
