### PR TITLE
chore: add happy dom bridge to all react wrappers

### DIFF
--- a/packages/ai-chat-components/src/react/button.ts
+++ b/packages/ai-chat-components/src/react/button.ts
@@ -18,12 +18,15 @@ import {
 } from "@carbon/web-components/es/components/button/defs.js";
 // Export the actual class for the component that will *directly* be wrapped with React.
 import CarbonButtonElement from "@carbon/web-components/es/components/button/button.js";
+import { withWebComponentBridge } from "./utils/withWebComponentBridge";
 
-const Button = createComponent({
-  tagName: "cds-button",
-  elementClass: CarbonButtonElement,
-  react: React,
-});
+const Button = withWebComponentBridge(
+  createComponent({
+    tagName: "cds-button",
+    elementClass: CarbonButtonElement,
+    react: React,
+  }),
+);
 
 export default Button;
 export {

--- a/packages/ai-chat-components/src/react/chain-of-thought.ts
+++ b/packages/ai-chat-components/src/react/chain-of-thought.ts
@@ -16,12 +16,15 @@ import {
   type ChainOfThoughtStep,
   ChainOfThoughtStepStatus,
 } from "../components/chain-of-thought/src/types.js";
+import { withWebComponentBridge } from "./utils/withWebComponentBridge.js";
 
-const ChainOfThought = createComponent({
-  tagName: "cds-aichat-chain-of-thought",
-  elementClass: CDSChatChainOfThoughtElement,
-  react: React,
-});
+const ChainOfThought = withWebComponentBridge(
+  createComponent({
+    tagName: "cds-aichat-chain-of-thought",
+    elementClass: CDSChatChainOfThoughtElement,
+    react: React,
+  }),
+);
 
 export type { ChainOfThoughtOnToggle, ChainOfThoughtStep };
 export { ChainOfThoughtStepStatus };

--- a/packages/ai-chat-components/src/react/chat-button.ts
+++ b/packages/ai-chat-components/src/react/chat-button.ts
@@ -19,12 +19,15 @@ import {
 
 // Export the actual class for the component that will *directly* be wrapped with React.
 import AIChatButton from "../components/chat-button/chat-button.js";
+import { withWebComponentBridge } from "./utils/withWebComponentBridge.js";
 
-const ChatButton = createComponent({
-  tagName: "cds-aichat-button",
-  elementClass: AIChatButton,
-  react: React,
-});
+const ChatButton = withWebComponentBridge(
+  createComponent({
+    tagName: "cds-aichat-button",
+    elementClass: AIChatButton,
+    react: React,
+  }),
+);
 
 export default ChatButton;
 export {

--- a/packages/ai-chat-components/src/react/content-switcher.ts
+++ b/packages/ai-chat-components/src/react/content-switcher.ts
@@ -13,20 +13,25 @@ import React from "react";
 // Export the actual class for the component that will *directly* be wrapped with React.
 import CarbonContentSwitcherElement from "@carbon/web-components/es/components/content-switcher/content-switcher.js";
 import CarbonContentSwitcherItemElement from "@carbon/web-components/es/components/content-switcher/content-switcher-item.js";
+import { withWebComponentBridge } from "./utils/withWebComponentBridge";
 
-const ContentSwitcher = createComponent({
-  tagName: "cds-content-switcher",
-  elementClass: CarbonContentSwitcherElement,
-  react: React,
-  events: {
-    onSelected: "cds-content-switcher-selected",
-  },
-});
-const ContentSwitcherItem = createComponent({
-  tagName: "cds-content-switcher-item",
-  elementClass: CarbonContentSwitcherItemElement,
-  react: React,
-});
+const ContentSwitcher = withWebComponentBridge(
+  createComponent({
+    tagName: "cds-content-switcher",
+    elementClass: CarbonContentSwitcherElement,
+    react: React,
+    events: {
+      onSelected: "cds-content-switcher-selected",
+    },
+  }),
+);
+const ContentSwitcherItem = withWebComponentBridge(
+  createComponent({
+    tagName: "cds-content-switcher-item",
+    elementClass: CarbonContentSwitcherItemElement,
+    react: React,
+  }),
+);
 
 export default ContentSwitcher;
 export { ContentSwitcher, ContentSwitcherItem };

--- a/packages/ai-chat-components/src/react/icon-button.ts
+++ b/packages/ai-chat-components/src/react/icon-button.ts
@@ -12,11 +12,14 @@ import React from "react";
 
 // Export the actual class for the component that will *directly* be wrapped with React.
 import CarbonIconButtonElement from "@carbon/web-components/es/components/icon-button/icon-button.js";
+import { withWebComponentBridge } from "./utils/withWebComponentBridge";
 
-const IconButton = createComponent({
-  tagName: "cds-icon-button",
-  elementClass: CarbonIconButtonElement,
-  react: React,
-});
+const IconButton = withWebComponentBridge(
+  createComponent({
+    tagName: "cds-icon-button",
+    elementClass: CarbonIconButtonElement,
+    react: React,
+  }),
+);
 
 export default IconButton;

--- a/packages/ai-chat-components/src/react/icon.ts
+++ b/packages/ai-chat-components/src/react/icon.ts
@@ -12,11 +12,14 @@ import React from "react";
 
 // Export the actual class for the component that will *directly* be wrapped with React.
 import CDSIcon from "@carbon/web-components/es/components/icon/icon.js";
+import { withWebComponentBridge } from "./utils/withWebComponentBridge";
 
-const Icon = createComponent({
-  tagName: "cds-icon",
-  elementClass: CDSIcon,
-  react: React,
-});
+const Icon = withWebComponentBridge(
+  createComponent({
+    tagName: "cds-icon",
+    elementClass: CDSIcon,
+    react: React,
+  }),
+);
 
 export default Icon;

--- a/packages/ai-chat-components/src/react/overflow-menu.ts
+++ b/packages/ai-chat-components/src/react/overflow-menu.ts
@@ -14,24 +14,31 @@ import React from "react";
 import CarbonOverflowMenuElement from "@carbon/web-components/es/components/overflow-menu/overflow-menu.js";
 import CarbonOverflowMenuBodyElement from "@carbon/web-components/es/components/overflow-menu/overflow-menu-body.js";
 import CarbonOverflowMenuItemElement from "@carbon/web-components/es/components/overflow-menu/overflow-menu-item.js";
+import { withWebComponentBridge } from "./utils/withWebComponentBridge";
 
-const OverflowMenu = createComponent({
-  tagName: "cds-overflow-menu",
-  elementClass: CarbonOverflowMenuElement,
-  react: React,
-});
+const OverflowMenu = withWebComponentBridge(
+  createComponent({
+    tagName: "cds-overflow-menu",
+    elementClass: CarbonOverflowMenuElement,
+    react: React,
+  }),
+);
 
-const OverflowMenuBody = createComponent({
-  tagName: "cds-overflow-menu-body",
-  elementClass: CarbonOverflowMenuBodyElement,
-  react: React,
-});
+const OverflowMenuBody = withWebComponentBridge(
+  createComponent({
+    tagName: "cds-overflow-menu-body",
+    elementClass: CarbonOverflowMenuBodyElement,
+    react: React,
+  }),
+);
 
-const OverflowMenuItem = createComponent({
-  tagName: "cds-overflow-menu-item",
-  elementClass: CarbonOverflowMenuItemElement,
-  react: React,
-});
+const OverflowMenuItem = withWebComponentBridge(
+  createComponent({
+    tagName: "cds-overflow-menu-item",
+    elementClass: CarbonOverflowMenuItemElement,
+    react: React,
+  }),
+);
 
 export default OverflowMenu;
 export { OverflowMenu, OverflowMenuBody, OverflowMenuItem };

--- a/packages/ai-chat-components/src/react/processing.ts
+++ b/packages/ai-chat-components/src/react/processing.ts
@@ -12,11 +12,14 @@ import React from "react";
 
 // Export the actual class for the component that will *directly* be wrapped with React.
 import CDSAIChatProcessing from "../components/processing/src/processing.js";
+import { withWebComponentBridge } from "./utils/withWebComponentBridge.js";
 
-const Processing = createComponent({
-  tagName: "cds-aichat-processing",
-  elementClass: CDSAIChatProcessing,
-  react: React,
-});
+const Processing = withWebComponentBridge(
+  createComponent({
+    tagName: "cds-aichat-processing",
+    elementClass: CDSAIChatProcessing,
+    react: React,
+  }),
+);
 
 export default Processing;

--- a/packages/ai-chat-components/src/react/toolbar.ts
+++ b/packages/ai-chat-components/src/react/toolbar.ts
@@ -12,11 +12,14 @@ import React from "react";
 
 // Export the actual class for the component that will *directly* be wrapped with React.
 import CDSAIChatToolbar from "../components/toolbar/src/toolbar.js";
+import { withWebComponentBridge } from "./utils/withWebComponentBridge.js";
 
-const Toolbar = createComponent({
-  tagName: "cds-aichat-toolbar",
-  elementClass: CDSAIChatToolbar,
-  react: React,
-});
+const Toolbar = withWebComponentBridge(
+  createComponent({
+    tagName: "cds-aichat-toolbar",
+    elementClass: CDSAIChatToolbar,
+    react: React,
+  }),
+);
 
 export default Toolbar;


### PR DESCRIPTION
React 19 changes how props are forwarded to custom elements, and @lit/react no longer reliably delivers property values in non-browser environments. Browsers still behave correctly, but DOM shims used in Jest (happy-dom/jsdom) do not implement the property reflection and upgrade timing that Lit depends on.

Several of our Lit components were therefore receiving only string attributes in tests, causing mismatches between browser behavior and our Jest environment.

This PR adds the `withWebComponentBridge` wrapper to affected components so that each React prop is explicitly mirrored onto the underlying custom element as a property. In production this is effectively a no-op; in tests it ensures Lit receives the correct values and our components behave consistently.

Once upstream fixes land in @lit/react or in DOM shim implementations, we can remove this bridge but for now it stabilizes the integration and unblocks reliable testing under React 19.