### PR TITLE
chore: rename panel slide animation to logical directions

### DIFF
--- a/packages/ai-chat-components/src/components/chat-shell/__stories__/panel-react.stories.jsx
+++ b/packages/ai-chat-components/src/components/chat-shell/__stories__/panel-react.stories.jsx
@@ -93,8 +93,8 @@ export const Default = {
       options: [
         "",
         "slide-in-from-bottom",
-        "slide-in-from-right",
-        "slide-in-from-left",
+        "slide-in-from-end",
+        "slide-in-from-start",
         "fade-in",
       ],
       description: "Animation when panel opens",
@@ -104,8 +104,8 @@ export const Default = {
       options: [
         "",
         "slide-out-to-bottom",
-        "slide-out-to-right",
-        "slide-out-to-left",
+        "slide-out-to-end",
+        "slide-out-to-start",
         "fade-out",
       ],
       description: "Animation when panel closes",

--- a/packages/ai-chat-components/src/components/chat-shell/__stories__/panel.stories.js
+++ b/packages/ai-chat-components/src/components/chat-shell/__stories__/panel.stories.js
@@ -181,8 +181,8 @@ export const Default = {
       options: [
         "",
         "slide-in-from-bottom",
-        "slide-in-from-right",
-        "slide-in-from-left",
+        "slide-in-from-end",
+        "slide-in-from-start",
         "fade-in",
       ],
     },
@@ -191,8 +191,8 @@ export const Default = {
       options: [
         "",
         "slide-out-to-bottom",
-        "slide-out-to-right",
-        "slide-out-to-left",
+        "slide-out-to-end",
+        "slide-out-to-start",
         "fade-out",
       ],
     },

--- a/packages/ai-chat-components/src/components/chat-shell/src/panel.scss
+++ b/packages/ai-chat-components/src/components/chat-shell/src/panel.scss
@@ -111,14 +111,14 @@ $border-radius: var(--#{$prefix}-rounded-modifier-radius, 0.5rem);
       slide-in-from-bottom both;
   }
 
-  :host(.panel--opening--slide-in-from-right) {
+  :host(.panel--opening--slide-in-from-end) {
     animation: motion.$duration-moderate-02 motion.motion(exit, expressive)
-      slide-in-from-right both;
+      slide-in-from-end both;
   }
 
-  :host(.panel--opening--slide-in-from-left) {
+  :host(.panel--opening--slide-in-from-start) {
     animation: motion.$duration-moderate-02 motion.motion(exit, expressive)
-      slide-in-from-left both;
+      slide-in-from-start both;
   }
 
   :host(.panel--closing--fade-out) {
@@ -136,14 +136,14 @@ $border-radius: var(--#{$prefix}-rounded-modifier-radius, 0.5rem);
       slide-out-to-bottom both;
   }
 
-  :host(.panel--closing--slide-out-to-right) {
+  :host(.panel--closing--slide-out-to-end) {
     animation: motion.$duration-moderate-01 motion.motion(exit, expressive)
-      slide-out-to-right both;
+      slide-out-to-end both;
   }
 
-  :host(.panel--closing--slide-out-to-left) {
+  :host(.panel--closing--slide-out-to-start) {
     animation: motion.$duration-moderate-01 motion.motion(exit, expressive)
-      slide-out-to-left both;
+      slide-out-to-start both;
   }
 }
 
@@ -168,24 +168,24 @@ $border-radius: var(--#{$prefix}-rounded-modifier-radius, 0.5rem);
       slide-out-to-bottom-with-header both;
   }
 
-  :host(.panel--with-chat-header.panel--opening--slide-in-from-right) {
+  :host(.panel--with-chat-header.panel--opening--slide-in-from-end) {
     animation: motion.$duration-moderate-02 motion.motion(exit, expressive)
-      slide-in-from-right both;
+      slide-in-from-end both;
   }
 
-  :host(.panel--with-chat-header.panel--closing--slide-out-to-right) {
+  :host(.panel--with-chat-header.panel--closing--slide-out-to-end) {
     animation: motion.$duration-moderate-01 motion.motion(exit, expressive)
-      slide-out-to-right both;
+      slide-out-to-end both;
   }
 
-  :host(.panel--with-chat-header.panel--opening--slide-in-from-left) {
+  :host(.panel--with-chat-header.panel--opening--slide-in-from-start) {
     animation: motion.$duration-moderate-02 motion.motion(exit, expressive)
-      slide-in-from-left both;
+      slide-in-from-start both;
   }
 
-  :host(.panel--with-chat-header.panel--closing--slide-out-to-left) {
+  :host(.panel--with-chat-header.panel--closing--slide-out-to-start) {
     animation: motion.$duration-moderate-01 motion.motion(exit, expressive)
-      slide-out-to-left both;
+      slide-out-to-start both;
   }
 }
 
@@ -354,7 +354,7 @@ $border-radius: var(--#{$prefix}-rounded-modifier-radius, 0.5rem);
   }
 }
 
-@keyframes slide-in-from-right {
+@keyframes slide-in-from-end {
   from {
     inset-inline-start: 100%;
   }
@@ -364,7 +364,7 @@ $border-radius: var(--#{$prefix}-rounded-modifier-radius, 0.5rem);
   }
 }
 
-@keyframes slide-out-to-right {
+@keyframes slide-out-to-end {
   from {
     inset-inline-start: 0;
   }
@@ -374,7 +374,7 @@ $border-radius: var(--#{$prefix}-rounded-modifier-radius, 0.5rem);
   }
 }
 
-@keyframes slide-in-from-left {
+@keyframes slide-in-from-start {
   from {
     inset-inline-start: -100%;
   }
@@ -384,7 +384,7 @@ $border-radius: var(--#{$prefix}-rounded-modifier-radius, 0.5rem);
   }
 }
 
-@keyframes slide-out-to-left {
+@keyframes slide-out-to-start {
   from {
     inset-inline-start: 0;
   }


### PR DESCRIPTION
Closes #

Renaming the panel slide animation names to use logical directions

ie. slide-out-from-right ---> slide-out-from-end

https://github.com/user-attachments/assets/001a95ff-980b-42dd-8182-7846a6940ea1

#### Changelog

**Changed**

- change the animation names in the panel storybook controls and the styles

#### Testing / Reviewing

Go to the panel Default stories for React and WC in the ai-chat-components and make sure the animations are as expected
