### PR TITLE
fix: audio/video width was more than 100%

### DIFF
--- a/packages/ai-chat/src/chat/components-legacy/MessageComponent.scss
+++ b/packages/ai-chat/src/chat/components-legacy/MessageComponent.scss
@@ -199,7 +199,9 @@ $one-line-message-height: 88px;
 
 .cds-aichat--assistant-message {
   position: relative;
-  inline-size: 100%;
+  display: flex;
+  flex-direction: row;
+  max-inline-size: 100%;
 }
 
 .cds-aichat--received--inline-error,


### PR DESCRIPTION
This is reverting a change from reasoning steps.

#### Testing / Reviewing

Make sure that audio/video response don't have width greater than chat container. Make sure reasoning steps don't get any regression with reverting this change that was originally meant to help render reasoning steps, but actually isn't needed.
