### PR TITLE
fix: above chat input field not right sized

### DIFF
--- a/packages/ai-chat/src/chat/components-legacy/AssistantChat.scss
+++ b/packages/ai-chat/src/chat/components-legacy/AssistantChat.scss
@@ -7,12 +7,18 @@
 
 @use "@carbon/layout";
 @use "@carbon/styles/scss/theme";
+@use "../styles/chat-theme";
 
 .cds-aichat--non-header-container {
   position: relative;
   display: flex;
   overflow: hidden;
   flex: 1 1 0%;
+}
+
+.cds-aichat--widget--max-width .cds-aichat--non-header-container {
+  margin: auto;
+  max-inline-size: chat-theme.$messages-max-width;
 }
 
 .cds-aichat--messages-and-input-container {


### PR DESCRIPTION
#### Testing / Reviewing

turn on custom elements and see the one above the input field is right sized
