### PR TITLE
chore: utilitize syntax tokens from carbon/styles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3348,9 +3348,9 @@
       "link": true
     },
     "node_modules/@carbon/colors": {
-      "version": "11.43.0",
-      "resolved": "https://registry.npmjs.org/@carbon/colors/-/colors-11.43.0.tgz",
-      "integrity": "sha512-Remz2fS6lreIi9qc6iQajaZCsbz68++bP7qNH3RyKmgm1R7xktGX7/WL2GpGi9kCOMe5+YxNLGygsqkzc28Vww==",
+      "version": "11.44.0",
+      "resolved": "https://registry.npmjs.org/@carbon/colors/-/colors-11.44.0.tgz",
+      "integrity": "sha512-DKyFn20o4PqN0lKsMNFNX5E1F5r6Whx+IkAr7RVRymKo/bF6wAQ+xjlBUvSOcnQswN3RcegdG36Ivw248Wa8Wg==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -3368,13 +3368,13 @@
       }
     },
     "node_modules/@carbon/grid": {
-      "version": "11.46.0",
-      "resolved": "https://registry.npmjs.org/@carbon/grid/-/grid-11.46.0.tgz",
-      "integrity": "sha512-671gBL/8diHQPHvlhdZe/IsVBBAMs8+/JrfmC6U/Y/rqBPf/LAeoynJtdZaoQKReCSHj20jc/gKCQvNZD28k1g==",
+      "version": "11.47.0",
+      "resolved": "https://registry.npmjs.org/@carbon/grid/-/grid-11.47.0.tgz",
+      "integrity": "sha512-iU9Z6XjImZvd2s5jcNBHKt+0FamHwdGgFP/UDymzK19Uzm5YheiVwFyg4MN3KU6cNCT380zOim8WRjRtZ4TuPQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@carbon/layout": "^11.44.0",
+        "@carbon/layout": "^11.45.0",
         "@ibm/telemetry-js": "^1.5.0"
       }
     },
