### PR TITLE
fix: card flush was reversed

### DIFF
--- a/examples/react/workspace-sidebar/src/OutstandingOrdersCard.tsx
+++ b/examples/react/workspace-sidebar/src/OutstandingOrdersCard.tsx
@@ -37,7 +37,7 @@ export function OutstandingOrdersCard({
   ]);
 
   return (
-    <Card>
+    <Card isFlush>
       <div slot="header">
         <Toolbar overflow actions={toolbarActions}>
           <div slot="title">Outstanding Orders</div>

--- a/examples/react/workspace/src/OutstandingOrdersCard.tsx
+++ b/examples/react/workspace/src/OutstandingOrdersCard.tsx
@@ -37,7 +37,7 @@ export function OutstandingOrdersCard({
   ]);
 
   return (
-    <Card>
+    <Card isFlush>
       <div slot="header">
         <Toolbar overflow actions={toolbarActions}>
           <div slot="title">Outstanding Orders</div>

--- a/examples/web-components/workspace-sidebar/src/outstanding-orders-card.ts
+++ b/examples/web-components/workspace-sidebar/src/outstanding-orders-card.ts
@@ -95,7 +95,7 @@ export class OutstandingOrdersCard extends LitElement {
 
   render() {
     return html`
-      <cds-aichat-card>
+      <cds-aichat-card is-flush>
         <div slot="header">
           <cds-aichat-toolbar overflow .actions=${this.toolbarActions}>
             <div slot="title">Outstanding Orders</div>

--- a/examples/web-components/workspace/src/outstanding-orders-card.ts
+++ b/examples/web-components/workspace/src/outstanding-orders-card.ts
@@ -95,7 +95,7 @@ export class OutstandingOrdersCard extends LitElement {
 
   render() {
     return html`
-      <cds-aichat-card>
+      <cds-aichat-card is-flush>
         <div slot="header">
           <cds-aichat-toolbar overflow .actions=${this.toolbarActions}>
             <div slot="title">Outstanding Orders</div>

--- a/packages/ai-chat-components/src/components/card/__stories__/card-react.stories.jsx
+++ b/packages/ai-chat-components/src/components/card/__stories__/card-react.stories.jsx
@@ -51,7 +51,11 @@ export const Default = {
   args: {
     ...DefaultWC.args,
   },
-  render: (args) => <Card isLayered={args.isLayered}>{cardContent}</Card>,
+  render: (args) => (
+    <Card isLayered={args.isLayered} isFlush={args.isFlush}>
+      {cardContent}
+    </Card>
+  ),
 };
 export const WithActions = {
   argTypes: {
@@ -61,7 +65,7 @@ export const WithActions = {
     ...WithActionsWC.args,
   },
   render: (args) => (
-    <Card isLayered={args.isLayered}>
+    <Card isLayered={args.isLayered} isFlush={args.isFlush}>
       {cardContent}
       <CardFooter
         size={args.footerSize}
@@ -80,7 +84,7 @@ export const WithImage = {
     ...WithImageWC.args,
   },
   render: (args) => (
-    <Card isLayered={args.isLayered}>
+    <Card isLayered={args.isLayered} isFlush={args.isFlush}>
       <div slot="media" data-rounded="top">
         <img src={args.image} alt="Card media" />
       </div>
@@ -102,7 +106,7 @@ export const OnlyImage = {
     ...OnlyImageWC.args,
   },
   render: (args) => (
-    <Card isLayered={args.isLayered}>
+    <Card isLayered={args.isLayered} isFlush={args.isFlush}>
       <div slot="media" data-rounded="">
         <img src={args.image} alt="Card image" />
       </div>
@@ -118,7 +122,7 @@ export const WithAudio = {
     ...WithAudioWC.args,
   },
   render: (args) => (
-    <Card isLayered={args.isLayered}>
+    <Card isLayered={args.isLayered} isFlush={args.isFlush}>
       <div slot="media" data-rounded="top">
         <iframe
           title="audio example"
@@ -144,7 +148,7 @@ export const OnlyVideo = {
     ...OnlyVideoWC.args,
   },
   render: (args) => (
-    <Card isLayered={args.isLayered}>
+    <Card isLayered={args.isLayered} isFlush={args.isFlush}>
       <div slot="media" data-rounded="">
         <iframe
           title="video example"

--- a/packages/ai-chat-components/src/components/card/__stories__/card.stories.js
+++ b/packages/ai-chat-components/src/components/card/__stories__/card.stories.js
@@ -56,7 +56,7 @@ export const Default = {
     isFlush: {
       control: { type: "boolean", disable: true },
       description:
-        "Default is `true`. which removes the padding of the card. this is useful when the elements inside the card are already padded. Set to `false` to add padding.",
+        "Setting this removes the padding of the card. This is useful when the elements inside the card are already padded.",
     },
     maxWidth: {
       control: "radio",

--- a/packages/ai-chat-components/src/components/card/__stories__/preview-card-react.stories.jsx
+++ b/packages/ai-chat-components/src/components/card/__stories__/preview-card-react.stories.jsx
@@ -51,9 +51,10 @@ export const Small = {
   },
   args: {
     ...SmallWC.args,
+    isFlush: true,
   },
   render: (args) => (
-    <Card isLayered={args.isLayered}>
+    <Card isLayered={args.isLayered} isFlush={args.isFlush}>
       <div slot="body" class="preview-card preview-card-small">
         <h4>Document title</h4>
         <p>Subtitle</p>
@@ -85,9 +86,10 @@ export const Default = {
   },
   args: {
     ...DefaultWC.args,
+    isFlush: true,
   },
   render: (args) => (
-    <Card isLayered={args.isLayered}>
+    <Card isLayered={args.isLayered} isFlush={args.isFlush}>
       <div slot="header" className="preview-card preview-card-default">
         <h4>Document title</h4>
         <p>Subtitle</p>
@@ -132,9 +134,10 @@ export const WithToolbar = {
   },
   args: {
     ...WithToolbarWC.args,
+    isFlush: true,
   },
   render: (args) => (
-    <Card isLayered={args.isLayered}>
+    <Card isLayered={args.isLayered} isFlush={args.isFlush}>
       <div slot="header" className="preview-card preview-card-toolbar">
         <Toolbar
           overflow
@@ -182,6 +185,7 @@ export const WithSteps = {
   },
   args: {
     ...WithStepsWC.args,
+    isFlush: true,
   },
   render: (args) => {
     const initialSteps = [
@@ -253,7 +257,7 @@ export const WithSteps = {
     }, [currentStep]);
 
     return (
-      <Card isLayered={args.isLayered}>
+      <Card isLayered={args.isLayered} isFlush={args.isFlush}>
         <div slot="header" className="preview-card preview-card-toolbar">
           <Toolbar className="preview-card-toolbar">
             <div slot="title">

--- a/packages/ai-chat-components/src/components/card/__stories__/preview-card.stories.js
+++ b/packages/ai-chat-components/src/components/card/__stories__/preview-card.stories.js
@@ -65,6 +65,7 @@ export const Small = {
   },
   args: {
     ...CardDefault.args,
+    isFlush: true,
     footerActions: "2 ghost icon buttons",
     aiLabel: true,
   },
@@ -111,6 +112,7 @@ export const Default = {
   },
   args: {
     ...Small.args,
+    isFlush: true,
     aiLabel: true,
     footerActions: "1 ghost button with icon",
     maxWidth: "lg",
@@ -119,7 +121,10 @@ export const Default = {
     maxWidthWrapper(
       args.maxWidth,
       () => html`
-        <cds-aichat-card ?is-layered=${args.isLayered}>
+        <cds-aichat-card
+          ?is-layered=${args.isLayered}
+          ?is-flush=${args.isFlush}
+        >
           <div slot="header" class="preview-card preview-card-default">
             <h4>Document title</h4>
             <p>Subtitle</p>
@@ -170,6 +175,7 @@ export const WithToolbar = {
   },
   args: {
     isLayered: false,
+    isFlush: true,
     maxWidth: "lg",
     footerActions: "none",
     aiLabel: true,
@@ -178,7 +184,10 @@ export const WithToolbar = {
     maxWidthWrapper(
       args.maxWidth,
       () => html`
-        <cds-aichat-card ?is-layered=${args.isLayered}>
+        <cds-aichat-card
+          ?is-layered=${args.isLayered}
+          ?is-flush=${args.isFlush}
+        >
           <div slot="header" class="preview-card preview-card-toolbar">
             <cds-aichat-toolbar
               class="preview-card-toolbar"
@@ -234,6 +243,7 @@ export const WithSteps = {
   },
   args: {
     ...WithToolbar.args,
+    isFlush: true,
     footerActions: "1 ghost button with icon",
   },
   render: (args) => {
@@ -310,7 +320,10 @@ export const WithSteps = {
     return maxWidthWrapper(
       args.maxWidth,
       () => html`
-        <cds-aichat-card ?is-layered=${args.isLayered}>
+        <cds-aichat-card
+          ?is-layered=${args.isLayered}
+          ?is-flush=${args.isFlush}
+        >
           <div slot="header" class="preview-card preview-card-toolbar">
             <cds-aichat-toolbar class="preview-card-toolbar">
               <div slot="title">

--- a/packages/ai-chat-components/src/components/card/__tests__/__snapshots__/card.test.snap.js
+++ b/packages/ai-chat-components/src/components/card/__tests__/__snapshots__/card.test.snap.js
@@ -2,10 +2,7 @@
 export const snapshots = {};
 
 snapshots["card should render with cds-aichat-card minimum attributes"] = 
-`<cds-aichat-card
-  color-scheme=""
-  is-flush=""
->
+`<cds-aichat-card color-scheme="">
   <div slot="body">
     <h4>
       AI Chat Card

--- a/packages/ai-chat-components/src/components/card/__tests__/card.test.ts
+++ b/packages/ai-chat-components/src/components/card/__tests__/card.test.ts
@@ -36,7 +36,7 @@ describe("card", function () {
     expect(el).to.be.instanceOf(Card);
     expect(el.shadowRoot).to.exist;
     expect(el.isLayered).to.be.false;
-    expect(el.isFlush).to.be.true;
+    expect(el.isFlush).to.be.false;
 
     await expect(el).dom.to.equalSnapshot();
   });

--- a/packages/ai-chat-components/src/components/card/src/card.scss
+++ b/packages/ai-chat-components/src/components/card/src/card.scss
@@ -23,6 +23,22 @@ $css--plex: true !default;
     --#{$prefix}-card-border-radius,
     0.5rem
   );
+  --#{$prefix}-rounded-modifier-radius-start-start: var(
+    --#{$prefix}-card-border-radius,
+    0.5rem
+  );
+  --#{$prefix}-rounded-modifier-radius-start-end: var(
+    --#{$prefix}-card-border-radius,
+    0.5rem
+  );
+  --#{$prefix}-rounded-modifier-radius-end-start: var(
+    --#{$prefix}-card-border-radius,
+    0.5rem
+  );
+  --#{$prefix}-rounded-modifier-radius-end-end: var(
+    --#{$prefix}-card-border-radius,
+    0.5rem
+  );
 
   border: 1px solid theme.$chat-bubble-border;
   border-radius: var(--#{$prefix}-rounded-modifier-radius);
@@ -39,4 +55,8 @@ $css--plex: true !default;
 
 :host(#{$prefix}-card[is-layered]) {
   background-color: theme.$layer;
+}
+
+:host(#{$prefix}-card[is-flush]) {
+  padding: 0;
 }

--- a/packages/ai-chat-components/src/components/card/src/card.ts
+++ b/packages/ai-chat-components/src/components/card/src/card.ts
@@ -29,22 +29,20 @@ class Card extends CDSTile {
   isLayered = false;
 
   /**
-   * Specify whether the padding should be removed from the card. default is true.
-   * This is useful when the card is used as a container for other components
-   * and you want to remove the default padding from cds-tile.
+   * Specify whether the padding should be removed from the card. default is false.
+   * When true, removes the default padding from cds-tile, useful when the card
+   * is used as a container for other components that need to be flush against edges.
    */
   @property({ type: Boolean, attribute: "is-flush", reflect: true })
-  isFlush = true;
+  isFlush = false;
 
   render() {
     return html`
-      <div ?data-flush=${this.isFlush}>
-        <slot name="header"></slot>
-        <slot name="media"></slot>
-        <slot name="body"></slot>
-        <slot name="footer"></slot>
-        <slot name="decorator"></slot>
-      </div>
+      <slot name="header"></slot>
+      <slot name="media"></slot>
+      <slot name="body"></slot>
+      <slot name="footer"></slot>
+      <slot name="decorator"></slot>
     `;
   }
 }

--- a/packages/ai-chat-components/src/components/chat-shell/__tests__/__snapshots__/shell.test.snap.js
+++ b/packages/ai-chat-components/src/components/chat-shell/__tests__/__snapshots__/shell.test.snap.js
@@ -1,8 +1,9 @@
 /* @web/test-runner snapshot v1 */
 export const snapshots = {};
 
-snapshots["cds-aichat-shell Snapshots should match snapshot with rounded corners"] =
+snapshots["cds-aichat-shell Snapshots should match snapshot with rounded corners"] = 
 `<cds-aichat-shell
+  content-max-width=""
   history-location="start"
   rounded-corners=""
   style="--cds-aichat-header-height: 0px;"

--- a/packages/ai-chat/src/chat/AppShellStyles.scss
+++ b/packages/ai-chat/src/chat/AppShellStyles.scss
@@ -62,7 +62,6 @@
 
 // Mixin for elements that should expand to fit their container
 @mixin expand-to-fit {
-  overflow: hidden;
   block-size: 100%;
   inline-size: 100%;
   max-block-size: 100%;
@@ -73,7 +72,6 @@
 
 // Mixin for workspace panel slotted content with additional constraints
 @mixin workspace-panel-slotted {
-  overflow: hidden;
   block-size: 100%;
   max-block-size: 100%;
 }

--- a/packages/ai-chat/src/chat/components-legacy/responseTypes/card/CardItemComponent.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/responseTypes/card/CardItemComponent.tsx
@@ -50,7 +50,6 @@ function CardItemComponent(props: CardItemComponentProps) {
   const item = props.localMessageItem.item as CardItem;
   return (
     <Card
-      isFlush={false}
       className={cx("cds-aichat--card-message-component", {
         "cds-aichat--max-width-small":
           !ignoreMaxWidth && item.max_width === WidthOptions.SMALL,

--- a/packages/ai-chat/src/chat/components-legacy/responseTypes/image/Image.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/responseTypes/image/Image.tsx
@@ -112,7 +112,6 @@ function Image(props: ImageProps) {
 
   return (
     <Card
-      isFlush={false}
       ref={rootRef}
       className={cx("cds-aichat--image", {
         "cds-aichat--image__text-and-icon": hasText && Boolean(renderIcon),

--- a/packages/ai-chat/src/chat/components-legacy/responseTypes/previewCard/PreviewCardComponent.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/responseTypes/previewCard/PreviewCardComponent.tsx
@@ -93,7 +93,8 @@ function PreviewCardComponent(props: PreviewCardComponentProps) {
   return (
     <Card
       data-rounded
-      class="cds-aichat-preview-card cds-aichat-preview-card__sm"
+      isFlush
+      className="cds-aichat-preview-card cds-aichat-preview-card__sm"
     >
       <div slot="body">
         <h5 className="cds-aichat-preview-card--title">{title}</h5>

--- a/packages/ai-chat/src/chat/components-legacy/responseTypes/util/citations/CitationCard.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/responseTypes/util/citations/CitationCard.tsx
@@ -66,7 +66,7 @@ function CitationCard({
         onClick={onSelectCitation}
         onFocus={onSelectCitation}
       >
-        <Card isFlush={false}>
+        <Card>
           <div slot="body">
             <CitationCardContent citation={citation} type={type} />
           </div>

--- a/packages/ai-chat/src/chat/components-legacy/responseTypes/util/citations/ExpandToPanelCard.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/responseTypes/util/citations/ExpandToPanelCard.tsx
@@ -54,7 +54,7 @@ function ExpandToPanelCard({
 
   function renderTile(className?: string) {
     return (
-      <Card isFlush={false} className={className}>
+      <Card className={className}>
         <div slot="body">
           <CitationCardContent
             citation={citation}


### PR DESCRIPTION
Closes https://github.com/carbon-design-system/carbon-ai-chat/issues/1042 https://github.com/carbon-design-system/carbon-ai-chat/issues/1037 https://github.com/carbon-design-system/carbon-ai-chat/issues/1035

We were not correctly passing in rounded corner variables from the card.

Setting isFlush to true on the card by default broke the brain of the react/lit bridge as isFlush={false} from React just meant that isFlush was removed from the bridge... setting it to true with the default. So, I switched the default.

We also had created a bug where the disclaimer wasn't scrollable if there was a lot of content.

#### Testing / Reviewing

Check audio, video and code responses in the demo site to see original bug fixed.

Check conversational search and human agent to make sure no regressions. 

Double check the Card examples on the storybooks are all good still. 

Check disclaimer with extra content (you can just throw more text in via dev tools) is scrollable
