### PR TITLE
chore: address lodash-es CVE

### DIFF
--- a/packages/ai-chat/package.json
+++ b/packages/ai-chat/package.json
@@ -137,7 +137,7 @@
     "focus-trap-react": "^10.2.3",
     "intl-messageformat": "^11.0.0",
     "lit": "^3.1.0",
-    "lodash-es": "^4.17.0",
+    "lodash-es": "^4.17.23",
     "react-player": "2.15.1",
     "swiper": "^11.1.1",
     "tabbable": "^6.2.0",


### PR DESCRIPTION
Closes:  n/a

Addressing lodash-es high CVE found in our security scans

#### Changelog

**Changed**

- Bumped lodash-es

#### Testing / Reviewing

n/a
