### PR TITLE
chore: add global type declaration for scss?lit imports

### DIFF
--- a/packages/ai-chat-components/src/components/card/src/card-footer.ts
+++ b/packages/ai-chat-components/src/components/card/src/card-footer.ts
@@ -19,7 +19,6 @@ import {
   BUTTON_KIND,
   BUTTON_SIZE,
 } from "@carbon/web-components/es/components/button/button.js";
-// @ts-ignore
 import styles from "./card-footer.scss?lit";
 import { CarbonIcon } from "@carbon/web-components/es/globals/internal/icon-loader-utils.js";
 import { carbonElement } from "../../../globals/decorators/index.js";

--- a/packages/ai-chat-components/src/components/card/src/card-steps.ts
+++ b/packages/ai-chat-components/src/components/card/src/card-steps.ts
@@ -15,7 +15,6 @@ import "@carbon/web-components/es/components/icon-indicator/icon-indicator.js";
 import "@carbon/web-components/es/components/loading/loading.js";
 import { ICON_INDICATOR_KIND } from "@carbon/web-components/es/components/icon-indicator/icon-indicator.js";
 import prefix from "../../../globals/settings.js";
-// @ts-ignore
 import styles from "./card-steps.scss?lit";
 import { carbonElement } from "../../../globals/decorators/index.js";
 

--- a/packages/ai-chat-components/src/components/card/src/card.ts
+++ b/packages/ai-chat-components/src/components/card/src/card.ts
@@ -9,7 +9,6 @@
 
 import { property } from "lit/decorators.js";
 import CDSTile from "@carbon/web-components/es/components/tile/tile.js";
-// @ts-ignore
 import styles from "./card.scss?lit";
 import { html } from "lit";
 import { carbonElement } from "../../../globals/decorators/index.js";

--- a/packages/ai-chat-components/src/components/chain-of-thought/src/chain-of-thought-step.ts
+++ b/packages/ai-chat-components/src/components/chain-of-thought/src/chain-of-thought-step.ts
@@ -17,8 +17,6 @@ import { iconLoader } from "@carbon/web-components/es/globals/internal/icon-load
 import CheckmarkFilled16 from "@carbon/icons/es/checkmark--filled/16.js";
 import ChevronRight16 from "@carbon/icons/es/chevron--right/16.js";
 import ErrorFilled16 from "@carbon/icons/es/error--filled/16.js";
-
-// @ts-ignore
 import styles from "./chain-of-thought-step.scss?lit";
 import prefix from "../../../globals/settings.js";
 import { carbonElement } from "../../../globals/decorators/index.js";

--- a/packages/ai-chat-components/src/components/chain-of-thought/src/chain-of-thought-toggle.ts
+++ b/packages/ai-chat-components/src/components/chain-of-thought/src/chain-of-thought-toggle.ts
@@ -13,8 +13,6 @@ import { html } from "lit";
 import { ifDefined } from "lit/directives/if-defined.js";
 import { iconLoader } from "@carbon/web-components/es/globals/internal/icon-loader.js";
 import ChevronDown16 from "@carbon/icons/es/chevron--down/16.js";
-
-// @ts-ignore
 import styles from "./chain-of-thought-toggle.scss?lit";
 import prefix from "../../../globals/settings.js";
 import { carbonElement } from "../../../globals/decorators/index.js";

--- a/packages/ai-chat-components/src/components/chain-of-thought/src/chain-of-thought.ts
+++ b/packages/ai-chat-components/src/components/chain-of-thought/src/chain-of-thought.ts
@@ -9,7 +9,6 @@
 
 import { LitElement, html } from "lit";
 import { property } from "lit/decorators.js";
-// @ts-ignore
 import styles from "./chain-of-thought.scss?lit";
 import prefix from "../../../globals/settings.js";
 import { uuid } from "../../../globals/utils/uuid.js";

--- a/packages/ai-chat-components/src/components/chain-of-thought/src/tool-call-data.ts
+++ b/packages/ai-chat-components/src/components/chain-of-thought/src/tool-call-data.ts
@@ -9,8 +9,6 @@
 
 import { LitElement, html } from "lit";
 import { property, state } from "lit/decorators.js";
-
-// @ts-ignore
 import styles from "./tool-call-data.scss?lit";
 import prefix from "../../../globals/settings.js";
 import { carbonElement } from "../../../globals/decorators/index.js";

