### PR TITLE
fix(a11y): add role and aria label attributes to ai header button

### DIFF
--- a/packages/ai-chat/src/chat/components-legacy/header/Header.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/header/Header.tsx
@@ -423,8 +423,10 @@ function Header(props: HeaderProps, ref: Ref<HasRequestFocus>) {
                     ? POPOVER_ALIGNMENT.BOTTOM_LEFT
                     : POPOVER_ALIGNMENT.BOTTOM_RIGHT
                 }
+                aria-label={aiSlugLabel}
+                role="button"
               >
-                <div slot="body-text">
+                <div role="dialog" slot="body-text">
                   {aiSlugLabel && (
                     <p className="cds-aichat--header__slug-label">
                       {aiSlugLabel}


### PR DESCRIPTION
Closes #

AI Slug text is not read automatically by screen readers. This PR addresses that

#### Changelog

**New**

n/a

**Changed**

- Added `role` and `aria-label` attributes to the AI slug

**Removed**

n/a

#### Testing / Reviewing

{{ Add descriptions, steps or a checklist for how reviewers can verify this PR works or not }}
