### PR TITLE
docs(toolbar): update ai-label slot name

### DIFF
--- a/packages/ai-chat-components/src/components/toolbar/__stories__/toolbar-react.mdx
+++ b/packages/ai-chat-components/src/components/toolbar/__stories__/toolbar-react.mdx
@@ -41,12 +41,7 @@ function ToolbarExample() {
 
       {/* AI Label slot */}
       {aiLabel && (
-        <AILabel
-          size="2xs"
-          autoalign
-          alignment="bottom"
-          slot="toolbar-ai-label"
-        >
+        <AILabel size="2xs" autoalign alignment="bottom" slot="decorator">
           <div slot="body-text">
             <h4 className="margin-bottom-05">Powered by IBM watsonx</h4>
             <div>

--- a/packages/ai-chat-components/src/components/toolbar/__stories__/toolbar.mdx
+++ b/packages/ai-chat-components/src/components/toolbar/__stories__/toolbar.mdx
@@ -36,7 +36,7 @@ import Toolbar from "@carbon/ai-chat-components/es/react/toolbar.js";
 ### HTML
 
 ```html
-<cds-aichat-toolbar overflow="" .actions="${actions}">
+<cds-aichat-toolbar overflow .actions="${actions}">
   <!-- Navigation slot -->
   <div slot="navigation" data-fixed="" data-rounded="top-left">
     <cds-icon-button
@@ -64,7 +64,7 @@ import Toolbar from "@carbon/ai-chat-components/es/react/toolbar.js";
     size="2xs"
     autoalign=""
     alignment="bottom"
-    slot="toolbar-ai-label"
+    slot="decorator"
   >
     <div slot="body-text">
       <h4 class="margin-bottom-05">Powered by IBM watsonx</h4>


### PR DESCRIPTION
Closes #

updates docs snippet for toolbar with the right slot name decorator for ai-label 

#### Changelog

**Changed**

- updated with right slot name in doc snippets

#### Testing / Reviewing

can be seen in storybook docs page
