### PR TITLE
fix(a11y): add dialog role to markdown template

### DIFF
--- a/packages/ai-chat-components/src/components/markdown/src/markdown.template.ts
+++ b/packages/ai-chat-components/src/components/markdown/src/markdown.template.ts
@@ -20,7 +20,9 @@ function markdownTemplate({
   renderedContent: unknown;
 }) {
   return html`
-    <div class="cds-aichat-markdown-stack">${renderedContent}</div>
+    <div role="dialog" class="cds-aichat-markdown-stack">
+      ${renderedContent}
+    </div>
     <div hidden>
       <slot ${ref(slotRef)} @slotchange=${onSlotChange}></slot>
     </div>


### PR DESCRIPTION
Closes n/a

Adding dialog role to markdown template to ensure that all text from the response is read out to the user

#### Changelog

**New**

- n/a

**Changed**

- Added `dialog` role to the markdown lit template

**Removed**

- n/a

#### Testing / Reviewing

I have tested with the JAWS screenreader using our test harness and the responses are read out by the screenreader.
