### PR TITLE
fix: add host-context selector for lighter themes in code-snippet

### DIFF
--- a/packages/ai-chat-components/src/components/code-snippet/src/code-snippet.scss
+++ b/packages/ai-chat-components/src/components/code-snippet/src/code-snippet.scss
@@ -19,6 +19,10 @@
 @use "../../../globals/scss/vars" as *;
 @use "../../../globals/scss/modifiers" as *;
 
+:host-context([data-theme="white"]),
+:host-context([storybook-carbon-theme="white"]),
+:host-context([data-theme="g10"]),
+:host-context([storybook-carbon-theme="g10"]),
 :host {
   @include rounded-modifiers;
 


### PR DESCRIPTION
Closes #953 

Syntax colors in code snippet were not coming through correctly in Firefox.

<img height="500" alt="Screenshot 2026-02-17 at 1 09 28 PM" src="https://github.com/user-attachments/assets/b25ccead-4da1-4d03-bf25-de8cb6797fcc" />


Chrome and Firefox handle `:host-context()` within nested shadow roots differently, Chrome was picking up on the `:host-context()` defined css variables while FF didn't. Solution is to add the `:host-context()` specific selectors for the lighter theme as well.

AFTER:
<img height="500" alt="Screenshot 2026-02-17 at 12 44 00 PM" src="https://github.com/user-attachments/assets/779b5ab0-6bf6-44da-b8e5-dde35c59a1fb" />

#### Changelog

**New**

- add `:host-context` selectors for the lighter themes in the code-snippet styles

#### Testing / Reviewing

Go to demo preview link (https://deploy-preview-954--carbon-ai-chat-demo.netlify.app/?pageTheme=cds--g90) in Firefox and make sure the code snippet syntax colors are visible in dark and light themes
