### PR TITLE
fix: use correct right panel close icon in header

### DIFF
--- a/packages/ai-chat/src/chat/components-legacy/header/Header.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/header/Header.tsx
@@ -13,6 +13,7 @@ import CloseLarge16 from "@carbon/icons/es/close--large/16.js";
 import Home16 from "@carbon/icons/es/home/16.js";
 import OverflowMenuVertical16 from "@carbon/icons/es/overflow-menu--vertical/16.js";
 import Restart16 from "@carbon/icons/es/restart/16.js";
+import RightPanelClose16 from "@carbon/icons/es/right-panel--close/16.js";
 import SidePanelClose16 from "@carbon/icons/es/side-panel--close/16.js";
 import SubtractLarge16 from "@carbon/icons/es/subtract--large/16.js";
 import { AI_LABEL_SIZE } from "@carbon/web-components/es/components/ai-label/defs.js";
@@ -60,6 +61,7 @@ const CloseLarge = carbonIconToReact(CloseLarge16);
 const Home = carbonIconToReact(Home16);
 const OverflowMenuVertical = carbonIconToReact(OverflowMenuVertical16);
 const Restart = carbonIconToReact(Restart16);
+const RightPanelClose = carbonIconToReact(RightPanelClose16);
 const SidePanelClose = carbonIconToReact(SidePanelClose16);
 const SubtractLarge = carbonIconToReact(SubtractLarge16);
 
@@ -327,7 +329,7 @@ function Header(props: HeaderProps, ref: Ref<HasRequestFocus>) {
     case MinimizeButtonIconType.SIDE_PANEL_RIGHT:
       closeIsReversible = false;
       closeReverseIcon = true;
-      closeIcon = <SidePanelClose aria-label={closeButtonLabel} slot="icon" />;
+      closeIcon = <RightPanelClose aria-label={closeButtonLabel} slot="icon" />;
       break;
     default: {
       closeIcon = <SubtractLarge aria-label={closeButtonLabel} slot="icon" />;


### PR DESCRIPTION
Closes #962 

Both SIDE_PANEL_LEFT and SIDE_PANEL_RIGHT minimize button icon types were using the same icon, when the SIDE_PANEL_RIGHT should be using the RightPanelClose icon instead.

<img height="300" alt="side-panel-right-icon" src="https://github.com/user-attachments/assets/60f2eb56-9a5e-4c7d-8532-661f58d4c81f" />

AFTER:
<img height="300" alt="Screenshot 2026-02-19 at 1 09 06 PM" src="https://github.com/user-attachments/assets/14984b05-606c-4ee7-8c9b-b81da7d9be4b" />

#### Changelog

**New**

-add `RightPanelClose` icon to Header component

#### Testing / Reviewing

Check demo deploy preview - uncheck the "hide header" option and select the `side panel right` option
