### PR TITLE
fix: remove overflow property for custom panel

### DIFF
--- a/packages/ai-chat-components/src/components/chat-shell/__tests__/panel.test.ts
+++ b/packages/ai-chat-components/src/components/chat-shell/__tests__/panel.test.ts
@@ -35,6 +35,7 @@ describe("cds-aichat-panel", function () {
       expect(el.open).to.be.false;
       expect(el.priority).to.equal(0);
       expect(el.fullWidth).to.be.false;
+      expect(el.noScroll).to.be.false;
       expect(el.showChatHeader).to.be.false;
       expect(el.showFrame).to.be.false;
       expect(el.animationOnOpen).to.be.undefined;
@@ -83,6 +84,14 @@ describe("cds-aichat-panel", function () {
       );
       expect(el.fullWidth).to.be.true;
       expect(el.hasAttribute("full-width")).to.be.true;
+    });
+
+    it("should reflect no-scroll attribute", async () => {
+      const el = await fixture<CDSAIChatPanel>(
+        html`<cds-aichat-panel no-scroll></cds-aichat-panel>`,
+      );
+      expect(el.noScroll).to.be.true;
+      expect(el.hasAttribute("no-scroll")).to.be.true;
     });
 
     it("should reflect show-chat-header attribute", async () => {
@@ -249,6 +258,13 @@ describe("cds-aichat-panel", function () {
         html`<cds-aichat-panel full-width></cds-aichat-panel>`,
       );
       expect(el.classList.contains("panel--full-width")).to.be.true;
+    });
+
+    it("should apply panel--no-scroll class when noScroll is true", async () => {
+      const el = await fixture<CDSAIChatPanel>(
+        html`<cds-aichat-panel no-scroll></cds-aichat-panel>`,
+      );
+      expect(el.classList.contains("panel--no-scroll")).to.be.true;
     });
 
     it("should apply panel--closed class initially when not open", async () => {

--- a/packages/ai-chat-components/src/components/chat-shell/src/panel.scss
+++ b/packages/ai-chat-components/src/components/chat-shell/src/panel.scss
@@ -224,6 +224,8 @@ $border-radius: var(--#{$prefix}-rounded-modifier-radius, 0.5rem);
 }
 
 .panel-body {
+  // Enable scrolling when content overflows
+  overflow: auto;
   box-sizing: border-box;
   // Allow body to grow and shrink, but constrain it
   flex: 1 1 auto;
@@ -239,6 +241,13 @@ $border-radius: var(--#{$prefix}-rounded-modifier-radius, 0.5rem);
 :host(.panel--full-width) {
   .panel-body {
     max-inline-size: 100%;
+  }
+}
+
+// No scroll on panel body, allows for slotted elements to set their own scroll configurations
+:host(.panel--no-scroll) {
+  .panel-body {
+    overflow: hidden;
   }
 }
 

--- a/packages/ai-chat-components/src/components/chat-shell/src/panel.ts
+++ b/packages/ai-chat-components/src/components/chat-shell/src/panel.ts
@@ -50,6 +50,13 @@ class CDSAIChatPanel extends LitElement {
   fullWidth = false;
 
   /**
+   * Sets overflow to hidden to the panel body container to allow
+   * scrolling to be customized within the slotted elements
+   */
+  @property({ type: Boolean, attribute: "no-scroll", reflect: true })
+  noScroll = false;
+
+  /**
    * Shows the chat header in the panel
    */
   @property({ type: Boolean, attribute: "show-chat-header", reflect: true })
@@ -173,6 +180,7 @@ class CDSAIChatPanel extends LitElement {
     this.classList.toggle("panel--with-chat-header", this.showChatHeader);
     this.classList.toggle("panel--with-frame", this.showFrame);
     this.classList.toggle("panel--full-width", this.fullWidth);
+    this.classList.toggle("panel--no-scroll", this.noScroll);
     this.classList.toggle("panel--ai-theme", this.aiEnabled);
     this.classList.toggle("panel--body--no-padding", this.bodyNoPadding);
     this.updateHostClasses();

--- a/packages/ai-chat-components/src/components/chat-shell/src/shell.ts
+++ b/packages/ai-chat-components/src/components/chat-shell/src/shell.ts
@@ -339,6 +339,7 @@ class CDSAIChatShell extends LitElement {
         data-internal-panel
         ?open=${this.workspacePanelOpen}
         full-width
+        no-scroll
         show-chat-header
         body-no-padding
         animation-on-open=${animationOnOpen}


### PR DESCRIPTION
Closes #

Add new attribute `noScroll` to panel component to set `overflow: hidden` to body content. This allows the writeable element to have scrolling on only certain parts of the element instead of the entire element itself. 

Currently affects the workspace component when it opens up in the panel
https://github.com/user-attachments/assets/575a46b0-1873-4324-b04a-d55db125bdbb

#### Changelog

**Changed**

- added `no-scroll` attribute to the panel component that sets overflow to hidden
- added tests for the new `no-scroll` attribute.

**Removed**

- removed `overflow: auto` property

#### Testing / Reviewing

1. Go to Web Component [deploy preview in float mode](https://deploy-preview-1066--carbon-ai-chat-demo.netlify.app/?settings=%7B%22framework%22%3A%22web-component%22%2C%22layout%22%3A%22float%22%2C%22writeableElements%22%3A%22false%22%2C%22direction%22%3A%22default%22%7D&config=%7B%22aiEnabled%22%3Atrue%2C%22messaging%22%3A%7B%7D%2C%22exposeServiceManagerForTesting%22%3Atrue%2C%22header%22%3A%7B%22isOn%22%3Afalse%7D%2C%22layout%22%3A%7B%22showFrame%22%3Afalse%7D%2C%22launcher%22%3A%7B%22isOn%22%3Atrue%7D%2C%22openChatByDefault%22%3Atrue%7D)
2. Select the "workspace preview card (open end)" option from the dropdown
3. Open up workspace and confirm there is no extra scrollbar for the entire panel.

