### PR TITLE
feat: track multiple workspaces

### DIFF
--- a/demo/src/customSendMessage/doPreviewCard.ts
+++ b/demo/src/customSendMessage/doPreviewCard.ts
@@ -8,11 +8,14 @@
  */
 
 import { ChatInstance, MessageResponseTypes } from "@carbon/ai-chat";
+import { v4 as uuid } from "uuid";
 
 function doPreviewCard(
   instance: ChatInstance,
   preferredLocation?: "start" | "end",
 ) {
+  const workspaceId = uuid();
+
   instance.messaging.addMessage({
     output: {
       generic: [
@@ -22,13 +25,13 @@ function doPreviewCard(
         },
         {
           title: "Optimizing excess inventory",
-          subtitle: `Created on: ${new Date().toLocaleDateString()}`,
+          subtitle: `Workspace id ${workspaceId} Created on: ${new Date().toLocaleDateString()}`,
           response_type: MessageResponseTypes.PREVIEW_CARD,
           workspace_options: {
             preferredLocation,
           },
+          workspace_id: workspaceId,
           additional_data: {
-            id: "some unique ID for the workspace",
             data: "some additional data for the workspace",
           },
         },

--- a/demo/src/react/DemoApp.css
+++ b/demo/src/react/DemoApp.css
@@ -39,10 +39,12 @@
 
 .sidebar--closing {
   right: calc(calc(320px + 1rem) * -1);
+  width: 320px;
 }
 
 .sidebar--closed {
   right: calc(calc(320px + 1rem) * -1);
+  width: 320px;
   visibility: hidden;
 }
 
@@ -78,8 +80,14 @@
   transition: left 100ms, width 300ms cubic-bezier(0.2, 0, 0.38, 0.9), visibility 0s 100ms;
 }
 
+[dir="rtl"] .sidebar--closing {
+  left: calc(calc(320px + 1rem) * -1);
+  width: 320px;
+}
+
 [dir="rtl"] .sidebar--closed {
   right: auto;
   left: calc(calc(320px + 1rem) * -1);
+  width: 320px;
   transition: left 100ms, visibility 0s 0s;
 }

--- a/demo/src/react/WorkspaceWriteableElementExample.tsx
+++ b/demo/src/react/WorkspaceWriteableElementExample.tsx
@@ -45,6 +45,8 @@ function WorkspaceWriteableElementExample({
   instance,
   parentStateText,
 }: WorkspaceExampleProps) {
+  const workspaceId = instance?.getState()?.workspace?.workspaceID || "unknown";
+
   const handleClose = () => {
     panel?.close();
   };
@@ -159,7 +161,7 @@ function WorkspaceWriteableElementExample({
         hideCloseButton
       />
       <WorkspaceShellHeader
-        titleText="Optimizing excess inventory plan"
+        titleText={`Optimizing excess inventory plan (ID: ${workspaceId.substring(0, 8)}...)`}
         subTitleText={`Created on: ${new Date().toLocaleDateString()}`}
       >
         <div slot="header-description">

--- a/demo/src/web-components/demo-app.ts
+++ b/demo/src/web-components/demo-app.ts
@@ -105,14 +105,24 @@ export class DemoApp extends LitElement {
 
     .sidebar--closing {
       right: calc(calc(320px + 1rem) * -1);
+      width: 320px;
     }
 
     .sidebar--closed {
       right: calc(calc(320px + 1rem) * -1);
+      width: 320px;
       visibility: hidden;
     }
 
     /* RTL support */
+    [dir="rtl"] .sidebar {
+      right: auto;
+      left: 0;
+      transition:
+        left 100ms,
+        visibility 0s 100ms;
+    }
+
     [dir="rtl"] .sidebar--expanded {
       left: 0;
       right: auto;
@@ -130,6 +140,20 @@ export class DemoApp extends LitElement {
         left 100ms,
         width 300ms cubic-bezier(0.2, 0, 0.38, 0.9),
         visibility 0s 100ms;
+    }
+
+    [dir="rtl"] .sidebar--closing {
+      left: calc(calc(320px + 1rem) * -1);
+      width: 320px;
+    }
+
+    [dir="rtl"] .sidebar--closed {
+      right: auto;
+      left: calc(calc(320px + 1rem) * -1);
+      width: 320px;
+      transition:
+        left 100ms,
+        visibility 0s 0s;
     }
   `;
 

--- a/demo/src/web-components/workspace-writeable-element-example.ts
+++ b/demo/src/web-components/workspace-writeable-element-example.ts
@@ -136,6 +136,9 @@ class WorkspaceWriteableElementExample extends LitElement {
   }
 
   render() {
+    const workspaceId =
+      this.instance?.getState()?.workspace?.workspaceID || "unknown";
+
     return html` <cds-aichat-workspace-shell>
       <cds-aichat-toolbar
         slot="toolbar"
@@ -163,7 +166,7 @@ class WorkspaceWriteableElementExample extends LitElement {
       >
       </cds-inline-notification>
       <cds-aichat-workspace-shell-header
-        title-text="Optimizing excess inventory plan"
+        title-text=${`Optimizing excess inventory plan (ID: ${workspaceId.substring(0, 8)}...)`}
         subtitle-text=${`Created on: ${new Date().toLocaleDateString()}`}
       >
         <div slot="header-description">

--- a/packages/ai-chat/src/chat/services/ChatActionsImpl.ts
+++ b/packages/ai-chat/src/chat/services/ChatActionsImpl.ts
@@ -340,7 +340,18 @@ class ChatActionsImpl {
           preferredLocation:
             state.workspacePanelState.options.preferredLocation,
         },
+        workspaceID: state.workspacePanelState.workspaceID,
+        additionalData: state.workspacePanelState.additionalData,
       },
+    });
+
+    const workspace = deepFreeze({
+      isOpen: Boolean(state.workspacePanelState.isOpen),
+      options: {
+        preferredLocation: state.workspacePanelState.options.preferredLocation,
+      },
+      workspaceID: state.workspacePanelState.workspaceID,
+      additionalData: state.workspacePanelState.additionalData,
     });
 
     return deepFreeze({
@@ -352,6 +363,7 @@ class ChatActionsImpl {
       activeResponseId: assistantMessageState.activeResponseId ?? null,
       input,
       customPanels,
+      workspace,
     });
   }
 

--- a/packages/ai-chat/src/chat/store/actions.ts
+++ b/packages/ai-chat/src/chat/store/actions.ts
@@ -81,6 +81,7 @@ const SET_CONVERSATIONAL_SEARCH_CITATION_PANEL_IS_OPEN =
   "SET_CONVERSATIONAL_SEARCH_CITATION_PANEL_IS_OPEN";
 const SET_CUSTOM_PANEL_OPTIONS = "SET_CUSTOM_PANEL_OPTIONS";
 const SET_WORKSPACE_PANEL_OPTIONS = "SET_WORKSPACE_PANEL_OPTIONS";
+const SET_WORKSPACE_PANEL_DATA = "SET_WORKSPACE_PANEL_DATA";
 const SET_CUSTOM_PANEL_OPEN = "SET_CUSTOM_PANEL_OPEN";
 const SET_WORKSPACE_PANEL_OPEN = "SET_WORKSPACE_PANEL_OPEN";
 const TOGGLE_HOME_SCREEN = "GO_BACK_TO_HOME";
@@ -113,6 +114,15 @@ interface UnknownAction {
 interface SetWorkspacePanelOptionsAction {
   type: typeof SET_WORKSPACE_PANEL_OPTIONS;
   options: Partial<WorkspaceCustomPanelConfigOptions>;
+  [key: string]: unknown;
+}
+
+interface SetWorkspacePanelDataAction {
+  type: typeof SET_WORKSPACE_PANEL_DATA;
+  workspaceID?: string;
+  localMessageItem?: LocalMessageItem;
+  fullMessage?: Message;
+  additionalData?: unknown;
   [key: string]: unknown;
 }
 
@@ -443,6 +453,21 @@ const actions = {
     return { type: SET_WORKSPACE_PANEL_OPEN, isOpen };
   },
 
+  setWorkspacePanelData(data: {
+    workspaceID?: string;
+    localMessageItem?: LocalMessageItem;
+    fullMessage?: Message;
+    additionalData?: unknown;
+  }): SetWorkspacePanelDataAction {
+    return {
+      type: SET_WORKSPACE_PANEL_DATA,
+      workspaceID: data.workspaceID,
+      localMessageItem: data.localMessageItem,
+      fullMessage: data.fullMessage,
+      additionalData: data.additionalData,
+    };
+  },
+
   /**
    * Switches between the bot and home screen views.
    */
@@ -623,6 +648,7 @@ export {
   SET_CUSTOM_PANEL_OPTIONS,
   SET_CUSTOM_PANEL_OPEN,
   SET_WORKSPACE_PANEL_OPTIONS,
+  SET_WORKSPACE_PANEL_DATA,
   SET_WORKSPACE_PANEL_OPEN,
   SET_CHAT_MESSAGES_PROPERTY,
   TOGGLE_HOME_SCREEN,

--- a/packages/ai-chat/src/chat/store/reducerUtils.ts
+++ b/packages/ai-chat/src/chat/store/reducerUtils.ts
@@ -106,8 +106,12 @@ deepFreeze(DEFAULT_CUSTOM_PANEL_STATE);
 
 const DEFAULT_WORKSPACE_PANEL_STATE: WorkspacePanelState = {
   isOpen: false,
+  workspaceID: undefined,
   panelID: WORKSPACE_CUSTOM_PANEL_ID,
   options: WORKSPACE_CUSTOM_PANEL_CONFIG_OPTIONS,
+  localMessageItem: undefined,
+  fullMessage: undefined,
+  additionalData: undefined,
 };
 deepFreeze(DEFAULT_WORKSPACE_PANEL_STATE);
 

--- a/packages/ai-chat/src/chat/store/reducers.ts
+++ b/packages/ai-chat/src/chat/store/reducers.ts
@@ -62,6 +62,7 @@ import {
   SET_CUSTOM_PANEL_OPTIONS,
   SET_WORKSPACE_PANEL_OPEN,
   SET_WORKSPACE_PANEL_OPTIONS,
+  SET_WORKSPACE_PANEL_DATA,
   SET_HOME_SCREEN_IS_OPEN,
   SET_INITIAL_VIEW_CHANGE_COMPLETE,
   SET_IS_BROWSER_PAGE_VISIBLE,
@@ -886,6 +887,17 @@ const reducers: { [key: string]: ReducerType } = {
     state: AppState,
     action: { isOpen: boolean },
   ) => {
+    // When closing the panel, reset the workspace panel state to default
+    if (!action.isOpen) {
+      return {
+        ...state,
+        workspacePanelState: {
+          ...DEFAULT_WORKSPACE_PANEL_STATE,
+          isOpen: false,
+        },
+      };
+    }
+
     return {
       ...state,
       workspacePanelState: {
@@ -907,6 +919,27 @@ const reducers: { [key: string]: ReducerType } = {
           ...(state.workspacePanelState.options ?? {}),
           ...action.options,
         },
+      },
+    };
+  },
+
+  [SET_WORKSPACE_PANEL_DATA]: (
+    state: AppState,
+    action: {
+      workspaceID?: string;
+      localMessageItem?: LocalMessageItem;
+      fullMessage?: Message;
+      additionalData?: unknown;
+    },
+  ) => {
+    return {
+      ...state,
+      workspacePanelState: {
+        ...state.workspacePanelState,
+        workspaceID: action.workspaceID,
+        localMessageItem: action.localMessageItem,
+        fullMessage: action.fullMessage,
+        additionalData: action.additionalData,
       },
     };
   },

--- a/packages/ai-chat/src/types/events/eventBusTypes.ts
+++ b/packages/ai-chat/src/types/events/eventBusTypes.ts
@@ -670,6 +670,16 @@ export interface BusEventWorkspacePreOpen extends BusEvent {
   type: BusEventType.WORKSPACE_PRE_OPEN;
   data: {
     /**
+     * The ID of the given workspace.
+     */
+    workspaceId?: string;
+
+    /**
+     * Additional meta data.
+     */
+    additionalData?: unknown;
+
+    /**
      * The individual message item that is being displayed in this custom response.
      */
     message: GenericItem;
@@ -688,6 +698,16 @@ export interface BusEventWorkspacePreOpen extends BusEvent {
 export interface BusEventWorkspaceOpen extends BusEvent {
   type: BusEventType.WORKSPACE_OPEN;
   data: {
+    /**
+     * The ID of the given workspace.
+     */
+    workspaceId?: string;
+
+    /**
+     * Additional meta data.
+     */
+    additionalData?: unknown;
+
     /**
      * The individual message item that is being displayed in this custom response.
      */
@@ -708,6 +728,16 @@ export interface BusEventWorkspacePreClose extends BusEvent {
   type: BusEventType.WORKSPACE_PRE_CLOSE;
   data: {
     /**
+     * The ID of the given workspace.
+     */
+    workspaceId?: string;
+
+    /**
+     * Additional meta data.
+     */
+    additionalData?: unknown;
+
+    /**
      * The individual message item that is being displayed in this custom response.
      */
     message: GenericItem;
@@ -726,6 +756,16 @@ export interface BusEventWorkspacePreClose extends BusEvent {
 export interface BusEventWorkspaceClose extends BusEvent {
   type: BusEventType.WORKSPACE_CLOSE;
   data: {
+    /**
+     * The ID of the given workspace.
+     */
+    workspaceId?: string;
+
+    /**
+     * Additional meta data.
+     */
+    additionalData?: unknown;
+
     /**
      * The individual message item that is being displayed in this custom response.
      */

--- a/packages/ai-chat/src/types/instance/ChatInstance.ts
+++ b/packages/ai-chat/src/types/instance/ChatInstance.ts
@@ -75,10 +75,21 @@ export interface PublicDefaultCustomPanelState {
 export interface PublicWorkspaceCustomPanelState {
   /** Indicates if the workspace custom panel overlay is currently open. */
   isOpen: boolean;
+
   /**
    * Config options for the workspace panels.
    */
   options: WorkspaceCustomPanelConfigOptions;
+
+  /**
+   * The ID of the workspace attached to this panel. Used to match with a given Preview Card.
+   */
+  workspaceID?: string;
+
+  /**
+   * Additional metadata associated with the workspace.
+   */
+  additionalData?: unknown;
 }
 
 /**
@@ -143,6 +154,13 @@ export type PublicChatState = Readonly<
      * State for any surfaced custom panels.
      */
     customPanels: PublicCustomPanelsState;
+
+    /**
+     * State for the workspace panel.
+     *
+     * @experimental
+     */
+    workspace: PublicWorkspaceCustomPanelState;
   }
 >;
 

--- a/packages/ai-chat/src/types/instance/apiTypes.ts
+++ b/packages/ai-chat/src/types/instance/apiTypes.ts
@@ -251,6 +251,16 @@ export interface WorkspaceCustomPanelConfigOptions {
    * Where the chat will attempt to render the workspace in logical terms. For a ltr layout "start" will render on the left and "end" will render on the right. If there is not enough room to render the workspace, it will be rendered as a panel overlaying the content with a back button.
    */
   preferredLocation?: "start" | "end";
+
+  /**
+   * The ID of the workspace being opened. This will be included in WORKSPACE_PRE_CLOSE and WORKSPACE_CLOSE events.
+   */
+  workspaceId?: string;
+
+  /**
+   * Additional metadata associated with the workspace. This will be included in WORKSPACE_PRE_CLOSE and WORKSPACE_CLOSE events.
+   */
+  additionalData?: unknown;
 }
 
 /**

--- a/packages/ai-chat/src/types/messaging/Messages.ts
+++ b/packages/ai-chat/src/types/messaging/Messages.ts
@@ -696,6 +696,11 @@ interface PreviewCardItem<
   TUserDefinedType = Record<string, unknown>,
 > extends BaseGenericItem<TUserDefinedType> {
   /**
+   * The id of the workspace that is attached to this card.
+   */
+  workspace_id: string;
+
+  /**
    * The title of the preview card.
    */
   title?: string;
@@ -713,7 +718,7 @@ interface PreviewCardItem<
   /**
    * Additional data to be passed to workspace.
    */
-  additional_data?: any;
+  additional_data?: unknown;
 }
 
 /**

--- a/packages/ai-chat/src/types/state/AppState.ts
+++ b/packages/ai-chat/src/types/state/AppState.ts
@@ -532,6 +532,11 @@ interface WorkspacePanelState {
   isOpen: boolean;
 
   /**
+   * The id of the workspace attached to this panel. Used to match with a given Preview Card.
+   */
+  workspaceID?: string;
+
+  /**
    * The id of the panel that is currently in focus.
    */
   panelID: string;
@@ -540,6 +545,21 @@ interface WorkspacePanelState {
    * Config options for the workspace panels.
    */
   options: WorkspaceCustomPanelConfigOptions;
+
+  /**
+   * The local message item that triggered the workspace panel to open.
+   */
+  localMessageItem?: LocalMessageItem;
+
+  /**
+   * The full message response that contains the message item.
+   */
+  fullMessage?: Message;
+
+  /**
+   * Additional metadata associated with the workspace.
+   */
+  additionalData?: unknown;
 }
 
 interface MessagePanelState<T extends GenericItem = GenericItem> {

--- a/packages/ai-chat/tests/instance/spec/workspacePanels_spec.ts
+++ b/packages/ai-chat/tests/instance/spec/workspacePanels_spec.ts
@@ -1,0 +1,593 @@
+/*
+ *  Copyright IBM Corp. 2025
+ *
+ *  This source code is licensed under the Apache-2.0 license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ *  @license
+ */
+
+import {
+  createBaseConfig,
+  renderChatAndGetInstance,
+  renderChatAndGetInstanceWithStore,
+  setupBeforeEach,
+  setupAfterEach,
+} from "../../test_helpers";
+import { BusEventType } from "../../../src/types/events/eventBusTypes";
+import {
+  PanelType,
+  WorkspaceCustomPanelConfigOptions,
+} from "../../../src/types/instance/apiTypes";
+import { waitFor } from "@testing-library/react";
+
+describe("ChatInstance.customPanels - Workspace Panels", () => {
+  beforeEach(setupBeforeEach);
+  afterEach(setupAfterEach);
+
+  describe("getPanel(PanelType.WORKSPACE)", () => {
+    it("should return a workspace panel instance", async () => {
+      const config = createBaseConfig();
+      const instance = await renderChatAndGetInstance(config);
+
+      const panel = instance.customPanels.getPanel(PanelType.WORKSPACE);
+
+      expect(panel).toBeDefined();
+      expect(typeof panel).toBe("object");
+      expect(typeof panel.open).toBe("function");
+      expect(typeof panel.close).toBe("function");
+    });
+
+    it("should return the same workspace panel instance on multiple calls", async () => {
+      const config = createBaseConfig();
+      const instance = await renderChatAndGetInstance(config);
+
+      const panel1 = instance.customPanels.getPanel(PanelType.WORKSPACE);
+      const panel2 = instance.customPanels.getPanel(PanelType.WORKSPACE);
+
+      expect(panel1).toBe(panel2);
+    });
+
+    it("should return different instances for default and workspace panels", async () => {
+      const config = createBaseConfig();
+      const instance = await renderChatAndGetInstance(config);
+
+      const defaultPanel = instance.customPanels.getPanel(PanelType.DEFAULT);
+      const workspacePanel = instance.customPanels.getPanel(
+        PanelType.WORKSPACE,
+      );
+
+      expect(defaultPanel).not.toBe(workspacePanel);
+    });
+  });
+
+  describe("open with workspace options", () => {
+    it("should open workspace panel with default options and update Redux state", async () => {
+      const config = createBaseConfig();
+      const { instance, store } =
+        await renderChatAndGetInstanceWithStore(config);
+      const panel = instance.customPanels.getPanel(PanelType.WORKSPACE);
+
+      // Verify initial state
+      let state = store.getState();
+      expect(state.workspacePanelState.isOpen).toBe(false);
+
+      // Open panel
+      panel.open();
+
+      // Verify Redux state updated
+      state = store.getState();
+      expect(state.workspacePanelState.isOpen).toBe(true);
+      // Default workspace panel has preferredLocation: "end"
+      expect(state.workspacePanelState.options.preferredLocation).toBe("end");
+    });
+
+    it("should open workspace panel with WorkspaceCustomPanelConfigOptions", async () => {
+      const config = createBaseConfig();
+      const { instance, store } =
+        await renderChatAndGetInstanceWithStore(config);
+      const panel = instance.customPanels.getPanel(PanelType.WORKSPACE);
+
+      const workspaceOptions: WorkspaceCustomPanelConfigOptions = {
+        preferredLocation: "start",
+      };
+
+      panel.open(workspaceOptions);
+
+      const state = store.getState();
+      expect(state.workspacePanelState.isOpen).toBe(true);
+      expect(state.workspacePanelState.options.preferredLocation).toBe("start");
+    });
+
+    it("should store workspaceId when provided in options", async () => {
+      const config = createBaseConfig();
+      const { instance, store } =
+        await renderChatAndGetInstanceWithStore(config);
+      const panel = instance.customPanels.getPanel(PanelType.WORKSPACE);
+
+      const workspaceOptions: WorkspaceCustomPanelConfigOptions = {
+        preferredLocation: "end",
+        workspaceId: "workspace-123",
+      };
+
+      panel.open(workspaceOptions);
+
+      const state = store.getState();
+      expect(state.workspacePanelState.isOpen).toBe(true);
+      expect(state.workspacePanelState.workspaceID).toBe("workspace-123");
+      expect(state.workspacePanelState.options.preferredLocation).toBe("end");
+    });
+
+    it("should store additionalData when provided in options", async () => {
+      const config = createBaseConfig();
+      const { instance, store } =
+        await renderChatAndGetInstanceWithStore(config);
+      const panel = instance.customPanels.getPanel(PanelType.WORKSPACE);
+
+      const workspaceOptions: WorkspaceCustomPanelConfigOptions = {
+        preferredLocation: "start",
+        workspaceId: "workspace-456",
+        additionalData: { userId: "user-789", context: "test" },
+      };
+
+      panel.open(workspaceOptions);
+
+      const state = store.getState();
+      expect(state.workspacePanelState.isOpen).toBe(true);
+      expect(state.workspacePanelState.workspaceID).toBe("workspace-456");
+      expect(state.workspacePanelState.additionalData).toEqual({
+        userId: "user-789",
+        context: "test",
+      });
+    });
+
+    it("should handle opening with only workspaceId and additionalData", async () => {
+      const config = createBaseConfig();
+      const { instance, store } =
+        await renderChatAndGetInstanceWithStore(config);
+      const panel = instance.customPanels.getPanel(PanelType.WORKSPACE);
+
+      const workspaceOptions: WorkspaceCustomPanelConfigOptions = {
+        workspaceId: "ws-only-id",
+        additionalData: { test: "data" },
+      };
+
+      panel.open(workspaceOptions);
+
+      const state = store.getState();
+      expect(state.workspacePanelState.isOpen).toBe(true);
+      expect(state.workspacePanelState.workspaceID).toBe("ws-only-id");
+      expect(state.workspacePanelState.additionalData).toEqual({
+        test: "data",
+      });
+    });
+  });
+
+  describe("close with data cleanup", () => {
+    it("should close workspace panel and reset state to default", async () => {
+      const config = createBaseConfig();
+      const { instance, store } =
+        await renderChatAndGetInstanceWithStore(config);
+      const panel = instance.customPanels.getPanel(PanelType.WORKSPACE);
+
+      // Open with data
+      panel.open({
+        preferredLocation: "start",
+        workspaceId: "workspace-123",
+        additionalData: { test: "data" },
+      });
+
+      let state = store.getState();
+      expect(state.workspacePanelState.isOpen).toBe(true);
+      expect(state.workspacePanelState.workspaceID).toBe("workspace-123");
+
+      // Close the panel
+      panel.close();
+
+      // Verify Redux state reset
+      state = store.getState();
+      expect(state.workspacePanelState.isOpen).toBe(false);
+      expect(state.workspacePanelState.workspaceID).toBeUndefined();
+      expect(state.workspacePanelState.additionalData).toBeUndefined();
+      expect(state.workspacePanelState.localMessageItem).toBeUndefined();
+      expect(state.workspacePanelState.fullMessage).toBeUndefined();
+    });
+
+    it("should handle multiple open/close cycles with data cleanup", async () => {
+      const config = createBaseConfig();
+      const { instance, store } =
+        await renderChatAndGetInstanceWithStore(config);
+      const panel = instance.customPanels.getPanel(PanelType.WORKSPACE);
+
+      // First cycle
+      panel.open({
+        workspaceId: "workspace-1",
+        additionalData: { cycle: 1 },
+      });
+      let state = store.getState();
+      expect(state.workspacePanelState.workspaceID).toBe("workspace-1");
+
+      panel.close();
+      state = store.getState();
+      expect(state.workspacePanelState.workspaceID).toBeUndefined();
+
+      // Second cycle with different data
+      panel.open({
+        workspaceId: "workspace-2",
+        additionalData: { cycle: 2 },
+      });
+      state = store.getState();
+      expect(state.workspacePanelState.workspaceID).toBe("workspace-2");
+      expect(state.workspacePanelState.additionalData).toEqual({ cycle: 2 });
+
+      panel.close();
+      state = store.getState();
+      expect(state.workspacePanelState.workspaceID).toBeUndefined();
+      expect(state.workspacePanelState.additionalData).toBeUndefined();
+    });
+  });
+
+  describe("Workspace Events", () => {
+    it("should fire WORKSPACE_PRE_OPEN and WORKSPACE_OPEN events when opening panel", async () => {
+      const config = createBaseConfig();
+      const instance = await renderChatAndGetInstance(config);
+      const panel = instance.customPanels.getPanel(PanelType.WORKSPACE);
+
+      const preOpenEventPromise = new Promise((resolve) => {
+        instance.on({
+          type: BusEventType.WORKSPACE_PRE_OPEN,
+          handler: (event) => {
+            expect(event.type).toBe(BusEventType.WORKSPACE_PRE_OPEN);
+            resolve(event);
+          },
+        });
+      });
+
+      const openEventPromise = new Promise((resolve) => {
+        instance.on({
+          type: BusEventType.WORKSPACE_OPEN,
+          handler: (event) => {
+            expect(event.type).toBe(BusEventType.WORKSPACE_OPEN);
+            resolve(event);
+          },
+        });
+      });
+
+      // Open the panel
+      panel.open({ preferredLocation: "start" });
+
+      // Wait for both events to fire
+      await Promise.all([preOpenEventPromise, openEventPromise]);
+    });
+
+    it("should fire WORKSPACE_PRE_CLOSE and WORKSPACE_CLOSE events when closing panel", async () => {
+      const config = createBaseConfig();
+      const instance = await renderChatAndGetInstance(config);
+      const panel = instance.customPanels.getPanel(PanelType.WORKSPACE);
+
+      // Set up event listeners first
+      const preCloseEventPromise = new Promise((resolve) => {
+        instance.on({
+          type: BusEventType.WORKSPACE_PRE_CLOSE,
+          handler: (event) => {
+            expect(event.type).toBe(BusEventType.WORKSPACE_PRE_CLOSE);
+            resolve(event);
+          },
+        });
+      });
+
+      const closeEventPromise = new Promise((resolve) => {
+        instance.on({
+          type: BusEventType.WORKSPACE_CLOSE,
+          handler: (event) => {
+            expect(event.type).toBe(BusEventType.WORKSPACE_CLOSE);
+            resolve(event);
+          },
+        });
+      });
+
+      // First open the panel
+      panel.open({ preferredLocation: "start" });
+
+      // Wait for the panel to be fully open, then close it
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      // Close the panel
+      panel.close();
+
+      // Wait for both events to fire
+      await Promise.all([preCloseEventPromise, closeEventPromise]);
+    });
+
+    it("should include workspaceId in close events when provided", async () => {
+      const config = createBaseConfig();
+      const instance = await renderChatAndGetInstance(config);
+      const panel = instance.customPanels.getPanel(PanelType.WORKSPACE);
+
+      const closeEventPromise = new Promise((resolve) => {
+        instance.on({
+          type: BusEventType.WORKSPACE_CLOSE,
+          handler: (event: any) => {
+            expect(event.data.workspaceId).toBe("workspace-with-id");
+            resolve(event);
+          },
+        });
+      });
+
+      // Open with workspaceId
+      panel.open({
+        preferredLocation: "start",
+        workspaceId: "workspace-with-id",
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      // Close and verify event data
+      panel.close();
+
+      await closeEventPromise;
+    });
+
+    it("should include additionalData in close events when provided", async () => {
+      const config = createBaseConfig();
+      const instance = await renderChatAndGetInstance(config);
+      const panel = instance.customPanels.getPanel(PanelType.WORKSPACE);
+
+      const testData = { userId: "user-123", context: "test-context" };
+
+      const closeEventPromise = new Promise((resolve) => {
+        instance.on({
+          type: BusEventType.WORKSPACE_CLOSE,
+          handler: (event: any) => {
+            expect(event.data.additionalData).toEqual(testData);
+            resolve(event);
+          },
+        });
+      });
+
+      // Open with additionalData
+      panel.open({
+        preferredLocation: "end",
+        workspaceId: "workspace-123",
+        additionalData: testData,
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      // Close and verify event data
+      panel.close();
+
+      await closeEventPromise;
+    });
+
+    it("should fire events in correct sequence during workspace open/close cycle", async () => {
+      const config = createBaseConfig();
+      const { instance } = await renderChatAndGetInstanceWithStore(config);
+      const panel = instance.customPanels.getPanel(PanelType.WORKSPACE);
+
+      const eventSequence: string[] = [];
+
+      // Set up event listeners for all workspace events
+      instance.on([
+        {
+          type: BusEventType.WORKSPACE_PRE_OPEN,
+          handler: () => eventSequence.push("PRE_OPEN"),
+        },
+        {
+          type: BusEventType.WORKSPACE_OPEN,
+          handler: () => eventSequence.push("OPEN"),
+        },
+        {
+          type: BusEventType.WORKSPACE_PRE_CLOSE,
+          handler: () => eventSequence.push("PRE_CLOSE"),
+        },
+        {
+          type: BusEventType.WORKSPACE_CLOSE,
+          handler: () => eventSequence.push("CLOSE"),
+        },
+      ]);
+
+      // Open the panel
+      panel.open({
+        preferredLocation: "start",
+        workspaceId: "test-workspace",
+      });
+
+      // Wait for open events
+      await waitFor(() => {
+        expect(eventSequence).toContain("PRE_OPEN");
+      });
+
+      await waitFor(
+        () => {
+          expect(eventSequence).toContain("OPEN");
+        },
+        { timeout: 1000 },
+      );
+
+      // Close the panel
+      panel.close();
+
+      // Wait for close events
+      await waitFor(() => {
+        expect(eventSequence).toContain("PRE_CLOSE");
+      });
+
+      await waitFor(
+        () => {
+          expect(eventSequence).toContain("CLOSE");
+        },
+        { timeout: 1000 },
+      );
+
+      // Verify complete event sequence
+      expect(eventSequence).toEqual(["PRE_OPEN", "OPEN", "PRE_CLOSE", "CLOSE"]);
+    });
+
+    it("should provide correct event context and instance in workspace event handlers", async () => {
+      const config = createBaseConfig();
+      const instance = await renderChatAndGetInstance(config);
+      const panel = instance.customPanels.getPanel(PanelType.WORKSPACE);
+
+      const eventPromise = new Promise((resolve) => {
+        instance.on({
+          type: BusEventType.WORKSPACE_OPEN,
+          handler: (event: any, eventInstance) => {
+            // Verify event structure
+            expect(event).toBeDefined();
+            expect(event.type).toBe(BusEventType.WORKSPACE_OPEN);
+            expect(event.data).toBeDefined();
+
+            // Verify instance is provided
+            expect(eventInstance).toBe(instance);
+            expect(eventInstance.customPanels).toBeDefined();
+
+            resolve(true);
+          },
+        });
+      });
+
+      // Open the panel to trigger the event
+      panel.open({ preferredLocation: "start" });
+
+      await eventPromise;
+    });
+  });
+
+  describe("Public State Access", () => {
+    it("should expose workspace state via instance.getState().workspace", async () => {
+      const config = createBaseConfig();
+      const instance = await renderChatAndGetInstance(config);
+      const panel = instance.customPanels.getPanel(PanelType.WORKSPACE);
+
+      // Open with data
+      panel.open({
+        preferredLocation: "start",
+        workspaceId: "public-state-test",
+        additionalData: { test: "public" },
+      });
+
+      // Wait for state to update
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      const state = instance.getState();
+      expect(state.workspace).toBeDefined();
+      expect(state.workspace.isOpen).toBe(true);
+      expect(state.workspace.workspaceID).toBe("public-state-test");
+      expect(state.workspace.additionalData).toEqual({ test: "public" });
+      expect(state.workspace.options.preferredLocation).toBe("start");
+    });
+
+    it("should also expose workspace state via customPanels.workspace", async () => {
+      const config = createBaseConfig();
+      const instance = await renderChatAndGetInstance(config);
+      const panel = instance.customPanels.getPanel(PanelType.WORKSPACE);
+
+      panel.open({
+        preferredLocation: "end",
+        workspaceId: "custom-panels-test",
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      const state = instance.getState();
+      expect(state.customPanels.workspace).toBeDefined();
+      expect(state.customPanels.workspace.isOpen).toBe(true);
+      expect(state.customPanels.workspace.workspaceID).toBe(
+        "custom-panels-test",
+      );
+      expect(state.customPanels.workspace.options.preferredLocation).toBe(
+        "end",
+      );
+    });
+
+    it("should reflect state changes in both workspace and customPanels.workspace", async () => {
+      const config = createBaseConfig();
+      const instance = await renderChatAndGetInstance(config);
+      const panel = instance.customPanels.getPanel(PanelType.WORKSPACE);
+
+      panel.open({
+        workspaceId: "sync-test",
+        additionalData: { synced: true },
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      const state = instance.getState();
+
+      // Both should reflect the same data
+      expect(state.workspace.workspaceID).toBe(
+        state.customPanels.workspace.workspaceID,
+      );
+      expect(state.workspace.additionalData).toEqual(
+        state.customPanels.workspace.additionalData,
+      );
+      expect(state.workspace.isOpen).toBe(state.customPanels.workspace.isOpen);
+    });
+
+    it("should clear workspace state from public API after close", async () => {
+      const config = createBaseConfig();
+      const instance = await renderChatAndGetInstance(config);
+      const panel = instance.customPanels.getPanel(PanelType.WORKSPACE);
+
+      // Open with data
+      panel.open({
+        workspaceId: "clear-test",
+        additionalData: { clear: "me" },
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      let state = instance.getState();
+      expect(state.workspace.workspaceID).toBe("clear-test");
+
+      // Close
+      panel.close();
+
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      state = instance.getState();
+      expect(state.workspace.isOpen).toBe(false);
+      expect(state.workspace.workspaceID).toBeUndefined();
+      expect(state.workspace.additionalData).toBeUndefined();
+    });
+  });
+
+  describe("Integration with Default Panels", () => {
+    it("should not affect default panel state when workspace panel opens/closes", async () => {
+      const config = createBaseConfig();
+      const { instance, store } =
+        await renderChatAndGetInstanceWithStore(config);
+      const workspacePanel = instance.customPanels.getPanel(
+        PanelType.WORKSPACE,
+      );
+      const defaultPanel = instance.customPanels.getPanel(PanelType.DEFAULT);
+
+      // Open default panel
+      defaultPanel.open({ title: "Default Panel" });
+      let state = store.getState();
+      expect(state.customPanelState.isOpen).toBe(true);
+      expect(state.customPanelState.options.title).toBe("Default Panel");
+
+      // Open workspace panel
+      workspacePanel.open({ workspaceId: "workspace-123" });
+      state = store.getState();
+      expect(state.workspacePanelState.isOpen).toBe(true);
+      expect(state.workspacePanelState.workspaceID).toBe("workspace-123");
+
+      // Default panel should still be open
+      expect(state.customPanelState.isOpen).toBe(true);
+      expect(state.customPanelState.options.title).toBe("Default Panel");
+
+      // Close workspace panel
+      workspacePanel.close();
+      state = store.getState();
+      expect(state.workspacePanelState.isOpen).toBe(false);
+
+      // Default panel should still be open
+      expect(state.customPanelState.isOpen).toBe(true);
+    });
+  });
+});
+
+// Made with Bob


### PR DESCRIPTION
## Add support for multiple workspace panels management

This PR introduces a new workspace panel system that allows managing multiple workspace instances within the Carbon AI Chat, enabling users to open and interact with different workspaces simultaneously.

#### Changelog

**New**

- Added `PanelType.WORKSPACE` enum value for workspace-specific panels
- Added `WorkspaceCustomPanelConfigOptions` interface with `preferredLocation`, `workspaceId`, and `additionalData` properties
- Added `PublicWorkspaceCustomPanelState` interface to expose workspace panel state
- Added `WorkspacePanelState` to Redux state for managing workspace panel data
- Added `workspaceId` and `additionalData` properties to workspace event bus events (WORKSPACE_PRE_OPEN, WORKSPACE_OPEN, WORKSPACE_PRE_CLOSE, WORKSPACE_CLOSE)
- Added Redux actions for workspace panel management:
  - `setWorkspaceCustomPanelConfigOptions` - Configure workspace panel options
  - `setWorkspaceCustomPanelOpen` - Open/close workspace panel
  - `setWorkspacePanelData` - Store workspace metadata (ID, message items, additional data)

**Changed**

- Updated `CustomPanelInstance` to support both default and workspace panel types with type-specific behavior
- Modified `createCustomPanelInstance` to accept `panelType` parameter and handle workspace-specific logic
- Enhanced `CustomPanels.getPanel()` to accept optional `PanelType` parameter for retrieving specific panel instances
- Updated `PublicChatState` to include `workspace` property exposing workspace panel state
- Modified `PreviewCardComponent` to integrate with workspace panel system
- Updated demo examples (`doPreviewCard.ts`, `WorkspaceWriteableElementExample.tsx`, `workspace-writeable-element-example.ts`) to demonstrate workspace panel usage
- Enhanced Redux reducers to handle workspace panel state updates
- Updated `ChatActionsImpl` to support workspace panel operations

**Removed**

- None

#### Testing / Reviewing

1. **Test single workspace:**
   - In the chat input, type: `workspace preview card (open start)`
   - Click the preview card that appears
   - Verify the workspace panel opens on the **left side** (start position) on large screens
   - Close the workspace using the toolbar close button
   - Type: `workspace preview card (open end)`
   - Click the preview card
   - Verify the workspace panel opens on the **right side** (end position) on large screens

3. **Test multiple workspace management:**
   - In the chat input, type: `workspace preview card (open start)` again.
   - Open the new workspace. See that the id rendered in the toolbar changes.
   - Swap back and forth between the workspaces and check the preview card state is correct.
   - Confirm smooth transition between workspaces
