### PR TITLE
fix(a11y): hide widget layer when closed

### DIFF
--- a/packages/ai-chat/src/chat/AppShell.tsx
+++ b/packages/ai-chat/src/chat/AppShell.tsx
@@ -437,7 +437,9 @@ export default function AppShell({
       <AppShellErrorBoundary onError={handleBoundaryError}>
         <ModalPortalRootProvider hostElement={modalPortalHostElement}>
           <Layer
-            className="cds-aichat--widget__layer"
+            className={cx("cds-aichat--widget__layer", {
+              "cds-aichat--widget__layer--hidden": !open,
+            })}
             level={
               theme.derivedCarbonTheme === CarbonTheme.G10 ||
               theme.derivedCarbonTheme === CarbonTheme.G100

--- a/packages/ai-chat/src/chat/AppShellStyles.scss
+++ b/packages/ai-chat/src/chat/AppShellStyles.scss
@@ -302,6 +302,10 @@
   inline-size: 100%;
 }
 
+.cds-aichat--widget__layer--hidden {
+  display: none;
+}
+
 .cds-aichat--widget--max-width {
   --cds-aichat-border-radius: 0;
 }


### PR DESCRIPTION
Closes #1011

The JAWS screen reader will read out all the elements of the chat window regardless of if it's hidden or not, this violated a11y guidelines.
As per the issue above I tried adding the `aria-hidden` attribute to various levels of the Chat in the DOM but the Accessibility API was still thinking it was visible.

note - Let me know if the format of the class is wrong or needs tweaking

#### Changelog

**New**

- Added new hidden class to the ai chat widget layer to add `display: none` whilst it is closed, then removed when opened

**Changed**

- n/a

**Removed**

- n/a

#### Testing / Reviewing

I have verified using the JAWS screen reader and can confirm that JAWS only readers out the `Launcher` when closed and then reads the Chat window when opened.
