### PR TITLE
fix: linkify was removed

### DIFF
--- a/packages/ai-chat-components/src/components/markdown/__stories__/markdown-react.stories.jsx
+++ b/packages/ai-chat-components/src/components/markdown/__stories__/markdown-react.stories.jsx
@@ -22,6 +22,13 @@ You can combine formatting: ==**bold highlight**== and ==*italic highlight*==.
 > This is a blockquote with **bold text** and *emphasis*.
 > It can span multiple lines and include other formatting.
 
+## Links
+URL like structures will be auto-linked like https://ibm.com or ibm.com.
+
+Also, Markdown links are supported like [Carbon Design System](https://carbondesignsystem.com).
+
+By default links open in a new window, you can make them open in the same window by adding \`{{target=_self}}\` to the URL [Carbon Design System](https://carbondesignsystem.com){{target=_self}}.
+
 ## Lists
 
 Unordered lists:

--- a/packages/ai-chat-components/src/components/markdown/__stories__/markdown.stories.js
+++ b/packages/ai-chat-components/src/components/markdown/__stories__/markdown.stories.js
@@ -23,6 +23,13 @@ You can combine formatting: ==**bold highlight**== and ==*italic highlight*==.
 > This is a blockquote with **bold text** and *emphasis*.
 > It can span multiple lines and include other formatting.
 
+## Links
+URL like structures will be auto-linked like https://ibm.com or ibm.com.
+
+Also, Markdown links are supported like [Carbon Design System](https://carbondesignsystem.com).
+
+By default links open in a new window, you can make them open in the same window by adding \`{{target=_self}}\` to the URL [Carbon Design System](https://carbondesignsystem.com){{target=_self}}.
+
 ## Lists
 
 Unordered lists:

--- a/packages/ai-chat-components/src/components/markdown/src/markdown-token-tree.ts
+++ b/packages/ai-chat-components/src/components/markdown/src/markdown-token-tree.ts
@@ -36,6 +36,7 @@ const htmlMarkdown = new MarkdownIt("commonmark", {
 })
   .enable("table")
   .enable("strikethrough")
+  .enable("linkify")
   .use(markdownItAttrs, {
     leftDelimiter: "{{",
     rightDelimiter: "}}",
@@ -55,6 +56,7 @@ const noHtmlMarkdown = new MarkdownIt("commonmark", {
 })
   .enable("table")
   .enable("strikethrough")
+  .enable("linkify")
   .use(markdownItAttrs, {
     leftDelimiter: "{{",
     rightDelimiter: "}}",


### PR DESCRIPTION
when moving to explicit commonmark autolinking stopped working. needed to register that extension. Added tests to make sure there isn't a regression here.

