### PR TITLE
fix: feedback, reasoning steps, shell border

### DIFF
--- a/packages/ai-chat-components/src/components/reasoning-steps/src/cds-aichat-reasoning-step.scss
+++ b/packages/ai-chat-components/src/components/reasoning-steps/src/cds-aichat-reasoning-step.scss
@@ -25,6 +25,10 @@
   display: none;
 }
 
+.#{$prefix}__panel--hidden {
+  display: none;
+}
+
 .#{$prefix}--reasoning-step {
   inline-size: 100%;
 }

--- a/packages/ai-chat-components/src/components/reasoning-steps/src/cds-aichat-reasoning-step.ts
+++ b/packages/ai-chat-components/src/components/reasoning-steps/src/cds-aichat-reasoning-step.ts
@@ -58,9 +58,18 @@ class CDSAIChatReasoningStep extends LitElement {
     const slot =
       this.shadowRoot?.querySelector<HTMLSlotElement>("slot:not([name])");
     const nodes = slot?.assignedNodes({ flatten: true });
+    this.evaluateBodyContent(nodes);
+    this.updatePanelInertState();
+  }
 
-    if (nodes) {
-      this.evaluateBodyContent(nodes);
+  updated(changedProperties: Map<string, unknown>) {
+    super.updated(changedProperties);
+
+    if (
+      changedProperties.has("open") ||
+      changedProperties.has("hasBodyContent")
+    ) {
+      this.updatePanelInertState();
     }
   }
 
@@ -96,6 +105,8 @@ class CDSAIChatReasoningStep extends LitElement {
       if (!hasContent && this.open && !this.controlled) {
         this.open = false;
       }
+
+      this.updatePanelInertState();
     }
   }
 
@@ -119,6 +130,7 @@ class CDSAIChatReasoningStep extends LitElement {
     const nodes = slot.assignedNodes({ flatten: true });
 
     this.evaluateBodyContent(nodes);
+    this.updatePanelInertState();
   }
 
   private handleToggleRequest(nextState = !this.open) {
@@ -239,6 +251,25 @@ class CDSAIChatReasoningStep extends LitElement {
         </div>
       </div>
     `;
+  }
+
+  /**
+   * Apply/remove inert on assigned elements so they are untabbable when closed.
+   */
+  private updatePanelInertState() {
+    const slot =
+      this.shadowRoot?.querySelector<HTMLSlotElement>("slot:not([name])");
+
+    if (!slot) {
+      return;
+    }
+
+    const shouldInert = !this.open || !this.hasBodyContent;
+    const assignedElements = slot.assignedElements({ flatten: true });
+
+    assignedElements.forEach((element) => {
+      element.toggleAttribute("inert", shouldInert);
+    });
   }
 
   render() {

--- a/packages/ai-chat-components/src/components/reasoning-steps/src/cds-aichat-reasoning-steps.scss
+++ b/packages/ai-chat-components/src/components/reasoning-steps/src/cds-aichat-reasoning-steps.scss
@@ -49,7 +49,7 @@
   display: flex;
   overflow: hidden;
   flex-direction: column;
+  padding: layout.$spacing-03;
   gap: layout.$spacing-03;
   min-block-size: 0;
-  padding-inline-start: layout.$spacing-03;
 }

--- a/packages/ai-chat-components/src/components/reasoning-steps/src/cds-aichat-reasoning-steps.ts
+++ b/packages/ai-chat-components/src/components/reasoning-steps/src/cds-aichat-reasoning-steps.ts
@@ -41,11 +41,25 @@ class CDSAIChatReasoningSteps extends LitElement {
       this.propagateControlled();
     }
 
+    if (changedProperties.has("open")) {
+      this.propagateOpen();
+    }
+
     this.markLastVisibleStep();
   }
 
   get steps(): NodeListOf<HTMLElement> {
     return this.querySelectorAll(stepSelector);
+  }
+
+  propagateOpen() {
+    this.steps.forEach((step) => {
+      if (this.open) {
+        step.removeAttribute("inert");
+      } else {
+        step.setAttribute("inert", "");
+      }
+    });
   }
 
   propagateControlled() {

--- a/packages/ai-chat-components/src/react/feedback-buttons.ts
+++ b/packages/ai-chat-components/src/react/feedback-buttons.ts
@@ -18,6 +18,9 @@ const FeedbackButtons = withWebComponentBridge(
     tagName: "cds-aichat-feedback-buttons",
     elementClass: CDSChatFeedbackButtonsElement,
     react: React,
+    events: {
+      onClick: "feedback-buttons-click",
+    },
   }),
 );
 

--- a/packages/ai-chat/src/chat/components-legacy/App.scss
+++ b/packages/ai-chat/src/chat/components-legacy/App.scss
@@ -98,7 +98,7 @@
 }
 
 .cds-aichat--ai-theme .cds-aichat--widget {
-  border: solid 1px transparent;
+  border: solid 1px theme.$ai-border-start;
   background-color: theme.$chat-shell-background;
   background-image: chat-theme.$ai-background-image;
   /* TODO: For AI theme only?

--- a/packages/ai-chat/src/types/config/LayoutCustomProperties.ts
+++ b/packages/ai-chat/src/types/config/LayoutCustomProperties.ts
@@ -57,7 +57,7 @@ export enum LayoutCustomProperties {
   /**
    * Custom element layouts only.
    *
-   * Max width of messages area in fullscreen / larger views if {@link LayoutConfig.hascontentmaxwidth} is not set to
+   * Max width of messages area in fullscreen / larger views if {@link LayoutConfig.hasContentMaxWidth} is not set to
    * true.
    *
    * Defaults to `672px`.


### PR DESCRIPTION
Closes #782 #777 

Three fixes:

1. The border on AI mode disappeared
2. The REACT version of thumbs up/down up wasn't defining the onClick handler correctly and was always coming back as "negative feedbacl
3. Applying aria-hidden or inert to a parent element of slotted content wasn't marking the slots as aria-hidden or inert so all the hidden reasoning step content was getting invisible keyboard focus when collapsed

#### Testing / Reviewing

1. Check if blue border is on chat when in AI mode, and that it is still gray with AI mode off
2. Make sure that hitting "thumbs" up actually selects thumbs up in demo site and both storybooks
3. From demo site, enter response for reasoning steps. When reasoning steps area is closed, you should be able to tab right passed it. When its open, you should be able to tab past all content collapsed in individual steps
