### PR TITLE
fix: disappearing actions

### DIFF
--- a/packages/ai-chat-components/src/components/toolbar/src/toolbar.ts
+++ b/packages/ai-chat-components/src/components/toolbar/src/toolbar.ts
@@ -113,12 +113,19 @@ class CDSAIChatToolbar extends LitElement {
   }
 
   updated(changedProps: Map<string, unknown>) {
-    if (changedProps.has("actions")) {
+    if (changedProps.has("actions") || changedProps.has("overflow")) {
       this.updateComplete
         .then(() => {
           this.hiddenItems = [];
         })
-        .then(() => this.setupOverflowHandler())
+        .then(() => {
+          // Use double requestAnimationFrame to ensure the browser has painted
+          requestAnimationFrame(() => {
+            requestAnimationFrame(() => {
+              this.setupOverflowHandler();
+            });
+          });
+        })
         .then(() => {
           this.measuring = false;
         });
@@ -133,23 +140,22 @@ class CDSAIChatToolbar extends LitElement {
     const containerWidth = Math.round(
       this.container.getBoundingClientRect().width,
     );
+
     if (containerWidth === 0) {
-      if (!this.visibilityObserver) {
-        this.visibilityObserver = new ResizeObserver(() => {
-          const width = Math.round(
-            this.container.getBoundingClientRect().width,
-          );
-          if (width > 0) {
-            this.visibilityObserver?.disconnect();
-            this.visibilityObserver = undefined;
-            // Use requestAnimationFrame to avoid ResizeObserver loop errors
-            requestAnimationFrame(() => {
-              this.setupOverflowHandler();
-            });
-          }
-        });
-        this.visibilityObserver.observe(this.container);
-      }
+      // Disconnect any existing observer before creating a new one
+      this.visibilityObserver?.disconnect();
+      this.visibilityObserver = new ResizeObserver(() => {
+        const width = Math.round(this.container.getBoundingClientRect().width);
+        if (width > 0) {
+          this.visibilityObserver?.disconnect();
+          this.visibilityObserver = undefined;
+          // Use requestAnimationFrame to avoid ResizeObserver loop errors
+          requestAnimationFrame(() => {
+            this.setupOverflowHandler();
+          });
+        }
+      });
+      this.visibilityObserver.observe(this.container);
       return;
     }
 

--- a/packages/ai-chat/src/chat/components/header/Header.scss
+++ b/packages/ai-chat/src/chat/components/header/Header.scss
@@ -24,13 +24,6 @@
   background-color: theme.$chat-shell-background;
   border-start-end-radius: var(--cds-aichat-border-radius-start-end, 0);
   border-start-start-radius: var(--cds-aichat-border-radius-start-start, 0);
-
-  @media screen and (prefers-reduced-motion: no-preference) {
-    transition:
-      margin motion.$duration-moderate-01 motion.motion(standard, productive),
-      inline-size motion.$duration-moderate-01
-        motion.motion(standard, productive);
-  }
 }
 
 // Only apply max-width constraint when header is configured to constrain width


### PR DESCRIPTION
Closes #1147 

Fix custom header actions disappearing after closing and reopening chat widget

#### Changelog

**Changed**

- Fixed toolbar component to properly reinitialize overflow handler when actions change or component becomes visible again, ensuring custom header actions persist across chat widget open/close cycles

#### Testing / Reviewing

To verify this fix works correctly:

1. Open the demo site for the chat component
2. Add custom actions to the `header.actions` prop of `ChatCustomElement` (e.g., an icon button with an href or onClick handler)
3. Open the chat widget and verify the custom action icons are visible in the header
4. Close the chat widget using the minimize/close button
5. Reopen the chat widget
6. **Expected result**: Custom action icons should still be visible in the header
7. Repeat steps 4-6 multiple times to ensure actions persist consistently