### PR TITLE
fix: disable homescreen input

### DIFF
--- a/packages/ai-chat/src/chat/components-legacy/OverlayPanel.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/OverlayPanel.tsx
@@ -339,6 +339,7 @@ class OverlayPanel extends PureComponent<OverlayPanelProps, OverlayPanelState> {
       children,
       className,
       shouldOpen,
+      shouldHide,
       animationOnClose,
       animationOnOpen,
       overlayPanelName,
@@ -348,7 +349,7 @@ class OverlayPanel extends PureComponent<OverlayPanelProps, OverlayPanelState> {
 
     return (
       <HideComponent
-        hidden={!isClosing && !shouldOpen}
+        hidden={(!isClosing && !shouldOpen) || shouldHide}
         className={cx("cds-aichat--overlay-panel-container", className, {
           "cds-aichat--overlay-panel-container--animating":
             isOpening || isClosing,

--- a/packages/ai-chat/src/chat/components-legacy/homeScreen/HomeScreen.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/homeScreen/HomeScreen.tsx
@@ -212,8 +212,8 @@ function HomeScreenComponent({
             <Input
               ref={homeScreenMessageInputRef}
               onSendInput={onSendInput}
-              disableInput={false}
-              isInputVisible
+              disableInput={inputConfig?.isDisabled}
+              isInputVisible={inputConfig?.isVisible !== false}
               disableSend={false}
               languagePack={languagePack}
               serviceManager={serviceManager}

--- a/packages/ai-chat/src/chat/components-legacy/main/MainWindow.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/main/MainWindow.tsx
@@ -433,8 +433,6 @@ class MainWindow
     });
   }
 
-  // No longer supports close-and-restart; use onClose and onRestart as separate actions
-
   /**
    * The callback that can be called to toggle between the home screen and the bot view.
    */
@@ -620,13 +618,13 @@ class MainWindow
    * otherwise it appears for a split second before home screen is loaded.
    */
   renderChat() {
-    const { isHydrated } = this.props;
+    const { isHydrated, assistantMessageState } = this.props;
 
     return (
       <div className="cds-aichat--widget--content">
-        {this.renderCustomPanel()}
         {this.renderHydrationPanel()}
-        {isHydrated && (
+        {this.renderCustomPanel()}
+        {isHydrated && !assistantMessageState.isHydratingCounter && (
           <>
             {this.renderDisclaimerPanel()}
             {this.renderResponsePanel()}
@@ -732,8 +730,7 @@ class MainWindow
 
     // We need to make an educated guess whether the home screen is going to be displayed after hydration is
     // complete, so we can show a version of the hydration panel that matches to avoid a flickering transition when
-    // the hydration panel is only displayed very briefly. If the user's assistant session has expired, this will be
-    // wrong, but it's rare enough to be not worth addressing.
+    // the hydration panel is only displayed very briefly.
     const homescreen = config.public.homescreen;
     const useHomeScreenVersion =
       homescreen?.isOn && !persistedToBrowserStorage.hasSentNonWelcomeMessage;
@@ -752,11 +749,10 @@ class MainWindow
         animationOnOpen={AnimationInType.NONE}
         animationOnClose={AnimationOutType.NONE}
         shouldOpen={
-          assistantMessageState.isHydratingCounter > 0 &&
+          assistantMessageState.isHydratingCounter &&
           !catastrophicErrorType &&
           viewState.mainWindow
         }
-        shouldHide={false}
         serviceManager={serviceManager}
         overlayPanelName={PageObjectId.HYDRATING_PANEL}
       >


### PR DESCRIPTION
didnt copy over input config to homescreen version of input

Closes #765 

#### Testing / Reviewing

Make sure if you disable/hide input via config settings that it applies to homescreen as well as main window.
