### PR TITLE
fix: modal only should show if there is content

### DIFF
--- a/packages/ai-chat/src/chat/components-legacy/App.scss
+++ b/packages/ai-chat/src/chat/components-legacy/App.scss
@@ -57,6 +57,7 @@
 .cds-aichat--modal-host {
   position: fixed;
   z-index: calc(#{chat-theme.$z-index} + 1);
+  display: none;
   block-size: 100vh;
   inline-size: 100vw;
   inset-block-start: 0;
@@ -67,6 +68,7 @@
 
 /* When there are modal children, enable pointer events on them and block interaction with background */
 .cds-aichat--modal-host:has(> *) {
+  display: block;
   pointer-events: auto;
 }
 

--- a/packages/ai-chat/src/chat/components-legacy/ModalPortal.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/ModalPortal.tsx
@@ -64,7 +64,7 @@ class ModalPortal extends Component<ModalPortalProps, ModalPortalState> {
   componentWillUnmount() {
     if (this.state.attachedToHost) {
       this.state.attachedToHost.removeChild(this.modalElement);
-      // this.attachedToHost = null;
+      this.setState({ attachedToHost: null });
     }
   }
 

--- a/packages/ai-chat/src/chat/components-legacy/modals/ConfirmModal.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/modals/ConfirmModal.tsx
@@ -140,7 +140,7 @@ class ConfirmModal extends Component<
           focusTrapOptions={{
             initialFocus: false,
             tabbableOptions: {
-              getShadowRoot: true, // Crucial for web components
+              getShadowRoot: true,
             },
           }}
         >


### PR DESCRIPTION
prevents empty 100vh x 100vw empty div from covering screen

Closes #754 

Since GA(!) we have been leaving cds-aichat--modal-host as 100vh x 100vw even if there is no inner content.

#### Changelog

**Changed**

- Made sure we don't display modal div unless it has inner content

#### Testing / Reviewing

- Make sure that when you select `cds-aichat--modal-host` in the DOM that it is not visible.
- Connect to human agent
- Click "Disconnect" from top toolbar after connected.
- See that `cds-aichat--modal-host` gets a size and the modal shows
- Close the modal and see we propertly revert
