### PR TITLE
fix(a11y): add aria label for processing component

### DIFF
--- a/packages/ai-chat/src/chat/components-legacy/MessagesComponent.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/MessagesComponent.tsx
@@ -1008,6 +1008,7 @@ class MessagesComponent extends PureComponent<MessagesProps, MessagesState> {
     index: number,
     statusMessage?: string,
   ) {
+    const languagePack = this.props.config.derived.languagePack;
     return (
       <div
         className={`cds-aichat--message cds-aichat--message-${index} cds-aichat--message--last-message`}
@@ -1022,6 +1023,7 @@ class MessagesComponent extends PureComponent<MessagesProps, MessagesState> {
                     className="cds-aichat--processing-component"
                     loop
                     carbonTheme={this.props.carbonTheme}
+                    aria-label={languagePack.messages_processingLabel}
                   />{" "}
                   <div className="cds-aichat--processing-label">
                     {statusMessage}

--- a/packages/ai-chat/src/chat/languages/en.json
+++ b/packages/ai-chat/src/chat/languages/en.json
@@ -48,6 +48,7 @@
   "messages_assistantIsLoading": "{assistantName} is thinking",
   "messages_agentIsTyping": "The live agent is typing",
   "messages_focusHandle": "Select message",
+  "messages_processingLabel": "Processing",
   "messages_scrollHandle": "Chat history begin",
   "messages_scrollHandleDetailed": "Chat history begin. Activate to focus the first message then use the arrow, home, and end keys to move between messages. Press escape to exit.",
   "messages_scrollHandleEnd": "Chat history end",


### PR DESCRIPTION
Closes #

{{ Short description }}

#### Changelog

**New**

- n/a

**Changed**

- Add aria-label to the `Processing` component to address a11y issue when waiting for a response 

**Removed**

- n/a

#### Testing / Reviewing
Tested using the storybook and has added the label
<img width="523" height="179" alt="Screenshot 2026-02-25 at 11 48 22" src="https://github.com/user-attachments/assets/ad239ab7-e96b-480d-b36f-0657b7f8c51c" />

