### PR TITLE
feat: better memoization

### DIFF
--- a/demo/src/react/DemoApp.tsx
+++ b/demo/src/react/DemoApp.tsx
@@ -64,7 +64,8 @@ function DemoApp({ config, settings, onChatInstanceReady }: AppProps) {
   const isSidebarLayout = settings.layout === "sidebar";
 
   useEffect(() => {
-    setInterval(() => setStateText(Date.now().toString()), 2000);
+    const id = setInterval(() => setStateText(Date.now().toString()), 2000);
+    return () => clearInterval(id);
   }, []);
   /**
    * Handler for user_defined response types. You can just have a switch statement here and return the right component
@@ -119,27 +120,26 @@ function DemoApp({ config, settings, onChatInstanceReady }: AppProps) {
   /**
    * Handler for custom footer slot.
    */
-  const renderCustomMessageFooter: RenderCustomMessageFooter = (
-    slotName,
-    message,
-    messageItem,
-    instance,
-    additionalData,
-  ) => {
-    return (
-      <CustomFooterExample
-        slotName={slotName}
-        message={message}
-        messageItem={messageItem}
-        instance={instance}
-        additionalData={additionalData}
-      />
-    );
-  };
+  const renderCustomMessageFooter: RenderCustomMessageFooter = useCallback(
+    (slotName, message, messageItem, instance, additionalData) => {
+      return (
+        <CustomFooterExample
+          slotName={slotName}
+          message={message}
+          messageItem={messageItem}
+          instance={instance}
+          additionalData={additionalData}
+        />
+      );
+    },
+    [],
+  );
 
   /**
    * You can return a React element for each writeable element.
    */
+  const historyIsMobile =
+    instance?.getState().customPanels.history.isMobile ?? false;
   const allWriteableElements = useMemo(
     () => ({
       headerBottomElement: (
@@ -213,12 +213,11 @@ function DemoApp({ config, settings, onChatInstanceReady }: AppProps) {
         <HistoryWriteableElementExample
           instance={instance as ChatInstance}
           parentStateText={stateText}
-          isMobile={instance?.getState().customPanels.history.isMobile ?? false}
+          isMobile={historyIsMobile}
         />
       ),
     }),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [instance, instance?.getState().customPanels.history.isMobile],
+    [instance, historyIsMobile, stateText],
   );
 
   /**

--- a/packages/ai-chat/src/chat/AppShell.tsx
+++ b/packages/ai-chat/src/chat/AppShell.tsx
@@ -63,6 +63,7 @@ import {
   selectHumanAgentDisplayState,
   selectInputState,
 } from "./store/selectors";
+import { shallowEqual } from "./store/appStore";
 import { consoleError, createDidCatchErrorData } from "./utils/miscUtils";
 import {
   IS_PHONE,
@@ -105,6 +106,31 @@ const WIDTH_BREAKPOINT_STANDARD = "cds-aichat--standard-width";
 const WIDTH_BREAKPOINT_NARROW = "cds-aichat--narrow-width";
 const WIDTH_BREAKPOINT_WIDE = "cds-aichat--wide-width";
 
+// Module-level selectors — stable references so useSelector can use Object.is
+// to skip re-renders when the slice hasn't changed.
+const selectConfig = (state: AppState) => state.config;
+const selectPersistedToBrowserStorage = (state: AppState) =>
+  state.persistedToBrowserStorage;
+const selectIsHydrated = (state: AppState) => state.isHydrated;
+const selectAssistantMessageState = (state: AppState) =>
+  state.assistantMessageState;
+const selectHumanAgentStateSlice = (state: AppState) => state.humanAgentState;
+const selectWorkspacePanelState = (state: AppState) =>
+  state.workspacePanelState;
+const selectHistoryPanelState = (state: AppState) => state.historyPanelState;
+const selectAllMessageItemsByID = (state: AppState) =>
+  state.allMessageItemsByID;
+const selectAllMessagesByID = (state: AppState) => state.allMessagesByID;
+const selectCatastrophicErrorType = (state: AppState) =>
+  state.catastrophicErrorType;
+const selectIFramePanelState = (state: AppState) => state.iFramePanelState;
+const selectViewSourcePanelState = (state: AppState) =>
+  state.viewSourcePanelState;
+const selectCustomPanelState = (state: AppState) => state.customPanelState;
+const selectResponsePanelState = (state: AppState) => state.responsePanelState;
+const selectChatWidthBreakpoint = (state: AppState) =>
+  state.chatWidthBreakpoint;
+
 interface AppShellProps extends HasServiceManager {
   hostElement?: Element;
   renderWriteableElements?: RenderWriteableElementResponse;
@@ -130,7 +156,7 @@ export interface MainWindowFunctions extends HasRequestFocus, HasDoAutoScroll {
   getMessagesScrollBottom(): number;
 }
 
-export default function AppShell({
+function AppShell({
   hostElement,
   serviceManager,
   renderWriteableElements,
@@ -143,24 +169,23 @@ export default function AppShell({
     serviceManager.ariaAnnouncer = ariaAnnouncer;
   }, [serviceManager, ariaAnnouncer]);
 
-  const appState = useSelector<AppState, AppState>((state) => state);
-  const {
-    config,
-    persistedToBrowserStorage,
-    isHydrated,
-    assistantMessageState,
-    humanAgentState,
-    workspacePanelState,
-    historyPanelState,
-    allMessageItemsByID,
-    allMessagesByID,
-    catastrophicErrorType,
-    iFramePanelState,
-    viewSourcePanelState,
-    customPanelState,
-    responsePanelState,
-    chatWidthBreakpoint,
-  } = appState;
+  const config = useSelector(selectConfig);
+  const persistedToBrowserStorage = useSelector(
+    selectPersistedToBrowserStorage,
+  );
+  const isHydrated = useSelector(selectIsHydrated);
+  const assistantMessageState = useSelector(selectAssistantMessageState);
+  const humanAgentState = useSelector(selectHumanAgentStateSlice);
+  const workspacePanelState = useSelector(selectWorkspacePanelState);
+  const historyPanelState = useSelector(selectHistoryPanelState);
+  const allMessageItemsByID = useSelector(selectAllMessageItemsByID);
+  const allMessagesByID = useSelector(selectAllMessagesByID);
+  const catastrophicErrorType = useSelector(selectCatastrophicErrorType);
+  const iFramePanelState = useSelector(selectIFramePanelState);
+  const viewSourcePanelState = useSelector(selectViewSourcePanelState);
+  const customPanelState = useSelector(selectCustomPanelState);
+  const responsePanelState = useSelector(selectResponsePanelState);
+  const chatWidthBreakpoint = useSelector(selectChatWidthBreakpoint);
 
   const {
     derived: {
@@ -215,8 +240,11 @@ export default function AppShell({
   );
   const useCustomHostElement = Boolean(hostElement);
   const headerDisplayName = header?.name;
-  const inputState = selectInputState(appState);
-  const agentDisplayState = selectHumanAgentDisplayState(appState);
+  const inputState = useSelector(selectInputState);
+  const agentDisplayState = useSelector(
+    selectHumanAgentDisplayState,
+    shallowEqual,
+  );
 
   // Use derived state hook for memoized calculations
   const {
@@ -318,11 +346,11 @@ export default function AppShell({
     showUploadButtonDisabled,
   } = useInputCallbacks({
     serviceManager,
-    appState,
     inputState,
     agentDisplayState,
     isHydrated,
     messagesRef,
+    humanAgentFileUploadInProgress: humanAgentState.fileUploadInProgress,
   });
 
   // Human agent callbacks
@@ -510,6 +538,12 @@ export default function AppShell({
       consoleError("An error occurred in handleFocusToggle", error);
     }
   }, []);
+
+  // Stable wrapper so <Input> receives a referentially stable onSendInput prop
+  const onSendInputFromInput = useCallback(
+    (text: string) => onSendInput(text, MessageSendSource.MESSAGE_INPUT),
+    [onSendInput],
+  );
 
   // Add keyboard event listener for focus toggle shortcut and Escape to exit message navigation
   useEffect(() => {
@@ -796,9 +830,7 @@ export default function AppShell({
                   disableInput={shouldDisableInput()}
                   disableSend={shouldDisableSend()}
                   isInputVisible={inputState.fieldVisible}
-                  onSendInput={(text: string) =>
-                    onSendInput(text, MessageSendSource.MESSAGE_INPUT)
-                  }
+                  onSendInput={onSendInputFromInput}
                   onUserTyping={onUserTyping}
                   showUploadButton={
                     inputState.allowFileUploads || isAssistantUploadEnabled
@@ -885,3 +917,5 @@ export default function AppShell({
     </div>
   );
 }
+
+export default React.memo(AppShell);

--- a/packages/ai-chat/src/chat/AppShellPanels.tsx
+++ b/packages/ai-chat/src/chat/AppShellPanels.tsx
@@ -86,7 +86,7 @@ function isCustomPanelConfigOptions(
 /**
  * Renders all ChatPanel instances inside the `panels` slot of ChatShell.
  */
-export function AppShellPanels({
+export const AppShellPanels = React.memo(function AppShellPanels({
   serviceManager,
   languagePack,
   isHydratingComplete,
@@ -588,4 +588,4 @@ export function AppShellPanels({
       )}
     </div>
   );
-}
+});

--- a/packages/ai-chat/src/chat/AppShellWriteableElements.tsx
+++ b/packages/ai-chat/src/chat/AppShellWriteableElements.tsx
@@ -89,53 +89,55 @@ const ELEMENT_CONFIGS: ElementConfig[] = [
 /**
  * Renders WriteableElement slots that live directly under ChatShell.
  */
-export function AppShellWriteableElements({
-  serviceManager,
-  showHomeScreen,
-  renderWriteableElements,
-}: AppShellWriteableElementsProps) {
-  const suffix = serviceManager.namespace.suffix;
-  const hasContentMaxWidth = useSelector(
-    (state: AppState) =>
-      state.config.derived.header.hasContentMaxWidth ?? false,
-  );
+export const AppShellWriteableElements = React.memo(
+  function AppShellWriteableElements({
+    serviceManager,
+    showHomeScreen,
+    renderWriteableElements,
+  }: AppShellWriteableElementsProps) {
+    const suffix = serviceManager.namespace.suffix;
+    const hasContentMaxWidth = useSelector(
+      (state: AppState) =>
+        state.config.derived.header.hasContentMaxWidth ?? false,
+    );
 
-  const elements = useMemo(
-    () =>
-      ELEMENT_CONFIGS.map((config) => {
-        const baseClassName = resolveValue(config.className, showHomeScreen);
-        // Add constrain-width class to header-bottom-element if configured
-        const isHeaderBottomElement =
-          baseClassName === "cds-aichat--header-bottom-element";
-        const className =
-          isHeaderBottomElement && hasContentMaxWidth
-            ? `${baseClassName} cds-aichat--header-constrain-width`
-            : baseClassName;
+    const elements = useMemo(
+      () =>
+        ELEMENT_CONFIGS.map((config) => {
+          const baseClassName = resolveValue(config.className, showHomeScreen);
+          // Add constrain-width class to header-bottom-element if configured
+          const isHeaderBottomElement =
+            baseClassName === "cds-aichat--header-bottom-element";
+          const className =
+            isHeaderBottomElement && hasContentMaxWidth
+              ? `${baseClassName} cds-aichat--header-constrain-width`
+              : baseClassName;
 
-        return {
-          wrapperSlot: config.wrapperSlot,
-          slotName: resolveValue(config.slotName, showHomeScreen),
-          id: `${resolveValue(config.idSuffix, showHomeScreen)}${suffix}`,
-          className,
-        };
-      }).filter((element) => {
-        // Only render the element if content exists in renderWriteableElements
-        // If renderWriteableElements is not provided, render all elements (backward compatibility)
-        if (!renderWriteableElements) {
-          return true;
-        }
-        return !!renderWriteableElements[
-          element.slotName as WriteableElementName
-        ];
-      }),
-    [showHomeScreen, suffix, renderWriteableElements, hasContentMaxWidth],
-  );
+          return {
+            wrapperSlot: config.wrapperSlot,
+            slotName: resolveValue(config.slotName, showHomeScreen),
+            id: `${resolveValue(config.idSuffix, showHomeScreen)}${suffix}`,
+            className,
+          };
+        }).filter((element) => {
+          // Only render the element if content exists in renderWriteableElements
+          // If renderWriteableElements is not provided, render all elements (backward compatibility)
+          if (!renderWriteableElements) {
+            return true;
+          }
+          return !!renderWriteableElements[
+            element.slotName as WriteableElementName
+          ];
+        }),
+      [showHomeScreen, suffix, renderWriteableElements, hasContentMaxWidth],
+    );
 
-  return (
-    <>
-      {elements.map((props) => (
-        <WriteableElement key={props.wrapperSlot} {...props} />
-      ))}
-    </>
-  );
-}
+    return (
+      <>
+        {elements.map((props) => (
+          <WriteableElement key={props.wrapperSlot} {...props} />
+        ))}
+      </>
+    );
+  },
+);

--- a/packages/ai-chat/src/chat/components-legacy/MessageTypeComponent.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/MessageTypeComponent.tsx
@@ -11,7 +11,13 @@
 
 import Attachment16 from "@carbon/icons/es/attachment/16.js";
 import { carbonIconToReact } from "./../utils/carbonIcon";
-import React, { useEffect, useMemo, useRef, useState } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { useIntl } from "../hooks/useIntl";
 import { useSelector } from "../hooks/useSelector";
 import { shallowEqual } from "../store/appStore";
@@ -164,6 +170,15 @@ function MessageTypeComponent(props: MessageTypeComponentProps) {
   useEffect(() => {
     setIsChainOfThoughtOpen(false);
   }, [message.ui_state.id]);
+
+  // Stable callback so children wrapped in React.memo (BodyMessageComponents,
+  // CardItemComponent, GridItemComponent) can actually skip re-renders.
+  const renderMessageComponent = useCallback(
+    (childProps: MessageTypeComponentProps) => (
+      <MessageTypeComponent {...childProps} />
+    ),
+    [],
+  );
 
   /**
    * Returns the appropriate component to render the given message.
@@ -532,9 +547,7 @@ function MessageTypeComponent(props: MessageTypeComponentProps) {
         fullMessage={originalMessage}
         isMessageForInput={isMessageForInput}
         requestFocus={requestInputFocus}
-        renderMessageComponent={(childProps) => (
-          <MessageTypeComponent {...childProps} />
-        )}
+        renderMessageComponent={renderMessageComponent}
       />
     );
   }
@@ -594,9 +607,7 @@ function MessageTypeComponent(props: MessageTypeComponentProps) {
         fullMessage={originalMessage}
         isMessageForInput={isMessageForInput}
         requestFocus={requestInputFocus}
-        renderMessageComponent={(childProps) => (
-          <MessageTypeComponent {...childProps} />
-        )}
+        renderMessageComponent={renderMessageComponent}
       />
     );
   }
@@ -609,9 +620,7 @@ function MessageTypeComponent(props: MessageTypeComponentProps) {
       <GridItemComponent
         localMessageItem={message}
         originalMessage={originalMessage}
-        renderMessageComponent={(childProps) => (
-          <MessageTypeComponent {...childProps} />
-        )}
+        renderMessageComponent={renderMessageComponent}
       />
     );
   }

--- a/packages/ai-chat/src/chat/components-legacy/MessagesComponent.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/MessagesComponent.tsx
@@ -28,6 +28,7 @@ import {
   selectInputState,
 } from "../store/selectors";
 import { AppState, ChatMessagesState } from "../../types/state/AppState";
+import { shallowEqual } from "../store/appStore";
 import { AutoScrollOptions } from "../../types/utilities/HasDoAutoScroll";
 import HasIntl from "../../types/utilities/HasIntl";
 import { HasRequestFocus } from "../../types/utilities/HasRequestFocus";
@@ -151,7 +152,19 @@ interface MessagesOwnProps extends HasIntl, HasServiceManager {
   carbonTheme: CarbonTheme;
 }
 
-interface MessagesProps extends MessagesOwnProps, AppState {}
+/**
+ * Only the AppState slices that MessagesComponent actually reads.
+ * Keeping this narrow avoids re-renders caused by unrelated state changes.
+ */
+interface MessagesInjectedState {
+  config: AppState["config"];
+  allMessagesByID: AppState["allMessagesByID"];
+  humanAgentState: AppState["humanAgentState"];
+  persistedToBrowserStorage: AppState["persistedToBrowserStorage"];
+  assistantInputState: AppState["assistantInputState"];
+}
+
+interface MessagesProps extends MessagesOwnProps, MessagesInjectedState {}
 
 interface MessagesState {
   /**
@@ -1006,8 +1019,9 @@ class MessagesComponent extends PureComponent<MessagesProps, MessagesState> {
       useAITheme,
     } = this.props;
 
-    const inputState = selectInputState(this.props);
-    const { isHumanAgentTyping } = selectHumanAgentDisplayState(this.props);
+    const propsAsState = this.props as unknown as AppState;
+    const inputState = selectInputState(propsAsState);
+    const { isHumanAgentTyping } = selectHumanAgentDisplayState(propsAsState);
     const { isMessageLoadingCounter } = messageState;
     const { disclaimersAccepted } = persistedToBrowserStorage;
 
@@ -1271,7 +1285,9 @@ class MessagesComponent extends PureComponent<MessagesProps, MessagesState> {
       },
     } = this.props;
     const { isMessageLoadingCounter, isMessageLoadingText } = messageState;
-    const { isHumanAgentTyping } = selectHumanAgentDisplayState(this.props);
+    const { isHumanAgentTyping } = selectHumanAgentDisplayState(
+      this.props as unknown as AppState,
+    );
     const { scrollHandleHasFocus, scrollDown } = this.state;
 
     const messageIDForInput = getMessageIDForUserInput(
@@ -1348,12 +1364,21 @@ function debugAutoScroll(message: string, ...args: any[]) {
   }
 }
 
-// Functional wrapper to supply AppState via hooks
+// Module-level selector — only the slices MessagesComponent actually reads.
+const selectMessagesState = (state: AppState): MessagesInjectedState => ({
+  config: state.config,
+  allMessagesByID: state.allMessagesByID,
+  humanAgentState: state.humanAgentState,
+  persistedToBrowserStorage: state.persistedToBrowserStorage,
+  assistantInputState: state.assistantInputState,
+});
+
+// Functional wrapper to supply the narrow state slice via hooks
 const MessagesStateInjector = React.forwardRef<
   MessagesComponent,
   MessagesOwnProps
 >((props, ref) => {
-  const state = useSelector<AppState, AppState>((s) => s);
+  const state = useSelector(selectMessagesState, shallowEqual);
   return (
     <MessagesComponent ref={ref} {...(props as MessagesOwnProps)} {...state} />
   );

--- a/packages/ai-chat/src/chat/hooks/useInputCallbacks.tsx
+++ b/packages/ai-chat/src/chat/hooks/useInputCallbacks.tsx
@@ -19,13 +19,12 @@ import {
   MessageSendSource,
 } from "../../types/events/eventBusTypes";
 import type { ServiceManager } from "../services/ServiceManager";
-import type { AppState, InputState } from "../../types/state/AppState";
+import type { InputState } from "../../types/state/AppState";
 import type { SendOptions } from "../../types/instance/ChatInstance";
 import type { MessagesComponentClass } from "../components-legacy/MessagesComponent";
 
 interface UseInputCallbacksProps {
   serviceManager: ServiceManager;
-  appState: AppState;
   inputState: InputState;
   agentDisplayState: {
     isConnectingOrConnected: boolean;
@@ -33,6 +32,7 @@ interface UseInputCallbacksProps {
   };
   isHydrated: boolean;
   messagesRef: React.RefObject<MessagesComponentClass | null>;
+  humanAgentFileUploadInProgress: boolean;
 }
 
 interface UseInputCallbacksReturn {
@@ -56,17 +56,18 @@ interface UseInputCallbacksReturn {
  */
 export function useInputCallbacks({
   serviceManager,
-  appState,
   inputState,
   agentDisplayState,
   isHydrated,
   messagesRef,
+  humanAgentFileUploadInProgress,
 }: UseInputCallbacksProps): UseInputCallbacksReturn {
   const onSendInput = useCallback(
     async (text: string, source: MessageSendSource, options?: SendOptions) => {
-      const isInputToHumanAgent = selectIsInputToHumanAgent(appState);
-      const state = serviceManager.store.getState();
-      const { files } = selectInputState(state);
+      // Read fresh state at call time — avoids closing over a stale render snapshot
+      const currentState = serviceManager.store.getState();
+      const isInputToHumanAgent = selectIsInputToHumanAgent(currentState);
+      const { files } = selectInputState(currentState);
 
       if (isInputToHumanAgent) {
         serviceManager.humanAgentService.sendMessageToAgent(text, files);
@@ -87,7 +88,7 @@ export function useInputCallbacks({
         );
       }
     },
-    [appState, serviceManager],
+    [serviceManager],
   );
 
   const onRestart = useCallback(async () => {
@@ -158,13 +159,12 @@ export function useInputCallbacks({
 
   const showUploadButtonDisabled = useMemo(() => {
     const numFiles = inputState.files?.length ?? 0;
-    const anyCurrentFiles =
-      numFiles > 0 || appState.humanAgentState.fileUploadInProgress;
+    const anyCurrentFiles = numFiles > 0 || humanAgentFileUploadInProgress;
     return anyCurrentFiles && !inputState.allowMultipleFileUploads;
   }, [
     inputState.files,
     inputState.allowMultipleFileUploads,
-    appState.humanAgentState.fileUploadInProgress,
+    humanAgentFileUploadInProgress,
   ]);
 
   return {


### PR DESCRIPTION
Reduce unnecessary re-renders across `@carbon/ai-chat` by replacing whole-state Redux selectors with granular per-slice selectors and adding targeted `React.memo` wrappers to key components. Previously, any Redux dispatch (even to an unrelated state slice) would re-render `AppShell` and `MessagesComponent` along with their entire subtrees. The demo app's 2-second `setInterval` made this especially visible: the whole component tree was re-rendering every tick.

#### Changelog

**Changed**

- `AppShell` now uses 15 individual `useSelector` calls (one per state slice) instead of `useSelector((state) => state)`, so it only re-renders when a slice it actually reads changes. Also wrapped in `React.memo` to prevent re-renders caused by parent (`ChatAppEntry`) prop changes that `AppShell` doesn't consume (e.g. `renderUserDefinedResponse`).
- `MessagesComponent`'s state injector now selects only the 5 `AppState` fields the class reads (`config`, `allMessagesByID`, `humanAgentState`, `persistedToBrowserStorage`, `assistantInputState`) with `shallowEqual` comparison, instead of spreading the entire state as props.
- `useInputCallbacks` no longer depends on `appState`. `onSendInput` reads fresh state from the store at call time (which is also more correct — avoids a stale closure). `showUploadButtonDisabled` takes `humanAgentFileUploadInProgress` as a direct boolean prop.
- `AppShellPanels` and `AppShellWriteableElements` wrapped in `React.memo` to prevent re-renders when parent re-renders but their props are unchanged.
- `MessageTypeComponent`'s inline `renderMessageComponent` callback (duplicated 3x in JSX) extracted into a single `useCallback` with empty deps, making the existing `React.memo` on `BodyMessageComponents`, `CardItemComponent`, and `GridItemComponent` actually effective.
- Demo: `renderCustomMessageFooter` wrapped in `useCallback`; `setInterval` cleanup added; `stateText` added to `allWriteableElements` dependency array so writeable elements properly receive parent state updates; extracted `historyIsMobile` variable to satisfy lint rules.

#### Testing / Reviewing

All verification should be done via the demo site (both React and Web Component modes). Use React DevTools Profiler with "Highlight updates when components render" enabled to confirm re-render boundaries.

- [ ] **Writeable elements update with parent state**: With writeable elements enabled in demo settings, confirm the green writeable element boxes display a changing timestamp value (the `parentStateText` prop from the 2-second interval). This verifies the `allWriteableElements` dependency fix.
- [ ] **User-defined responses update with parent state**: Send a message that triggers a `user_defined` response type (e.g. the "green" type). Confirm the response displays an updating `parentStateText` timestamp and its own local timestamp.
- [ ] Similarly, double check the basic react and web component examples user_defined responses are fine
- [ ] **No cascading re-renders on interval tick**: With React DevTools Profiler recording, observe that the 2-second interval does NOT cause `AppShell`, `MessagesComponent`, `Header`, `Input`, or `AppShellPanels` to highlight/re-render. Only the portal containers for user-defined responses and writeable elements should update.
- [ ] **Messages render correctly**: Send text messages, receive responses with various types (text, buttons, cards, carousels, images). Verify all render correctly and streaming works.
- [ ] **Panels work**: Open/close the workspace panel, history panel, iframe panel, and custom panel. Confirm animations and content render correctly.
- [ ] **Home screen**: Toggle between the home screen and conversation view. Confirm starters work and the transition is smooth.
- [ ] **Custom footer slots**: Trigger a response with a custom footer. Confirm the footer content renders in the correct slot.
- [ ] **Web component demo**: Switch to the web component demo tab. Confirm writeable elements, user-defined responses, and custom footers all function identically to the React demo.
