### PR TITLE
fix(a11y): add role and aria label attributes to homescreen greeting

### DIFF
--- a/packages/ai-chat/src/chat/components/homeScreen/HomeScreen.tsx
+++ b/packages/ai-chat/src/chat/components/homeScreen/HomeScreen.tsx
@@ -81,8 +81,6 @@ function HomeScreenComponent({
   const homeScreenWithStarters =
     starters?.isOn && Boolean(starters.buttons?.length);
 
-  const homeScreenGreetingClass = "cds-aichat--home-screen__greeting";
-
   return (
     <div
       data-testid={PageObjectId.HOME_SCREEN_PANEL}
@@ -94,7 +92,7 @@ function HomeScreenComponent({
       <div
         className="cds-aichat--home-screen__content"
         role="dialog"
-        aria-describedby={homeScreenGreetingClass}
+        aria-label={languagePack.homeScreen_ariaHomeScreenContent}
       >
         <div className="cds-aichat--home-screen__body-wrapper">
           <div
@@ -108,7 +106,9 @@ function HomeScreenComponent({
           >
             <div className="cds-aichat--home-screen__initial-content">
               {!customContentOnly && (
-                <h2 className={homeScreenGreetingClass}>{greeting}</h2>
+                <h2 className="cds-aichat--home-screen__greeting">
+                  {greeting}
+                </h2>
               )}
               {!customContentOnly && homeScreenWithStarters && (
                 <div

--- a/packages/ai-chat/src/chat/languages/en.json
+++ b/packages/ai-chat/src/chat/languages/en.json
@@ -70,6 +70,7 @@
   "homeScreen_ariaQuickStartListButton": "Quick start menu",
   "homeScreen_ariaQuickStartListOpened": "The quick start menu has been opened.",
   "homeScreen_ariaQuickStartListClosed": "The quick start menu has been closed.",
+  "homeScreen_ariaHomeScreenContent": "Greeting",
   "default_agent_availableMessage": "Request an agent, and I'll notify you when they're ready. Your wait time may vary based on availability.",
   "default_agent_unavailableMessage": "Sorry, no agents are available right now.",
   "agent_reason_error": "Hmmm... I'm experiencing some difficulties. I need a human agent to manually continue the chat.",


### PR DESCRIPTION
Closes #

The greeting text is not automatically read out by screen readers, this PR addresses this issue

#### Changelog

**New**

- n/a
- 
**Changed**

- Add `role` and `aria-describedby` attributes to Home Screen panel so that the greeting is read out by screen readers

**Removed**

- n/a

#### Testing / Reviewing

I have tested using the JAWS screen reader and can confirm the text is read out to the user
