### PR TITLE
fix: raw value correctly updates

### DIFF
--- a/examples/react/basic/src/App.tsx
+++ b/examples/react/basic/src/App.tsx
@@ -41,6 +41,7 @@ function App() {
   const [activeResponseId, setActiveResponseId] = useState<string | null>(null);
 
   function onBeforeRender(instance: ChatInstance) {
+    window.chatInstance = instance;
     const initialState = instance.getState();
     setActiveResponseId(initialState.activeResponseId ?? null);
 

--- a/examples/react/basic/src/global.d.ts
+++ b/examples/react/basic/src/global.d.ts
@@ -1,0 +1,18 @@
+/*
+ *  Copyright IBM Corp. 2025
+ *
+ *  This source code is licensed under the Apache-2.0 license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ *  @license
+ */
+
+import { ChatInstance } from "@carbon/ai-chat";
+
+declare global {
+  interface Window {
+    chatInstance?: ChatInstance;
+  }
+}
+
+export {};

--- a/packages/ai-chat/src/chat/services/ChatActionsImpl.ts
+++ b/packages/ai-chat/src/chat/services/ChatActionsImpl.ts
@@ -385,7 +385,14 @@ class ChatActionsImpl {
     const { store } = this.serviceManager;
     const state = store.getState();
     const inputState = selectInputState(state);
-    const previousValue = (inputState[field] ?? "") as string;
+    let previousValue = (inputState[field] ?? "") as string;
+
+    // Normalize the previous value: treat "\n" as empty string
+    // This handles the case where the user manually deleted all input,
+    // leaving behind a newline character that should be treated as empty.
+    if (field === "rawValue" && previousValue === "\n") {
+      previousValue = "";
+    }
 
     let nextValue: string;
     try {
@@ -406,10 +413,9 @@ class ChatActionsImpl {
 
     const payload: Partial<InputState> = { [field]: nextValue };
 
-    if (
-      field === "rawValue" &&
-      (inputState.displayValue ?? "") === previousValue
-    ) {
+    // When updating rawValue, always sync displayValue to keep them consistent.
+    // The component will re-render and apply any custom rendering (e.g., toDisplayHTML conversion).
+    if (field === "rawValue") {
       payload.displayValue = nextValue;
     }
 


### PR DESCRIPTION
Closes #1067 

Fix `instance.input.updateRawValue()` not updating displayValue after manual input deletion

#### Changelog

**Changed**

- Fixed `instance.input.updateRawValue()` to always sync `displayValue` with `rawValue`, ensuring the UI updates correctly even after users manually delete input content
- Simplified the sync logic in `ChatActionsImpl.updateInputValue()` by removing the conditional check that compared values in different formats (HTML vs plain text)

#### Testing / Reviewing

**Problem:** When users manually deleted all input content, the `displayValue` was set to `"\n"` or `"<br>"`, but `instance.input.updateRawValue()` failed to update it because the condition `(inputState.displayValue ?? "") === previousValue` compared HTML format (`"<br>"`) with plain text format (`"\n"`), causing them to never match.

**Solution:** Always sync `displayValue` when `rawValue` is updated. The component handles format conversion during re-render.

### Manual Testing Steps

#### Setup
```bash
cd examples/react/basic
npm install
npm start
```

#### Test Case 1: Append text to empty input
1. Type text in the input field: "hello world"
2. Select all and delete (input should be empty)
3. Open browser console and run:
   ```javascript
   window.chatInstance.input.updateRawValue(() => "New text");
   ```
4. **Expected:** Input field shows "New text" ✅
5. **Before fix:** Input remained empty (bug) ❌

#### Test Case 2: Append to Existing Text
1. Type: "hello"
2. Console:
   ```javascript
   window.chatInstance.input.updateRawValue((prev) => prev + " @user");
   ```
3. **Expected:** Input shows "hello @user" ✅

#### Test Case 3: Multi-line Text
1. Type multi-line text (Shift+Enter for line breaks):
   ```
   Line 1
   Line 2
   ```
2. Console:
   ```javascript
   window.chatInstance.input.updateRawValue((prev) => prev + "\nLine 3");
   ```
3. **Expected:** All 3 lines display correctly with proper formatting ✅

#### Test Case 4: Empty to Non-Empty
1. Ensure input is empty
2. Console:
   ```javascript
   window.chatInstance.input.updateRawValue(() => "First text");
   ```
3. **Expected:** Input shows "First text" ✅

