### PR TITLE
feat: add mobile menu config and unified history panel state for external control

### DIFF
--- a/demo/src/framework/demo-body.tsx
+++ b/demo/src/framework/demo-body.tsx
@@ -641,6 +641,7 @@ export class DemoBody extends LitElement {
                     </div>
                     <demo-chat-history-switcher
                       .config=${this.config}
+                      .instance=${this.chatInstance}
                     ></demo-chat-history-switcher>
                   </div>
                   <div

--- a/demo/src/framework/demo-chat-history-switcher.ts
+++ b/demo/src/framework/demo-chat-history-switcher.ts
@@ -48,22 +48,47 @@ export class DemoChatHistorySwitcher extends LitElement {
     );
   }
 
-  private _onChanged = (event: Event) => {
+  private _onHistoryChanged = (event: Event) => {
     const customEvent = event as CustomEvent;
     const checked = customEvent.detail.checked;
 
-    this._updateConfig({ history: { isOn: checked } });
+    this._updateConfig({
+      history: {
+        ...this.config.history,
+        isOn: checked,
+      },
+    });
+  };
+
+  private _onMobileMenuChanged = (event: Event) => {
+    const customEvent = event as CustomEvent;
+    const checked = customEvent.detail.checked;
+
+    this._updateConfig({
+      history: {
+        ...this.config.history,
+        showMobileMenu: checked,
+      },
+    });
   };
 
   render() {
     const showHistory = this.config.history?.isOn ?? false;
+    const showMobileMenu = this.config.history?.showMobileMenu ?? true;
 
     return html` <div class="section">
       <cds-checkbox
         ?checked=${showHistory}
-        @cds-checkbox-changed=${this._onChanged}
+        @cds-checkbox-changed=${this._onHistoryChanged}
       >
         Show chat history
+      </cds-checkbox>
+      <cds-checkbox
+        ?checked=${showMobileMenu}
+        ?disabled=${!showHistory}
+        @cds-checkbox-changed=${this._onMobileMenuChanged}
+      >
+        Show mobile menu
       </cds-checkbox>
     </div>`;
   }

--- a/demo/src/framework/demo-chat-history-switcher.ts
+++ b/demo/src/framework/demo-chat-history-switcher.ts
@@ -6,9 +6,10 @@
  *
  *  @license
  */
-import { PublicConfig } from "@carbon/ai-chat";
+import { PublicConfig, ChatInstance, PanelType } from "@carbon/ai-chat";
 import { css, html, LitElement } from "lit";
 import { customElement, property } from "lit/decorators.js";
+import "@carbon/web-components/es/components/button/index.js";
 
 @customElement("demo-chat-history-switcher")
 export class DemoChatHistorySwitcher extends LitElement {
@@ -28,10 +29,17 @@ export class DemoChatHistorySwitcher extends LitElement {
     cds-checkbox {
       margin-bottom: 0.5rem;
     }
+
+    cds-button {
+      margin-top: 0.5rem;
+    }
   `;
 
   @property({ type: Object })
   accessor config!: PublicConfig;
+
+  @property({ type: Object })
+  accessor instance: ChatInstance | undefined = undefined;
 
   private _updateConfig(updates: Partial<PublicConfig>) {
     const newConfig = {
@@ -72,16 +80,48 @@ export class DemoChatHistorySwitcher extends LitElement {
     });
   };
 
+  private _onStartClosedChanged = (event: Event) => {
+    const customEvent = event as CustomEvent;
+    const checked = customEvent.detail.checked;
+
+    this._updateConfig({
+      history: {
+        ...this.config.history,
+        startClosed: checked,
+      },
+    });
+  };
+
+  private _onToggleHistoryClick = async () => {
+    if (this.instance?.customPanels) {
+      try {
+        const historyPanel = this.instance.customPanels.getPanel(
+          PanelType.HISTORY,
+        );
+        const isOpen = this.instance.getState().customPanels.history.isOpen;
+
+        if (isOpen) {
+          await historyPanel.close();
+        } else {
+          await historyPanel.open();
+        }
+      } catch (error) {
+        console.error("Failed to toggle history panel:", error);
+      }
+    }
+  };
+
   render() {
     const showHistory = this.config.history?.isOn ?? false;
     const showMobileMenu = this.config.history?.showMobileMenu ?? true;
+    const startClosed = this.config.history?.startClosed ?? false;
 
     return html` <div class="section">
       <cds-checkbox
         ?checked=${showHistory}
         @cds-checkbox-changed=${this._onHistoryChanged}
       >
-        Show chat history
+        Enable chat history
       </cds-checkbox>
       <cds-checkbox
         ?checked=${showMobileMenu}
@@ -90,6 +130,20 @@ export class DemoChatHistorySwitcher extends LitElement {
       >
         Show mobile menu
       </cds-checkbox>
+      <cds-checkbox
+        ?checked=${startClosed}
+        ?disabled=${!showHistory}
+        @cds-checkbox-changed=${this._onStartClosedChanged}
+      >
+        Start closed & preserve state across desktop/mobile
+      </cds-checkbox>
+      <cds-button
+        kind="secondary"
+        ?disabled=${!this.instance}
+        @click=${this._onToggleHistoryClick}
+      >
+        Toggle history (external action)
+      </cds-button>
     </div>`;
   }
 }

--- a/packages/ai-chat/src/chat/AppShell.tsx
+++ b/packages/ai-chat/src/chat/AppShell.tsx
@@ -344,7 +344,13 @@ export default function AppShell({
 
   // Header config override for mobile history
   const headerConfigOverride = useMemo(() => {
-    if (!publicConfig.history?.isOn || !historyPanelState.isMobile) {
+    const showMobileMenu = publicConfig.history?.showMobileMenu ?? true;
+
+    if (
+      !publicConfig.history?.isOn ||
+      !historyPanelState.isMobile ||
+      !showMobileMenu
+    ) {
       return undefined;
     }
 
@@ -379,6 +385,7 @@ export default function AppShell({
     languagePack.history_new_chat,
     languagePack.history_view_chats,
     publicConfig.history?.isOn,
+    publicConfig.history?.showMobileMenu,
   ]);
 
   // Resize observer

--- a/packages/ai-chat/src/chat/AppShell.tsx
+++ b/packages/ai-chat/src/chat/AppShell.tsx
@@ -17,7 +17,7 @@ import React, {
 import cx from "classnames";
 import type CDSButton from "@carbon/web-components/es/components/button/button.js";
 import { useIntl } from "./hooks/useIntl";
-import { updateHistoryMobileDetection } from "./hooks/useHistoryMobileDetection";
+import { useHistoryMobileDetection } from "./hooks/useHistoryMobileDetection";
 import { useAriaAnnouncer } from "./hooks/useAriaAnnouncer";
 import { matchesShortcut } from "./utils/keyboardUtils";
 import { getDeepActiveElement } from "./utils/domUtils";
@@ -388,6 +388,13 @@ export default function AppShell({
     publicConfig.history?.showMobileMenu,
   ]);
 
+  // History mobile detection hook
+  const updateHistoryMobileDetection = useHistoryMobileDetection({
+    container: widgetContainerRef.current,
+    useCustomHostElement,
+    serviceManager,
+  });
+
   // Resize observer
   const handleResize = useCallback(() => {
     const container = widgetContainerRef.current;
@@ -406,13 +413,8 @@ export default function AppShell({
     );
 
     // Update history mobile detection
-    updateHistoryMobileDetection({
-      width,
-      container,
-      useCustomHostElement,
-      serviceManager,
-    });
-  }, [widgetContainerRef, useCustomHostElement, serviceManager]);
+    updateHistoryMobileDetection(width);
+  }, [widgetContainerRef, serviceManager, updateHistoryMobileDetection]);
 
   useResizeObserver({
     containerRef: widgetContainerRef,
@@ -644,7 +646,10 @@ export default function AppShell({
               contentMaxWidth={layout.hasContentMaxWidth}
               showWorkspace={workspacePanelState.isOpen}
               workspaceLocation={workspacePanelState.options.preferredLocation}
-              showHistory={config.public.history?.isOn ?? false}
+              showHistory={
+                (config.public.history?.isOn ?? false) &&
+                historyPanelState.isOpen
+              }
               workspaceAriaLabel={languagePack.aria_workspaceRegion}
               historyAriaLabel={languagePack.aria_historyRegion}
               messagesAriaLabel={languagePack.aria_messagesRegion}

--- a/packages/ai-chat/src/chat/hooks/useHistoryMobileDetection.tsx
+++ b/packages/ai-chat/src/chat/hooks/useHistoryMobileDetection.tsx
@@ -7,21 +7,21 @@
  *  @license
  */
 
+import { useCallback } from "react";
 import { getCSSVariableValue } from "../utils/colors";
 import actions from "../store/actions";
 import { ServiceManager } from "../services/ServiceManager";
 
-interface UpdateHistoryMobileDetectionParams {
-  width: number;
-  container: HTMLElement;
+interface UseHistoryMobileDetectionProps {
+  container: HTMLElement | null;
   useCustomHostElement: boolean;
   serviceManager: ServiceManager;
 }
 
 /**
- * Updates history panel mobile mode based on container width.
+ * Custom hook that returns a function to update history panel mobile mode based on container width.
  *
- * This function determines if the history panel should be in mobile mode by:
+ * This hook determines if the history panel should be in mobile mode by:
  * - Checking if the app is in float mode (ChatContainer)
  * - Comparing container width against required width for history panel
  * - Reading CSS custom properties for messages min width and history width
@@ -29,41 +29,64 @@ interface UpdateHistoryMobileDetectionParams {
  * Float mode (ChatContainer) always uses mobile mode.
  * Otherwise, history is shown when width >= messagesMinWidth + historyWidth
  * (same logic as shell.ts)
+ *
+ * @returns A memoized callback function that accepts width and updates mobile detection state
  */
-export function updateHistoryMobileDetection({
-  width,
+export function useHistoryMobileDetection({
   container,
   useCustomHostElement,
   serviceManager,
-}: UpdateHistoryMobileDetectionParams): void {
-  // Float mode (ChatContainer) always uses mobile mode
-  const isFloatMode = !useCustomHostElement;
+}: UseHistoryMobileDetectionProps) {
+  return useCallback(
+    (width: number) => {
+      if (!container) {
+        return;
+      }
 
-  // Helper to parse CSS length value with fallback
-  const parseCSSLength = (variableName: string, fallback: number): number => {
-    const value = getCSSVariableValue(variableName, container);
-    if (!value) {
-      return fallback;
-    }
-    const parsed = Number.parseFloat(value);
-    return Number.isNaN(parsed) ? fallback : parsed;
-  };
+      // Float mode (ChatContainer) always uses mobile mode
+      const isFloatMode = !useCustomHostElement;
 
-  const messagesMinWidth = parseCSSLength(
-    "--cds-aichat-messages-min-width",
-    320,
+      // Helper to parse CSS length value with fallback
+      const parseCSSLength = (
+        variableName: string,
+        fallback: number,
+      ): number => {
+        const value = getCSSVariableValue(variableName, container);
+        if (!value) {
+          return fallback;
+        }
+        const parsed = Number.parseFloat(value);
+        return Number.isNaN(parsed) ? fallback : parsed;
+      };
+
+      const messagesMinWidth = parseCSSLength(
+        "--cds-aichat-messages-min-width",
+        320,
+      );
+      const historyWidth = parseCSSLength("--cds-aichat-history-width", 320);
+      const requiredWidthForHistory = messagesMinWidth + historyWidth;
+      const shouldBeMobile = isFloatMode || width < requiredWidthForHistory;
+
+      // Get current state directly from store to avoid dependency loop
+      const currentState = serviceManager.store.getState();
+      const currentIsMobile = currentState.historyPanelState.isMobile;
+
+      if (currentIsMobile !== shouldBeMobile) {
+        const config = currentState.config.public;
+        let newIsOpen = currentState.historyPanelState.isOpen;
+
+        // Only auto-adjust open state if NOT using startClosed
+        if (!config.history?.startClosed) {
+          // Default behavior: open in desktop, closed in mobile
+          newIsOpen = !shouldBeMobile;
+        }
+        // If startClosed is true, preserve current state
+
+        serviceManager.store.dispatch(
+          actions.setHistoryPanelOptions(shouldBeMobile, newIsOpen),
+        );
+      }
+    },
+    [container, useCustomHostElement, serviceManager],
   );
-  const historyWidth = parseCSSLength("--cds-aichat-history-width", 320);
-  const requiredWidthForHistory = messagesMinWidth + historyWidth;
-  const shouldBeMobile = isFloatMode || width < requiredWidthForHistory;
-
-  // Get current state directly from store to avoid dependency loop
-  const currentState = serviceManager.store.getState();
-  const currentIsMobile = currentState.historyPanelState.isMobile;
-
-  if (currentIsMobile !== shouldBeMobile) {
-    serviceManager.store.dispatch(
-      actions.setHistoryPanelOptions(shouldBeMobile),
-    );
-  }
 }

--- a/packages/ai-chat/src/chat/store/actions.ts
+++ b/packages/ai-chat/src/chat/store/actions.ts
@@ -474,8 +474,8 @@ const actions = {
     return { type: SET_HISTORY_PANEL_OPEN, isOpen };
   },
 
-  setHistoryPanelOptions(isMobile: boolean) {
-    return { type: SET_HISTORY_PANEL_OPTIONS, isMobile };
+  setHistoryPanelOptions(isMobile: boolean, isOpen?: boolean) {
+    return { type: SET_HISTORY_PANEL_OPTIONS, isMobile, isOpen };
   },
 
   /**

--- a/packages/ai-chat/src/chat/store/doCreateStore.ts
+++ b/packages/ai-chat/src/chat/store/doCreateStore.ts
@@ -183,7 +183,12 @@ function createInitialState(config: AppConfig): AppState {
     viewSourcePanelState: DEFAULT_CITATION_PANEL_STATE,
     customPanelState: DEFAULT_CUSTOM_PANEL_STATE,
     workspacePanelState: DEFAULT_WORKSPACE_PANEL_STATE,
-    historyPanelState: DEFAULT_HISTORY_PANEL_STATE,
+    historyPanelState: {
+      ...DEFAULT_HISTORY_PANEL_STATE,
+      // If startClosed is true, start closed everywhere
+      // Otherwise, start open (will be adjusted by mobile detection)
+      isOpen: config.public.history?.startClosed ? false : true,
+    },
     responsePanelState: DEFAULT_MESSAGE_PANEL_STATE,
   };
 

--- a/packages/ai-chat/src/chat/store/reducers.ts
+++ b/packages/ai-chat/src/chat/store/reducers.ts
@@ -970,23 +970,14 @@ const reducers: { [key: string]: ReducerType } = {
 
   [SET_HISTORY_PANEL_OPTIONS]: (
     state: AppState,
-    action: { isMobile: boolean },
+    action: { isMobile: boolean; isOpen?: boolean },
   ): AppState => {
-    if (!action.isMobile) {
-      return {
-        ...state,
-        historyPanelState: {
-          ...state.historyPanelState,
-          isMobile: false,
-        },
-      };
-    }
-
     return {
       ...state,
       historyPanelState: {
         ...state.historyPanelState,
         isMobile: action.isMobile,
+        isOpen: action.isOpen ?? state.historyPanelState.isOpen,
       },
     };
   },

--- a/packages/ai-chat/src/types/config/PublicConfig.ts
+++ b/packages/ai-chat/src/types/config/PublicConfig.ts
@@ -410,6 +410,22 @@ export interface HistoryConfig {
    * @default true
    */
   showMobileMenu?: boolean;
+
+  /**
+   * Controls whether history starts closed and enables state preservation across mode changes.
+   *
+   * When false (default):
+   * - Desktop starts open, mobile starts closed
+   * - Resizing between modes resets to default state
+   *
+   * When true:
+   * - Both desktop and mobile start closed
+   * - User's open/closed state is preserved when resizing between modes
+   * - Enables external control via: instance.customPanels.getPanel(PanelType.HISTORY).open()/close()
+   *
+   * @default false
+   */
+  startClosed?: boolean;
 }
 
 /**

--- a/packages/ai-chat/src/types/config/PublicConfig.ts
+++ b/packages/ai-chat/src/types/config/PublicConfig.ts
@@ -397,6 +397,19 @@ export interface HistoryConfig {
    * Indicates if the history panel should be shown.
    */
   isOn?: boolean;
+
+  /**
+   * Controls whether the mobile menu options (New chat, View chats) should be shown
+   * in the header when the history panel is in mobile mode.
+   *
+   * When true (default), the mobile menu will appear in the header on small screens,
+   * providing quick access to start a new chat or view chat history.
+   *
+   * When false, the mobile menu will be hidden even when in mobile mode.
+   *
+   * @default true
+   */
+  showMobileMenu?: boolean;
 }
 
 /**


### PR DESCRIPTION
Closes #1206 

Default chat history behavior today depends on viewport size:
- When history.isOn is true, the chat history panel is always visible on desktop (rendered in the chat-shell history slot).
- On mobile, the panel is instead placed inside a custom panel and accessed via the overflow menu in the chat header.

This results in two separate visibility states between desktop and mobile.

For teams that want external control over chat history visibility (for example, via a custom action in the chat header), they need a way to:
- Opt out of the automatically rendered mobile overflow menu behavior, and
- Use a single, unified visibility state so that toggling the chat history panel on mobile is reflected on desktop, and vice versa.

**NOTE:** Next steps are to look at animating the opening and closing of the chat history in larger breakpoints

<img height="552" alt="Screenshot 2026-04-10 at 11 49 00 AM" src="https://github.com/user-attachments/assets/8a6f2044-858f-4b7b-96b2-0f20aae4883e" />


#### Changelog

**New**

- Added `showMobileMenu` config option to `HistoryConfig` - controls whether mobile menu (New chat, View chats) appears in header on small screens (default: `true`)
- Added `startClosed` config option to `HistoryConfig` - enables history to start closed on both desktop/mobile and preserves open/closed state across mode changes (default: `false`)
- Added external history panel control via `instance.customPanels.getPanel(PanelType.HISTORY).open()/close()` API - this will tap into the unified state of the history panel being open / closed
- Added demo controls for new config options in `demo-chat-history-switcher`

**Changed**

- Refactored `updateHistoryMobileDetection` from utility function to React hook `useHistoryMobileDetection` for better encapsulation
- Modified `setHistoryPanelOptions` action to accept optional `isOpen` parameter for state preservation
- Updated history panel initialization in `doCreateStore` to respect `startClosed` config
- Enhanced `SET_HISTORY_PANEL_OPTIONS` reducer to handle optional `isOpen` state updates
- Modified mobile detection logic to preserve history panel state when `startClosed` is enabled
- Updated `AppShell` to conditionally show mobile menu based on `showMobileMenu` config
- Changed history visibility in shell to respect both `isOn` config and actual `isOpen` state

#### Testing / Reviewing

1. **Default behavior (no config changes)**:
   - Desktop: History panel should start open
   - Mobile: History panel should start closed with mobile menu visible
   - Resize between modes: Panel state resets to defaults

2. **Test `showMobileMenu: false`**:
   - Enable history: `config.history = { isOn: true, showMobileMenu: false }` via the "Chat configuration" section in the sidebar
   - On mobile viewport: Verify the overflow menu in the header is hidden
         - Enable the "add menu options" checkbox under the "Header" config. Verify the "New chat" and "View chats" options are not rendered in the overflow menu
   - Desktop viewport should be unaffected

3. **Test `startClosed: true`**:
   - Enable history: `config.history = { isOn: true, startClosed: true }` via the "Chat configuration" section in the sidebar
   - Both desktop and mobile: History panel should start closed
   - Open the panel manually, then resize window between desktop/mobile
   - Verify panel stays open across mode changes (state preserved)
   - Close the panel manually, then resize again
   - Verify panel stays closed across mode changes

4. **Test external API control**:
   - Use demo "Toggle history (external action)" button
   - Verify panel opens/closes programmatically
   - Works in both desktop and mobile modes
   - State is preserved when `startClosed: true`
