### PR TITLE
fix: remove input field visibility reset on conversation restart

### DIFF
--- a/packages/ai-chat/src/chat/services/ChatActionsImpl.ts
+++ b/packages/ai-chat/src/chat/services/ChatActionsImpl.ts
@@ -1702,7 +1702,6 @@ class ChatActionsImpl {
         await serviceManager.humanAgentService.endChat(true, false, false);
       }
 
-      this.serviceManager.instance.updateInputFieldVisibility(true);
       await this.serviceManager.messageService.cancelAllMessageRequests();
 
       // Hide the stop streaming button since we've cancelled all streams


### PR DESCRIPTION
Closes #1123

When the chat has input visibility set to false, restarting the conversation makes the input field visible again, ignoring the initial input config settings.

#### Changelog

**Removed**

- Removed line that resets the input field to visible on `restartConversation()` that gets triggered when user clicks on restart action in the chat header

#### Testing / Reviewing

- Go to demo deploy preview
- Go to Chat Configuration section in the demo sidebar and check "Show restart button" and set "Show input field" dropdown to false.
- Click the restart / refresh icon in the chat header and confirm that the input field is _not_ visible
