### PR TITLE
fix: restarting chat clears "back to assistant"

### DIFF
--- a/packages/ai-chat/src/chat/store/reducers.ts
+++ b/packages/ai-chat/src/chat/store/reducers.ts
@@ -198,7 +198,7 @@ const reducers: { [key: string]: ReducerType } = {
     };
 
     if (newState.config.public.homescreen?.isOn) {
-      newState = setHomeScreenOpenState(newState, true);
+      newState = setHomeScreenOpenState(newState, true, false);
     }
     return newState;
   },


### PR DESCRIPTION
no need to navigate from homescreen if there is nothing there

Closes #941 

Turn on homescreen and restart conversation toggles in demo site.

Start a conversation and then hit restart conversation button.

You should go to homescreen with no "back to assistant" button.