### PR TITLE
fix: fix homescreen alignment

### DIFF
--- a/packages/ai-chat/src/chat/components/homeScreen/HomeScreen.scss
+++ b/packages/ai-chat/src/chat/components/homeScreen/HomeScreen.scss
@@ -13,7 +13,8 @@
 @use "../../styles/chat-theme";
 
 .cds-aichat--widget--max-width
-  .cds-aichat--home-screen__home-screen-bottom-element {
+  .cds-aichat--home-screen__home-screen-bottom-element,
+.cds-aichat--home-screen {
   margin: auto;
   max-inline-size: var(--cds-aichat-messages-max-width, 672px);
 }


### PR DESCRIPTION
Before:
<img width="1537" height="695" alt="Screenshot 2026-02-11 at 12 07 23 PM" src="https://github.com/user-attachments/assets/3b110c9a-de76-4e86-926b-b0d86f25eaf4" />

After:

<img width="1451" height="762" alt="Screenshot 2026-02-11 at 12 07 47 PM" src="https://github.com/user-attachments/assets/4cf226fa-1cc0-449c-aae3-f09d32c523b6" />
