### PR TITLE
chore: use carbon/icons package for panel header component

### DIFF
--- a/packages/ai-chat/src/chat/components/panels/PanelHeader.tsx
+++ b/packages/ai-chat/src/chat/components/panels/PanelHeader.tsx
@@ -9,7 +9,8 @@
 
 import React, { useMemo } from "react";
 
-import { ChevronDown, CloseLarge } from "@carbon/icons-react";
+import ChevronDown20 from "@carbon/icons/es/chevron--down/20.js";
+import CloseLarge20 from "@carbon/icons/es/close--large/20.js";
 import Toolbar from "@carbon/ai-chat-components/es/react/toolbar.js";
 
 interface PanelHeaderProps {
@@ -36,7 +37,7 @@ function PanelHeader({
       ? [
           {
             text: labelBackButton ?? "",
-            icon: backButtonType === "close" ? CloseLarge : ChevronDown,
+            icon: backButtonType === "close" ? CloseLarge20 : ChevronDown20,
             size: "md",
             onClick: () => onClickBack?.(),
           },


### PR DESCRIPTION
When opening the standalone stackblitz example of our react chat: https://stackblitz.com/github/carbon-design-system/carbon-ai-chat/tree/main/examples/react/basic, we run into dependency error around `@carbon/icons-react`. We don't have `@carbon/icons-react` listed as a dependency in `@carbon/ai-chat` as it's up to the adopter to pull that in if they are using the React chat version

<img height="300" alt="Screenshot 2026-02-18 at 11 53 10 AM" src="https://github.com/user-attachments/assets/8ecb186a-30f2-4102-8e4f-e77bb17ca4c1" />

Use `@carbon/icons` instead for `PanelHeader` component.

#### Testing / Reviewing

Make sure panel icons look correct in the demo.
