### PR TITLE
fix: avatar sizing

### DIFF
--- a/packages/ai-chat/src/chat/components-legacy/MessageComponent.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/MessageComponent.tsx
@@ -528,8 +528,8 @@ class MessageComponent extends PureComponent<MessageProps, MessageState> {
             <ResponseUserAvatar
               responseUserProfile={responseUserProfile}
               languagePack={languagePack}
-              width="32px"
-              height="32px"
+              width="24px"
+              height="24px"
             />
           );
         }

--- a/packages/ai-chat/src/chat/components-legacy/ResponseUserAvatar.scss
+++ b/packages/ai-chat/src/chat/components-legacy/ResponseUserAvatar.scss
@@ -19,6 +19,7 @@
 }
 
 .cds-aichat--response-user-avatar .cds-aichat--response-user-avatar__circle {
+  padding: 2px;
   border: button.$button-border-width solid currentcolor;
   border-radius: 50%;
   background-color: transparent;

--- a/packages/ai-chat/src/chat/components-legacy/humanAgent/HumanAgentBanner.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/humanAgent/HumanAgentBanner.tsx
@@ -90,8 +90,8 @@ function HumanAgentBanner(
       <ResponseUserAvatar
         responseUserProfile={responseUserProfile}
         languagePack={languagePack}
-        width="32px"
-        height="32px"
+        width="24px"
+        height="24px"
       />
     );
   }


### PR DESCRIPTION
Closes #1040 

adjusted size and padding of the response avatar to make the circle smaller, but still maintain the 32px dimensions. here's a before and after:

https://github.com/user-attachments/assets/f172251d-2d6f-4260-90d9-e6934c468509

#### Changelog

**Changed**

- size of 32px height and width props on ResponseUserAvatar to 24px
- added 2px padding in ResponseUserAvatar.scss

#### Testing / Reviewing

`npm test` and manual testing
