### PR TITLE
fix: messages stacking context

### DIFF
--- a/packages/ai-chat/src/chat/components-legacy/MessageComponent.scss
+++ b/packages/ai-chat/src/chat/components-legacy/MessageComponent.scss
@@ -31,12 +31,6 @@ $message-bar-width: 3px;
   /* We cannot use margin on messages as that affects the position calculations that determine how to auto-scroll the
    panel. Padding on the .cds-aichat--message--padding element must be used instead. */
   margin: 0;
-  animation: cds-aichat-fade-in motion.$duration-moderate-02
-    motion.motion(entrance, productive) forwards;
-}
-
-.cds-aichat--message.cds-aichat--message--no-animation {
-  animation: none;
 }
 
 .cds-aichat--message.cds-aichat--message--has-focus::after {

--- a/packages/ai-chat/src/chat/components-legacy/MessageComponent.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/MessageComponent.tsx
@@ -958,8 +958,7 @@ class MessageComponent extends PureComponent<
       allowNewFeedback,
     } = this.props;
 
-    const { isIntermediateStreaming, isWelcomeResponse, disableFadeAnimation } =
-      localMessageItem.ui_state;
+    const { isIntermediateStreaming } = localMessageItem.ui_state;
     const messageItem = localMessageItem.item;
     const responseType = messageItem.response_type;
     const agentMessageType = messageItem.agent_message_type;
@@ -992,9 +991,6 @@ class MessageComponent extends PureComponent<
     );
 
     const isCustomMessage = renderAsUserDefinedMessage(localMessageItem.item);
-
-    // Don't show animation on the welcome node or for messages that explicitly turn it off.
-    const noAnimation = isWelcomeResponse || disableFadeAnimation;
 
     // If this is a user_defined response type with silent set, we don't want to render all the extra cruft around it.
     const agentClassName = agentMessageType
@@ -1035,7 +1031,6 @@ class MessageComponent extends PureComponent<
             "cds-aichat--message--request": messageIsRequest,
             "cds-aichat--message--system-message": isSystemMessage,
             "cds-aichat--message--response": !messageIsRequest,
-            "cds-aichat--message--no-animation": noAnimation,
             "cds-aichat--message--custom": isCustomMessage,
             "cds-aichat--message--disabled-inputs": disableUserInputs,
             "cds-aichat--message--has-focus": this.state.focusHandleHasFocus,

--- a/packages/ai-chat/src/chat/instance/ChatInstanceImpl.ts
+++ b/packages/ai-chat/src/chat/instance/ChatInstanceImpl.ts
@@ -255,9 +255,6 @@ function createChatInstance({
           message,
           options?.isLatestWelcomeNode ?? false,
           null,
-          {
-            disableFadeAnimation: options?.disableFadeAnimation,
-          },
         );
       },
 

--- a/packages/ai-chat/src/chat/schema/outputItemToLocalItem.tsx
+++ b/packages/ai-chat/src/chat/schema/outputItemToLocalItem.tsx
@@ -41,13 +41,11 @@ import { consoleError } from "../utils/miscUtils";
  * @param isLatestWelcomeNode Indicates if this message is a new welcome message that has just been shown to the user
  * and isn't a historical welcome message.
  * ID as the message.
