### PR TITLE
fix: reasoning step icon vertical alignment

### DIFF
--- a/packages/ai-chat-components/src/components/reasoning-steps/src/reasoning-step.scss
+++ b/packages/ai-chat-components/src/components/reasoning-steps/src/reasoning-step.scss
@@ -81,7 +81,7 @@
 
 .#{$prefix}--reasoning-step__static {
   display: flex;
-  align-items: center;
+  align-items: start;
   gap: layout.$spacing-02;
 }
 
@@ -89,7 +89,7 @@
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  block-size: layout.$spacing-05;
+  block-size: 1lh;
   inline-size: layout.$spacing-05;
 
   svg {


### PR DESCRIPTION
Closes #1140

Adjust reasoning step styles so chevron/static step icon stays vertically aligned with top of step title when text wraps

#### Testing / Reviewing

- Go to demo deploy preview
- Type "text (stream) with reasoning steps"
- Choose a reasoning step title that is paired with a chevron icon. Edit the title in dev tools so it's long enough to wrap
- Verify the chevron is aligned with the top line of text
- Check the same thing for a static step