### PR TITLE
chore: refactor message service

### DIFF
--- a/packages/ai-chat/package.json
+++ b/packages/ai-chat/package.json
@@ -150,7 +150,7 @@
     "postinstall": "ibmtelemetry --config=telemetry.yml",
     "start": "concurrently \"rollup -c ./tasks/rollup.aichat.js --watch\" \"typedoc --watch\" \"serve dist/docs/carbon-tsdocs -l 5001 --no-port-switching\" \"wait-on dist/docs/carbon-tsdocs/index.html && open http://localhost:5001\"",
     "telemetry:config": "npx -y @ibm/telemetry-js-config-generator generate --id ef967584-5788-47d4-b9c2-a60da7ad901d --endpoint https://www-api.ibm.com/ibm-telemetry/v1/metrics --files ./src --wc",
-    "test": "jest"
+    "test": "jest --coverage --coverageReporters=text --coverageReporters=text-summary"
   },
   "repository": {
     "type": "git",

--- a/packages/ai-chat/src/chat/components-legacy/humanAgent/AvailabilityMessage.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/humanAgent/AvailabilityMessage.tsx
@@ -11,7 +11,6 @@ import React from "react";
 import { FormattedMessage } from "react-intl";
 
 import { isNil } from "../../utils/lang/langUtils";
-import { addHTMLSupport } from "../../utils/languages";
 import RichText from "../responseTypes/util/RichText";
 import { AgentAvailability } from "../../../types/config/ServiceDeskConfig";
 import { LanguagePack } from "../../../types/config/PublicConfig";
@@ -54,6 +53,20 @@ function AvailabilityMessage({
       values={addHTMLSupport(availabilityValues)}
     />
   );
+}
+
+function addHTMLSupport(values: Record<string, any>) {
+  values.b = handleBTag;
+  values.br = handleBRTag;
+  return values;
+}
+
+function handleBTag(chunks: any) {
+  return <b>{chunks}</b>;
+}
+
+function handleBRTag() {
+  return <br />;
 }
 
 export { AvailabilityMessage };

--- a/packages/ai-chat/src/chat/components-legacy/responseTypes/datePicker/DatePickerComponent.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/responseTypes/datePicker/DatePickerComponent.tsx
@@ -34,7 +34,7 @@ import {
   toUserDateFormat,
 } from "../../../utils/dateUtils";
 import { uuid, UUIDType } from "../../../utils/lang/uuid";
-import { loadDayjsLocale } from "../../../utils/languages";
+import { loadDayjsLocale } from "../../../utils/languageUtils";
 import { createMessageRequestForDate } from "../../../utils/messageUtils";
 import { consoleError } from "../../../utils/miscUtils";
 import {

--- a/packages/ai-chat/src/chat/languages/en.json
+++ b/packages/ai-chat/src/chat/languages/en.json
@@ -21,7 +21,7 @@
   "errors_somethingWrong": "Something went wrong",
   "input_ariaLabel": "Message to send",
   "input_placeholder": "Type something...",
-  "input_buttonLabel": "Click to send message",
+  "input_buttonLabel": "Send message",
   "input_uploadButtonLabel": "Add files to upload",
   "window_title": "Chat window",
   "window_ariaChatRegion": "Chat",

--- a/packages/ai-chat/src/chat/services/InboundStreamingCoordinator.ts
+++ b/packages/ai-chat/src/chat/services/InboundStreamingCoordinator.ts
@@ -1,0 +1,168 @@
+/*
+ *  Copyright IBM Corp. 2025
+ *
+ *  This source code is licensed under the Apache-2.0 license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ *  @license
+ */
+
+import { StreamingTracker } from "../utils/streamingUtils";
+import { MessageRequest } from "../../types/messaging/Messages";
+
+type StreamingCurrent =
+  | {
+      message: MessageRequest<any>;
+      sendMessageController?: AbortController;
+      isStreaming?: boolean;
+    }
+  | null
+  | undefined;
+
+class InboundStreamingCoordinator {
+  /**
+   * Tracks the ID of the message that is currently streaming. This is set when the first chunk arrives
+   * and cleared when the FinalResponseChunk is processed. Used to handle cancellation even after queue is cleared.
+   */
+  public streamingMessageID: string | null = null;
+
+  /**
+   * Tracks streaming response/item mappings.
+   */
+  private streamingTracker = new StreamingTracker();
+
+  constructor(
+    private messageAbortControllers: Map<string, AbortController>,
+    private moveToNextQueueItem: () => void,
+  ) {}
+
+  /**
+   * Resolve a responseId from a provided id (could be an item_id or response_id).
+   */
+  resolveResponseId(id: string) {
+    return this.streamingTracker.resolveResponseId(id);
+  }
+
+  /**
+   * Returns metadata for a streaming response.
+   */
+  getStreamingMeta(responseId: string) {
+    return this.streamingTracker.getMeta(responseId);
+  }
+
+  /**
+   * Marks the current message as streaming and tracks response/item IDs.
+   */
+  markStreaming(
+    current: StreamingCurrent,
+    messageID?: string,
+    itemID?: string,
+    lastProcessedMessageID?: string | null,
+  ) {
+    // Set the messageID (from the chunk); otherwise fall back to the current queued message id.
+    const responseId = messageID ?? current?.message.id;
+    this.streamingMessageID = responseId;
+
+    // If we have the last processed message ID, copy its controller to the response_id
+    if (responseId && lastProcessedMessageID) {
+      const controller = this.messageAbortControllers.get(
+        lastProcessedMessageID,
+      );
+      if (controller) {
+        this.messageAbortControllers.set(responseId, controller);
+      }
+    }
+
+    if (!current || !responseId) {
+      return;
+    }
+
+    current.isStreaming = true;
+
+    // If messageID is provided (from chunk response_id), also store the controller under that ID
+    // because the chunk's response_id may differ from message.id
+    if (responseId && responseId !== current.message.id) {
+      const controller = current.sendMessageController;
+      if (controller) {
+        this.messageAbortControllers.set(responseId, controller);
+      }
+    }
+
+    // Track streaming metadata so item-level cancellation can be handled.
+    const controller =
+      this.messageAbortControllers.get(responseId) ||
+      this.messageAbortControllers.get(current.message.id);
+    this.streamingTracker.track(
+      responseId,
+      current.message.id,
+      controller,
+      itemID,
+    );
+  }
+
+  /**
+   * Called when a FinalResponseChunk is processed to clear the streaming message from the queue.
+   */
+  finalizeStreamingMessage(messageID: string) {
+    const responseId = this.resolveResponseId(messageID);
+    if (this.streamingMessageID === responseId) {
+      this.moveToNextQueueItem();
+    }
+
+    // Clean up tracking for this streaming response
+    const cleared = this.streamingTracker.clear(responseId);
+    this.messageAbortControllers.delete(responseId);
+    if (cleared?.requestId && cleared.requestId !== responseId) {
+      this.messageAbortControllers.delete(cleared.requestId);
+    }
+    if (this.streamingMessageID === responseId) {
+      this.streamingMessageID = null;
+    }
+  }
+
+  /**
+   * Clear tracking (without queue movement) and return metadata for the response.
+   */
+  clearStreamingResponse(responseId: string) {
+    const cleared = this.streamingTracker.clear(responseId);
+    this.messageAbortControllers.delete(responseId);
+    if (cleared?.requestId && cleared.requestId !== responseId) {
+      this.messageAbortControllers.delete(cleared.requestId);
+    }
+    if (this.streamingMessageID === responseId) {
+      this.streamingMessageID = null;
+    }
+    return cleared;
+  }
+
+  /**
+   * Returns false if the chunk is from an outdated generation. If true, the chunk should be processed.
+   */
+  public validateChunkGeneration(
+    messageID: string | undefined,
+    messageGenerations: Map<string, number>,
+    currentGeneration: number,
+    hideStopStreaming: () => void,
+  ): boolean {
+    if (!messageID) {
+      return true;
+    }
+
+    const messageGeneration = messageGenerations.get(messageID);
+    if (
+      messageGeneration !== undefined &&
+      messageGeneration !== currentGeneration
+    ) {
+      hideStopStreaming();
+      return false;
+    }
+
+    if (messageGeneration === undefined) {
+      messageGenerations.set(messageID, currentGeneration);
+    }
+
+    return true;
+  }
+}
+
+export { InboundStreamingCoordinator };

--- a/packages/ai-chat/src/chat/services/OutboundMessageCoordinator.ts
+++ b/packages/ai-chat/src/chat/services/OutboundMessageCoordinator.ts
@@ -1,0 +1,214 @@
+/*
+ *  Copyright IBM Corp. 2025
+ *
+ *  This source code is licensed under the Apache-2.0 license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ *  @license
+ */
+
+import { createLocalMessageForInlineError } from "../schema/outputItemToLocalItem";
+import actions from "../store/actions";
+import { MessageLoadingManager } from "../utils/messageServiceUtils";
+import { MessageErrorState } from "../../types/messaging/LocalMessageItem";
+import {
+  MessageInputType,
+  MessageRequest,
+  MessageResponse,
+} from "../../types/messaging/Messages";
+import { CustomSendMessageOptions } from "../../types/config/MessagingConfig";
+import { OnErrorType } from "../../types/config/PublicConfig";
+import { ServiceManager } from "./ServiceManager";
+import { PendingMessageRequest } from "./MessageService";
+import cloneDeep from "lodash-es/cloneDeep.js";
+import { consoleError, debugLog } from "../utils/miscUtils";
+import { BusEventSend, BusEventType } from "../../types/events/eventBusTypes";
+import { ChatInstance } from "../../types/instance/ChatInstance";
+
+type CustomSendMessageFn = (
+  message: MessageRequest<any>,
+  options: CustomSendMessageOptions,
+  instance: ChatInstance,
+) => void | Promise<void>;
+
+/**
+ * Handles outbound send lifecycle concerns: inline errors, error states, and queue advancement.
+ * Retries are expected to be handled by customSendMessage upstream.
+ */
+class OutboundMessageCoordinator {
+  constructor(
+    private serviceManager: ServiceManager,
+    private messageLoadingManager: MessageLoadingManager,
+    private setMessageErrorState: (
+      pendingRequest: PendingMessageRequest,
+      errorState: MessageErrorState,
+    ) => void,
+    private getCurrent: () => PendingMessageRequest | null,
+    private moveToNextQueueItem: () => void,
+    private processSuccess: (
+      current: PendingMessageRequest,
+      received?: MessageResponse,
+    ) => Promise<void>,
+  ) {}
+
+  /**
+   * Adds an inline error message to the list.
+   */
+  private addErrorMessage() {
+    const { store } = this.serviceManager;
+    const errorMessage =
+      store.getState().config.derived.languagePack.errors_singleMessage;
+    const { originalMessage, localMessage } =
+      createLocalMessageForInlineError(errorMessage);
+    store.dispatch(
+      actions.addLocalMessageItem(localMessage, originalMessage, true),
+    );
+  }
+
+  /**
+   * Process a message returned from the assistant send path with an error. Custom senders handle retries upstream;
+   * we mark this attempt as failed and advance the queue.
+   */
+  async processError(
+    pendingRequest: PendingMessageRequest,
+    resultText: string,
+  ) {
+    const { timeFirstRequest, timeLastRequest, isProcessed, requestOptions } =
+      pendingRequest;
+
+    // If this message was already invalidated, don't do anything.
+    if (isProcessed) {
+      return;
+    }
+
+    pendingRequest.trackData.lastRequestTime = Date.now() - timeLastRequest;
+    pendingRequest.trackData.totalRequestTime = Date.now() - timeFirstRequest;
+
+    if (requestOptions.silent) {
+      // If the message that was sent was silent, we have to throw an error manually since there isn't any user message to reference.
+      this.addErrorMessage();
+    }
+
+    this.serviceManager.actions.errorOccurred({
+      errorType: OnErrorType.MESSAGE_COMMUNICATION,
+      message: "An error occurred sending a message",
+      otherData: resultText,
+    });
+
+    this.rejectFinalErrorOnMessage(pendingRequest, resultText);
+  }
+
+  /**
+   * Marks a message as failed.
+   */
+  rejectFinalErrorOnMessage(
+    pendingRequest: PendingMessageRequest,
+    resultText = "An undefined error occurred trying to send your message.",
+  ) {
+    const { sendMessagePromise } = pendingRequest;
+
+    // At this point we've failed; mark the message accordingly.
+    this.setMessageErrorState(pendingRequest, MessageErrorState.FAILED);
+
+    // After updating the error state get the message from the pendingRequest since it has potentially been updated by
+    // setting the error state.
+    const { message } = pendingRequest;
+
+    // No need to call this if it's an event message or a welcome node request.
+    if (
+      pendingRequest === this.getCurrent() &&
+      message.input.message_type !== MessageInputType.EVENT
+    ) {
+      this.messageLoadingManager.end();
+    }
+
+    // Reject the promise that lets the original caller who sent the message know that the message failed to be sent.
+    sendMessagePromise.doReject(new Error(resultText));
+    pendingRequest.isProcessed = true;
+
+    if (pendingRequest === this.getCurrent()) {
+      // Move on to next item in queue.
+      this.moveToNextQueueItem();
+    }
+  }
+
+  /**
+   * Marks a cancelled message as completed without error.
+   */
+  resolveCancelledMessage(pendingRequest: PendingMessageRequest) {
+    const { sendMessagePromise } = pendingRequest;
+
+    this.setMessageErrorState(pendingRequest, MessageErrorState.NONE);
+
+    const { message } = pendingRequest;
+
+    if (
+      pendingRequest === this.getCurrent() &&
+      message.input.message_type !== MessageInputType.EVENT
+    ) {
+      this.messageLoadingManager.end();
+    }
+
+    sendMessagePromise.doResolve();
+    pendingRequest.isProcessed = true;
+
+    if (pendingRequest === this.getCurrent()) {
+      this.moveToNextQueueItem();
+    }
+  }
+
+  /**
+   * Sends the message using the provided customSendMessage and handles success/error flow.
+   */
+  async send(
+    current: PendingMessageRequest,
+    customSendMessage: CustomSendMessageFn,
+    startLoading: (() => void) | null,
+  ) {
+    current.timeLastRequest = Date.now();
+
+    if (current.isProcessed) {
+      return;
+    }
+
+    try {
+      // We may update the timezone and locale on this message so we need to clone it and then update the store with
+      // the new object.
+      const message = cloneDeep(current.message);
+      current.message = message;
+      this.serviceManager.store.dispatch(actions.updateMessage(message));
+      // AbortController was already created when message was added to queue
+      debugLog("Called customSendMessage", message);
+      const busEventSend: BusEventSend = {
+        type: BusEventType.SEND,
+        data: message,
+        source: current.source,
+      };
+      startLoading?.();
+
+      await Promise.resolve(
+        customSendMessage(
+          message,
+          {
+            signal: current.sendMessageController.signal,
+            silent: current.requestOptions.silent,
+            busEventSend: busEventSend,
+          },
+          this.serviceManager.instance,
+        ),
+      );
+      await this.processSuccess(current, null);
+    } catch (error) {
+      consoleError("An error occurred while sending a message", error);
+      const resultText =
+        (error &&
+          (typeof error === "string" ? error : JSON.stringify(error))) ||
+        "There was an unidentified error.";
+      this.processError(current, resultText);
+    } finally {
+      // Loading manager is ended via processSuccess/reject handlers.
+    }
+  }
+}
+
+export { OutboundMessageCoordinator };

--- a/packages/ai-chat/src/chat/services/ServiceManager.ts
+++ b/packages/ai-chat/src/chat/services/ServiceManager.ts
@@ -11,8 +11,6 @@ import { IntlShape } from "react-intl";
 import type { AppStore } from "../store/appStore";
 
 import { AppWindowFunctions } from "../components-legacy/AppWindowFunctions";
-import type { MainWindowFunctions } from "../AppShell";
-import { ChatActionsImpl } from "../events/ChatActionsImpl";
 import { EventBus } from "../events/EventBus";
 import { AppState } from "../../types/state/AppState";
 import { HumanAgentService } from "./haa/HumanAgentService";
@@ -27,6 +25,8 @@ import {
   WriteableElements,
 } from "../../types/instance/ChatInstance";
 import { BusEvent } from "../../types/events/eventBusTypes";
+import { MainWindowFunctions } from "../AppShell";
+import { ChatActionsImpl } from "./ChatActionsImpl";
 
 export interface UserDefinedElementRegistryItem {
   slotName: string;

--- a/packages/ai-chat/src/chat/services/loadServices.ts
+++ b/packages/ai-chat/src/chat/services/loadServices.ts
@@ -7,7 +7,7 @@
  *  @license
  */
 
-import { ChatActionsImpl } from "../events/ChatActionsImpl";
+import { ChatActionsImpl } from "./ChatActionsImpl";
 import { EventBus } from "../events/EventBus";
 import { HistoryService } from "./HistoryService";
 import { createCustomPanelManager } from "./CustomPanelManager";

--- a/packages/ai-chat/src/chat/utils/chatBoot.ts
+++ b/packages/ai-chat/src/chat/utils/chatBoot.ts
@@ -17,7 +17,6 @@ import { createServiceManager } from "../services/loadServices";
 import { ServiceManager } from "../services/ServiceManager";
 import { createChatInstance } from "../instance/ChatInstanceImpl";
 import { createAppConfig } from "../store/doCreateStore";
-import { loadLocale } from "./languages";
 import { setIntl } from "./intlUtils";
 import createHumanAgentService from "../services/haa/HumanAgentServiceImpl";
 
@@ -31,6 +30,7 @@ import {
 import { VIEW_STATE_ALL_CLOSED } from "../store/reducerUtils";
 import { PublicConfig } from "../../types/config/PublicConfig";
 import { ChatInstance } from "../../types/instance/ChatInstance";
+import { loadLocale } from "./languageUtils";
 
 /**
  * Default values applied to the provided `PublicConfig` before boot. This keeps

--- a/packages/ai-chat/src/chat/utils/languageUtils.ts
+++ b/packages/ai-chat/src/chat/utils/languageUtils.ts
@@ -9,7 +9,6 @@
 
 import dayjs from "dayjs";
 import enLocaleData from "dayjs/locale/en.js";
-import React from "react";
 import { consoleError } from "./miscUtils";
 import { normalizeModuleInterop } from "./moduleInterop";
 
@@ -255,29 +254,6 @@ async function loadLocale(requestedLocale: string): Promise<ILocale> {
 }
 
 /**
- * Handles a "b" tag.
- */
-function handleBTag(chunks: any) {
-  return <b>{chunks}</b>;
-}
-
-/**
- * Handles a "br" tag.
- */
-function handleBRTag() {
-  return <br />;
-}
-
-/**
- * Adds the functions for processing HTML to the given object for use with FormattedMessage.
- */
-function addHTMLSupport(values: Record<string, any>) {
-  values.b = handleBTag;
-  values.br = handleBRTag;
-  return values;
-}
-
-/**
  * Loads a dayjs locale if it hasn't been loaded already, but doesn't replace the current globally set locale.
  *
  * @param locale The dayjs locale to load.
@@ -308,4 +284,4 @@ async function loadDayjsLocale(locale: string): Promise<string> {
   return locale;
 }
 
-export { loadLocale, addHTMLSupport, loadDayjsLocale, localeLoaders };
+export { loadLocale, loadDayjsLocale, localeLoaders };

--- a/packages/ai-chat/src/chat/utils/streamingUtils.ts
+++ b/packages/ai-chat/src/chat/utils/streamingUtils.ts
@@ -1,0 +1,183 @@
+/*
+ *  Copyright IBM Corp. 2025
+ *
+ *  This source code is licensed under the Apache-2.0 license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ *  @license
+ */
+
+import actions from "../store/actions";
+import {
+  CompleteItemChunk,
+  FinalResponseChunk,
+  GenericItem,
+  PartialItemChunk,
+  PartialOrCompleteItemChunk,
+  StreamChunk,
+} from "../../types/messaging/Messages";
+import { DeepPartial } from "../../types/utilities/DeepPartial";
+import {
+  isStreamCompleteItem,
+  isStreamFinalResponse,
+  isStreamPartialItem,
+} from "./messageUtils";
+
+type StoreLike = {
+  dispatch: (action: any) => void;
+  getState: () => any;
+};
+
+export interface ChunkContext {
+  messageID?: string;
+  item?: DeepPartial<GenericItem>;
+  isCompleteItem: boolean;
+  isPartialItem: boolean;
+  isFinalResponse: boolean;
+}
+
+interface StreamingResponseMeta {
+  requestId?: string;
+  itemIds: Set<string>;
+  controller?: AbortController;
+}
+
+/**
+ * Tracks streaming response/item IDs and related metadata.
+ */
+class StreamingTracker {
+  private responseToMeta = new Map<string, StreamingResponseMeta>();
+  private itemToResponse = new Map<string, string>();
+
+  resolveResponseId(id: string) {
+    return this.itemToResponse.get(id) ?? id;
+  }
+
+  track(
+    responseId: string,
+    requestId?: string,
+    controller?: AbortController,
+    itemId?: string,
+  ) {
+    const existing = this.responseToMeta.get(responseId);
+    if (existing) {
+      if (requestId && !existing.requestId) {
+        existing.requestId = requestId;
+      }
+      if (controller && !existing.controller) {
+        existing.controller = controller;
+      }
+      if (itemId) {
+        existing.itemIds.add(itemId);
+        this.itemToResponse.set(itemId, responseId);
+      }
+      return existing;
+    }
+
+    const entry: StreamingResponseMeta = {
+      requestId,
+      controller,
+      itemIds: new Set<string>(),
+    };
+
+    if (itemId) {
+      entry.itemIds.add(itemId);
+      this.itemToResponse.set(itemId, responseId);
+    }
+
+    this.responseToMeta.set(responseId, entry);
+    return entry;
+  }
+
+  getMeta(responseId: string) {
+    return this.responseToMeta.get(responseId);
+  }
+
+  clear(responseId: string) {
+    const entry = this.responseToMeta.get(responseId);
+    if (entry) {
+      entry.itemIds.forEach((itemId) => this.itemToResponse.delete(itemId));
+      this.responseToMeta.delete(responseId);
+    }
+    return entry;
+  }
+}
+
+/**
+ * Resolve chunk metadata and the associated message/item IDs.
+ */
+function resolveChunkContext(
+  chunk: StreamChunk,
+  providedMessageID?: string,
+): ChunkContext {
+  const isPartialItem = isStreamPartialItem(chunk);
+  const isCompleteItem = isStreamCompleteItem(chunk);
+  const isFinalResponse = isStreamFinalResponse(chunk);
+
+  let messageID = providedMessageID;
+  if (!messageID) {
+    if ("streaming_metadata" in chunk && chunk.streaming_metadata) {
+      messageID = chunk.streaming_metadata.response_id;
+    } else if (isFinalResponse && chunk.final_response?.id) {
+      messageID = chunk.final_response.id;
+    }
+  }
+
+  let item: DeepPartial<GenericItem>;
+  if (isPartialItem || isCompleteItem) {
+    item =
+      (chunk as PartialItemChunk).partial_item ||
+      (chunk as CompleteItemChunk).complete_item;
+  }
+
+  return { messageID, item, isPartialItem, isCompleteItem, isFinalResponse };
+}
+
+/**
+ * Returns true if the stop streaming button should be shown for this chunk.
+ */
+function shouldShowStopStreaming(
+  streamingData: { cancellable?: boolean } | undefined,
+  isStopGeneratingVisible: boolean,
+) {
+  return Boolean(streamingData?.cancellable && !isStopGeneratingVisible);
+}
+
+/**
+ * Hides and re-enables the stop streaming button if currently visible.
+ */
+function resetStopStreamingButton(store: StoreLike) {
+  const stopStreamingState =
+    store.getState().assistantInputState.stopStreamingButtonState;
+  if (stopStreamingState.isVisible) {
+    store.dispatch(actions.setStopStreamingButtonDisabled(false));
+    store.dispatch(actions.setStopStreamingButtonVisible(false));
+  }
+}
+
+/**
+ * Merge message options only, ignoring unexpected partial_response fields.
+ */
+function mergePartialResponseOptions(
+  store: StoreLike,
+  messageID: string | undefined,
+  chunk: PartialOrCompleteItemChunk,
+) {
+  if (chunk.partial_response?.message_options && messageID) {
+    store.dispatch(
+      actions.streamingMergeMessageOptions(
+        messageID,
+        chunk.partial_response.message_options,
+      ),
+    );
+  }
+}
+
+export {
+  FinalResponseChunk,
+  StreamingTracker,
+  mergePartialResponseOptions,
+  resetStopStreamingButton,
+  resolveChunkContext,
+  shouldShowStopStreaming,
+};

--- a/packages/ai-chat/src/testing/helpers.ts
+++ b/packages/ai-chat/src/testing/helpers.ts
@@ -17,7 +17,7 @@
 // Reuse the component-level preload helper so CodeMirror/DataTable deps stay in sync.
 import { loadAllLazyDeps as loadComponentLazyDeps } from "@carbon/ai-chat-components/es/testing/load-all-lazy-deps.js";
 import { normalizeModuleInterop } from "../chat/utils/moduleInterop.js";
-import { localeLoaders } from "../chat/utils/languages.js";
+import { localeLoaders } from "../chat/utils/languageUtils.js";
 
 async function preloadSwiper() {
   await Promise.all([import("swiper/react"), import("swiper/modules")]);

--- a/packages/ai-chat/src/types/events/eventBusTypes.ts
+++ b/packages/ai-chat/src/types/events/eventBusTypes.ts
@@ -252,12 +252,6 @@ export enum MessageSendSource {
   OPTION_DROP_DOWN = "optionDropDown",
 
   /**
-   * The message was sent as an automatic re-send when Carbon AI Chat is loaded. This occurs when Carbon AI Chat sees that the
-   * last message request did not receive a response.
-   */
-  HYDRATE_RESEND = "hydrateResend",
-
-  /**
    * The message was sent as an event history update.
    */
   HISTORY_UPDATE = "historyUpdate",

--- a/packages/ai-chat/tests/instance/spec/changeView_spec.ts
+++ b/packages/ai-chat/tests/instance/spec/changeView_spec.ts
@@ -121,6 +121,19 @@ describe("ChatInstance.changeView", () => {
     );
   });
 
+  it("triggers hydration when mainWindow is opened and chat is not hydrated", async () => {
+    const config = createBaseConfig();
+    const { instance, serviceManager } =
+      await renderChatAndGetInstanceWithStore(config);
+    const hydrateSpy = jest
+      .spyOn(serviceManager.actions, "hydrateChat")
+      .mockResolvedValue(undefined);
+
+    await instance.changeView(ViewType.MAIN_WINDOW);
+
+    expect(hydrateSpy).toHaveBeenCalled();
+  });
+
   describe("comprehensive ViewType tests", () => {
     it("should handle switching between all ViewType values", async () => {
       const config = createBaseConfig();

--- a/packages/ai-chat/tests/services/spec/MessageService_spec.ts
+++ b/packages/ai-chat/tests/services/spec/MessageService_spec.ts
@@ -1,0 +1,285 @@
+/*
+ *  Copyright IBM Corp. 2025
+ *
+ *  This source code is licensed under the Apache-2.0 license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ *  @license
+ */
+
+import MessageService, {
+  PendingMessageRequest,
+} from "../../../src/chat/services/MessageService";
+import { ServiceManager } from "../../../src/chat/services/ServiceManager";
+import {
+  MessageRequest,
+  MessageInputType,
+} from "../../../src/types/messaging/Messages";
+import { MessageSendSource } from "../../../src/types/events/eventBusTypes";
+import { resolvablePromise } from "../../../src/chat/utils/resolvablePromise";
+import { OnErrorType } from "../../../src/types/config/PublicConfig";
+import { CancellationReason } from "../../../src/types/config/MessagingConfig";
+
+const createMessage = (id: string): MessageRequest<any> => ({
+  id,
+  input: {
+    message_type: MessageInputType.TEXT,
+    text: "hello",
+  },
+  history: {
+    timestamp: Date.now(),
+    silent: false,
+  },
+});
+
+const createServiceManagerStub = (customSendMessage = jest.fn()) => {
+  const store = {
+    dispatch: jest.fn(),
+    getState: () => ({
+      config: {
+        public: {
+          messaging: {
+            customSendMessage,
+            messageTimeoutSecs: 0,
+            messageLoadingIndicatorTimeoutSecs: 0,
+          },
+        },
+        derived: {
+          languagePack: {
+            errors_singleMessage: "error",
+          },
+        },
+      },
+      assistantMessageState: { messageIDs: [] as string[] },
+      allMessagesByID: {},
+      targetViewState: {},
+      persistedToBrowserStorage: {
+        launcherState: { wasLoadedFromBrowser: false },
+      },
+    }),
+  };
+
+  const actions = {
+    receive: jest.fn().mockResolvedValue(undefined),
+    errorOccurred: jest.fn(),
+  };
+
+  const eventBus = {
+    fire: jest.fn().mockResolvedValue(undefined),
+  };
+
+  const serviceManager = {
+    store,
+    actions,
+    eventBus,
+    instance: {},
+  } as unknown as ServiceManager;
+
+  return serviceManager;
+};
+
+describe("MessageService", () => {
+  it("sends a message and advances the queue", async () => {
+    const customSendMessage = jest.fn().mockResolvedValue(undefined);
+    const serviceManager = createServiceManagerStub(customSendMessage);
+
+    const messageService = new MessageService(serviceManager, {
+      messaging: {
+        customSendMessage,
+        messageTimeoutSecs: 0,
+        messageLoadingIndicatorTimeoutSecs: 0,
+      },
+    } as any);
+
+    const message = createMessage("m-1");
+    await messageService.send(
+      message,
+      MessageSendSource.MESSAGE_INPUT,
+      "local-1",
+      { silent: false },
+    );
+
+    expect(customSendMessage).toHaveBeenCalledTimes(1);
+    const [, options] = customSendMessage.mock.calls[0];
+    expect(options.signal).toBeInstanceOf(AbortSignal);
+    expect((messageService as any).queue.current).toBeNull();
+  });
+
+  it("cancels a streaming message by response id and advances the queue", async () => {
+    const serviceManager = createServiceManagerStub(jest.fn());
+    const messageService = new MessageService(serviceManager, {
+      messaging: {
+        customSendMessage: jest.fn().mockResolvedValue(undefined),
+        messageTimeoutSecs: 0,
+        messageLoadingIndicatorTimeoutSecs: 0,
+      },
+    } as any);
+
+    const sendMessagePromise = resolvablePromise<void>();
+    const abortController = new AbortController();
+    const pendingRequest: PendingMessageRequest = {
+      localMessageID: "local-1",
+      message: createMessage("m-2"),
+      sendMessagePromise,
+      requestOptions: {},
+      timeFirstRequest: 0,
+      timeLastRequest: 0,
+      trackData: {
+        numErrors: 0,
+        lastRequestTime: 0,
+        totalRequestTime: 0,
+      },
+      isProcessed: false,
+      source: MessageSendSource.MESSAGE_INPUT,
+      sendMessageController: abortController,
+    };
+
+    (messageService as any).queue.current = pendingRequest;
+    messageService.markCurrentMessageAsStreaming("resp-1", "item-1");
+
+    await messageService.cancelCurrentMessageRequest();
+
+    expect(abortController.signal.aborted).toBe(true);
+    expect((messageService as any).queue.current).toBeNull();
+  });
+
+  it("cancels a waiting message using its abort controller", async () => {
+    const serviceManager = createServiceManagerStub(jest.fn());
+    const messageService = new MessageService(serviceManager, {
+      messaging: {
+        customSendMessage: jest.fn().mockResolvedValue(undefined),
+        messageTimeoutSecs: 0,
+        messageLoadingIndicatorTimeoutSecs: 0,
+      },
+    } as any);
+
+    // Keep the queue busy so the next send stays in the waiting list.
+    (messageService as any).queue.current = {
+      localMessageID: "local-current",
+      message: createMessage("m-current"),
+      sendMessagePromise: resolvablePromise<void>(),
+      requestOptions: {},
+      timeFirstRequest: 0,
+      timeLastRequest: 0,
+      trackData: {
+        numErrors: 0,
+        lastRequestTime: 0,
+        totalRequestTime: 0,
+      },
+      isProcessed: false,
+      source: MessageSendSource.MESSAGE_INPUT,
+      sendMessageController: new AbortController(),
+    };
+
+    const sendPromise = messageService.send(
+      createMessage("m-waiting"),
+      MessageSendSource.MESSAGE_INPUT,
+      "local-waiting",
+      { silent: false },
+    );
+
+    const controller = (messageService as any).messageAbortControllers.get(
+      "m-waiting",
+    );
+    expect(controller).toBeInstanceOf(AbortController);
+
+    await messageService.cancelMessageRequestByID(
+      "m-waiting",
+      false,
+      CancellationReason.CONVERSATION_RESTARTED,
+    );
+
+    await expect(sendPromise).resolves.toBeUndefined();
+    expect(controller.signal.aborted).toBe(true);
+    expect((messageService as any).queue.waiting).toHaveLength(0);
+  });
+
+  it("rejects a send when it exceeds the configured timeout", async () => {
+    const customSendMessage = jest.fn(() => new Promise<void>(() => undefined));
+    const serviceManager = createServiceManagerStub(customSendMessage);
+
+    const messageService = new MessageService(serviceManager, {
+      messaging: {
+        customSendMessage,
+        messageTimeoutSecs: 1,
+        messageLoadingIndicatorTimeoutSecs: 0,
+      },
+    } as any);
+
+    const startSpy = jest
+      .spyOn(messageService.messageLoadingManager, "start")
+      .mockImplementation((_, __, onTimeout) => {
+        onTimeout();
+      });
+
+    try {
+      const sendPromise = messageService.send(
+        createMessage("m-timeout"),
+        MessageSendSource.MESSAGE_INPUT,
+        "local-timeout",
+        { silent: false },
+      );
+
+      await expect(sendPromise).rejects.toThrow(CancellationReason.TIMEOUT);
+      expect(customSendMessage).toHaveBeenCalledTimes(1);
+      expect(serviceManager.actions.errorOccurred).toHaveBeenCalledWith({
+        errorType: OnErrorType.MESSAGE_COMMUNICATION,
+        message: CancellationReason.TIMEOUT,
+        otherData: undefined,
+      });
+    } finally {
+      startSpy.mockRestore();
+    }
+  });
+
+  it("cancels streaming by item id even when response_id differs", async () => {
+    const serviceManager = createServiceManagerStub(jest.fn());
+    const messageService = new MessageService(serviceManager, {
+      messaging: {
+        customSendMessage: jest.fn().mockResolvedValue(undefined),
+        messageTimeoutSecs: 0,
+        messageLoadingIndicatorTimeoutSecs: 0,
+      },
+    } as any);
+
+    const sendMessagePromise = resolvablePromise<void>();
+    const abortController = new AbortController();
+    const pendingRequest: PendingMessageRequest = {
+      localMessageID: "local-streaming",
+      message: createMessage("m-streaming"),
+      sendMessagePromise,
+      requestOptions: {},
+      timeFirstRequest: 0,
+      timeLastRequest: 0,
+      trackData: {
+        numErrors: 0,
+        lastRequestTime: 0,
+        totalRequestTime: 0,
+      },
+      isProcessed: false,
+      source: MessageSendSource.MESSAGE_INPUT,
+      sendMessageController: abortController,
+    };
+
+    (messageService as any).queue.current = pendingRequest;
+    (messageService as any).messageAbortControllers.set(
+      "m-streaming",
+      abortController,
+    );
+
+    messageService.markCurrentMessageAsStreaming("resp-1", "item-1");
+
+    await messageService.cancelMessageRequestByID(
+      "item-1",
+      false,
+      CancellationReason.STOP_STREAMING,
+    );
+
+    await expect(sendMessagePromise).resolves.toBeUndefined();
+    expect(abortController.signal.aborted).toBe(true);
+    expect((messageService as any).inboundStreaming.streamingMessageID).toBe(
+      null,
+    );
+    expect((messageService as any).queue.current).toBeNull();
+  });
+});

--- a/packages/ai-chat/tests/utils/spec/languageUtils_spec.ts
+++ b/packages/ai-chat/tests/utils/spec/languageUtils_spec.ts
@@ -1,0 +1,37 @@
+/*
+ *  Copyright IBM Corp. 2025
+ *
+ *  This source code is licensed under the Apache-2.0 license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ *  @license
+ */
+
+import dayjs from "dayjs";
+import {
+  localeLoaders,
+  loadDayjsLocale,
+} from "../../../src/chat/utils/languageUtils";
+
+describe("languageUtils", () => {
+  it("exposes locale loaders", () => {
+    expect(typeof localeLoaders.en).toBe("function");
+    expect(typeof localeLoaders.fr).toBe("function");
+  });
+
+  it("loads a locale when requested", async () => {
+    await loadDayjsLocale("fr");
+    expect(dayjs.Ls.fr).toBeDefined();
+  });
+
+  it("falls back to language when region is unsupported", async () => {
+    const locale = await loadDayjsLocale("en-zz");
+    expect(locale).toBe("en");
+  });
+
+  it("throws for unknown locale code", async () => {
+    await expect(loadDayjsLocale("zz")).rejects.toThrow(
+      "Locale is not recognized.",
+    );
+  });
+});

--- a/packages/ai-chat/tests/utils/spec/messageServiceUtils_spec.ts
+++ b/packages/ai-chat/tests/utils/spec/messageServiceUtils_spec.ts
@@ -1,0 +1,46 @@
+/*
+ *  Copyright IBM Corp. 2025
+ *
+ *  This source code is licensed under the Apache-2.0 license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ *  @license
+ */
+
+import { MessageLoadingManager } from "../../../src/chat/utils/messageServiceUtils";
+
+describe("MessageLoadingManager", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("triggers silent loading and end callbacks", () => {
+    const manager = new MessageLoadingManager();
+    const onExceeded = jest.fn();
+    const onEnd = jest.fn();
+    const onTimeout = jest.fn();
+
+    manager.start(onExceeded, onEnd, onTimeout, 100, 0);
+    jest.advanceTimersByTime(150);
+
+    manager.end();
+
+    expect(onExceeded).toHaveBeenCalledTimes(1);
+    expect(onEnd).toHaveBeenCalledWith(true);
+    expect(onTimeout).not.toHaveBeenCalled();
+  });
+
+  it("triggers timeout callback", () => {
+    const manager = new MessageLoadingManager();
+    const onTimeout = jest.fn();
+
+    manager.start(jest.fn(), jest.fn(), onTimeout, 0, 200);
+
+    jest.advanceTimersByTime(250);
+    expect(onTimeout).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/ai-chat/tests/utils/spec/messageUtils_spec.ts
+++ b/packages/ai-chat/tests/utils/spec/messageUtils_spec.ts
@@ -1,0 +1,215 @@
+/*
+ *  Copyright IBM Corp. 2025
+ *
+ *  This source code is licensed under the Apache-2.0 license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ *  @license
+ */
+
+import cloneDeep from "lodash-es/cloneDeep.js";
+import {
+  THREAD_ID_MAIN,
+  addDefaultsToMessage,
+  createMessageRequestForButtonItemOption,
+  createMessageRequestForChoice,
+  createMessageRequestForFileUpload,
+  createMessageRequestForText,
+  createMessageResponseForItem,
+  createMessageResponseForText,
+  getOptionType,
+  hasServiceDesk,
+  isTyping,
+  isButtonResponseType,
+  isCardResponseType,
+  isCarouselResponseType,
+  isConnectToHumanAgent,
+  isEventRequest,
+  isGridResponseType,
+  isItemSupportedInResponseBody,
+  isLiveHumanAgentMessage,
+  isOptionItem,
+  isPause,
+  isRequest,
+  isResponse,
+  isResponseWithNestedItems,
+  isShowPanelButtonType,
+  isStreamCompleteItem,
+  isStreamFinalResponse,
+  isStreamPartialItem,
+  isTextItem,
+  renderAsUserDefinedMessage,
+  streamItemID,
+} from "../../../src/chat/utils/messageUtils";
+import {
+  ButtonItemType,
+  MessageInputType,
+  MessageResponseTypes,
+} from "../../../src/types/messaging/Messages";
+import { FileStatusValue } from "../../../src/chat/utils/constants";
+
+describe("messageUtils", () => {
+  it("addDefaultsToMessage applies ids, thread, timestamps, and flags", () => {
+    const msg = addDefaultsToMessage({} as any);
+    expect(msg.id).toBeDefined();
+    expect(msg.thread_id).toBe(THREAD_ID_MAIN);
+    expect(msg.history.timestamp).toBeDefined();
+    expect(msg.ui_state_internal.from_history).toBe(false);
+  });
+
+  it("isResponse and isRequest type guards", () => {
+    const response = { output: {} } as any;
+    const request = { input: {} } as any;
+    expect(isResponse(response)).toBe(true);
+    expect(isRequest(response)).toBe(false);
+    expect(isRequest(request)).toBe(true);
+    expect(isResponse(request)).toBe(false);
+  });
+
+  it("detects event requests", () => {
+    const event = {
+      input: { message_type: MessageInputType.EVENT },
+    } as any;
+    expect(isEventRequest(event)).toBe(true);
+  });
+
+  it("detects live human agent messages", () => {
+    const message = {
+      item: { agent_message_type: "agent" },
+    } as any;
+    expect(isLiveHumanAgentMessage(message)).toBe(true);
+    const resp = {
+      output: { generic: [{ agent_message_type: "x" }] },
+    } as any;
+    expect(
+      isResponse(resp) &&
+        resp.output.generic.some((item: any) => item.agent_message_type),
+    ).toBe(true);
+  });
+
+  it("creates message requests for choice and button items", () => {
+    const choiceReq = createMessageRequestForChoice(
+      { label: "L", value: { input: { text: "t" } } } as any,
+      "resp-1",
+    );
+    expect(choiceReq.history.related_message_id).toBe("resp-1");
+    const buttonReq = createMessageRequestForButtonItemOption(
+      { label: "lbl" } as any,
+      "resp-2",
+    );
+    expect(buttonReq.input.text).toBe("lbl");
+    expect(buttonReq.history.related_message_id).toBe("resp-2");
+  });
+
+  it("creates message requests for text/file", () => {
+    const textReq = createMessageRequestForText("hello");
+    expect(textReq.input.text).toBe("hello");
+    const fileReq = createMessageRequestForFileUpload({
+      id: "file-1",
+      file: { name: "f" },
+    } as any);
+    expect(fileReq.history.file_upload_status).toBe(FileStatusValue.UPLOADING);
+  });
+
+  it("creates message responses", () => {
+    const resp = createMessageResponseForText("hi", "thread-1");
+    expect(resp.thread_id).toBe("thread-1");
+    expect((resp.output.generic[0] as any).text).toBe("hi");
+
+    const itemResp = createMessageResponseForItem({
+      response_type: "text",
+    } as any);
+    expect(itemResp.id).toBeDefined();
+    expect(itemResp.thread_id).toBe(THREAD_ID_MAIN);
+  });
+
+  it("response/item type guards", () => {
+    const button = {
+      response_type: MessageResponseTypes.BUTTON,
+      button_type: ButtonItemType.SHOW_PANEL,
+    } as any;
+    expect(isButtonResponseType(button)).toBe(true);
+    expect(isShowPanelButtonType(button)).toBe(true);
+    expect(
+      isOptionItem({
+        response_type: MessageResponseTypes.OPTION,
+        options: [],
+      } as any),
+    ).toBe(true);
+    expect(
+      isCardResponseType({ response_type: MessageResponseTypes.CARD } as any),
+    ).toBe(true);
+    expect(
+      isCarouselResponseType({
+        response_type: MessageResponseTypes.CAROUSEL,
+      } as any),
+    ).toBe(true);
+    expect(
+      isGridResponseType({ response_type: MessageResponseTypes.GRID } as any),
+    ).toBe(true);
+    expect(
+      isItemSupportedInResponseBody({
+        response_type: MessageResponseTypes.AUDIO,
+      } as any),
+    ).toBe(true);
+  });
+
+  it("nested/streaming helpers", () => {
+    expect(
+      isResponseWithNestedItems({
+        response_type: MessageResponseTypes.GRID,
+      } as any),
+    ).toBe(true);
+    expect(renderAsUserDefinedMessage({ response_type: "custom" } as any)).toBe(
+      true,
+    );
+    expect(isStreamPartialItem({ partial_item: {} } as any)).toBe(true);
+    expect(isStreamCompleteItem({ complete_item: {} } as any)).toBe(true);
+    expect(isStreamFinalResponse({ final_response: {} } as any)).toBe(true);
+    expect(
+      streamItemID("msg-1", { streaming_metadata: { id: "chunk-1" } }),
+    ).toBe("msg-1-chunk-1");
+  });
+
+  it("getOptionType returns dropdown when many options", () => {
+    expect(getOptionType(undefined as any, 5)).toBe("dropdown");
+    expect(getOptionType("button" as any, 2)).toBe("button");
+  });
+
+  it("hasServiceDesk checks config", () => {
+    expect(
+      hasServiceDesk({
+        public: { serviceDeskFactory: () => null as any },
+      } as any),
+    ).toBe(true);
+    expect(hasServiceDesk({ public: {} } as any)).toBe(false);
+  });
+
+  it("isConnectToHumanAgent detects agent connect type", () => {
+    expect(
+      isConnectToHumanAgent({
+        response_type: MessageResponseTypes.CONNECT_TO_HUMAN_AGENT,
+      } as any),
+    ).toBe(true);
+  });
+
+  it("isTextItem, isTyping, isPause guards", () => {
+    expect(isTextItem({ response_type: "text", text: "hi" } as any)).toBe(true);
+    expect(
+      isTyping({
+        response_type: MessageResponseTypes.PAUSE,
+        typing: true,
+      } as any),
+    ).toBe(true);
+    expect(isPause({ response_type: MessageResponseTypes.PAUSE } as any)).toBe(
+      true,
+    );
+  });
+
+  it("clone safety for choice request", () => {
+    const option = { label: "L", value: { input: { text: "x" } } };
+    const cloned = createMessageRequestForChoice(option as any);
+    expect(cloned).not.toBe(option.value);
+    expect(cloneDeep(option.value)).toEqual(option.value);
+  });
+});

--- a/packages/ai-chat/tests/utils/spec/streamingUtils_spec.ts
+++ b/packages/ai-chat/tests/utils/spec/streamingUtils_spec.ts
@@ -1,0 +1,113 @@
+/*
+ *  Copyright IBM Corp. 2025
+ *
+ *  This source code is licensed under the Apache-2.0 license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ *  @license
+ */
+
+import {
+  mergePartialResponseOptions,
+  resetStopStreamingButton,
+  resolveChunkContext,
+  shouldShowStopStreaming,
+  StreamingTracker,
+} from "../../../src/chat/utils/streamingUtils";
+
+describe("streamingUtils", () => {
+  const createStore = (isVisible = true) => {
+    const dispatch = jest.fn();
+    return {
+      dispatch,
+      getState: () => ({
+        assistantInputState: {
+          stopStreamingButtonState: { isVisible },
+        },
+      }),
+    };
+  };
+
+  describe("resolveChunkContext", () => {
+    it("extracts metadata for partial chunks", () => {
+      const partialChunk = {
+        partial_item: {
+          text: "chunk",
+          streaming_metadata: {
+            id: "item-1",
+            response_id: "resp-1",
+          },
+        },
+      } as any;
+
+      const context = resolveChunkContext(partialChunk, "resp-1");
+
+      expect(context.messageID).toBe("resp-1");
+      expect(context.isPartialItem).toBe(true);
+      expect(context.item).toEqual(partialChunk.partial_item);
+    });
+
+    it("extracts metadata for final response chunks", () => {
+      const finalChunk = {
+        final_response: { id: "resp-final" },
+      } as any;
+
+      const context = resolveChunkContext(finalChunk);
+
+      expect(context.isFinalResponse).toBe(true);
+      expect(context.messageID).toBe("resp-final");
+    });
+  });
+
+  describe("stop streaming helpers", () => {
+    it("should show stop streaming when cancellable and not visible", () => {
+      expect(shouldShowStopStreaming({ cancellable: true }, false)).toBe(true);
+      expect(shouldShowStopStreaming({ cancellable: true }, true)).toBe(false);
+      expect(shouldShowStopStreaming(undefined, false)).toBe(false);
+    });
+
+    it("resets stop streaming button when visible", () => {
+      const store = createStore(true);
+      resetStopStreamingButton(store as any);
+      expect(store.dispatch).toHaveBeenCalledTimes(2);
+    });
+
+    it("does nothing when button not visible", () => {
+      const store = createStore(false);
+      resetStopStreamingButton(store as any);
+      expect(store.dispatch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("mergePartialResponseOptions", () => {
+    it("dispatches merge when message options exist", () => {
+      const store = createStore();
+      const chunk = {
+        partial_response: {
+          message_options: { foo: "bar" },
+        },
+      } as any;
+      mergePartialResponseOptions(store as any, "msg-1", chunk);
+      expect(store.dispatch).toHaveBeenCalledTimes(1);
+    });
+
+    it("skips dispatch when no options or message id", () => {
+      const store = createStore();
+      mergePartialResponseOptions(store as any, undefined, {} as any);
+      expect(store.dispatch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("StreamingTracker", () => {
+    it("tracks, resolves, and clears response/item IDs", () => {
+      const tracker = new StreamingTracker();
+      tracker.track("resp-1", "req-1", new AbortController(), "item-1");
+      expect(tracker.resolveResponseId("item-1")).toBe("resp-1");
+      expect(tracker.getMeta("resp-1")?.requestId).toBe("req-1");
+
+      tracker.clear("resp-1");
+      expect(tracker.getMeta("resp-1")).toBeUndefined();
+      expect(tracker.resolveResponseId("item-1")).toBe("item-1");
+    });
+  });
+});

--- a/packages/ai-chat/tests/utils/spec/viewStateUtils_spec.ts
+++ b/packages/ai-chat/tests/utils/spec/viewStateUtils_spec.ts
@@ -1,0 +1,34 @@
+/*
+ *  Copyright IBM Corp. 2025
+ *
+ *  This source code is licensed under the Apache-2.0 license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ *  @license
+ */
+
+import { constructViewState } from "../../../src/chat/utils/viewStateUtils";
+import { VIEW_STATE_ALL_CLOSED } from "../../../src/chat/store/reducerUtils";
+import { ViewType } from "../../../src/types/state/AppState";
+
+describe("viewStateUtils", () => {
+  const baseState = {
+    persistedToBrowserStorage: {
+      viewState: {
+        launcher: false,
+        mainWindow: true,
+      },
+    },
+  } as any;
+
+  it("builds view state from string view type", () => {
+    const result = constructViewState(ViewType.MAIN_WINDOW, baseState);
+    expect(result).toEqual({ ...VIEW_STATE_ALL_CLOSED, mainWindow: true });
+  });
+
+  it("merges partial view state", () => {
+    const result = constructViewState({ launcher: true }, baseState);
+    expect(result.launcher).toBe(true);
+    expect(result.mainWindow).toBe(true);
+  });
+});


### PR DESCRIPTION
This PR splits up message service into three different services with defined responsibilities.

An inbound service, and outbound service and then message service just coordinates. 

Also, added a bunch of tests!