### PR TITLE
fix: add side panel down option

### DIFF
--- a/demo/src/framework/demo-header-switcher.ts
+++ b/demo/src/framework/demo-header-switcher.ts
@@ -339,6 +339,9 @@ export class DemoHeaderSwitcher extends LitElement {
           <cds-dropdown-item value="side-panel-right"
             >Side Panel Right</cds-dropdown-item
           >
+          <cds-dropdown-item value="side-panel-down"
+            >Side Panel Down</cds-dropdown-item
+          >
           <cds-dropdown-item value="none">None</cds-dropdown-item>
         </cds-dropdown>
       </div>

--- a/packages/ai-chat/src/chat/components/header/Header.tsx
+++ b/packages/ai-chat/src/chat/components/header/Header.tsx
@@ -14,6 +14,8 @@ import OverflowMenuVertical16 from "@carbon/icons/es/overflow-menu--vertical/16.
 import Restart16 from "@carbon/icons/es/restart/16.js";
 import RightPanelOpen16 from "@carbon/icons/es/right-panel--open/16.js";
 import RightPanelClose16 from "@carbon/icons/es/right-panel--close/16.js";
+import BottomPanelClose16 from "@carbon/icons/es/bottom-panel--close/16.js";
+import BottomPanelOpen16 from "@carbon/icons/es/bottom-panel--open/16.js";
 import SubtractLarge16 from "@carbon/icons/es/subtract--large/16.js";
 import { AI_LABEL_SIZE } from "@carbon/web-components/es/components/ai-label/defs.js";
 import { POPOVER_ALIGNMENT } from "@carbon/web-components/es/components/popover/defs.js";
@@ -289,6 +291,9 @@ function Header(props: HeaderProps, ref: Ref<HasRequestFocus>) {
           break;
         case MinimizeButtonIconType.SIDE_PANEL_RIGHT:
           closeIconToUse = isOpen ? RightPanelClose16 : RightPanelOpen16;
+          break;
+        case MinimizeButtonIconType.SIDE_PANEL_DOWN:
+          closeIconToUse = isOpen ? BottomPanelClose16 : BottomPanelOpen16;
           break;
         default:
           closeIconToUse = SubtractLarge16;

--- a/packages/ai-chat/src/types/config/PublicConfig.ts
+++ b/packages/ai-chat/src/types/config/PublicConfig.ts
@@ -272,6 +272,11 @@ export enum MinimizeButtonIconType {
    * This shows an icon that indicates that the Carbon AI Chat can be collapsed into a side panel.
    */
   SIDE_PANEL_RIGHT = "side-panel-right",
+
+  /**
+   * This shows an icon that indicates that the Carbon AI Chat can be collapsed into a side panel.
+   */
+  SIDE_PANEL_DOWN = "side-panel-down",
 }
 
 /**


### PR DESCRIPTION
Closes #1012 

Added an option to allow the sidepanel down icon to be used in the sidebar

<img width="1840" height="1105" alt="Screenshot 2026-03-25 at 3 31 02 PM" src="https://github.com/user-attachments/assets/1c294fea-9a9d-4458-9a5e-d59765280c0d" />


#### Changelog

**New**

- Added an option to allow the sidepanel down icon to be used in the sidebar 

#### Testing / Reviewing

`npm test` and visual testing
