### PR TITLE
fix(bug): disclaimer not getting accepted when initially closed

### DIFF
--- a/packages/ai-chat/src/chat/components/panels/DisclaimerPanel.tsx
+++ b/packages/ai-chat/src/chat/components/panels/DisclaimerPanel.tsx
@@ -42,6 +42,9 @@ const DisclaimerPanel = ({
   const { derivedCarbonTheme } = useSelector(
     (state: AppState) => state.config.derived.themeWithDefaults,
   );
+  const isOpen = useSelector(
+    (state: AppState) => state.persistedToBrowserStorage.viewState.mainWindow,
+  );
   const isDarkTheme =
     derivedCarbonTheme === CarbonTheme.G90 ||
     derivedCarbonTheme === CarbonTheme.G100;
@@ -50,6 +53,9 @@ const DisclaimerPanel = ({
   const disclaimerContent = React.useRef<HTMLDivElement | null>(null);
 
   useEffect(() => {
+    if (!isOpen) {
+      return undefined;
+    }
     const panelElement = disclaimerContent.current?.closest("cds-aichat-panel");
     if (!panelElement) {
       return undefined;
@@ -75,7 +81,7 @@ const DisclaimerPanel = ({
       clearTimeout(timeoutId2);
       clearTimeout(timeoutId3);
     };
-  }, []);
+  }, [isOpen]);
 
   const handleBodyScroll = React.useCallback((event: CustomEvent) => {
     const { isScrollable, isAtBottom } = event.detail;


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon-ai-chat/issues/1029

Fix the disclaimer accept button enabling when the main window is closed initially and when the disclaimer HTML is a small paragraph.

For some reason (when the disclaimer HTML is small) the `isScrollable` property from the event (when closed) was `true`, but when initially open it's false

#### Changelog

**New**

- n/a

**Changed**

- Adjust the `useEffect` to fire the `onBodyScroll` event when the mainWindow is toggled on.

**Removed**

- n/a

#### Testing / Reviewing

Will post videos of before and after
