### PR TITLE
fix: display name bug in panel

### DIFF
--- a/demo/src/framework/demo-chat-instance-switcher.ts
+++ b/demo/src/framework/demo-chat-instance-switcher.ts
@@ -180,6 +180,31 @@ export class DemoChatInstanceSwitcher extends LitElement {
       `,
     },
     {
+      id: "panel-hidden-back-button",
+      buttonLabel: "Panel with hidden back button",
+      description: "Hides the back button in the panel header.",
+      apiType: "deprecated",
+      options: {
+        title: "Panel without back button",
+        hideBackButton: true,
+      },
+      panelBody: `
+        <div>
+          <h3>Panel without back button</h3>
+          <p><strong>API:</strong> CustomPanelConfigOptions (Deprecated)</p>
+          <p style="color: #da1e28;">⚠️ This API is deprecated. Use DefaultCustomPanelConfigOptions instead.</p>
+          <p>The back button in the header is hidden. Users are stuck interacting with the panel.</p>
+          <ul>
+            <li><code>title</code>: <strong>"Panel without back button"</strong></li>
+            <li><code>hideBackButton</code>: <strong>true</strong></li>
+          </ul>
+          <cds-button kind="danger" data-close-panel>
+            Close Panel
+          </cds-button>
+        </div>
+      `,
+    },
+    {
       id: "panel-hidden-header",
       buttonLabel: "Panel with hidden header",
       description: "Completely hides the panel header chrome.",

--- a/packages/ai-chat/src/chat/AppShellPanels.tsx
+++ b/packages/ai-chat/src/chat/AppShellPanels.tsx
@@ -135,12 +135,7 @@ export function AppShellPanels({
     "hidePanelHeader" in customPanelOptions &&
     customPanelOptions.hidePanelHeader
   );
-  const panelTitle = isLegacyCustomPanel
-    ? (customPanelOptions.title ??
-      config.derived.header?.title ??
-      config.derived.header?.name ??
-      assistantName)
-    : customPanelOptions.title;
+  const panelTitle = customPanelOptions.title;
   const headerConfigOverride = isLegacyCustomPanel
     ? {
         hideMinimizeButton:
@@ -281,7 +276,6 @@ export function AppShellPanels({
                       legacyCustomPanelOptions?.onClickRestart?.();
                     }}
                     onToggleHomeScreen={onToggleHomeScreen}
-                    headerDisplayName={assistantName}
                     isHomeScreenActive={isHomeScreenActive}
                     headerConfigOverride={headerConfigOverride}
                   />

--- a/packages/ai-chat/src/chat/components-legacy/header/Header.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/header/Header.tsx
@@ -88,7 +88,7 @@ interface HeaderProps {
   /**
    * The name of the bot to display.
    */
-  headerDisplayName: string;
+  headerDisplayName?: string;
 
   /**
    * Indicates if the homescreen is currently active/visible.


### PR DESCRIPTION
If you visit https://chat.carbondesignsystem.com/tag/latest/demo/index.html?settings=%7B%22framework%22%3A%22react%22%2C%22layout%22%3A%22float%22%2C%22writeableElements%22%3A%22false%22%2C%22direction%22%3A%22default%22%7D&config=%7B%22aiEnabled%22%3Atrue%2C%22messaging%22%3A%7B%7D%2C%22header%22%3A%7B%22isOn%22%3Afalse%7D%2C%22layout%22%3A%7B%22showFrame%22%3Afalse%7D%2C%22launcher%22%3A%7B%22isOn%22%3Atrue%7D%2C%22openChatByDefault%22%3Atrue%7D and click on the Panel with hidden close button from the screenshot:

<img width="401" height="251" alt="Screenshot 2026-02-25 at 2 35 16 PM" src="https://github.com/user-attachments/assets/83dd0af7-c1cc-4151-b11c-50d2dca15fd6" />

it will randomly show "watsonx" in the title.

now it doesn't.