- * @param disableFadeAnimation Indicates if the entrance fade animation for the message should be disabled.
  */
 function outputItemToLocalItem(
   messageItem: GenericItem,
   fullMessage: MessageResponse,
   isLatestWelcomeNode = false,
-  disableFadeAnimation = false,
 ): LocalMessageItem {
   // If the item comes with a streaming id, use that. Otherwise assign a new id.
   const id =
@@ -59,7 +57,6 @@ function outputItemToLocalItem(
     ui_state: {
       id,
       needsAnnouncement: !fullMessage.ui_state_internal?.from_history,
-      disableFadeAnimation,
     },
     item: messageItem,
     fullMessageID: fullMessage.id,
@@ -214,7 +211,6 @@ function createLocalMessageItemsForNestedType(
         nestedMessageItem,
         originalMessage,
         false,
-        true,
       );
 
       nestedMessageItemIDs.push(nestedLocalMessageItem.ui_state.id);

--- a/packages/ai-chat/src/chat/services/MessageService.ts
+++ b/packages/ai-chat/src/chat/services/MessageService.ts
@@ -257,7 +257,7 @@ class MessageService {
     current: PendingMessageRequest,
     received?: MessageResponse,
   ) {
-    const { requestOptions, isProcessed } = current;
+    const { isProcessed } = current;
 
     // If this message was already invalidated (cancel/timeout/error already resolved it), bail out.
     if (isProcessed) {
@@ -286,7 +286,6 @@ class MessageService {
           received,
           Boolean(current.message.history.is_welcome_request),
           message,
-          requestOptions,
         );
       }
       this.messageLoadingManager.end();

--- a/packages/ai-chat/src/chat/store/actions.ts
+++ b/packages/ai-chat/src/chat/store/actions.ts
@@ -534,14 +534,12 @@ const actions = {
     fullMessageID: string,
     chunkItem: DeepPartial<GenericItem>,
     isCompleteItem: boolean,
-    disableFadeAnimation: boolean,
   ) {
     return {
       type: STREAMING_ADD_CHUNK,
       fullMessageID,
       chunkItem,
       isCompleteItem,
-      disableFadeAnimation,
     };
   },
 

--- a/packages/ai-chat/src/chat/store/reducers.ts
+++ b/packages/ai-chat/src/chat/store/reducers.ts
@@ -1113,12 +1113,10 @@ const reducers: { [key: string]: ReducerType } = {
       chunkItem,
       fullMessageID,
       isCompleteItem,
-      disableFadeAnimation,
     }: {
       fullMessageID: string;
       chunkItem: DeepPartial<GenericItem>;
       isCompleteItem: boolean;
-      disableFadeAnimation: boolean;
     },
   ) => {
     const message = state.allMessagesByID[fullMessageID] as MessageResponse;
@@ -1137,7 +1135,6 @@ const reducers: { [key: string]: ReducerType } = {
         false,
       );
       newItem.ui_state.needsAnnouncement = false;
-      newItem.ui_state.disableFadeAnimation = disableFadeAnimation;
       newItem.ui_state.isIntermediateStreaming = true;
       if (isCompleteItem) {
         newItem.ui_state.streamingState = { chunks: [], isDone: true };

--- a/packages/ai-chat/src/types/config/MessagingConfig.ts
+++ b/packages/ai-chat/src/types/config/MessagingConfig.ts
@@ -86,11 +86,6 @@ export interface ChatInstanceMessaging {
  */
 export interface AddMessageOptions {
   /**
-   * Indicates if the entrance fade animation for the message should be disabled.
-   */
-  disableFadeAnimation?: boolean;
-
-  /**
    * Indicates if the message should be treated as a new welcome message (as opposed to an existing one loaded from
    * history).
    */

--- a/packages/ai-chat/src/types/instance/ChatInstance.ts
+++ b/packages/ai-chat/src/types/instance/ChatInstance.ts
@@ -369,12 +369,6 @@ export interface SendOptions {
    * original message to be able to show which option was selected in the UI.
    */
   setValueSelectedForMessageID?: string;
-
-  /**
-   * @internal
-   * Indicates if the entrance fade animation for the message should be disabled.
-   */
-  disableFadeAnimation?: boolean;
 }
 
 /**

--- a/packages/ai-chat/src/types/messaging/LocalMessageItem.ts
+++ b/packages/ai-chat/src/types/messaging/LocalMessageItem.ts
@@ -111,11 +111,6 @@ interface LocalMessageUIState<
   originalUserText?: string;
 
   /**
-   * Indicates if the entrance fade animation for the message should be disabled.
-   */
-  disableFadeAnimation?: boolean;
-
-  /**
    * Indicates if this message was used to start an agent conversation that was then ended.
    */
   wasHumanAgentChatEnded?: boolean;


### PR DESCRIPTION
Closes #803 

Removes brief animation when message is recevied in order to avoid creating a new stacking context and all the passing along of arguments to optionally disable that animation that no longer exists.

#### Testing / Reviewing

Grab the user defined response from https://stackblitz.com/edit/github-5wv4fgmf-2qdbzbco?file=src%2FResponseWrapper.tsx (or just make your own that does something big and z-index-y like AI slug) and make sure that the tooltip opens on top of any messages below it.
