### PR TITLE
fix: adjust check for invalid direction

### DIFF
--- a/packages/ai-chat/src/chat/instance/ChatInstanceImpl.ts
+++ b/packages/ai-chat/src/chat/instance/ChatInstanceImpl.ts
@@ -217,7 +217,7 @@ function createChatInstance({
         store.dispatch(actions.addIsLoadingCounter(-1, message));
       } else if (!direction && message) {
         store.dispatch(actions.addIsLoadingCounter(0, message));
-      } else {
+      } else if (direction) {
         consoleError(
           `[updateIsMessageLoadingCounter] Invalid direction: ${direction}. Valid values are undefined (with loading message), "reset", "increase" and "decrease".`,
         );


### PR DESCRIPTION
Closes #788 

Error was getting thrown on valid direction types. Adjust the check for the error to only get triggered when direction is not one of the 4 ('reset', 'increase' or 'decrease', undefined)

<img width="2178" height="1042" alt="Screenshot 2025-12-18 at 11 17 38 AM" src="https://github.com/user-attachments/assets/7ce54b93-6408-4868-aa16-3202c0daf907" />


#### Changelog

**Changed**

- change check to get triggered if the direction is not one of the 4 expected

#### Testing / Reviewing

Go to deploy preview and click the loading counter options, check the console to see there is no error