@@ -3414,9 +3414,9 @@
       }
     },
     "node_modules/@carbon/layout": {
-      "version": "11.44.0",
-      "resolved": "https://registry.npmjs.org/@carbon/layout/-/layout-11.44.0.tgz",
-      "integrity": "sha512-YvStlTZKqFbdIWta4WFbl7k3cTJ4B5ocdP2IMk6v296FPgawlIc3VlPnjZt9LhMJm7YJjY1dQ0jVaLF3ON0Reg==",
+      "version": "11.45.0",
+      "resolved": "https://registry.npmjs.org/@carbon/layout/-/layout-11.45.0.tgz",
+      "integrity": "sha512-KTga7nB42jFtE+eKGUoji7C2hxXqf2/Pl1Ax9y8PNFNVrSr9VIYoRio52C9wjXRWpkek9vMi0dAilHm7aVQugA==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -3424,9 +3424,9 @@
       }
     },
     "node_modules/@carbon/motion": {
-      "version": "11.38.0",
-      "resolved": "https://registry.npmjs.org/@carbon/motion/-/motion-11.38.0.tgz",
-      "integrity": "sha512-u8puVC/fopX6IPYWZDGyEQm5pWOIqTXdFKUQIlTpU9UBjhzIfGrWdP1oUH3e1oPQjs+oBzbZr7TJbzEtQ8zQgw==",
+      "version": "11.39.0",
+      "resolved": "https://registry.npmjs.org/@carbon/motion/-/motion-11.39.0.tgz",
+      "integrity": "sha512-5Hd+fU5gb5snl1vZ0HlZSJQwllbvDrXZOU8wBYJJSsZTZLARkHjziaa3tm1uxk/miy0GZ44Z/T3+a9ogY882Eg==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -3467,19 +3467,19 @@
       }
     },
     "node_modules/@carbon/styles": {
-      "version": "1.96.0",
-      "resolved": "https://registry.npmjs.org/@carbon/styles/-/styles-1.96.0.tgz",
-      "integrity": "sha512-okYedWOdfUBY+4FTF8Mfcatigu8c8WVoyC6msWeJ1UKGovuMvMdg4wfz/w8+MYzEmmjv1XqEs6V81jGTKi43NA==",
+      "version": "1.97.0",
+      "resolved": "https://registry.npmjs.org/@carbon/styles/-/styles-1.97.0.tgz",
+      "integrity": "sha512-hxTZp+1B0pPqYQH74kyBmHpbg+vl/4CKuxarA7EfSNawTA1pbqFm2hERQHp9cUb7mlfeN1WpRkPjWkps6Iok9g==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@carbon/colors": "^11.43.0",
+        "@carbon/colors": "^11.44.0",
         "@carbon/feature-flags": ">=0.32.0",
-        "@carbon/grid": "^11.46.0",
-        "@carbon/layout": "^11.44.0",
-        "@carbon/motion": "^11.38.0",
-        "@carbon/themes": "^11.64.0",
-        "@carbon/type": "^11.50.0",
+        "@carbon/grid": "^11.47.0",
+        "@carbon/layout": "^11.45.0",
+        "@carbon/motion": "^11.39.0",
+        "@carbon/themes": "^11.65.0",
+        "@carbon/type": "^11.51.0",
         "@ibm/plex": "6.0.0-next.6",
         "@ibm/plex-mono": "1.1.0",
         "@ibm/plex-sans": "1.1.0",
@@ -3501,28 +3501,28 @@
       }
     },
     "node_modules/@carbon/themes": {
-      "version": "11.64.0",
-      "resolved": "https://registry.npmjs.org/@carbon/themes/-/themes-11.64.0.tgz",
-      "integrity": "sha512-Eof0ZxxBOElVMqbbOd69TI882LXcC4VFGRPQMgq1Vvqh27M5r/naY2sa0XelxNxE0An4Yp108RLRU3r2lSJe+w==",
+      "version": "11.65.0",
+      "resolved": "https://registry.npmjs.org/@carbon/themes/-/themes-11.65.0.tgz",
+      "integrity": "sha512-O57gLX+iNorLqw5MrJEMpafu0JDpIdD3NMxNeWsiEp/XOZierXa0NKlovpdPnTwE1IiXjAOMnyvqhiQ6qx2hOA==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@carbon/colors": "^11.43.0",
-        "@carbon/layout": "^11.44.0",
-        "@carbon/type": "^11.50.0",
+        "@carbon/colors": "^11.44.0",
+        "@carbon/layout": "^11.45.0",
+        "@carbon/type": "^11.51.0",
         "@ibm/telemetry-js": "^1.5.0",
         "color": "^4.0.0"
       }
     },
     "node_modules/@carbon/type": {
-      "version": "11.50.0",
-      "resolved": "https://registry.npmjs.org/@carbon/type/-/type-11.50.0.tgz",
-      "integrity": "sha512-rYMuV5xWi3rqVyUd2sNISx18U4iHo6d1CN5sZq+77YAcEYBMSEBe6aCP20ezgGXVLFPXJi/EfI62pcqvEYUHvg==",
+      "version": "11.51.0",
+      "resolved": "https://registry.npmjs.org/@carbon/type/-/type-11.51.0.tgz",
+      "integrity": "sha512-ZcAH6TiRqR/QHdY7sMJ6OF0BpXEulHDRsvhE/ACpN0n8zErhPowrJPzYvF/E3gKnvTpNrFc0d/n/PuGOu9nm7A==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@carbon/grid": "^11.46.0",
-        "@carbon/layout": "^11.44.0",
+        "@carbon/grid": "^11.47.0",
+        "@carbon/layout": "^11.45.0",
         "@ibm/telemetry-js": "^1.5.0"
       }
     },
