### PR TITLE
fix: remove low contrast from workspace notifications

### DIFF
--- a/demo/src/react/WorkspaceWriteableElementExample.tsx
+++ b/demo/src/react/WorkspaceWriteableElementExample.tsx
@@ -160,7 +160,6 @@ function WorkspaceWriteableElementExample({
         title="Notification Title"
         subtitle="Notification Subtitle"
         kind="warning"
-        lowContrast={true}
         hideCloseButton
       />
       <WorkspaceShellHeader

--- a/packages/ai-chat-components/src/components/workspace-shell/__stories__/workspace-shell-react.mdx
+++ b/packages/ai-chat-components/src/components/workspace-shell/__stories__/workspace-shell-react.mdx
@@ -52,7 +52,6 @@ import "@carbon/ai-chat-components/es/react/workspace-shell-footer.js";
   slot="notification"
   title={notificationTitle}
   kind="warning"
-  lowContrast={true}
   hideCloseButton
   >
   </InlineNotification>

--- a/packages/ai-chat-components/src/components/workspace-shell/__stories__/workspace-shell-react.stories.jsx
+++ b/packages/ai-chat-components/src/components/workspace-shell/__stories__/workspace-shell-react.stories.jsx
@@ -130,7 +130,6 @@ export const Default = {
           slot="notification"
           title={notificationTitle}
           kind="warning"
-          lowContrast={true}
           hideCloseButton
         ></InlineNotification>
         <WorkspaceShellHeader


### PR DESCRIPTION
Closes #1052 

fixes incorrect text color of the notification in the workspace examples

#### Changelog

**Changed**

- removes `lowcontrast` from inline notifications in workspace

#### Testing / Reviewing

before

<img width="1840" height="1106" alt="Screenshot 2026-03-04 at 3 07 23 PM" src="https://github.com/user-attachments/assets/123fe0da-f074-4ea2-8119-dca97e759c54" />

after

<img width="1840" height="1106" alt="Screenshot 2026-03-04 at 3 15 46 PM" src="https://github.com/user-attachments/assets/6b2ce5b3-04b3-42b6-895d-9e22beb7493a" />

here's the after with the white theme just to make sure removing `lowcontrast` didn't break it

<img width="1840" height="1106" alt="Screenshot 2026-03-04 at 3 15 38 PM" src="https://github.com/user-attachments/assets/338aebe3-2840-412f-8f8f-ef78f83ccaf2" />

