### PR TITLE
fix: chain of thought chevron spacing

### DIFF
--- a/packages/ai-chat-components/src/components/chain-of-thought/src/chain-of-thought-toggle.scss
+++ b/packages/ai-chat-components/src/components/chain-of-thought/src/chain-of-thought-toggle.scss
@@ -30,6 +30,7 @@
 .#{$prefix}--chain-of-thought-button-chevron {
   display: flex;
   flex-basis: layout.$spacing-06;
+  margin-inline-end: 2px;
   @media screen and (prefers-reduced-motion: reduce) {
     svg {
       transform: rotate(-90deg);


### PR DESCRIPTION
Closes #1041 

adds spacing between chain of thought chevron and text

#### Changelog

**Changed**

- adds spacing between chain of thought chevron and text

#### Testing / Reviewing

standard testing procedures and visual confirmation.
