### PR TITLE
chore: rename shell and panel classes

### DIFF
--- a/packages/ai-chat-components/src/components/chat-shell/__tests__/panel.test.ts
+++ b/packages/ai-chat-components/src/components/chat-shell/__tests__/panel.test.ts
@@ -9,7 +9,7 @@
 
 import { html, fixture, expect } from "@open-wc/testing";
 import "@carbon/ai-chat-components/es/components/chat-shell/index.js";
-import CdsAiChatPanel from "@carbon/ai-chat-components/es/components/chat-shell/src/panel.js";
+import CDSAIChatPanel from "@carbon/ai-chat-components/es/components/chat-shell/src/panel.js";
 
 /**
  * This repository uses the @web/test-runner library for testing
@@ -21,15 +21,15 @@ describe("cds-aichat-panel", function () {
   // ========== Basic Rendering Tests ==========
   describe("Basic Rendering", () => {
     it("should render with minimum attributes", async () => {
-      const el = await fixture<CdsAiChatPanel>(
+      const el = await fixture<CDSAIChatPanel>(
         html`<cds-aichat-panel></cds-aichat-panel>`,
       );
-      expect(el).to.be.instanceOf(CdsAiChatPanel);
+      expect(el).to.be.instanceOf(CDSAIChatPanel);
       expect(el.shadowRoot).to.exist;
     });
 
     it("should have default property values", async () => {
-      const el = await fixture<CdsAiChatPanel>(
+      const el = await fixture<CDSAIChatPanel>(
         html`<cds-aichat-panel></cds-aichat-panel>`,
       );
       expect(el.open).to.be.false;
@@ -43,7 +43,7 @@ describe("cds-aichat-panel", function () {
     });
 
     it("should apply panel and panel-container classes", async () => {
-      const el = await fixture<CdsAiChatPanel>(
+      const el = await fixture<CDSAIChatPanel>(
         html`<cds-aichat-panel></cds-aichat-panel>`,
       );
       expect(el.classList.contains("panel")).to.be.true;
@@ -51,7 +51,7 @@ describe("cds-aichat-panel", function () {
     });
 
     it("should render panel-content wrapper", async () => {
-      const el = await fixture<CdsAiChatPanel>(
+      const el = await fixture<CDSAIChatPanel>(
         html`<cds-aichat-panel></cds-aichat-panel>`,
       );
       const panelContent = el.shadowRoot!.querySelector(".panel-content");
@@ -62,7 +62,7 @@ describe("cds-aichat-panel", function () {
   // ========== Property/Attribute Tests ==========
   describe("Properties and Attributes", () => {
     it("should reflect open attribute", async () => {
-      const el = await fixture<CdsAiChatPanel>(
+      const el = await fixture<CDSAIChatPanel>(
         html`<cds-aichat-panel open></cds-aichat-panel>`,
       );
       expect(el.open).to.be.true;
@@ -70,7 +70,7 @@ describe("cds-aichat-panel", function () {
     });
 
     it("should reflect priority attribute", async () => {
-      const el = await fixture<CdsAiChatPanel>(
+      const el = await fixture<CDSAIChatPanel>(
         html`<cds-aichat-panel priority="5"></cds-aichat-panel>`,
       );
       expect(el.priority).to.equal(5);
@@ -78,7 +78,7 @@ describe("cds-aichat-panel", function () {
     });
 
     it("should reflect full-width attribute", async () => {
-      const el = await fixture<CdsAiChatPanel>(
+      const el = await fixture<CDSAIChatPanel>(
         html`<cds-aichat-panel full-width></cds-aichat-panel>`,
       );
       expect(el.fullWidth).to.be.true;
@@ -86,7 +86,7 @@ describe("cds-aichat-panel", function () {
     });
 
     it("should reflect show-chat-header attribute", async () => {
-      const el = await fixture<CdsAiChatPanel>(
+      const el = await fixture<CDSAIChatPanel>(
         html`<cds-aichat-panel show-chat-header></cds-aichat-panel>`,
       );
       expect(el.showChatHeader).to.be.true;
@@ -94,7 +94,7 @@ describe("cds-aichat-panel", function () {
     });
 
     it("should reflect show-frame attribute", async () => {
-      const el = await fixture<CdsAiChatPanel>(
+      const el = await fixture<CDSAIChatPanel>(
         html`<cds-aichat-panel show-frame></cds-aichat-panel>`,
       );
       expect(el.showFrame).to.be.true;
@@ -102,7 +102,7 @@ describe("cds-aichat-panel", function () {
     });
 
     it("should reflect animation-on-open attribute", async () => {
-      const el = await fixture<CdsAiChatPanel>(
+      const el = await fixture<CDSAIChatPanel>(
         html`<cds-aichat-panel
           animation-on-open="slide-in-from-bottom"
         ></cds-aichat-panel>`,
@@ -114,7 +114,7 @@ describe("cds-aichat-panel", function () {
     });
 
     it("should reflect animation-on-close attribute", async () => {
-      const el = await fixture<CdsAiChatPanel>(
+      const el = await fixture<CDSAIChatPanel>(
         html`<cds-aichat-panel
           animation-on-close="slide-out-to-bottom"
         ></cds-aichat-panel>`,
@@ -126,7 +126,7 @@ describe("cds-aichat-panel", function () {
     });
 
     it("should reflect inert attribute", async () => {
-      const el = await fixture<CdsAiChatPanel>(
+      const el = await fixture<CDSAIChatPanel>(
         html`<cds-aichat-panel inert></cds-aichat-panel>`,
       );
       expect(el.inert).to.be.true;
@@ -137,7 +137,7 @@ describe("cds-aichat-panel", function () {
   // ========== Slot Content Tests ==========
   describe("Slot Content", () => {
     it("should render header slot content", async () => {
-      const el = await fixture<CdsAiChatPanel>(
+      const el = await fixture<CDSAIChatPanel>(
         html`<cds-aichat-panel>
           <div slot="header">Header Content</div>
         </cds-aichat-panel>`,
@@ -152,7 +152,7 @@ describe("cds-aichat-panel", function () {
     });
 
     it("should render body slot content", async () => {
-      const el = await fixture<CdsAiChatPanel>(
+      const el = await fixture<CDSAIChatPanel>(
         html`<cds-aichat-panel>
           <div slot="body">Body Content</div>
         </cds-aichat-panel>`,
@@ -167,7 +167,7 @@ describe("cds-aichat-panel", function () {
     });
 
     it("should render footer slot content", async () => {
-      const el = await fixture<CdsAiChatPanel>(
+      const el = await fixture<CDSAIChatPanel>(
         html`<cds-aichat-panel>
           <div slot="footer">Footer Content</div>
         </cds-aichat-panel>`,
@@ -182,7 +182,7 @@ describe("cds-aichat-panel", function () {
     });
 
     it("should apply has-content class to header when it has content", async () => {
-      const el = await fixture<CdsAiChatPanel>(
+      const el = await fixture<CDSAIChatPanel>(
         html`<cds-aichat-panel>
           <div slot="header">Header</div>
         </cds-aichat-panel>`,
@@ -193,7 +193,7 @@ describe("cds-aichat-panel", function () {
     });
 
     it("should apply has-content class to body when it has content", async () => {
-      const el = await fixture<CdsAiChatPanel>(
+      const el = await fixture<CDSAIChatPanel>(
         html`<cds-aichat-panel>
           <div slot="body">Body</div>
         </cds-aichat-panel>`,
@@ -204,7 +204,7 @@ describe("cds-aichat-panel", function () {
     });
 
     it("should apply has-content class to footer when it has content", async () => {
-      const el = await fixture<CdsAiChatPanel>(
+      const el = await fixture<CDSAIChatPanel>(
         html`<cds-aichat-panel>
           <div slot="footer">Footer</div>
         </cds-aichat-panel>`,
@@ -215,7 +215,7 @@ describe("cds-aichat-panel", function () {
     });
 
     it("should not apply has-content class when slots are empty", async () => {
-      const el = await fixture<CdsAiChatPanel>(
+      const el = await fixture<CDSAIChatPanel>(
         html`<cds-aichat-panel></cds-aichat-panel>`,
       );
       await el.updateComplete;
@@ -231,28 +231,28 @@ describe("cds-aichat-panel", function () {
   // ========== CSS Class Application Tests ==========
   describe("CSS Classes", () => {
     it("should apply panel--with-chat-header class when showChatHeader is true", async () => {
-      const el = await fixture<CdsAiChatPanel>(
+      const el = await fixture<CDSAIChatPanel>(
         html`<cds-aichat-panel show-chat-header></cds-aichat-panel>`,
       );
       expect(el.classList.contains("panel--with-chat-header")).to.be.true;
     });
 
     it("should apply panel--with-frame class when showFrame is true", async () => {
-      const el = await fixture<CdsAiChatPanel>(
+      const el = await fixture<CDSAIChatPanel>(
         html`<cds-aichat-panel show-frame></cds-aichat-panel>`,
       );
       expect(el.classList.contains("panel--with-frame")).to.be.true;
     });
 
     it("should apply panel--full-width class when fullWidth is true", async () => {
-      const el = await fixture<CdsAiChatPanel>(
+      const el = await fixture<CDSAIChatPanel>(
         html`<cds-aichat-panel full-width></cds-aichat-panel>`,
       );
       expect(el.classList.contains("panel--full-width")).to.be.true;
     });
 
     it("should apply panel--closed class initially when not open", async () => {
-      const el = await fixture<CdsAiChatPanel>(
+      const el = await fixture<CDSAIChatPanel>(
         html`<cds-aichat-panel></cds-aichat-panel>`,
       );
       expect(el.classList.contains("panel--closed")).to.be.true;
@@ -260,7 +260,7 @@ describe("cds-aichat-panel", function () {
     });
 
     it("should apply panel--open class when open is true", async () => {
-      const el = await fixture<CdsAiChatPanel>(
+      const el = await fixture<CDSAIChatPanel>(
         html`<cds-aichat-panel open></cds-aichat-panel>`,
       );
       await el.updateComplete;
@@ -272,14 +272,14 @@ describe("cds-aichat-panel", function () {
   // ========== Animation State Tests ==========
   describe("Animation States", () => {
     it("should start in closed state", async () => {
-      const el = await fixture<CdsAiChatPanel>(
+      const el = await fixture<CDSAIChatPanel>(
         html`<cds-aichat-panel></cds-aichat-panel>`,
       );
       expect(el.classList.contains("panel--closed")).to.be.true;
     });
 
     it("should start in open state when open attribute is set", async () => {
-      const el = await fixture<CdsAiChatPanel>(
+      const el = await fixture<CDSAIChatPanel>(
         html`<cds-aichat-panel open></cds-aichat-panel>`,
       );
       await el.updateComplete;
@@ -287,7 +287,7 @@ describe("cds-aichat-panel", function () {
     });
 
     it("should apply animation class when animationOnOpen is set", async () => {
-      const el = await fixture<CdsAiChatPanel>(
+      const el = await fixture<CDSAIChatPanel>(
         html`<cds-aichat-panel
           animation-on-open="slide-in-from-bottom"
         ></cds-aichat-panel>`,
@@ -300,7 +300,7 @@ describe("cds-aichat-panel", function () {
     });
 
     it("should apply animation class when animationOnClose is set", async () => {
-      const el = await fixture<CdsAiChatPanel>(
+      const el = await fixture<CDSAIChatPanel>(
         html`<cds-aichat-panel
           open
           animation-on-close="slide-out-to-bottom"
@@ -315,7 +315,7 @@ describe("cds-aichat-panel", function () {
     });
 
     it("should apply panel-container--animating class during transitions", async () => {
-      const el = await fixture<CdsAiChatPanel>(
+      const el = await fixture<CDSAIChatPanel>(
         html`<cds-aichat-panel
           animation-on-open="slide-in-from-bottom"
         ></cds-aichat-panel>`,
@@ -326,7 +326,7 @@ describe("cds-aichat-panel", function () {
     });
 
     it("should not open when inert is true", async () => {
-      const el = await fixture<CdsAiChatPanel>(
+      const el = await fixture<CDSAIChatPanel>(
         html`<cds-aichat-panel inert></cds-aichat-panel>`,
       );
       el.open = true;
@@ -337,7 +337,7 @@ describe("cds-aichat-panel", function () {
     });
 
     it("should close when inert becomes true while open", async () => {
-      const el = await fixture<CdsAiChatPanel>(
+      const el = await fixture<CDSAIChatPanel>(
         html`<cds-aichat-panel open></cds-aichat-panel>`,
       );
       await el.updateComplete;
@@ -353,7 +353,7 @@ describe("cds-aichat-panel", function () {
   // ========== Event Emission Tests ==========
   describe("Event Emission", () => {
     it("should emit openstart event when opening", async () => {
-      const el = await fixture<CdsAiChatPanel>(
+      const el = await fixture<CDSAIChatPanel>(
         html`<cds-aichat-panel></cds-aichat-panel>`,
       );
 
@@ -378,7 +378,7 @@ describe("cds-aichat-panel", function () {
     });
 
     it("should emit openend event after opening completes", async () => {
-      const el = await fixture<CdsAiChatPanel>(
+      const el = await fixture<CDSAIChatPanel>(
         html`<cds-aichat-panel></cds-aichat-panel>`,
       );
 
@@ -406,7 +406,7 @@ describe("cds-aichat-panel", function () {
     });
 
     it("should emit closestart event when closing", async () => {
-      const el = await fixture<CdsAiChatPanel>(
+      const el = await fixture<CDSAIChatPanel>(
         html`<cds-aichat-panel open></cds-aichat-panel>`,
       );
       await el.updateComplete;
@@ -430,7 +430,7 @@ describe("cds-aichat-panel", function () {
     });
 
     it("should emit closeend event after closing completes", async () => {
-      const el = await fixture<CdsAiChatPanel>(
+      const el = await fixture<CDSAIChatPanel>(
         html`<cds-aichat-panel open></cds-aichat-panel>`,
       );
       await el.updateComplete;
@@ -462,14 +462,14 @@ describe("cds-aichat-panel", function () {
   // ========== Rounded Corners Tests ==========
   describe("Rounded Corners", () => {
     it("should apply rounded corners for full-width panels", async () => {
-      const el = await fixture<CdsAiChatPanel>(
+      const el = await fixture<CDSAIChatPanel>(
         html`<cds-aichat-panel full-width></cds-aichat-panel>`,
       );
       expect(el.classList.contains("panel--full-width")).to.be.true;
     });
 
     it("should apply rounded corners when panel width is less than messages max width", async () => {
-      const el = await fixture<CdsAiChatPanel>(
+      const el = await fixture<CDSAIChatPanel>(
         html`<cds-aichat-panel></cds-aichat-panel>`,
       );
       // The panel--with-less-than-messages-max-width class is applied by ResizeObserver
@@ -478,7 +478,7 @@ describe("cds-aichat-panel", function () {
     });
 
     it("should handle rounded corners with show-chat-header", async () => {
-      const el = await fixture<CdsAiChatPanel>(
+      const el = await fixture<CDSAIChatPanel>(
         html`<cds-aichat-panel full-width show-chat-header></cds-aichat-panel>`,
       );
       expect(el.classList.contains("panel--full-width")).to.be.true;
@@ -486,7 +486,7 @@ describe("cds-aichat-panel", function () {
     });
 
     it("should handle rounded corners without show-chat-header", async () => {
-      const el = await fixture<CdsAiChatPanel>(
+      const el = await fixture<CDSAIChatPanel>(
         html`<cds-aichat-panel full-width></cds-aichat-panel>`,
       );
       expect(el.classList.contains("panel--full-width")).to.be.true;
@@ -497,7 +497,7 @@ describe("cds-aichat-panel", function () {
   // ========== Complex Scenarios ==========
   describe("Complex Scenarios", () => {
     it("should handle all properties together", async () => {
-      const el = await fixture<CdsAiChatPanel>(
+      const el = await fixture<CDSAIChatPanel>(
         html`<cds-aichat-panel
           open
           priority="10"
@@ -529,7 +529,7 @@ describe("cds-aichat-panel", function () {
     });
 
     it("should handle dynamic property changes", async () => {
-      const el = await fixture<CdsAiChatPanel>(
+      const el = await fixture<CDSAIChatPanel>(
         html`<cds-aichat-panel></cds-aichat-panel>`,
       );
 
@@ -550,7 +550,7 @@ describe("cds-aichat-panel", function () {
     });
 
     it("should handle priority changes", async () => {
-      const el = await fixture<CdsAiChatPanel>(
+      const el = await fixture<CDSAIChatPanel>(
         html`<cds-aichat-panel priority="1"></cds-aichat-panel>`,
       );
       expect(el.priority).to.equal(1);
@@ -562,7 +562,7 @@ describe("cds-aichat-panel", function () {
     });
 
     it("should handle slot content changes dynamically", async () => {
-      const el = await fixture<CdsAiChatPanel>(
+      const el = await fixture<CDSAIChatPanel>(
         html`<cds-aichat-panel></cds-aichat-panel>`,
       );
       await el.updateComplete;
@@ -590,21 +590,21 @@ describe("cds-aichat-panel", function () {
   // ========== Snapshot Tests ==========
   describe("Snapshots", () => {
     it("should match snapshot with default configuration", async () => {
-      const el = await fixture<CdsAiChatPanel>(
+      const el = await fixture<CDSAIChatPanel>(
         html`<cds-aichat-panel></cds-aichat-panel>`,
       );
       await expect(el).dom.to.equalSnapshot();
     });
 
     it("should match snapshot when open", async () => {
-      const el = await fixture<CdsAiChatPanel>(
+      const el = await fixture<CDSAIChatPanel>(
         html`<cds-aichat-panel open></cds-aichat-panel>`,
       );
       await expect(el).dom.to.equalSnapshot();
     });
 
     it("should match snapshot with all properties", async () => {
-      const el = await fixture<CdsAiChatPanel>(
+      const el = await fixture<CDSAIChatPanel>(
         html`<cds-aichat-panel
           open
           priority="5"

--- a/packages/ai-chat-components/src/components/chat-shell/__tests__/shell.test.ts
+++ b/packages/ai-chat-components/src/components/chat-shell/__tests__/shell.test.ts
@@ -9,7 +9,7 @@
 
 import { html, fixture, expect } from "@open-wc/testing";
 import "@carbon/ai-chat-components/es/components/chat-shell/index.js";
-import CdsAiChatShell from "@carbon/ai-chat-components/es/components/chat-shell/src/shell.js";
+import CDSAIChatShell from "@carbon/ai-chat-components/es/components/chat-shell/src/shell.js";
 
 /**
  * This repository uses the @web/test-runner library for testing
@@ -39,15 +39,15 @@ describe("cds-aichat-shell", function () {
   // ========== Basic Rendering Tests ==========
   describe("Basic Rendering", () => {
     it("should render with minimum attributes", async () => {
-      const el = await fixture<CdsAiChatShell>(
+      const el = await fixture<CDSAIChatShell>(
         html`<cds-aichat-shell></cds-aichat-shell>`,
       );
-      expect(el).to.be.instanceOf(CdsAiChatShell);
+      expect(el).to.be.instanceOf(CDSAIChatShell);
       expect(el.shadowRoot).to.exist;
     });
 
     it("should have default property values", async () => {
-      const el = await fixture<CdsAiChatShell>(
+      const el = await fixture<CDSAIChatShell>(
         html`<cds-aichat-shell></cds-aichat-shell>`,
       );
       expect(el.aiEnabled).to.be.false;
@@ -60,7 +60,7 @@ describe("cds-aichat-shell", function () {
     });
 
     it("should render shell root element", async () => {
-      const el = await fixture<CdsAiChatShell>(
+      const el = await fixture<CDSAIChatShell>(
         html`<cds-aichat-shell></cds-aichat-shell>`,
       );
       const shell = el.shadowRoot!.querySelector(".shell");
@@ -71,7 +71,7 @@ describe("cds-aichat-shell", function () {
   // ========== Property/Attribute Tests ==========
   describe("Properties and Attributes", () => {
     it("should reflect ai-enabled attribute", async () => {
-      const el = await fixture<CdsAiChatShell>(
+      const el = await fixture<CDSAIChatShell>(
         html`<cds-aichat-shell ai-enabled></cds-aichat-shell>`,
       );
       expect(el.aiEnabled).to.be.true;
@@ -79,7 +79,7 @@ describe("cds-aichat-shell", function () {
     });
 
     it("should reflect show-frame attribute", async () => {
-      const el = await fixture<CdsAiChatShell>(
+      const el = await fixture<CDSAIChatShell>(
         html`<cds-aichat-shell show-frame></cds-aichat-shell>`,
       );
       expect(el.showFrame).to.be.true;
@@ -87,7 +87,7 @@ describe("cds-aichat-shell", function () {
     });
 
     it("should reflect rounded-corners attribute", async () => {
-      const el = await fixture<CdsAiChatShell>(
+      const el = await fixture<CDSAIChatShell>(
         html`<cds-aichat-shell rounded-corners></cds-aichat-shell>`,
       );
       expect(el.roundedCorners).to.be.true;
@@ -95,7 +95,7 @@ describe("cds-aichat-shell", function () {
     });
 
     it("should reflect show-history attribute", async () => {
-      const el = await fixture<CdsAiChatShell>(
+      const el = await fixture<CDSAIChatShell>(
         html`<cds-aichat-shell show-history></cds-aichat-shell>`,
       );
       expect(el.showHistory).to.be.true;
@@ -103,7 +103,7 @@ describe("cds-aichat-shell", function () {
     });
 
     it("should reflect show-workspace attribute", async () => {
-      const el = await fixture<CdsAiChatShell>(
+      const el = await fixture<CDSAIChatShell>(
         html`<cds-aichat-shell show-workspace></cds-aichat-shell>`,
       );
       expect(el.showWorkspace).to.be.true;
@@ -111,7 +111,7 @@ describe("cds-aichat-shell", function () {
     });
 
     it("should reflect workspace-location attribute with start value", async () => {
-      const el = await fixture<CdsAiChatShell>(
+      const el = await fixture<CDSAIChatShell>(
         html`<cds-aichat-shell workspace-location="start"></cds-aichat-shell>`,
       );
       expect(el.workspaceLocation).to.equal("start");
@@ -119,7 +119,7 @@ describe("cds-aichat-shell", function () {
     });
 
     it("should reflect workspace-location attribute with end value", async () => {
-      const el = await fixture<CdsAiChatShell>(
+      const el = await fixture<CDSAIChatShell>(
         html`<cds-aichat-shell workspace-location="end"></cds-aichat-shell>`,
       );
       expect(el.workspaceLocation).to.equal("end");
@@ -127,7 +127,7 @@ describe("cds-aichat-shell", function () {
     });
 
     it("should reflect history-location attribute with start value", async () => {
-      const el = await fixture<CdsAiChatShell>(
+      const el = await fixture<CDSAIChatShell>(
         html`<cds-aichat-shell history-location="start"></cds-aichat-shell>`,
       );
       expect(el.historyLocation).to.equal("start");
@@ -135,7 +135,7 @@ describe("cds-aichat-shell", function () {
     });
 
     it("should reflect history-location attribute with end value", async () => {
-      const el = await fixture<CdsAiChatShell>(
+      const el = await fixture<CDSAIChatShell>(
         html`<cds-aichat-shell history-location="end"></cds-aichat-shell>`,
       );
       expect(el.historyLocation).to.equal("end");
@@ -146,7 +146,7 @@ describe("cds-aichat-shell", function () {
   // ========== CSS Class Application Tests ==========
   describe("CSS Classes", () => {
     it("should apply ai-theme class when aiEnabled is true", async () => {
-      const el = await fixture<CdsAiChatShell>(
+      const el = await fixture<CDSAIChatShell>(
         html`<cds-aichat-shell ai-enabled></cds-aichat-shell>`,
       );
       const shell = el.shadowRoot!.querySelector(".shell");
@@ -154,7 +154,7 @@ describe("cds-aichat-shell", function () {
     });
 
     it("should not apply ai-theme class when aiEnabled is false", async () => {
-      const el = await fixture<CdsAiChatShell>(
+      const el = await fixture<CDSAIChatShell>(
         html`<cds-aichat-shell></cds-aichat-shell>`,
       );
       const shell = el.shadowRoot!.querySelector(".shell");
@@ -162,7 +162,7 @@ describe("cds-aichat-shell", function () {
     });
 
     it("should apply frameless class when showFrame is false", async () => {
-      const el = await fixture<CdsAiChatShell>(
+      const el = await fixture<CDSAIChatShell>(
         html`<cds-aichat-shell></cds-aichat-shell>`,
       );
       const shell = el.shadowRoot!.querySelector(".shell");
@@ -170,7 +170,7 @@ describe("cds-aichat-shell", function () {
     });
 
     it("should not apply frameless class when showFrame is true", async () => {
-      const el = await fixture<CdsAiChatShell>(
+      const el = await fixture<CDSAIChatShell>(
         html`<cds-aichat-shell show-frame></cds-aichat-shell>`,
       );
       const shell = el.shadowRoot!.querySelector(".shell");
@@ -178,7 +178,7 @@ describe("cds-aichat-shell", function () {
     });
 
     it("should apply rounded class when roundedCorners is true", async () => {
-      const el = await fixture<CdsAiChatShell>(
+      const el = await fixture<CDSAIChatShell>(
         html`<cds-aichat-shell rounded-corners></cds-aichat-shell>`,
       );
       const shell = el.shadowRoot!.querySelector(".shell");
@@ -186,7 +186,7 @@ describe("cds-aichat-shell", function () {
     });
 
     it("should not apply rounded class when roundedCorners is false", async () => {
-      const el = await fixture<CdsAiChatShell>(
+      const el = await fixture<CDSAIChatShell>(
         html`<cds-aichat-shell></cds-aichat-shell>`,
       );
       const shell = el.shadowRoot!.querySelector(".shell");
@@ -194,7 +194,7 @@ describe("cds-aichat-shell", function () {
     });
 
     it("should apply has-header-content class when header slot has content", async () => {
-      const el = await fixture<CdsAiChatShell>(
+      const el = await fixture<CDSAIChatShell>(
         html`<cds-aichat-shell>
           <div slot="header">Header Content</div>
         </cds-aichat-shell>`,
@@ -205,7 +205,7 @@ describe("cds-aichat-shell", function () {
     });
 
     it("should apply has-footer-content class when footer slot has content", async () => {
-      const el = await fixture<CdsAiChatShell>(
+      const el = await fixture<CDSAIChatShell>(
         html`<cds-aichat-shell>
           <div slot="footer">Footer Content</div>
         </cds-aichat-shell>`,
@@ -219,7 +219,7 @@ describe("cds-aichat-shell", function () {
   // ========== Slot Content Tests ==========
   describe("Slot Content", () => {
     it("should render header slot content", async () => {
-      const el = await fixture<CdsAiChatShell>(
+      const el = await fixture<CDSAIChatShell>(
         html`<cds-aichat-shell>
           <div slot="header">Header Content</div>
         </cds-aichat-shell>`,
@@ -234,7 +234,7 @@ describe("cds-aichat-shell", function () {
     });
 
     it("should render header-after slot content", async () => {
-      const el = await fixture<CdsAiChatShell>(
+      const el = await fixture<CDSAIChatShell>(
         html`<cds-aichat-shell>
           <div slot="header-after">Header After Content</div>
         </cds-aichat-shell>`,
@@ -248,7 +248,7 @@ describe("cds-aichat-shell", function () {
     });
 
     it("should render messages slot content", async () => {
-      const el = await fixture<CdsAiChatShell>(
+      const el = await fixture<CDSAIChatShell>(
         html`<cds-aichat-shell>
           <div slot="messages">Messages Content</div>
         </cds-aichat-shell>`,
@@ -262,7 +262,7 @@ describe("cds-aichat-shell", function () {
     });
 
     it("should render input slot content", async () => {
-      const el = await fixture<CdsAiChatShell>(
+      const el = await fixture<CDSAIChatShell>(
         html`<cds-aichat-shell>
           <div slot="input">Input Content</div>
         </cds-aichat-shell>`,
@@ -276,7 +276,7 @@ describe("cds-aichat-shell", function () {
     });
 
     it("should render input-before slot content", async () => {
-      const el = await fixture<CdsAiChatShell>(
+      const el = await fixture<CDSAIChatShell>(
         html`<cds-aichat-shell>
           <div slot="input-before">Input Before Content</div>
         </cds-aichat-shell>`,
@@ -290,7 +290,7 @@ describe("cds-aichat-shell", function () {
     });
 
     it("should render input-after slot content", async () => {
-      const el = await fixture<CdsAiChatShell>(
+      const el = await fixture<CDSAIChatShell>(
         html`<cds-aichat-shell>
           <div slot="input-after">Input After Content</div>
         </cds-aichat-shell>`,
@@ -304,7 +304,7 @@ describe("cds-aichat-shell", function () {
     });
 
     it("should render footer slot content", async () => {
-      const el = await fixture<CdsAiChatShell>(
+      const el = await fixture<CDSAIChatShell>(
         html`<cds-aichat-shell>
           <div slot="footer">Footer Content</div>
         </cds-aichat-shell>`,
@@ -318,7 +318,7 @@ describe("cds-aichat-shell", function () {
     });
 
     it("should render panels slot content", async () => {
-      const el = await fixture<CdsAiChatShell>(
+      const el = await fixture<CDSAIChatShell>(
         html`<cds-aichat-shell>
           <div slot="panels">
             <cds-aichat-panel>Panel Content</cds-aichat-panel>
@@ -337,7 +337,7 @@ describe("cds-aichat-shell", function () {
   // ========== History Integration Tests ==========
   describe("History Integration", () => {
     it("should render history slot when showHistory is true", async () => {
-      const el = await fixture<CdsAiChatShell>(
+      const el = await fixture<CDSAIChatShell>(
         html`<cds-aichat-shell show-history>
           <div slot="history">History Content</div>
         </cds-aichat-shell>`,
@@ -347,7 +347,7 @@ describe("cds-aichat-shell", function () {
     });
 
     it("should not render history slot when showHistory is false", async () => {
-      const el = await fixture<CdsAiChatShell>(
+      const el = await fixture<CDSAIChatShell>(
         html`<cds-aichat-shell>
           <div slot="history">History Content</div>
         </cds-aichat-shell>`,
@@ -361,7 +361,7 @@ describe("cds-aichat-shell", function () {
   describe("Rounded Corners - Critical Functionality", () => {
     describe("Base Rounded Corners Behavior", () => {
       it("should apply rounded class to shell when roundedCorners is true", async () => {
-        const el = await fixture<CdsAiChatShell>(
+        const el = await fixture<CDSAIChatShell>(
           html`<cds-aichat-shell rounded-corners></cds-aichat-shell>`,
         );
         const shell = el.shadowRoot!.querySelector(".shell");
@@ -369,7 +369,7 @@ describe("cds-aichat-shell", function () {
       });
 
       it("should not apply rounded corners when roundedCorners is false", async () => {
-        const el = await fixture<CdsAiChatShell>(
+        const el = await fixture<CDSAIChatShell>(
           html`<cds-aichat-shell></cds-aichat-shell>`,
         );
         const shell = el.shadowRoot!.querySelector(".shell");
@@ -377,7 +377,7 @@ describe("cds-aichat-shell", function () {
       });
 
       it("should not apply rounded corners when frameless", async () => {
-        const el = await fixture<CdsAiChatShell>(
+        const el = await fixture<CDSAIChatShell>(
           html`<cds-aichat-shell rounded-corners></cds-aichat-shell>`,
         );
         const shell = el.shadowRoot!.querySelector(".shell");
@@ -389,7 +389,7 @@ describe("cds-aichat-shell", function () {
 
     describe("Header Rounded Corners", () => {
       it("should apply has-header-content class when header has content", async () => {
-        const el = await fixture<CdsAiChatShell>(
+        const el = await fixture<CDSAIChatShell>(
           html`<cds-aichat-shell rounded-corners>
             <div slot="header">Header</div>
           </cds-aichat-shell>`,
@@ -400,7 +400,7 @@ describe("cds-aichat-shell", function () {
       });
 
       it("should detect header content with text nodes", async () => {
-        const el = await fixture<CdsAiChatShell>(
+        const el = await fixture<CDSAIChatShell>(
           html`<cds-aichat-shell rounded-corners>
             <span slot="header">Text content</span>
           </cds-aichat-shell>`,
@@ -411,7 +411,7 @@ describe("cds-aichat-shell", function () {
       });
 
       it("should apply has-content class to header slot wrapper", async () => {
-        const el = await fixture<CdsAiChatShell>(
+        const el = await fixture<CDSAIChatShell>(
           html`<cds-aichat-shell rounded-corners>
             <div slot="header">Header</div>
           </cds-aichat-shell>`,
@@ -424,7 +424,7 @@ describe("cds-aichat-shell", function () {
       });
 
       it("should not apply has-content class when header is empty", async () => {
-        const el = await fixture<CdsAiChatShell>(
+        const el = await fixture<CDSAIChatShell>(
           html`<cds-aichat-shell rounded-corners></cds-aichat-shell>`,
         );
         await el.updateComplete;
@@ -437,7 +437,7 @@ describe("cds-aichat-shell", function () {
 
     describe("Header-After Rounded Corners", () => {
       it("should apply has-content class to header-after when it has content", async () => {
-        const el = await fixture<CdsAiChatShell>(
+        const el = await fixture<CDSAIChatShell>(
           html`<cds-aichat-shell rounded-corners>
             <div slot="header-after">Header After</div>
           </cds-aichat-shell>`,
@@ -450,7 +450,7 @@ describe("cds-aichat-shell", function () {
       });
 
       it("should prioritize header over header-after for top corners", async () => {
-        const el = await fixture<CdsAiChatShell>(
+        const el = await fixture<CDSAIChatShell>(
           html`<cds-aichat-shell rounded-corners>
             <div slot="header">Header</div>
             <div slot="header-after">Header After</div>
@@ -474,7 +474,7 @@ describe("cds-aichat-shell", function () {
 
     describe("Footer Rounded Corners", () => {
       it("should apply has-footer-content class when footer has content", async () => {
-        const el = await fixture<CdsAiChatShell>(
+        const el = await fixture<CDSAIChatShell>(
           html`<cds-aichat-shell rounded-corners>
             <div slot="footer">Footer</div>
           </cds-aichat-shell>`,
@@ -485,7 +485,7 @@ describe("cds-aichat-shell", function () {
       });
 
       it("should apply has-content class to footer slot wrapper", async () => {
-        const el = await fixture<CdsAiChatShell>(
+        const el = await fixture<CDSAIChatShell>(
           html`<cds-aichat-shell rounded-corners>
             <div slot="footer">Footer</div>
           </cds-aichat-shell>`,
@@ -500,7 +500,7 @@ describe("cds-aichat-shell", function () {
 
     describe("Input Slots Rounded Corners Priority", () => {
       it("should detect input-after content", async () => {
-        const el = await fixture<CdsAiChatShell>(
+        const el = await fixture<CDSAIChatShell>(
           html`<cds-aichat-shell rounded-corners>
             <div slot="input-after">Input After</div>
           </cds-aichat-shell>`,
@@ -513,7 +513,7 @@ describe("cds-aichat-shell", function () {
       });
 
       it("should detect input content", async () => {
-        const el = await fixture<CdsAiChatShell>(
+        const el = await fixture<CDSAIChatShell>(
           html`<cds-aichat-shell rounded-corners>
             <div slot="input">Input</div>
           </cds-aichat-shell>`,
@@ -526,7 +526,7 @@ describe("cds-aichat-shell", function () {
       });
 
       it("should detect input-before content", async () => {
-        const el = await fixture<CdsAiChatShell>(
+        const el = await fixture<CDSAIChatShell>(
           html`<cds-aichat-shell rounded-corners>
             <div slot="input-before">Input Before</div>
           </cds-aichat-shell>`,
@@ -539,7 +539,7 @@ describe("cds-aichat-shell", function () {
       });
 
       it("should handle all input slots with content simultaneously", async () => {
-        const el = await fixture<CdsAiChatShell>(
+        const el = await fixture<CDSAIChatShell>(
           html`<cds-aichat-shell rounded-corners>
             <div slot="input-before">Input Before</div>
             <div slot="input">Input</div>
@@ -562,7 +562,7 @@ describe("cds-aichat-shell", function () {
 
     describe("Messages Slots Rounded Corners", () => {
       it("should always consider messages slot as having content", async () => {
-        const el = await fixture<CdsAiChatShell>(
+        const el = await fixture<CDSAIChatShell>(
           html`<cds-aichat-shell rounded-corners></cds-aichat-shell>`,
         );
         await el.updateComplete;
@@ -576,7 +576,7 @@ describe("cds-aichat-shell", function () {
 
     describe("Complex Rounded Corners Scenarios", () => {
       it("should handle header + footer with rounded corners", async () => {
-        const el = await fixture<CdsAiChatShell>(
+        const el = await fixture<CDSAIChatShell>(
           html`<cds-aichat-shell rounded-corners>
             <div slot="header">Header</div>
             <div slot="footer">Footer</div>
@@ -590,7 +590,7 @@ describe("cds-aichat-shell", function () {
       });
 
       it("should handle all slots with content", async () => {
-        const el = await fixture<CdsAiChatShell>(
+        const el = await fixture<CDSAIChatShell>(
           html`<cds-aichat-shell rounded-corners>
             <div slot="header">Header</div>
             <div slot="header-after">Header After</div>
@@ -629,7 +629,7 @@ describe("cds-aichat-shell", function () {
       });
 
       it("should handle dynamic slot content changes", async () => {
-        const el = await fixture<CdsAiChatShell>(
+        const el = await fixture<CDSAIChatShell>(
           html`<cds-aichat-shell rounded-corners></cds-aichat-shell>`,
         );
         await el.updateComplete;
@@ -654,7 +654,7 @@ describe("cds-aichat-shell", function () {
       });
 
       it("should maintain rounded corners with show-frame enabled", async () => {
-        const el = await fixture<CdsAiChatShell>(
+        const el = await fixture<CDSAIChatShell>(
           html`<cds-aichat-shell
             rounded-corners
             show-frame
@@ -666,7 +666,7 @@ describe("cds-aichat-shell", function () {
       });
 
       it("should handle rounded corners with ai-enabled", async () => {
-        const el = await fixture<CdsAiChatShell>(
+        const el = await fixture<CDSAIChatShell>(
           html`<cds-aichat-shell
             rounded-corners
             ai-enabled
@@ -680,7 +680,7 @@ describe("cds-aichat-shell", function () {
 
     describe("Rounded Corners Edge Cases", () => {
       it("should detect element nodes even with whitespace", async () => {
-        const el = await fixture<CdsAiChatShell>(
+        const el = await fixture<CDSAIChatShell>(
           html`<cds-aichat-shell rounded-corners>
             <div slot="header"></div>
           </cds-aichat-shell>`,
@@ -693,7 +693,7 @@ describe("cds-aichat-shell", function () {
       });
 
       it("should detect element nodes in footer slot", async () => {
-        const el = await fixture<CdsAiChatShell>(
+        const el = await fixture<CDSAIChatShell>(
           html`<cds-aichat-shell rounded-corners>
             <span slot="footer"> </span>
           </cds-aichat-shell>`,
@@ -705,7 +705,7 @@ describe("cds-aichat-shell", function () {
       });
 
       it("should handle nested elements in slots", async () => {
-        const el = await fixture<CdsAiChatShell>(
+        const el = await fixture<CDSAIChatShell>(
           html`<cds-aichat-shell rounded-corners>
             <div slot="header">
               <span><strong>Nested</strong> Header</span>
@@ -733,7 +733,7 @@ describe("cds-aichat-shell", function () {
     });
 
     it("should render workspace inline when width supports container mode", async () => {
-      const el = await fixture<CdsAiChatShell>(
+      const el = await fixture<CDSAIChatShell>(
         html`<cds-aichat-shell
           show-workspace
           style="
@@ -765,7 +765,7 @@ describe("cds-aichat-shell", function () {
       const requiredWidth = window.innerWidth + 200;
       const workspaceMinWidth = requiredWidth - 320;
 
-      const el = await fixture<CdsAiChatShell>(
+      const el = await fixture<CDSAIChatShell>(
         html`<cds-aichat-shell
           show-workspace
           style="
@@ -804,7 +804,7 @@ describe("cds-aichat-shell", function () {
       const requiredWidth = window.innerWidth + 200;
       const workspaceMinWidth = requiredWidth - 320;
 
-      const el = await fixture<CdsAiChatShell>(
+      const el = await fixture<CDSAIChatShell>(
         html`<cds-aichat-shell
           show-workspace
           style="
@@ -853,21 +853,21 @@ describe("cds-aichat-shell", function () {
   // ========== Snapshot Tests ==========
   describe("Snapshots", () => {
     it("should match snapshot with default configuration", async () => {
-      const el = await fixture<CdsAiChatShell>(
+      const el = await fixture<CDSAIChatShell>(
         html`<cds-aichat-shell></cds-aichat-shell>`,
       );
       expect(el).dom.to.equalSnapshot();
     });
 
     it("should match snapshot with rounded corners", async () => {
-      const el = await fixture<CdsAiChatShell>(
+      const el = await fixture<CDSAIChatShell>(
         html`<cds-aichat-shell rounded-corners></cds-aichat-shell>`,
       );
       expect(el).dom.to.equalSnapshot();
     });
 
     it("should match snapshot with all properties enabled", async () => {
-      const el = await fixture<CdsAiChatShell>(
+      const el = await fixture<CDSAIChatShell>(
         html`<cds-aichat-shell
           ai-enabled
           show-frame

--- a/packages/ai-chat-components/src/components/chat-shell/src/panel.ts
+++ b/packages/ai-chat-components/src/components/chat-shell/src/panel.ts
@@ -19,7 +19,7 @@ const MESSAGES_MAX_WIDTH_FALLBACK = 672; // Fallback if CSS custom property is n
 type AnimationState = "closed" | "closing" | "opening" | "open";
 
 @carbonElement("cds-aichat-panel")
-class CdsAiChatPanel extends LitElement {
+class CDSAIChatPanel extends LitElement {
   static styles = styles;
 
   /**
@@ -509,17 +509,17 @@ class CdsAiChatPanel extends LitElement {
   private observeSlotContent() {
     const updateSlotStates = () => {
       const previousStates = new Map(
-        CdsAiChatPanel.OBSERVED_SLOTS.map(({ stateKey }) => [
+        CDSAIChatPanel.OBSERVED_SLOTS.map(({ stateKey }) => [
           stateKey,
           this[stateKey],
         ]),
       );
 
-      CdsAiChatPanel.OBSERVED_SLOTS.forEach(({ name, stateKey }) => {
+      CDSAIChatPanel.OBSERVED_SLOTS.forEach(({ name, stateKey }) => {
         this[stateKey] = this.hasSlotContent(name);
       });
 
-      const hasChanged = CdsAiChatPanel.OBSERVED_SLOTS.some(
+      const hasChanged = CDSAIChatPanel.OBSERVED_SLOTS.some(
         ({ stateKey }) => previousStates.get(stateKey) !== this[stateKey],
       );
 
@@ -532,7 +532,7 @@ class CdsAiChatPanel extends LitElement {
     updateSlotStates();
 
     // Observe slot changes
-    const slots = CdsAiChatPanel.OBSERVED_SLOTS.map(({ name }) =>
+    const slots = CDSAIChatPanel.OBSERVED_SLOTS.map(({ name }) =>
       this.renderRoot.querySelector<HTMLSlotElement>(`slot[name="${name}"]`),
     ).filter((slot): slot is HTMLSlotElement => slot !== null);
 
@@ -600,4 +600,4 @@ class CdsAiChatPanel extends LitElement {
   }
 }
 
-export default CdsAiChatPanel;
+export default CDSAIChatPanel;

--- a/packages/ai-chat-components/src/components/chat-shell/src/shell.ts
+++ b/packages/ai-chat-components/src/components/chat-shell/src/shell.ts
@@ -19,7 +19,7 @@ import "./panel.js";
 type StartOrEnd = "start" | "end";
 
 @carbonElement("cds-aichat-shell")
-class CdsAiChatShell extends LitElement {
+class CDSAIChatShell extends LitElement {
   static styles = styles;
 
   /**
@@ -448,17 +448,17 @@ class CdsAiChatShell extends LitElement {
   private observeSlotContent() {
     const updateSlotStates = () => {
       const previousStates = new Map(
-        CdsAiChatShell.OBSERVED_SLOTS.map(({ stateKey }) => [
+        CDSAIChatShell.OBSERVED_SLOTS.map(({ stateKey }) => [
           stateKey,
           this[stateKey],
         ]),
       );
 
-      CdsAiChatShell.OBSERVED_SLOTS.forEach(({ name, stateKey }) => {
+      CDSAIChatShell.OBSERVED_SLOTS.forEach(({ name, stateKey }) => {
         this[stateKey] = this.hasSlotContent(name);
       });
 
-      const hasChanged = CdsAiChatShell.OBSERVED_SLOTS.some(
+      const hasChanged = CDSAIChatShell.OBSERVED_SLOTS.some(
         ({ stateKey }) => previousStates.get(stateKey) !== this[stateKey],
       );
 
@@ -471,7 +471,7 @@ class CdsAiChatShell extends LitElement {
     updateSlotStates();
 
     // Observe slot changes
-    const slots = CdsAiChatShell.OBSERVED_SLOTS.map(({ name }) =>
+    const slots = CDSAIChatShell.OBSERVED_SLOTS.map(({ name }) =>
       this.renderRoot.querySelector<HTMLSlotElement>(`slot[name="${name}"]`),
     ).filter((slot): slot is HTMLSlotElement => slot !== null);
 
@@ -812,4 +812,4 @@ class CdsAiChatShell extends LitElement {
   };
 }
 
-export default CdsAiChatShell;
+export default CDSAIChatShell;

--- a/packages/ai-chat-components/src/components/reasoning-steps/__stories__/reasoning-steps-toggle.stories.js
+++ b/packages/ai-chat-components/src/components/reasoning-steps/__stories__/reasoning-steps-toggle.stories.js
@@ -75,15 +75,22 @@ class ReasoningStepsToggleDemo extends LitElement {
           .closedLabelText=${this.closedLabelText}
           @reasoning-steps-toggle=${this._handleToggle}
         ></cds-aichat-reasoning-steps-toggle>
-        <cds-aichat-reasoning-steps id=${this.panelId} .open=${this.open}>
-          ${this.steps?.map(
-            (step) => html`
-              <cds-aichat-reasoning-step title=${step.title} ?open=${step.open}>
-                ${step.body ?? nothing}
-              </cds-aichat-reasoning-step>
-            `,
-          )}
-        </cds-aichat-reasoning-steps>
+        ${this.open
+          ? html`
+              <cds-aichat-reasoning-steps id=${this.panelId} .open=${this.open}>
+                ${this.steps?.map(
+                  (step) => html`
+                    <cds-aichat-reasoning-step
+                      title=${step.title}
+                      ?open=${step.open}
+                    >
+                      ${step.body ?? nothing}
+                    </cds-aichat-reasoning-step>
+                  `,
+                )}
+              </cds-aichat-reasoning-steps>
+            `
+          : nothing}
       </div>
     `;
   }

--- a/packages/ai-chat-components/src/react/chat-shell.ts
+++ b/packages/ai-chat-components/src/react/chat-shell.ts
@@ -12,7 +12,7 @@ import React from "react";
 import CDSChatShellElement from "../components/chat-shell/src/shell.js";
 import { withWebComponentBridge } from "./utils/withWebComponentBridge.js";
 
-const CdsAiChatShell = withWebComponentBridge(
+const CDSAIChatShell = withWebComponentBridge(
   createComponent({
     tagName: "cds-aichat-shell",
     elementClass: CDSChatShellElement,
@@ -20,4 +20,4 @@ const CdsAiChatShell = withWebComponentBridge(
   }),
 );
 
-export default CdsAiChatShell;
+export default CDSAIChatShell;

--- a/packages/ai-chat-components/src/react/panel.ts
+++ b/packages/ai-chat-components/src/react/panel.ts
@@ -12,7 +12,7 @@ import React from "react";
 import CdsChatPanelElement from "../components/chat-shell/src/panel.js";
 import { withWebComponentBridge } from "./utils/withWebComponentBridge.js";
 
-const CdsAiChatPanel = withWebComponentBridge(
+const CDSAIChatPanel = withWebComponentBridge(
   createComponent({
     tagName: "cds-aichat-panel",
     elementClass: CdsChatPanelElement,
@@ -27,4 +27,4 @@ const CdsAiChatPanel = withWebComponentBridge(
   }),
 );
 
-export default CdsAiChatPanel;
+export default CDSAIChatPanel;

--- a/packages/ai-chat/src/chat/components/panels/PanelHeader.tsx
+++ b/packages/ai-chat/src/chat/components/panels/PanelHeader.tsx
@@ -21,7 +21,7 @@ interface PanelHeaderProps {
 }
 
 /**
- * Lightweight header wrapper for slotting into CdsAiChatPanel.
+ * Lightweight header wrapper for slotting into CDSAIChatPanel.
  * Derives defaults from header config when a custom title isn't provided.
  */
 function PanelHeader({


### PR DESCRIPTION
Rename the panel and shell classes to use the uppercase `CDSAI` prefix to align with how the other component classes are named in the `ai-chat-components` package.

Also add a check in the reasoning-trace toggle demo component to not render the reasoning steps if not open.

#### Changelog

**Changed**

- rename `CdsAi` prefix to `CDSAI` for panel and shell
- add check for reasoning trace toggle demo

#### Testing / Reviewing

passes ci-checks