@@ -46089,7 +46089,7 @@
       },
       "devDependencies": {
         "@carbon/icons": "^11.53.0",
-        "@carbon/styles": "^1.88.0",
+        "@carbon/styles": "^1.97.0",
         "@carbon/themes": "^11.58.0",
         "@carbon/web-components": "^2.42.0",
         "@open-wc/testing": "4.0.0",
@@ -46150,7 +46150,7 @@
       "dependencies": {
         "@carbon/icon-helpers": "^10.47.0",
         "@carbon/icons": "^11.53.0",
-        "@carbon/styles": "^1.39.0",
+        "@carbon/styles": "^1.97.0",
         "@carbon/web-components": "^2.42.0",
         "@codemirror/lang-angular": "^0.1.4",
         "@codemirror/lang-cpp": "^6.0.3",

--- a/packages/ai-chat-components/package.json
+++ b/packages/ai-chat-components/package.json
@@ -44,7 +44,7 @@
   "dependencies": {
     "@carbon/icon-helpers": "^10.47.0",
     "@carbon/icons": "^11.53.0",
-    "@carbon/styles": "^1.39.0",
+    "@carbon/styles": "^1.97.0",
     "@carbon/web-components": "^2.42.0",
     "@codemirror/lang-angular": "^0.1.4",
     "@codemirror/lang-cpp": "^6.0.3",

--- a/packages/ai-chat-components/src/components/code-snippet/src/code-snippet.scss
+++ b/packages/ai-chat-components/src/components/code-snippet/src/code-snippet.scss
@@ -5,10 +5,13 @@
  *  LICENSE file in the root directory of this source tree.
  */
 
+@use "sass:string";
+
 @use "@carbon/styles/scss/components/code-snippet/index";
 @use "@carbon/styles/scss/type";
 @use "@carbon/layout";
 @use "@carbon/styles/scss/motion";
+@use "@carbon/styles/scss/themes";
 @use "@carbon/styles/scss/theme";
 @use "@carbon/styles/scss/colors";
 @use "@carbon/styles/scss/spacing";
@@ -19,54 +22,12 @@
 :host {
   @include rounded-modifiers;
 
-  /* Comments and documentation */
-  --cds-syntax-comment: #{colors.$green-60};
-  --cds-syntax-line-comment: var(--cds-syntax-comment);
-  --cds-syntax-block-comment: var(--cds-syntax-comment);
-  --cds-syntax-doc-comment: var(--cds-syntax-comment);
-  --cds-syntax-doc-string: var(--cds-syntax-string);
-
-  /* Keywords */
-  --cds-syntax-keyword: #{colors.$blue-60};
-  --cds-syntax-operator-keyword: var(--cds-syntax-keyword);
-  --cds-syntax-control-keyword: #{colors.$purple-70};
-  --cds-syntax-definition-keyword: #{colors.$cyan-70};
-  --cds-syntax-module-keyword: #{colors.$purple-70};
-
-  /* Identifiers */
-  --cds-syntax-variable: #{colors.$blue-60};
-  --cds-syntax-name: var(--cds-syntax-variable);
-  --cds-syntax-variable-name: var(--cds-syntax-variable);
-  --cds-syntax-label-name: var(--cds-syntax-variable);
-  --cds-syntax-attribute: #{colors.$cyan-70};
-  --cds-syntax-attribute-name: var(--cds-syntax-attribute);
-  --cds-syntax-property-name: var(--cds-syntax-attribute);
-  --cds-syntax-tag: #{colors.$teal-60};
-  --cds-syntax-tag-name: var(--cds-syntax-tag);
-  --cds-syntax-type: #{colors.$teal-60};
-  --cds-syntax-type-name: var(--cds-syntax-type);
-  --cds-syntax-class-name: var(--cds-syntax-type);
-  --cds-syntax-namespace: var(--cds-syntax-type);
-  --cds-syntax-macro-name: var(--cds-syntax-variable);
-
-  /* Literals and primitives */
-  --cds-syntax-atom: var(--cds-text-primary);
-  --cds-syntax-literal: var(--cds-syntax-atom);
-  --cds-syntax-bool: var(--cds-syntax-atom);
-  --cds-syntax-null: var(--cds-syntax-atom);
-  --cds-syntax-self: var(--cds-syntax-tag);
-  --cds-syntax-number: #{colors.$green-60};
-  --cds-syntax-integer: var(--cds-syntax-number);
-  --cds-syntax-float: var(--cds-syntax-number);
-  --cds-syntax-unit: var(--cds-syntax-number);
-  --cds-syntax-string: theme.$text-primary;
-  --cds-syntax-special-string: #{colors.$purple-60};
-  --cds-syntax-character: var(--cds-syntax-string);
-  --cds-syntax-attribute-value: var(--cds-syntax-string);
-  --cds-syntax-regexp: #{colors.$purple-70};
-  --cds-syntax-escape: #{colors.$cool-gray-80};
-  --cds-syntax-url: var(--cds-syntax-escape);
-  --cds-syntax-color: var(--cds-text-primary);
+  // Automatically output all syntax-* tokens from the Carbon $white theme
+  @each $token, $value in themes.$white {
+    @if string.index($token, "syntax-") == 1 {
+      --cds-#{$token}: #{$value};
+    }
+  }
 
   /* Operators and punctuation */
   --cds-syntax-operator: #{colors.$cool-gray-80};
@@ -76,10 +37,10 @@
   --cds-syntax-bitwise-operator: var(--cds-syntax-operator);
   --cds-syntax-compare-operator: var(--cds-syntax-operator);
   --cds-syntax-update-operator: var(--cds-syntax-operator);
-  --cds-syntax-definition-operator: var(--cds-syntax-definition-keyword);
-  --cds-syntax-type-operator: var(--cds-syntax-tag);
-  --cds-syntax-control-operator: var(--cds-syntax-module-keyword);
-  --cds-syntax-modifier: var(--cds-syntax-keyword);
+  --cds-syntax-definition-operator: #{theme.$syntax-definition-keyword};
+  --cds-syntax-type-operator: #{theme.$syntax-tag};
+  --cds-syntax-control-operator: #{theme.$syntax-module-keyword};
+  --cds-syntax-modifier: #{theme.$syntax-keyword};
   --cds-syntax-punctuation: #{colors.$cool-gray-80};
   --cds-syntax-separator: var(--cds-syntax-punctuation);
   --cds-syntax-bracket: var(--cds-syntax-punctuation);
@@ -113,7 +74,7 @@
   --cds-syntax-meta: #{colors.$green-60};
   --cds-syntax-document-meta: var(--cds-syntax-meta);
   --cds-syntax-annotation: #{colors.$teal-60};
-  --cds-syntax-processing-instruction: var(--cds-syntax-string);
+  --cds-syntax-processing-instruction: #{theme.$syntax-string};
 
   /* Modifiers */
   --cds-syntax-definition: #{colors.$cyan-70};
@@ -139,27 +100,13 @@
 :host-context([storybook-carbon-theme="g90"]),
 :host-context([data-theme="g100"]),
 :host-context([storybook-carbon-theme="g100"]) {
-  /* Comments and documentation */
-  --cds-syntax-comment: #{colors.$green-40};
-
-  /* Keywords */
-  --cds-syntax-keyword: #{colors.$blue-50};
-  --cds-syntax-control-keyword: #{colors.$purple-40};
-  --cds-syntax-definition-keyword: #{colors.$cyan-40};
-  --cds-syntax-module-keyword: #{colors.$purple-40};
-
-  /* Identifiers */
-  --cds-syntax-variable: #{colors.$blue-30};
-  --cds-syntax-attribute: #{colors.$cyan-40};
-  --cds-syntax-tag: #{colors.$teal-30};
-  --cds-syntax-type: #{colors.$teal-30};
+  @each $token, $value in themes.$g90 {
+    @if string.index($token, "syntax-") == 1 {
+      --cds-#{$token}: #{$value};
+    }
+  }
 
   /* Literals and primitives */
-  --cds-syntax-number: #{colors.$green-30};
-  --cds-syntax-special-string: #{colors.$purple-40};
-  --cds-syntax-regexp: #{colors.$purple-40};
-  --cds-syntax-escape: #{colors.$gray-20};
-  --cds-syntax-url: var(--cds-syntax-escape);
   --cds-syntax-operator: #{colors.$gray-20};
   --cds-syntax-punctuation: #{colors.$gray-20};
   --cds-syntax-angle-bracket: #{colors.$gray-50};

--- a/packages/ai-chat/package.json
+++ b/packages/ai-chat/package.json
@@ -73,7 +73,7 @@
   ],
   "devDependencies": {
     "@carbon/icons": "^11.53.0",
-    "@carbon/styles": "^1.88.0",
+    "@carbon/styles": "^1.97.0",
     "@carbon/themes": "^11.58.0",
     "@carbon/web-components": "^2.42.0",
     "@open-wc/testing": "4.0.0",


### PR DESCRIPTION
Contributes to #746 

Replaces the defined css variables within `code-snippet` with the syntax highlighting tokens from `@carbon/styles`. There are still some tokens used that aren't set in Carbon core, those have been left in the `code-snippet` file.

#### Changelog

**Changed**

- update version of `@carbon/styles` to `1.97.0`
- iterate and apply all carbon tokens that start with `syntax-*` to the `code-snippet` stylesheet

#### Testing / Reviewing

Check the ai-chat-components demo and check that the highlighting colors in code-snippet are the same as in the latest version of ai-chat-components here: https://chat.carbondesignsystem.com/components/storybook/tag/latest/index.html?path=/story/components-code-snippet--highlight
