### PR TITLE
fix: buttons reverting to ghost

### DIFF
--- a/packages/ai-chat-components/src/components/chat-button/src/chat-button.ts
+++ b/packages/ai-chat-components/src/components/chat-button/src/chat-button.ts
@@ -67,15 +67,22 @@ class CDSAIChatButton extends CDSButton {
   ];
 
   protected willUpdate(changedProps: PropertyValues<this>): void {
-    if (changedProps.has("isQuickAction") || changedProps.has("size")) {
-      this._normalizeButtonState();
+    if (
+      changedProps.has("isQuickAction") ||
+      changedProps.has("size") ||
+      changedProps.has("kind")
+    ) {
+      this._normalizeButtonState(changedProps);
     }
   }
 
-  private _normalizeButtonState(): void {
+  private _normalizeButtonState(changedProps: PropertyValues<this>): void {
     if (this.isQuickAction) {
-      this.kind = CHAT_BUTTON_KIND.GHOST;
       this.size = CHAT_BUTTON_SIZE.SMALL;
+      // Only default to ghost when kind was not explicitly provided in this update.
+      if (!changedProps.has("kind")) {
+        this.kind = CHAT_BUTTON_KIND.GHOST;
+      }
       return;
     }
     // Do not allow size larger than `lg`

--- a/packages/ai-chat/src/types/utilities/HasDoAutoScroll.d.ts
+++ b/packages/ai-chat/src/types/utilities/HasDoAutoScroll.d.ts
@@ -21,6 +21,8 @@ interface HasDoAutoScroll {
 
 /**
  * Options for controlling how the scrolling occurs.
+ *
+ * @category Instance
  */
 interface AutoScrollOptions {
   /**


### PR DESCRIPTION
Closes #1085 

respect explicit `kind` prop when `isQuickAction` is set

#### Changelog

**Changed**

- `_normalizeButtonState()` no longer unconditionally overrides `kind` to `ghost` when `isQuickAction={true}`. It now only defaults to `ghost` when `kind` was not explicitly provided in the same update cycle.
- `willUpdate` now also triggers `_normalizeButtonState()` when `kind` changes, preventing React/Lit state drift where React re-applying `kind` after a normalization override would go unchecked.

#### Testing / Reviewing

The bug manifests when option/starter buttons using both `isQuickAction` and an explicit `kind` (e.g. `kind="tertiary"`) appear greyed out after navigating away from and back to the home screen.

- [ ] Render a `<cds-aichat-button is-quick-action kind="tertiary">` button and confirm it renders as **tertiary**, not ghost.
- [ ] Render a `<cds-aichat-button is-quick-action>` button (no `kind` prop) and confirm it still renders as **ghost** (default behaviour preserved).
- [ ] In an app with client-side routing: navigate to a page that shows option buttons (`OptionComponent`) or home screen starters (`HomeScreen`), click one to navigate away, then navigate back. Confirm the buttons no longer appear greyed out on return.
- [ ] Confirm the existing `chat-button` snapshot test still passes (`pnpm test` in `packages/ai-chat-components`).
