### PR TITLE
fix: make header overflow menu icon a hamburger

### DIFF
--- a/packages/ai-chat-components/src/components/chat-shell/__stories__/chat-header-react.stories.jsx
+++ b/packages/ai-chat-components/src/components/chat-shell/__stories__/chat-header-react.stories.jsx
@@ -10,12 +10,7 @@ import {
   AILabel,
   AILabelContent,
 } from "@carbon/react";
-import {
-  Close,
-  Restart,
-  OverflowMenuVertical,
-  ChevronLeft,
-} from "@carbon/icons-react";
+import { Close, Restart, Menu, ChevronLeft } from "@carbon/icons-react";
 import "./story-styles.scss";
 
 const sampleActions = [
@@ -185,7 +180,7 @@ export const WithOverflowNavigation = {
           headerName={args.headerName}
           actions={actions}
           navigationType="overflow"
-          navigationOverflowIcon={OverflowMenuVertical}
+          navigationOverflowIcon={Menu}
           navigationOverflowLabel={args.navigationOverflowLabel}
           navigationOverflowAriaLabel={args.navigationOverflowAriaLabel}
           navigationOverflowItems={sampleOverflowItems}

--- a/packages/ai-chat-components/src/components/chat-shell/__stories__/chat-header.stories.js
+++ b/packages/ai-chat-components/src/components/chat-shell/__stories__/chat-header.stories.js
@@ -16,7 +16,7 @@ import { html } from "lit";
 import { ref, createRef } from "lit/directives/ref.js";
 import Close from "@carbon/icons/es/close/16.js";
 import Restart from "@carbon/icons/es/restart/16.js";
-import OverflowMenuVertical from "@carbon/icons/es/overflow-menu--vertical/16.js";
+import Menu16 from "@carbon/icons/es/menu/16.js";
 import ChevronLeft from "@carbon/icons/es/chevron--left/16.js";
 import styles from "./story-styles.scss?lit";
 
@@ -191,7 +191,7 @@ export const WithOverflowNavigation = {
           .headerName=${args.headerName}
           .actions=${actions}
           navigation-type="overflow"
-          .navigationOverflowIcon=${OverflowMenuVertical}
+          .navigationOverflowIcon=${Menu16}
           navigation-overflow-label=${args.navigationOverflowLabel}
           navigation-overflow-aria-label=${args.navigationOverflowAriaLabel}
           .navigationOverflowItems=${sampleOverflowItems}

--- a/packages/ai-chat/src/chat/components/header/Header.tsx
+++ b/packages/ai-chat/src/chat/components/header/Header.tsx
@@ -10,7 +10,7 @@
 import type CDSButton from "@carbon/web-components/es/components/button/button.js";
 import CloseLarge16 from "@carbon/icons/es/close--large/16.js";
 import Home16 from "@carbon/icons/es/home/16.js";
-import OverflowMenuVertical16 from "@carbon/icons/es/overflow-menu--vertical/16.js";
+import Menu16 from "@carbon/icons/es/menu/16.js";
 import Restart16 from "@carbon/icons/es/restart/16.js";
 import RightPanelOpen16 from "@carbon/icons/es/right-panel--open/16.js";
 import RightPanelClose16 from "@carbon/icons/es/right-panel--close/16.js";
@@ -383,7 +383,7 @@ function Header(props: HeaderProps, ref: Ref<HasRequestFocus>) {
         navigationOverflowItems={navigationOverflowItemsWithHandlers}
         navigationOverflowLabel={overflowMenuTooltip}
         navigationOverflowAriaLabel={overflowMenuAriaLabel}
-        navigationOverflowIcon={OverflowMenuVertical16}
+        navigationOverflowIcon={Menu16}
         navigationOverflowOnClick={handleOverflowMenuClick}
         navigationTooltipAlign="right"
       >


### PR DESCRIPTION
Closes #1198

Changes the header component overflow menu icon to a hamburger

#### Changelog

**Changed**

- Updated icon in the `ai-chat` Header component as well as the `ai-chat-components` storybook examples


#### Testing / Reviewing

- Go to demo deploy preview and check "Add menu options" in the header config
- Verify that the overflow menu icon is a hamburger
- Go to Storybook deploy preview (React & WC) -> Chat shell -> Header -> With Overflow Navigation and verify the icon is updated