### PR TITLE
fix: streaming re-rendering needlessly

### DIFF
--- a/examples/react/basic/src/customSendMessage.ts
+++ b/examples/react/basic/src/customSendMessage.ts
@@ -12,6 +12,7 @@ import {
   CustomSendMessageOptions,
   MessageRequest,
   MessageResponseTypes,
+  PartialItemChunkWithId,
   StreamChunk,
 } from "@carbon/ai-chat";
 
@@ -120,7 +121,7 @@ async function doFakeTextStreaming(
             streaming_metadata: {
               response_id: responseID,
             },
-          });
+          } as PartialItemChunkWithId);
         }
       }, index * WORD_DELAY);
       timeouts.push(timeoutId as unknown as number);

--- a/packages/ai-chat-components/src/components/markdown/src/markdown.ts
+++ b/packages/ai-chat-components/src/components/markdown/src/markdown.ts
@@ -311,19 +311,23 @@ class CDSAIChatMarkdown extends LitElement {
   /**
    * @internal
    */
-  private scheduleRender = throttle(() => {
-    // Lit's getter/setter pipeline can schedule multiple renders quickly.
-    // We capture the active render promise so we can report completion later.
-    const task = this.renderMarkdown();
-    const trackedTask = task.finally(() => {
-      if (this.renderTask === trackedTask) {
-        this.renderTask = null;
-      }
-    });
+  private scheduleRender = throttle(
+    () => {
+      // Lit's getter/setter pipeline can schedule multiple renders quickly.
+      // We capture the active render promise so we can report completion later.
+      const task = this.renderMarkdown();
+      const trackedTask = task.finally(() => {
+        if (this.renderTask === trackedTask) {
+          this.renderTask = null;
+        }
+      });
 
-    this.renderTask = trackedTask;
-    return trackedTask;
-  }, 150);
+      this.renderTask = trackedTask;
+      return trackedTask;
+    },
+    100,
+    { leading: true },
+  );
 
   protected async getUpdateComplete(): Promise<boolean> {
     // `updateComplete` is Lit's public hook for consumers/tests to await

--- a/packages/ai-chat/docs/CustomServer.md
+++ b/packages/ai-chat/docs/CustomServer.md
@@ -117,6 +117,7 @@ The final response chunk ({@link FinalResponseChunk}) signals the end of all str
 - Triggers cleanup of streaming UI states (like hiding "stop streaming" buttons)
 - Should contain the complete {@link MessageResponse} with all items
 - Must have an `id` matching the `response_id` from previous chunks
+- For any item that was streamed, include `streaming_metadata.id` to preserve identity
 - Represents what you should save in your history store.
 
 Example:
@@ -129,6 +130,9 @@ const finalResponse: MessageResponse = {
       {
         response_type: MessageResponseTypes.TEXT,
         text: finalText,
+        streaming_metadata: {
+          id: "1",
+        },
         message_item_options: {
           feedback: feedbackOptions,
         },

--- a/packages/ai-chat/docs/Customization.md
+++ b/packages/ai-chat/docs/Customization.md
@@ -37,7 +37,7 @@ To show custom content, you return the following from your server. Refer to the 
 
 The `user_defined` response injects into a slot within the Carbon AI Chat's shadow DOM. This means that it can be styled from global CSS and have a small amount of the CSS inherited from the Carbon AI Chat (font styling, and so on) styles. You can use Carbon components in addition to your own custom components.
 
-When streaming `user_defined` responses, the API only supports sending chunks of strings, not partially completed JSON. You can stringify JSON and then have your user defined handler that responds to it deal with try/catch based parsing or an optimistic parsing library.
+When streaming `user_defined` responses, the API only supports sending chunks of strings, not partially completed JSON. You can stringify JSON and then have your user defined handler that responds to it deal with try/catch based parsing or an optimistic parsing library. If you are streaming via `addMessageChunk`, be sure to include `streaming_metadata.response_id` for the message and `streaming_metadata.id` for each item so chunks correlate correctly.
 
 For more information, see the documentation for [React](React.md) and [web components](WebComponent.md).
 

--- a/packages/ai-chat/docs/React.md
+++ b/packages/ai-chat/docs/React.md
@@ -276,6 +276,7 @@ function App() {
 You may also want your `user_defined` responses to stream. In that case, you will want to make use of {@link RenderUserDefinedState.partialItems}. The partialItems come back as an array of every chunk we have received.
 They are _not_ concatenated for you. Some folks pass in stringified JSON or JSON that needs to be passed through
 an optimistic JSON parser (one that auto fixes up partial JSON), so unlike the text response_type, we leave that concatenation to your use case.
+If you are streaming via `addMessageChunk`, be sure to include `streaming_metadata.response_id` for the message and `streaming_metadata.id` for each item so chunks correlate correctly.
 
 ```typescript
 import React, { useCallback, useEffect, useState } from 'react';

--- a/packages/ai-chat/docs/WebComponent.md
+++ b/packages/ai-chat/docs/WebComponent.md
@@ -339,7 +339,7 @@ export class Demo extends LitElement {
 }
 ```
 
-You may also want your `user_defined` responses to stream. In that case, you will want to listen for both {@link BusEventType.USER_DEFINED_RESPONSE} and {@link BusEventType.CHUNK_USER_DEFINED_RESPONSE} events, and make use of the `partialItems` that accumulate over time. The partialItems come back as an array of every chunk received. They are \_not\* concatenated for you. Some folks pass in stringified JSON or JSON that needs to be passed through an optimistic JSON parser (one that auto fixes up partial JSON), so unlike the text response_type, we leave that concatenation to your use case.
+You may also want your `user_defined` responses to stream. In that case, you will want to listen for both {@link BusEventType.USER_DEFINED_RESPONSE} and {@link BusEventType.CHUNK_USER_DEFINED_RESPONSE} events, and make use of the `partialItems` that accumulate over time. The partialItems come back as an array of every chunk received. They are \_not\* concatenated for you. Some folks pass in stringified JSON or JSON that needs to be passed through an optimistic JSON parser (one that auto fixes up partial JSON), so unlike the text response_type, we leave that concatenation to your use case. If you are streaming via `addMessageChunk`, be sure to include `streaming_metadata.response_id` for the message and `streaming_metadata.id` for each item so chunks correlate correctly.
 
 ```typescript
 import "@carbon/ai-chat/dist/es/web-components/cds-aichat-container/index.js";

--- a/packages/ai-chat/src/aiChatEntry.tsx
+++ b/packages/ai-chat/src/aiChatEntry.tsx
@@ -203,6 +203,7 @@ export {
   OptionItem,
   OptionItemPreference,
   PartialItemChunk,
+  PartialItemChunkWithId,
   PauseItem,
   PreviewCardItem,
   StreamChunk,

--- a/packages/ai-chat/src/chat/components-legacy/responseTypes/conversationalSearch/ConversationalSearchText.scss
+++ b/packages/ai-chat/src/chat/components-legacy/responseTypes/conversationalSearch/ConversationalSearchText.scss
@@ -9,12 +9,6 @@
 @use "@carbon/styles/scss/motion";
 @use "@carbon/styles/scss/theme";
 
-.cds-aichat--received--conversational-search .cds-aichat--received--feedback,
-.cds-aichat--wide-width .cds-aichat--conversational-search-text,
-.cds-aichat--standard-width .cds-aichat--conversational-search-text {
-  margin-inline: 56px 16px;
-}
-
 .cds-aichat--conversational-search-text__CitationsToggleContainer {
   padding-block-start: layout.$spacing-04;
 }

--- a/packages/ai-chat/src/serverEntry.ts
+++ b/packages/ai-chat/src/serverEntry.ts
@@ -204,6 +204,7 @@ export {
   OptionItem,
   OptionItemPreference,
   PartialItemChunk,
+  PartialItemChunkWithId,
   PauseItem,
   PreviewCardItem,
   StreamChunk,

--- a/packages/ai-chat/tests/instance/spec/messaging/addMessageChunk_spec.ts
+++ b/packages/ai-chat/tests/instance/spec/messaging/addMessageChunk_spec.ts
@@ -370,6 +370,105 @@ describe("ChatInstance.messaging.addMessageChunk", () => {
     expect(messageItem.ui_state.isIntermediateStreaming).toBeUndefined();
   });
 
+  it("should reuse streaming IDs when final response items match existing items but omit IDs", async () => {
+    const config = createBaseConfig();
+    const { instance, store } = await renderChatAndGetInstanceWithStore(config);
+    const responseId = "msg-final-id-patch";
+    const itemId = "chunk-1";
+
+    await instance.messaging.addMessageChunk({
+      streaming_metadata: { response_id: responseId },
+      partial_item: {
+        streaming_metadata: { id: itemId },
+        response_type: MessageResponseTypes.TEXT,
+        text: "Partial ",
+      },
+    });
+
+    await instance.messaging.addMessageChunk({
+      streaming_metadata: { response_id: responseId },
+      complete_item: {
+        streaming_metadata: { id: itemId },
+        response_type: MessageResponseTypes.TEXT,
+        text: "Complete text",
+      },
+    });
+
+    const finalResponseChunk: FinalResponseChunk = {
+      final_response: {
+        id: responseId,
+        output: {
+          generic: [
+            {
+              response_type: MessageResponseTypes.TEXT,
+              text: "Complete text",
+            },
+          ],
+        },
+      },
+    };
+
+    await instance.messaging.addMessageChunk(finalResponseChunk);
+
+    const state = store.getState();
+    const message = state.allMessagesByID[responseId] as MessageResponse;
+    const finalItem = message.output.generic[0] as TextItem;
+
+    expect(finalItem.streaming_metadata?.id).toBe(itemId);
+    expect(state.allMessageItemsByID[`${responseId}-${itemId}`]).toBeDefined();
+  });
+
+  it("should not reuse streaming IDs when final response items differ", async () => {
+    const config = createBaseConfig();
+    const { instance, store } = await renderChatAndGetInstanceWithStore(config);
+    const responseId = "msg-final-id-no-patch";
+    const itemId = "chunk-1";
+
+    await instance.messaging.addMessageChunk({
+      streaming_metadata: { response_id: responseId },
+      partial_item: {
+        streaming_metadata: { id: itemId },
+        response_type: MessageResponseTypes.TEXT,
+        text: "Partial ",
+      },
+    });
+
+    await instance.messaging.addMessageChunk({
+      streaming_metadata: { response_id: responseId },
+      complete_item: {
+        streaming_metadata: { id: itemId },
+        response_type: MessageResponseTypes.TEXT,
+        text: "Complete text",
+      },
+    });
+
+    const finalResponseChunk: FinalResponseChunk = {
+      final_response: {
+        id: responseId,
+        output: {
+          generic: [
+            {
+              response_type: MessageResponseTypes.TEXT,
+              text: "Different final text",
+            },
+          ],
+        },
+      },
+    };
+
+    await instance.messaging.addMessageChunk(finalResponseChunk);
+
+    const state = store.getState();
+    const message = state.allMessagesByID[responseId] as MessageResponse;
+    const finalItem = message.output.generic[0] as TextItem;
+
+    expect(finalItem.streaming_metadata?.id).toBeUndefined();
+    // Orphaned streaming items should be removed when content differs
+    expect(
+      state.allMessageItemsByID[`${responseId}-${itemId}`],
+    ).toBeUndefined();
+  });
+
   describe("Abort signal behavior during streaming", () => {
     it("should trigger abort signal with STOP_STREAMING reason when stop button is used", async () => {
       const config = createBaseConfig();


### PR DESCRIPTION
#### Changelog

**New**

- Added `PartialItemChunkWithId` type for compile-time enforcement of streaming metadata IDs
- Added automatic ID patching for final responses that match streamed items but omit IDs
- Added console warnings when streaming metadata IDs are missing from complete items or final responses

**Changed**

- Improved streaming performance by preserving item identity across partial chunks, complete items, and final responses
- Enhanced streaming documentation with clearer guidance on when to use `streaming_metadata.id`
- Updated example implementations in `customSendMessage.ts` to use proper streaming metadata types

**Removed**

- Removed unnecessary margin styles from conversational search text component

#### Testing / Reviewing

**Documentation Review:**
1. Review the updated streaming documentation in `packages/ai-chat/docs/CustomServer.md`, `packages/ai-chat/docs/React.md`, and `packages/ai-chat/docs/WebComponent.md`
2. Check that the new `PartialItemChunkWithId` type and streaming metadata guidance is clear

**Functional Testing:**
1. Copy the example `customSendMessage.ts` from this StackBlitz into `examples/react/basic`: https://stackblitz.com/edit/github-kyhq9hyf?file=src%2FcustomSendMessage.ts
2. Run the React basic example: `cd examples/react/basic && npm install && npm run dev`
3. Send a message and verify:
   - Text streams smoothly without unnecessary re-renders
   - No console warnings appear about missing streaming metadata IDs
   - The streaming response completes correctly
   - Items maintain their identity throughout the streaming process (no visual "flashing" or remounting)

**Code Review:**
1. Review `ChatActionsImpl.ts` changes for the new ID patching logic
2. Check the new test cases in `addMessageChunk_spec.ts` that verify ID reuse behavior
3. Verify that the `PartialItemChunkWithId` type properly enforces streaming metadata requirements
4. Confirm that warning messages are helpful and actionable for developers

**Edge Cases to Test:**
- Streaming multiple items in a single response
- Sending a final response that differs from streamed content (should not reuse IDs)
- Sending a final response that matches streamed content but omits IDs (should auto-patch)
- Streaming without any IDs (should work but show warnings)