### PR TITLE
fix: handle arrow key events in chat toolbar

### DIFF
--- a/demo/tests/overflow-menu-arrow-navigation.spec.ts
+++ b/demo/tests/overflow-menu-arrow-navigation.spec.ts
@@ -1,0 +1,171 @@
+/*
+ *  Copyright IBM Corp. 2026
+ *
+ *  This source code is licensed under the Apache-2.0 license found in the
+ *  LICENSE file in the root directory of this source tree.
+ */
+
+import { test, expect } from "@playwright/test";
+import { PageObjectId } from "@carbon/ai-chat/server";
+import {
+  prepareDemoPage,
+  destroyChatSession,
+  openChatWindow,
+  waitForChatReady,
+  waitForSetChatConfigApplied,
+} from "./utils";
+
+// Import types for window.setChatConfig without emitting runtime code
+import type {} from "../types/window";
+
+// Setup common to all tests
+test.beforeEach(async ({ page }) => {
+  // Load demo in setChatConfig mode and block analytics pop-ups
+  await prepareDemoPage(page, { setChatConfig: true });
+});
+
+// Clear session between all tests to ensure clean state
+test.afterEach(async ({ page }) => {
+  await destroyChatSession(page);
+});
+
+/**
+ * Helper function to find the currently focused overflow menu item by traversing shadow DOM.
+ * Returns the text content of the focused item, or null if no item is focused.
+ */
+async function getFocusedMenuItemText(page: any): Promise<string | null> {
+  return await page.evaluate(() => {
+    function findFocusedElement(root: Document | ShadowRoot): Element | null {
+      const activeElement = root.activeElement;
+
+      if (!activeElement) {
+        return null;
+      }
+
+      // Check if this is an overflow menu item
+      if (
+        activeElement.tagName.toLowerCase() === "cds-overflow-menu-item" ||
+        activeElement.getAttribute("role") === "menuitem"
+      ) {
+        return activeElement;
+      }
+
+      // Traverse into shadow DOM if it exists
+      if (activeElement.shadowRoot) {
+        return findFocusedElement(activeElement.shadowRoot);
+      }
+
+      return null;
+    }
+
+    const focusedItem = findFocusedElement(document);
+    return focusedItem ? focusedItem.textContent?.trim() || null : null;
+  });
+}
+
+/**
+ * Helper function to open the overflow menu and wait for it to be visible.
+ */
+async function openOverflowMenu(page: any) {
+  // Find and click the overflow menu button in the navigation slot
+  const overflowMenuButton = page.locator("cds-overflow-menu").first();
+  await overflowMenuButton.click();
+
+  // Wait for the first menu item to be visible
+  await page
+    .locator("cds-overflow-menu-item")
+    .first()
+    .waitFor({ state: "visible" });
+}
+
+/**
+ * Helper function to focus the first menu item in the overflow menu.
+ */
+async function focusFirstMenuItem(page: any) {
+  // Focus the first menu item
+  const firstMenuItem = page.locator("cds-overflow-menu-item").first();
+  await firstMenuItem.focus();
+}
+
+test("arrow key navigation in overflow menu", async ({ page }) => {
+  // Configure chat with menu options enabled
+  await page.evaluate(async () => {
+    if (!window.setChatConfig) {
+      throw new Error("setChatConfig is not available");
+    }
+    await window.setChatConfig({
+      header: {
+        title: "Test Chat",
+        menuOptions: [
+          {
+            text: "Help",
+            handler: () => alert("Help clicked!"),
+          },
+          {
+            text: "Documentation",
+            href: "https://example.com",
+            target: "_blank",
+          },
+          {
+            text: "Settings",
+            handler: () => alert("Settings clicked!"),
+          },
+        ],
+      },
+      launcher: { isOn: false },
+      openChatByDefault: true,
+    });
+  });
+
+  await waitForSetChatConfigApplied(page);
+
+  // Open the chat interface and wait for it to be ready
+  await openChatWindow(page);
+  await waitForChatReady(page, { panelTestId: PageObjectId.MAIN_PANEL });
+
+  // Open the overflow menu
+  await openOverflowMenu(page);
+
+  // Focus the first menu item
+  await focusFirstMenuItem(page);
+
+  // Verify first item is focused
+  let focusedText = await getFocusedMenuItemText(page);
+  expect(focusedText).toBe("Help");
+
+  // Press ArrowDown key
+  await page.keyboard.press("ArrowDown");
+
+  // Wait for focus to update by checking that the second item is focused
+  await page.waitForFunction(
+    () => {
+      function findFocusedElement(root: Document | ShadowRoot): Element | null {
+        const activeElement = root.activeElement;
+        if (!activeElement) {
+          return null;
+        }
+
+        if (
+          activeElement.tagName.toLowerCase() === "cds-overflow-menu-item" ||
+          activeElement.getAttribute("role") === "menuitem"
+        ) {
+          return activeElement;
+        }
+
+        if (activeElement.shadowRoot) {
+          return findFocusedElement(activeElement.shadowRoot);
+        }
+
+        return null;
+      }
+
+      const focusedItem = findFocusedElement(document);
+      return focusedItem?.textContent?.trim() === "Documentation";
+    },
+    { timeout: 2000 },
+  );
+
+  // Verify second item is now focused
+  focusedText = await getFocusedMenuItemText(page);
+  expect(focusedText).toBe("Documentation");
+});