--- a/packages/ai-chat-components/src/components/chat-button/src/chat-button.ts
+++ b/packages/ai-chat-components/src/components/chat-button/src/chat-button.ts
@@ -19,7 +19,6 @@ import {
 import CDSButton from "@carbon/web-components/es/components/button/button.js";
 import { carbonElement } from "../../../globals/decorators/index.js";
 import prefix from "../../../globals/settings.js";
-// @ts-ignore
 import styles from "./chat-button.scss?lit";
 
 export {

--- a/packages/ai-chat-components/src/components/chat-shell/src/cds-aichat-panel.ts
+++ b/packages/ai-chat-components/src/components/chat-shell/src/cds-aichat-panel.ts
@@ -10,7 +10,6 @@
 import { LitElement, PropertyValues, html } from "lit";
 import { property } from "lit/decorators.js";
 import { carbonElement } from "../../../globals/decorators/carbon-element.js";
-// @ts-ignore
 import styles from "./cds-aichat-panel.scss?lit";
 
 const ANIMATION_START_DETECTION_DELAY_MS = 120;

--- a/packages/ai-chat-components/src/components/chat-shell/src/cds-aichat-shell.ts
+++ b/packages/ai-chat-components/src/components/chat-shell/src/cds-aichat-shell.ts
@@ -9,7 +9,6 @@
 
 import { LitElement, PropertyValues, html, nothing } from "lit";
 import { property } from "lit/decorators.js";
-// @ts-ignore
 import styles from "./cds-aichat-shell.scss?lit";
 import { PanelManager } from "./panel-manager.js";
 import { WorkspaceManager } from "./workspace-manager.js";

--- a/packages/ai-chat-components/src/components/code-snippet/src/code-snippet.ts
+++ b/packages/ai-chat-components/src/components/code-snippet/src/code-snippet.ts
@@ -33,7 +33,7 @@ import { loadCodeMirrorRuntime } from "./codemirror/codemirror-loader.js";
 import "@carbon/web-components/es/components/skeleton-text/index.js";
 
 type CodeMirrorRuntime = Awaited<ReturnType<typeof loadCodeMirrorRuntime>>;
-// @ts-ignore
+
 import styles from "./code-snippet.scss?lit";
 import "@carbon/web-components/es/components/copy-button/index.js";
 import "@carbon/web-components/es/components/copy/copy.js";

--- a/packages/ai-chat-components/src/components/feedback/src/feedback-buttons.ts
+++ b/packages/ai-chat-components/src/components/feedback/src/feedback-buttons.ts
@@ -12,7 +12,6 @@ import { property } from "lit/decorators.js";
 import { carbonElement } from "../../../globals/decorators/index.js";
 import { feedbackButtonsElementTemplate } from "./feedback-buttons.template.js";
 import prefix from "../../../globals/settings.js";
-// @ts-ignore
 import styles from "./feedback-buttons.scss?lit";
 
 /**

--- a/packages/ai-chat-components/src/components/feedback/src/feedback.ts
+++ b/packages/ai-chat-components/src/components/feedback/src/feedback.ts
@@ -12,7 +12,6 @@ import { property, state } from "lit/decorators.js";
 import { carbonElement } from "../../../globals/decorators/index.js";
 import { feedbackElementTemplate } from "./feedback.template.js";
 import prefix from "../../../globals/settings.js";
-// @ts-ignore
 import styles from "./feedback.scss?lit";
 
 /**

--- a/packages/ai-chat-components/src/components/markdown/src/markdown.ts
+++ b/packages/ai-chat-components/src/components/markdown/src/markdown.ts
@@ -11,7 +11,6 @@ import { LitElement, PropertyValues, TemplateResult } from "lit";
 import { property, state } from "lit/decorators.js";
 import { carbonElement } from "../../../globals/decorators/carbon-element.js";
 import prefix from "../../../globals/settings.js";
-// @ts-ignore
 import styles from "./markdown.scss?lit";
 import throttle from "lodash-es/throttle.js";
 import { createRef } from "lit/directives/ref.js";

--- a/packages/ai-chat-components/src/components/processing/src/processing.ts
+++ b/packages/ai-chat-components/src/components/processing/src/processing.ts
@@ -10,8 +10,6 @@
 import { LitElement, html } from "lit";
 import { property } from "lit/decorators.js";
 import { classMap } from "lit/directives/class-map.js";
-
-// @ts-ignore
 import styles from "./processing.scss?lit";
 import { carbonElement } from "../../../globals/decorators";
 import prefix from "../../../globals/settings.js";

--- a/packages/ai-chat-components/src/components/reasoning-steps/src/reasoning-step.ts
+++ b/packages/ai-chat-components/src/components/reasoning-steps/src/reasoning-step.ts
@@ -13,8 +13,6 @@ import { ifDefined } from "lit/directives/if-defined.js";
 import { property, state } from "lit/decorators.js";
 import { iconLoader } from "@carbon/web-components/es/globals/internal/icon-loader.js";
 import ChevronRight16 from "@carbon/icons/es/chevron--right/16.js";
-
-// @ts-ignore
 import styles from "./reasoning-step.scss?lit";
 import prefix from "../../../globals/settings.js";
 import { carbonElement } from "../../../globals/decorators";

--- a/packages/ai-chat-components/src/components/reasoning-steps/src/reasoning-steps-toggle.ts
+++ b/packages/ai-chat-components/src/components/reasoning-steps/src/reasoning-steps-toggle.ts
@@ -11,7 +11,6 @@ import { LitElement } from "lit";
 import { property } from "lit/decorators.js";
 import { carbonElement } from "../../../globals/decorators/index.js";
 import { reasoningStepsToggleTemplate } from "./reasoning-steps-toggle.template.js";
-// @ts-ignore
 import styles from "./reasoning-steps-toggle.scss?lit";
 import prefix from "../../../globals/settings.js";
 

--- a/packages/ai-chat-components/src/components/reasoning-steps/src/reasoning-steps.ts
+++ b/packages/ai-chat-components/src/components/reasoning-steps/src/reasoning-steps.ts
@@ -9,8 +9,6 @@
 
 import { LitElement, html } from "lit";
 import { property } from "lit/decorators.js";
-
-// @ts-ignore
 import styles from "./reasoning-steps.scss?lit";
 import prefix from "../../../globals/settings.js";
 import { carbonElement } from "../../../globals/decorators";

--- a/packages/ai-chat-components/src/components/table/src/table.ts
+++ b/packages/ai-chat-components/src/components/table/src/table.ts
@@ -13,7 +13,6 @@ import { property, state } from "lit/decorators.js";
 import { carbonElement } from "../../../globals/decorators";
 import { tableSkeletonTemplate } from "./table-skeleton.template";
 import { loadTableRuntime } from "./table-loader.js";
-// @ts-ignore
 import styles from "./table.scss?lit";
 import prefix from "../../../globals/settings.js";
 

--- a/packages/ai-chat-components/src/components/toolbar/src/toolbar.ts
+++ b/packages/ai-chat-components/src/components/toolbar/src/toolbar.ts
@@ -18,7 +18,6 @@ import { createOverflowHandler } from "@carbon/utilities";
 import OverflowMenuVertical16 from "@carbon/icons/es/overflow-menu--vertical/16.js";
 import { iconLoader } from "@carbon/web-components/es/globals/internal/icon-loader.js";
 import prefix from "../../../globals/settings.js";
-// @ts-ignore
 import styles from "./toolbar.scss?lit";
 import { CarbonIcon } from "@carbon/web-components/es/globals/internal/icon-loader-utils.js";
 import { carbonElement } from "../../../globals/decorators/index.js";

--- a/packages/ai-chat-components/src/components/workspace-shell/src/workspace-shell-body.ts
+++ b/packages/ai-chat-components/src/components/workspace-shell/src/workspace-shell-body.ts
@@ -9,7 +9,6 @@
 
 import { LitElement, html } from "lit";
 import { property } from "lit/decorators.js";
-// @ts-ignore
 import styles from "./workspace-shell.scss?lit";
 import { carbonElement } from "../../../globals/decorators/index.js";
 import prefix from "../../../globals/settings.js";

--- a/packages/ai-chat-components/src/components/workspace-shell/src/workspace-shell-footer.ts
+++ b/packages/ai-chat-components/src/components/workspace-shell/src/workspace-shell-footer.ts
@@ -15,7 +15,6 @@ import { iconLoader } from "@carbon/web-components/es/globals/internal/icon-load
 import { BUTTON_KIND } from "@carbon/web-components/es/components/button/button.js";
 import { carbonElement } from "../../../globals/decorators/index.js";
 import prefix from "../../../globals/settings.js";
-// @ts-ignore
 import styles from "./workspace-shell-footer.scss?lit";
 
 export type Action = {

--- a/packages/ai-chat-components/src/components/workspace-shell/src/workspace-shell-header.ts
+++ b/packages/ai-chat-components/src/components/workspace-shell/src/workspace-shell-header.ts
@@ -11,7 +11,6 @@ import { LitElement, html } from "lit";
 import { property } from "lit/decorators.js";
 import { carbonElement } from "../../../globals/decorators/index.js";
 import prefix from "../../../globals/settings.js";
-// @ts-ignore
 import styles from "./workspace-shell-header.scss?lit";
 
 /**

--- a/packages/ai-chat-components/src/components/workspace-shell/src/workspace-shell.ts
+++ b/packages/ai-chat-components/src/components/workspace-shell/src/workspace-shell.ts
@@ -10,7 +10,6 @@
 import { LitElement, html } from "lit";
 import { carbonElement } from "../../../globals/decorators/index.js";
 import prefix from "../../../globals/settings.js";
-// @ts-ignore
 import styles from "./workspace-shell.scss?lit";
 
 /**

--- a/packages/ai-chat-components/src/typings/resources.d.ts
+++ b/packages/ai-chat-components/src/typings/resources.d.ts
@@ -1,0 +1,9 @@
+/**
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+declare module "*.scss";
+declare module "*.scss?lit";


### PR DESCRIPTION
Closes #

Add global type declaration for `*.scss?lit` imports so we don't have TS errors.

#### Changelog

**New**

- add type declaration file 

**Removed**

- remove all the `ts-ignore` lines from the ai-chat-components files

#### Testing / Reviewing

ci-checks should pass
