### PR TITLE
fix: change table button to ghost

### DIFF
--- a/packages/ai-chat-components/src/components/table/src/table.template.ts
+++ b/packages/ai-chat-components/src/components/table/src/table.template.ts
@@ -9,7 +9,7 @@
 
 import "@carbon/web-components/es/components/data-table/index.js";
 import "@carbon/web-components/es/components/checkbox/index.js";
-import "@carbon/web-components/es/components/button/index.js";
+import "@carbon/web-components/es/components/icon-button/index.js";
 import "@carbon/web-components/es/components/layer/index.js";
 
 import { iconLoader } from "@carbon/web-components/es/globals/internal/icon-loader.js";
@@ -51,15 +51,14 @@ function tableTemplate(tableElement: CDSAIChatTable) {
               aria-label=${filterPlaceholderText}
             ></cds-table-toolbar-search>`
           : ""}
-        <cds-button
+        <cds-icon-button
           @click=${handleDownload}
-          tooltip-text=${downloadLabelText}
-          tooltip-position=${tooltipPosition}
+          align=${tooltipPosition}
           kind="ghost"
         >
-          ${iconLoader(Download16)}
+          ${iconLoader(Download16, { slot: "icon" })}
           <span slot="tooltip-content">${downloadLabelText}</span>
-        </cds-button>
+        </cds-icon-button>
       </cds-table-toolbar-content>
     </cds-table-toolbar>`;
   }

--- a/packages/ai-chat-components/src/components/table/src/table.template.ts
+++ b/packages/ai-chat-components/src/components/table/src/table.template.ts
@@ -55,6 +55,7 @@ function tableTemplate(tableElement: CDSAIChatTable) {
           @click=${handleDownload}
           tooltip-text=${downloadLabelText}
           tooltip-position=${tooltipPosition}
+          kind="ghost"
         >
           ${iconLoader(Download16)}
           <span slot="tooltip-content">${downloadLabelText}</span>


### PR DESCRIPTION
Closes #1039 

makes the download button in the table component a ghost button

#### Changelog

**Changed**

- makes the download button in the table component a ghost button

#### Testing / Reviewing

unit and manual testing

<img width="1840" height="1105" alt="Screenshot 2026-04-13 at 4 09 48 PM" src="https://github.com/user-attachments/assets/7a6d9133-ac31-4aeb-884a-0ffa2fdfd7a1" />

