### PR TITLE
fix(scroll): checkMessagesOutOfView return false when no scrollElement 

### DIFF
--- a/packages/ai-chat/src/chat/shared/containers/MessagesComponent.tsx
+++ b/packages/ai-chat/src/chat/shared/containers/MessagesComponent.tsx
@@ -562,11 +562,14 @@ class MessagesComponent extends PureComponent<MessagesProps, MessagesState> {
    */
   public checkMessagesOutOfView() {
     const scrollElement = this.messagesContainerWithScrollingRef.current;
-    const remainingPixelsToScroll =
-      scrollElement.scrollHeight -
-      scrollElement.scrollTop -
-      scrollElement.clientHeight;
-    return remainingPixelsToScroll > 60;
+    if (scrollElement) {
+      const remainingPixelsToScroll =
+        scrollElement.scrollHeight -
+        scrollElement.scrollTop -
+        scrollElement.clientHeight;
+      return remainingPixelsToScroll > 60;
+    }
+    return false;
   }
 
   /**


### PR DESCRIPTION
Fix null reference error in checkMessagesOutOfView method

We are encounter this error when using v0.5.1 carbon-ai-chat
<img width="654" height="147" alt="image (6)" src="https://github.com/user-attachments/assets/28d6c4cf-1549-47b8-bc35-170fc8b00e3c" />

This PR aims for resolving this error by adding null check for `scrollElement` in the `checkMessagesOutOfView()` method to prevent potential runtime errors when the messages container reference is not yet available or has been unmounted.

#### Changelog

**Changed**

- Added null safety check in `checkMessagesOutOfView()` method to return `false` when `scrollElement` is null or undefined

**Expected behavior:**
- No runtime errors calling checkMessagesOutOfView when `scrollElement` is null
