### PR TITLE
chore: reset default for code-snippet syntax highlighting

### DIFF
--- a/packages/ai-chat-components/src/components/markdown/src/markdown.ts
+++ b/packages/ai-chat-components/src/components/markdown/src/markdown.ts
@@ -136,7 +136,7 @@ class CDSAIChatMarkdown extends LitElement {
   // Code snippet properties
   /** Enable syntax highlighting for any code fence blocks. */
   @property({ type: Boolean, attribute: "code-snippet-highlight" })
-  codeSnippetHighlight = false;
+  codeSnippetHighlight = true;
 
   /** Label for collapsing long code blocks. */
   @property({ type: String, attribute: "code-snippet-show-less-text" })


### PR DESCRIPTION
Closes #

The code snippet from markdown used to have syntax highlighting by default. Restoring that in this PR.

#### Changelog

**Changed**

- set new property `codeSnippetHighlight` to true

#### Testing / Reviewing

Go to demo deploy preview and select "code" from dropdown. Confirm that the code snippet has syntax highlighting
