### PR TITLE
fix: toolbar react rendering

### DIFF
--- a/packages/ai-chat-components/src/components/toolbar/src/toolbar.scss
+++ b/packages/ai-chat-components/src/components/toolbar/src/toolbar.scss
@@ -19,6 +19,8 @@ $block-class: #{$prefix}-toolbar;
 :host {
   @include rounded-modifiers;
 
+  display: block;
+
   .#{$block-class} {
     display: flex;
     align-items: flex-start;


### PR DESCRIPTION
Closes #821 

Just needed display block on the toolbar component to stop crazy title rendering in React storybook

Before:
https://private-user-images.githubusercontent.com/22176794/535243140-a1efa674-44a5-4def-8796-37b31bf39d6c.png?jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3Njg0MDQ3MDUsIm5iZiI6MTc2ODQwNDQwNSwicGF0aCI6Ii8yMjE3Njc5NC81MzUyNDMxNDAtYTFlZmE2NzQtNDRhNS00ZGVmLTg3OTYtMzdiMzFiZjM5ZDZjLnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNjAxMTQlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjYwMTE0VDE1MjY0NVomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPTg2NjcxMzQwYTIzNTlmYmMwM2M2ODM0OTdkOGIwOGFhZWEzODU0MmIwNzU1M2UyYTVkMTQwMWMxZTgzOWZhNTImWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0In0.Ua1gLRvycCZXHaGa4v5CsUvi4Keq2Ljf9WMPtzpH6dQ

After:

<img width="966" height="233" alt="Screenshot 2026-01-14 at 10 30 10 AM" src="https://github.com/user-attachments/assets/d70c1c4b-6ccf-4215-bab5-1a1520d980d9" />