--- a/packages/ai-chat-components/src/components/toolbar/src/toolbar.ts
+++ b/packages/ai-chat-components/src/components/toolbar/src/toolbar.ts
@@ -99,6 +99,7 @@ class CDSAIChatToolbar extends LitElement {
 
   connectedCallback(): void {
     super.connectedCallback();
+    this.addEventListener("keydown", this._handleToolbarKeydown);
     this.style.visibility = this.overflow ? "hidden" : "visible";
   }
 
@@ -178,8 +179,63 @@ class CDSAIChatToolbar extends LitElement {
     this.overflowHandler?.disconnect();
     this.visibilityObserver?.disconnect();
     this.visibilityObserver = undefined;
+    this.removeEventListener("keydown", this._handleToolbarKeydown);
     super.disconnectedCallback();
   }
+
+  /**
+   * Returns the focused overflow menu item (if exists) by traversing shadow DOM
+   */
+  private findFocusedOverflowMenuItem(activeElem: Element): Element | null {
+    if (activeElem.tagName.toLowerCase() === "cds-overflow-menu-item") {
+      return activeElem;
+    }
+
+    if (activeElem?.shadowRoot?.activeElement) {
+      return this.findFocusedOverflowMenuItem(
+        activeElem.shadowRoot.activeElement,
+      );
+    }
+
+    return null;
+  }
+
+  private _handleToolbarKeydown = (event: KeyboardEvent) => {
+    if (event.key !== "ArrowUp" && event.key !== "ArrowDown") {
+      return;
+    }
+
+    let focusedMenuItem: Element | null = null;
+
+    if (document.activeElement) {
+      focusedMenuItem = this.findFocusedOverflowMenuItem(
+        document.activeElement,
+      );
+    }
+
+    if (focusedMenuItem) {
+      event.preventDefault();
+      const menuBody = focusedMenuItem.closest("cds-overflow-menu-body");
+
+      if (!menuBody) {
+        return;
+      }
+
+      const items = Array.from(
+        menuBody.querySelectorAll("cds-overflow-menu-item:not([disabled])"),
+      ) as HTMLElement[];
+
+      const currentIndex = items.indexOf(focusedMenuItem as HTMLElement);
+      if (currentIndex === -1) {
+        return;
+      }
+
+      const direction = event.key === "ArrowDown" ? 1 : -1;
+      const nextIndex =
+        (currentIndex + direction + items.length) % items.length;
+      items[nextIndex]?.focus();
+    }
+  };
 
   /**
    * Renders an action as an icon button.


### PR DESCRIPTION
Closes #1105

Fixes issue in demo where the chat header overflow menu wasn't keyboard navigable. The arrow key nav had worked as expected in the toolbar component storybook example, but when the toolbar/menu was nested inside the chat shell, those events weren't getting handled. These changes handle the Arrow Up/Down events explicitly on the chat toolbar component.



#### Changelog

**New**
- handle arrow key events in `toolbar.ts`
- arrow key nav playwright test for demo

#### Testing / Reviewing

- Go to demo deploy preview
- Under the header config select "Add menu options"
- Open the overflow menu in the chat header
- Verify that keyboard nav works
