### PR TITLE
chore: add workflow to deploy demo to GH Pages from `main`

### DIFF
--- a/.github/workflows/deploy-dev-env.yml
+++ b/.github/workflows/deploy-dev-env.yml
@@ -21,10 +21,10 @@ jobs:
         with:
           node-version: "24.x"
           cache: "npm"
-      - name: Install dependencies and build
+      - name: Install dependencies and build chat packages
         run: |
           npm install
-          npm run build
+          npm run aiChat:build
 
       # Deploy demo to Github Pages using `gh-pages` package
       - name: Deploy demo


### PR DESCRIPTION
Adding workflow that will deploy the demo app to GH Pages every time we push to `main` for our dev testing purposes

Link to this will be: https://carbon-design-system.github.io/carbon-ai-chat/demo/index.html 
