### PR TITLE
chore(release): add empty commit on full releases

### DIFF
--- a/.github/workflows/release-base.yml
+++ b/.github/workflows/release-base.yml
@@ -89,7 +89,10 @@ jobs:
         if: |
           github.event.inputs.type == 'full release' &&
           github.event.inputs.semver-type == 'minor'
+        # pass in an empty commit so lerna will graduate the version to stable
+        # even though there are no new changes from last rc
         run: |
+          git commit --allow-empty -m "chore(release): graduate prerelease to stable"
           npx lerna publish minor --conventional-graduate ${{ env.PUBLISH }} ${{ env.FORCE }}
 
       - name: Publish first minor RC (ie. v1.x.0-rc.0)
@@ -103,7 +106,10 @@ jobs:
         if: |
           github.event.inputs.type == 'full release' &&
           github.event.inputs.semver-type == 'patch'
+        # pass in an empty commit so lerna will graduate the version to stable
+        # even though there are no new changes from last rc
         run: |
+          git commit --allow-empty -m "chore(release): graduate prerelease to stable"
           npx lerna publish patch --conventional-graduate ${{ env.PUBLISH }} ${{ env.FORCE }}
 
       - name: Publish first patch RC (ie. v1.0.x-rc.0)

--- a/docs/publishing-releases.md
+++ b/docs/publishing-releases.md
@@ -126,6 +126,7 @@ available for testing. If there are any issues during the testing period, fixes
 can be pushed to the release branch. We can then publish subsequent prereleases
 from the release branch for further testing. To publish subsequent prereleases,
 
+- [ ] Ensure the new fixes that have been pushed to the release branch have also been cherry-picked into the `main` branch.
 - [ ] Run the
       [minor release workflow](https://github.com/carbon-design-system/carbon-ai-chat/actions/workflows/release-start.yml)
       to generate the prerelease versions for the packages
@@ -155,6 +156,7 @@ from the release branch for further testing. To publish subsequent prereleases,
       candidate (ie. v0.10.0-rc.0)
   - [ ] Merge in the generated PR (the title of the PR should start with
         `chore(release):` followed by the version).
+    - If you encounter merge conflicts in this PR, resolve them by merging the main branch into the PR branch (typically named something like `chore/v1.2.0-release`), then push the updated branch to re-run the checks and complete the merge.
   - [ ] Check the generated
         [release](https://github.com/carbon-design-system/carbon-ai-chat/releases)
         to ensure the release notes are correct.


### PR DESCRIPTION
When running the full release workflow, it will not publish as lerna detects that the latest commit on the branch has already been published (in the last rc). To work around this and not use the `force publish` option, generate an empty commit first before publishing.

Also updated the docs around publishing the release candidates and making sure we cherry-pick any fixes into `main`