### PR TITLE
chore: replace npm install with npm ci in our workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
           node-version-file: '.nvmrc'
           cache: "npm"
       - name: Install dependencies
-        run: npm install
+        run: npm ci --prefer-offline
       - name: Run build
         run: npm run build
 
@@ -37,7 +37,7 @@ jobs:
           cache: "npm"
       - name: Install dependencies
         run: |
-          npm install
+          npm ci --prefer-offline
           npx playwright install --with-deps
       - name: Build ai-chat
         run: npm run aiChat:build
@@ -56,7 +56,7 @@ jobs:
           node-version-file: '.nvmrc'
           cache: "npm"
       - name: Install dependencies
-        run: npm install
+        run: npm ci --prefer-offline
       - name: Check formatting of project files (staged)
         if: ${{ github.event_name == 'pull_request' }}
         run: npm run format:staged
@@ -74,7 +74,7 @@ jobs:
           node-version-file: '.nvmrc'
           cache: "npm"
       - name: Install dependencies
-        run: npm install
+        run: npm ci --prefer-offline
       - name: Lint
         run: npm run lint && npm run lint:styles
 
@@ -88,6 +88,6 @@ jobs:
           node-version-file: '.nvmrc'
           cache: "npm"
       - name: Install dependencies
-        run: npm install
+        run: npm ci --prefer-offline
       - name: License check
         run: npm run lint:license

--- a/.github/workflows/create-release-tag-and-pr.yml
+++ b/.github/workflows/create-release-tag-and-pr.yml
@@ -109,7 +109,7 @@ jobs:
           registry-url: https://registry.npmjs.org
           cache: "npm"
       - name: Install dependencies
-        run: npm install
+        run: npm ci --prefer-offline
 
       # Generate the changelog with the local 'get-changelog.js' script and output to 'changelog.txt' file
       - name: Run changelog script

--- a/.github/workflows/deploy-dev-env.yml
+++ b/.github/workflows/deploy-dev-env.yml
@@ -23,7 +23,7 @@ jobs:
           cache: "npm"
       - name: Install dependencies and build chat packages
         run: |
-          npm install
+          npm ci --prefer-offline
           npm run aiChat:build
 
       # Deploy demo to Github Pages using `gh-pages` package

--- a/.github/workflows/publish-chat-cdn.yml
+++ b/.github/workflows/publish-chat-cdn.yml
@@ -30,7 +30,7 @@ jobs:
           cache: "npm"
       - name: Install dependencies
         run: |
-          npm install
+          npm ci --prefer-offline
           npm run build
       - name: Check release type
         if: contains(github.event.client_payload.tag, '-rc.') || contains(github.event.inputs.tag, '-rc.')

--- a/.github/workflows/publish-components-cdn.yml
+++ b/.github/workflows/publish-components-cdn.yml
@@ -30,7 +30,7 @@ jobs:
           cache: "npm"
       - name: Install dependencies
         run: |
-          npm install
+          npm ci --prefer-offline
           npm run build
       - name: Build Storybook
         run: |

--- a/.github/workflows/release-base.yml
+++ b/.github/workflows/release-base.yml
@@ -57,7 +57,7 @@ jobs:
           cache: "npm"
       - name: Install dependencies and build
         run: |
-          npm install
+          npm ci --prefer-offline
           npx playwright install --with-deps
           npm run build
       - name: Continuous integration check


### PR DESCRIPTION
Closes #

Using `npm install` in our workflows can update the package-lock.json file which we don't want. Use `npm ci` instead to use the lock file exactly as-is and it won't rewrite the lock file. Add the `--prefer-offline` flag to optimize our ci workflows - it'll use cached tarballs if available before fetching the registry for anything missing

#### Changelog

**Changed**

- `npm install` --> `npm ci --prefer-offline` in our workflow files

#### Testing / Reviewing

should pass ci-checks
