### PR TITLE
fix: workspace shell vertical overflow

### DIFF
--- a/packages/ai-chat-components/src/components/workspace-shell/src/workspace-shell.scss
+++ b/packages/ai-chat-components/src/components/workspace-shell/src/workspace-shell.scss
@@ -22,7 +22,7 @@ $css--plex: true !default;
   @include type.type-style("body-01");
 
   display: flex;
-  overflow: scroll;
+  overflow: auto;
   /* stylelint-disable-next-line declaration-no-important */
   box-sizing: border-box !important;
   flex-direction: column;


### PR DESCRIPTION
Closes #819 

Adds `overflow: scroll` to workspace shell to allow for more graceful handling of shrinking

#### Changelog

**New**

- `overflow: scroll;` to `cds-aichat-workspace-shell` styling

#### Testing / Reviewing

Verified in storybook by resizing vertical space of the workspace shell component
