### PR TITLE
fix: 'reason': undefined from onViewChange

### DIFF
--- a/packages/ai-chat/src/chat/components-legacy/launcher/LauncherContainer.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/launcher/LauncherContainer.tsx
@@ -19,7 +19,10 @@ import { TIME_TO_ENTRANCE_ANIMATION_START } from "../../../types/config/Launcher
 import { AppState, ViewType } from "../../../types/state/AppState";
 import { Launcher } from "./Launcher";
 import type { LauncherHandle } from "./Launcher";
-import { MainWindowOpenReason } from "../../../types/events/eventBusTypes";
+import {
+  MainWindowOpenReason,
+  ViewChangeReason,
+} from "../../../types/events/eventBusTypes";
 import { PageObjectId } from "../../../testing/PageObjectId";
 
 function LauncherContainer() {
@@ -119,6 +122,7 @@ function LauncherContainer() {
   const onDoToggle = useCallback(() => {
     // Otherwise try to open the main window on launcher click.
     return serviceManager.actions.changeView(ViewType.MAIN_WINDOW, {
+      viewChangeReason: ViewChangeReason.LAUNCHER_CLICKED,
       mainWindowOpenReason: MainWindowOpenReason.DEFAULT_LAUNCHER,
     });
   }, [serviceManager.actions]);

--- a/packages/ai-chat/src/chat/components-legacy/main/MainWindow.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/main/MainWindow.tsx
@@ -60,6 +60,7 @@ import {
   BusEventType,
   MainWindowCloseReason,
   MessageSendSource,
+  ViewChangeReason,
 } from "../../../types/events/eventBusTypes";
 import { SendOptions } from "../../../types/instance/ChatInstance";
 import { ButtonItem, SingleOption } from "../../../types/messaging/Messages";
@@ -427,6 +428,7 @@ class MainWindow
 
     // Fire the view:change and window:close events. If the view change is canceled then the main window will stay open.
     await serviceManager.actions.changeView(ViewType.LAUNCHER, {
+      viewChangeReason: ViewChangeReason.MAIN_WINDOW_MINIMIZED,
       mainWindowCloseReason: MainWindowCloseReason.DEFAULT_MINIMIZE,
     });
   }

--- a/packages/ai-chat/src/chat/events/ChatActionsImpl.ts
+++ b/packages/ai-chat/src/chat/events/ChatActionsImpl.ts
@@ -1181,7 +1181,7 @@ class ChatActionsImpl {
   async changeView(
     newView: ViewType | Partial<ViewState>,
     reason: {
-      viewChangeReason?: ViewChangeReason;
+      viewChangeReason: ViewChangeReason;
       mainWindowOpenReason?: MainWindowOpenReason;
       mainWindowCloseReason?: MainWindowCloseReason;
     },
@@ -1233,7 +1233,7 @@ class ChatActionsImpl {
   private async fireViewChangeEventsAndChangeView(
     newViewState: ViewState,
     reason: {
-      viewChangeReason?: ViewChangeReason;
+      viewChangeReason: ViewChangeReason;
       mainWindowOpenReason?: MainWindowOpenReason;
       mainWindowCloseReason?: MainWindowCloseReason;
     },

--- a/packages/ai-chat/src/chat/utils/chatBoot.ts
+++ b/packages/ai-chat/src/chat/utils/chatBoot.ts
@@ -129,6 +129,7 @@ export async function performInitialViewChange(serviceManager: ServiceManager) {
       mainWindowOpenReason = MainWindowOpenReason.OPEN_BY_DEFAULT;
     }
     await serviceManager.actions.changeView(targetViewState, {
+      viewChangeReason: ViewChangeReason.WEB_CHAT_LOADED,
       mainWindowOpenReason,
     });
   } else {


### PR DESCRIPTION
was missing setting `viewChangeReason` in a couple places

Closes #745 

Made "viewChangeReason" required instead of optional and then found the places it wasn't being set
