### PR TITLE
fix: forgot to update to new prop names

### DIFF
--- a/packages/ai-chat/src/chat/components/util/MarkdownWithDefaults.tsx
+++ b/packages/ai-chat/src/chat/components/util/MarkdownWithDefaults.tsx
@@ -118,24 +118,26 @@ function MarkdownWithDefaults(props: MarkdownWithDefaultsProps) {
       markdown={text}
       sanitizeHTML={doSanitize}
       streaming={streaming}
-      highlight={highlight}
       removeHTML={removeHTML}
-      // Table strings
-      filterPlaceholderText={languagePack.table_filterPlaceholder}
-      previousPageText={languagePack.table_previousPage}
-      nextPageText={languagePack.table_nextPage}
-      itemsPerPageText={languagePack.table_itemsPerPage}
-      locale={locale}
-      getPaginationSupplementalText={getPaginationSupplementalText}
-      getPaginationStatusText={getPaginationStatusText}
-      // Code snippet strings
-      feedback={languagePack.codeSnippet_feedback}
-      showLessText={languagePack.codeSnippet_showLessText}
-      showMoreText={languagePack.codeSnippet_showMoreText}
-      tooltipContent={languagePack.codeSnippet_tooltipContent}
-      getLineCountText={getLineCountText}
+      // Code snippet properties
+      codeSnippetHighlight={highlight}
+      codeSnippetShowLessText={languagePack.codeSnippet_showLessText}
+      codeSnippetShowMoreText={languagePack.codeSnippet_showMoreText}
+      codeSnippetCopyButtonTooltipContent={
+        languagePack.codeSnippet_tooltipContent
+      }
+      codeSnippetGetLineCountText={getLineCountText}
       codeSnippetAriaLabelReadOnly={languagePack.codeSnippet_ariaLabelReadOnly}
       codeSnippetAriaLabelEditable={languagePack.codeSnippet_ariaLabelEditable}
+      // Table properties
+      tableFilterPlaceholderText={languagePack.table_filterPlaceholder}
+      tablePreviousPageText={languagePack.table_previousPage}
+      tableNextPageText={languagePack.table_nextPage}
+      tableItemsPerPageText={languagePack.table_itemsPerPage}
+      tableDownloadLabelText={languagePack.table_downloadButton}
+      tableLocale={locale}
+      tableGetPaginationSupplementalText={getPaginationSupplementalText}
+      tableGetPaginationStatusText={getPaginationStatusText}
     />
   );
 }


### PR DESCRIPTION
Contributes to #1144 

Fix custom translation strings not being applied to Markdown table and code snippet elements. This does not handle the separate tooltip issue in #1144.

#### Changelog

**Changed**

- Fixed property name mappings in `MarkdownWithDefaults.tsx` to correctly pass custom translation strings to the Markdown web component
- Updated table property names: `filterPlaceholderText` → `tableFilterPlaceholderText`, `previousPageText` → `tablePreviousPageText`, `nextPageText` → `tableNextPageText`, `itemsPerPageText` → `tableItemsPerPageText`, `locale` → `tableLocale`
- Updated code snippet property names: `showLessText` → `codeSnippetShowLessText`, `showMoreText` → `codeSnippetShowMoreText`, `tooltipContent` → `codeSnippetCopyButtonTooltipContent`, `highlight` → `codeSnippetHighlight`
- Added missing `tableDownloadLabelText` property mapping for table download button
- Removed incorrect `feedback` property (not a Markdown component property)

#### Testing / Reviewing

**Root Cause:**
The `MarkdownWithDefaults` component was using shortened property names that didn't match the actual property definitions in the Markdown web component. This caused the web component bridge to fail to apply custom translation strings.

**Affected Translation Keys:**
- `table_filterPlaceholder`
- `table_paginationStatus`
- `table_nextPage`
- `table_previousPage`
- `table_downloadButton`
- `codeSnippet_lineCount`
- `codeSnippet_showMoreText`
- `codeSnippet_tooltipContent`
- `codeSnippet_showLessText`

**To Verify the Fix:**

1. **Test with custom strings:**
   ```tsx
   <ChatCustomElement
     strings={{
       table_filterPlaceholder: "Custom Filter",
       table_nextPage: "Custom Next",
       table_previousPage: "Custom Previous",
       codeSnippet_showMoreText: "Custom Show More",
       codeSnippet_showLessText: "Custom Show Less",
       codeSnippet_tooltipContent: "Custom Copy Tooltip"
     }}
     // ... other props
   />
   ```

2. **Verify custom strings appear in:**
   - Table filter placeholder text
   - Table pagination controls (next/previous buttons)
   - Code snippet expand/collapse buttons
   - Code snippet copy button tooltip

3. **Check that default English strings still work** when no custom strings are provided

4. **Test with non-English locales** to ensure translation strings flow correctly through the component hierarchy

**Files Changed:**
- `packages/ai-chat/src/chat/components/util/MarkdownWithDefaults.tsx` (lines 116-139)

**Property Name Reference:**
All property names now match the exact camelCase definitions in `packages/ai-chat-components/src/components/markdown/src/markdown.ts` (lines 109-180)