### PR TITLE
fix: replace hardcoded background colors on tile

### DIFF
--- a/packages/ai-chat/src/chat/ChatAppStyles.scss
+++ b/packages/ai-chat/src/chat/ChatAppStyles.scss
@@ -33,22 +33,11 @@
 cds-tile {
   border: 1px solid theme.$chat-bubble-border;
   border-radius: layout.$spacing-03;
-}
-
-.cds-aichat--light,
-.cds--white,
-.cds--g10 {
-  cds-tile {
-    background-color: theme.$chat-shell-background;
-  }
+  background-color: theme.$chat-shell-background;
 }
 
 .cds-aichat--dark,
 .cds--g90,
 .cds--g100 {
   scrollbar-color: theme.$layer-03 theme.$layer-01;
-
-  cds-tile {
-    background-color: theme.$chat-shell-background;
-  }
 }


### PR DESCRIPTION
Closes #

This is a temporary fix to deal with hardcoded background colors on tile.

This uses `$chat-shell-background` as a temporary fix. and the ai-chat design says 

> non user tiles must have the same color as chat shell.

Which can be found [here](https://w3.ibm.com/w3publisher/design-for-ai/carbon-for-ai/ai-chat-patterns/patterns#message-anatomy). 
Therefore, `$chat-shell-background` is the closest available alternative until a dedicated token, `$chat-bubble-non-user`, is provided for more customizable theming specific to tiles.

#### Changelog

**Changed**

- changed hardcoded background colors to tokens

#### Testing / Reviewing

can be verified in card response type visually
