### PR TITLE
feat: add feedback config option

### DIFF
--- a/demo/src/framework/demo-body.tsx
+++ b/demo/src/framework/demo-body.tsx
@@ -26,6 +26,7 @@ import { ConfigManager } from "./config-manager";
 import { ReactAppManager } from "./react-app-manager";
 import "./demo-chat-theme-switcher";
 import "./demo-header-switcher";
+import "./demo-chat-feedback-switcher";
 import "./demo-layout-config-switcher";
 import "./demo-launcher-switcher";
 import "./demo-input-config-switcher";
@@ -524,6 +525,12 @@ export class DemoBody extends LitElement {
                   <demo-chat-theme-switcher
                     .config=${this.config}
                   ></demo-chat-theme-switcher>
+                  <div class="config-section">
+                    <div class="config-section__title">Feedback</div>
+                    <demo-chat-feedback-switcher
+                      .config=${this.config}
+                    ></demo-chat-feedback-switcher>
+                  </div>
                   <div class="config-section">
                     <div class="config-section__title">
                       Homescreen & disclaimer

--- a/demo/src/framework/demo-chat-feedback-switcher.ts
+++ b/demo/src/framework/demo-chat-feedback-switcher.ts
@@ -1,0 +1,81 @@
+/*
+ *  Copyright IBM Corp. 2025
+ *
+ *  This source code is licensed under the Apache-2.0 license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ *  @license
+ */
+import { PublicConfig } from "@carbon/ai-chat";
+import { css, html, LitElement } from "lit";
+import { customElement, property } from "lit/decorators.js";
+
+@customElement("demo-chat-feedback-switcher")
+export class DemoChatFeedbackSwitcher extends LitElement {
+  static styles = css`
+    :host {
+      display: block;
+    }
+
+    .section {
+      margin-bottom: 1rem;
+    }
+
+    .section:last-child {
+      margin-bottom: 0;
+    }
+
+    cds-checkbox {
+      margin-bottom: 0.5rem;
+    }
+  `;
+
+  @property({ type: Object })
+  accessor config!: PublicConfig;
+
+  private _updateConfig(updates: Partial<PublicConfig>) {
+    const newConfig = {
+      ...this.config,
+      ...updates,
+    };
+
+    console.log("newConfig", newConfig);
+
+    this.dispatchEvent(
+      new CustomEvent("config-changed", {
+        detail: newConfig,
+        bubbles: true,
+        composed: true,
+      }),
+    );
+  }
+
+  private _onChanged = (event: Event) => {
+    const customEvent = event as CustomEvent;
+    const checked = customEvent.detail.checked;
+
+    console.log("feedback", checked);
+
+    this._updateConfig({ persistFeedback: checked });
+  };
+
+  render() {
+    const persistFeedback = this.config.persistFeedback ?? false;
+
+    return html` <div class="section">
+      <cds-checkbox
+        ?checked=${persistFeedback}
+        @cds-checkbox-changed=${this._onChanged}
+      >
+        Persist feedback
+      </cds-checkbox>
+    </div>`;
+  }
+}
+
+// Register the custom element if not already defined
+declare global {
+  interface HTMLElementTagNameMap {
+    "demo-chat-feedback-switcher": DemoChatFeedbackSwitcher;
+  }
+}

--- a/demo/src/framework/demo-homescreen-switcher.ts
+++ b/demo/src/framework/demo-homescreen-switcher.ts
@@ -136,10 +136,10 @@ export class DemoHomeScreenSwitcher extends LitElement {
     if (!hasHomescreen) {
       return "none";
     }
-    if (this.config.homescreen.customContentOnly) {
+    if (this.config.homescreen?.customContentOnly) {
       return "custom";
     }
-    if (this.config.homescreen.disableReturn) {
+    if (this.config.homescreen?.disableReturn) {
       return "splash";
     }
     return "default";

--- a/demo/src/web-components/demo-app.ts
+++ b/demo/src/web-components/demo-app.ts
@@ -398,6 +398,7 @@ export class DemoApp extends LitElement {
             .layout=${this.config.layout}
             .messaging=${this.config.messaging}
             .isReadonly=${this.config.isReadonly ?? undefined}
+            .persistFeedback=${this.config.persistFeedback ?? undefined}
             .assistantName=${this.config.assistantName}
             locale=${this.config.locale}
             .homescreen=${this.config.homescreen}
@@ -427,6 +428,7 @@ export class DemoApp extends LitElement {
             .layout=${this.config.layout}
             .messaging=${this.config.messaging}
             .isReadonly=${this.config.isReadonly ?? undefined}
+            .persistFeedback=${this.config.persistFeedback ?? undefined}
             .assistantName=${this.config.assistantName}
             locale=${this.config.locale}
             .homescreen=${this.config.homescreen}

--- a/packages/ai-chat/docs/Customization.md
+++ b/packages/ai-chat/docs/Customization.md
@@ -84,6 +84,10 @@ The Carbon AI Chat launcher welcomes and engages customers so they know where to
 
 For more information, see the documentation for {@link PublicConfig.launcher}.
 
+### Persist feedback options
+
+By default, Carbon AI Chat only displays the feedback options to the latest message. To allow for feedback options to persist for all previous messages, configure {@link PublicConfig.persistFeedback} to true.
+
 ### Writeable elements (slotted content)
 
 The Carbon AI Chat strategically provides access to various slots around the Carbon AI Chat. You can directly write to them as portals from your application with frameworks like React, Angular, Vue, or a web component. The writeable elements available are defined at {@link WriteableElementName}.

--- a/packages/ai-chat/src/chat/components-legacy/MessagesComponent.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/MessagesComponent.tsx
@@ -727,8 +727,11 @@ class MessagesComponent extends PureComponent<MessagesProps, MessagesState> {
       "cds-aichat--message--last-message": isLastMessage,
     });
 
-    // The user can only provide feedback on the last message.
-    const allowNewFeedback = localMessage.fullMessageID === lastMessageID;
+    // Allow for feedback to persist if configured to otherwise user can only
+    // provide feedback on the last message.
+    const allowNewFeedback =
+      config.public.persistFeedback ||
+      localMessage.fullMessageID === lastMessageID;
 
     const messageItemID = localMessage.ui_state.id;
     const message = (

--- a/packages/ai-chat/src/react/ChatContainer.tsx
+++ b/packages/ai-chat/src/react/ChatContainer.tsx
@@ -97,6 +97,7 @@ function ChatContainer(props: ChatContainerProps) {
     layout,
     messaging,
     isReadonly,
+    persistFeedback,
     assistantName,
     locale,
     homescreen,
@@ -122,6 +123,7 @@ function ChatContainer(props: ChatContainerProps) {
       layout,
       messaging,
       isReadonly,
+      persistFeedback,
       assistantName,
       locale,
       homescreen,
@@ -145,6 +147,7 @@ function ChatContainer(props: ChatContainerProps) {
       layout,
       messaging,
       isReadonly,
+      persistFeedback,
       assistantName,
       locale,
       homescreen,
@@ -152,6 +155,7 @@ function ChatContainer(props: ChatContainerProps) {
       input,
     ],
   );
+
   const wrapperRef = useRef(null); // Ref for the React wrapper component
   const [wrapper, setWrapper] = useState(null);
   const [container, setContainer] = useState<HTMLElement | null>(null); // Actual element we render the React Portal to in the Shadowroot.

--- a/packages/ai-chat/src/react/ChatCustomElement.tsx
+++ b/packages/ai-chat/src/react/ChatCustomElement.tsx
@@ -164,6 +164,7 @@ function ChatCustomElement(props: ChatCustomElementProps) {
     layout,
     messaging,
     isReadonly,
+    persistFeedback,
     assistantName,
     locale,
     homescreen,
@@ -233,6 +234,7 @@ function ChatCustomElement(props: ChatCustomElementProps) {
           layout={layout}
           messaging={messaging}
           isReadonly={isReadonly}
+          persistFeedback={persistFeedback}
           assistantName={assistantName}
           locale={locale}
           homescreen={homescreen}

--- a/packages/ai-chat/src/types/config/PublicConfig.ts
+++ b/packages/ai-chat/src/types/config/PublicConfig.ts
@@ -162,6 +162,11 @@ export interface PublicConfig {
   isReadonly?: boolean;
 
   /**
+   * Allows for feedback to persist in all messages, not just the latest message.
+   */
+  persistFeedback?: boolean;
+
+  /**
    * Sets the name of the assistant. Defaults to "watsonx". Used in screen reader announcements and error messages.
    */
   assistantName?: string;


### PR DESCRIPTION
Closes #761 

Currently feedback options (thumbs up and down buttons) are rendered only for the latest message. This PR adds a `persistFeedback` config option to allow for feedback options to persist in past messages.

<img width="2474" height="1148" alt="Screenshot 2025-12-22 at 3 33 10 PM" src="https://github.com/user-attachments/assets/215cb0d5-93d9-4d0b-928d-561288ae8793" />

#### Changelog

**New**

- `demo-chat-feedback-switcher` component for the demo

**Changed**

- add `persistFeedback` to the `PublicConfig` interface
- pass the `persistFeedback` to the `MessagesComponent` to decided whether to render the feedback options

#### Testing / Reviewing

Go to demo, check the `Persist feedback` checkbox and select `text with feedback` option from dropdown twice. See that there is feedback options for the previous and latest feedback messages.
