### PR TITLE
fix: always allow table filtering/sorting

### DIFF
--- a/packages/ai-chat-components/src/components/table/src/table.template.ts
+++ b/packages/ai-chat-components/src/components/table/src/table.template.ts
@@ -90,8 +90,8 @@ function tableTemplate(tableElement: CDSAIChatTable) {
   return html`<cds-table
     size="md"
     locale=${locale}
-    .isSortable=${allowTableFiltering}
-    .useZebraStyles=${true}
+    is-sortable
+    use-zebra-styles
     @cds-table-filtered=${handleFilterEvent}
   >
     ${tableTitle &&

--- a/packages/ai-chat-components/src/components/table/src/table.ts
+++ b/packages/ai-chat-components/src/components/table/src/table.ts
@@ -214,7 +214,7 @@ class CDSAIChatTable extends LitElement {
    * @internal
    */
   @state()
-  public _allowFiltering = false;
+  public _allowFiltering = true;
 
   static styles = styles;
 
@@ -362,7 +362,7 @@ class CDSAIChatTable extends LitElement {
    */
   private _setPageSize() {
     // If there are more rows than the page size then enable filtering.
-    this._allowFiltering = this.rows.length > this._currentPageSize;
+    // this._allowFiltering = this.rows.length > this._currentPageSize;
 
     // Update the visible rows in case the page size has changed or this is the first time this web component has
     // rendered.


### PR DESCRIPTION
Always allow filtering and sorting of tables. Folks were getting confused when it just disappeared at lower row counts.