### PR TITLE
fix: sometimes selector calls didn't work

### DIFF
--- a/packages/ai-chat/src/chat/hooks/useSelector.tsx
+++ b/packages/ai-chat/src/chat/hooks/useSelector.tsx
@@ -8,23 +8,16 @@
  */
 
 /**
- * Basic selector using `useSyncExternalStore`.
- * Pure snapshot returns previous ref when values are equal. Caches last value...comparator defaults to `Object.is`.
+ * Basic selector backed by `useSyncExternalStoreWithSelector` — the same
+ * utility `react-redux` uses internally. This delegates selector identity,
+ * equality-check, and snapshot-purity handling.
  *
- * For object/array outputs, pass `shallowEqual` or a custom comparator.
+ * For object/array outputs, pass `shallowEqual` or a custom comparator as
+ * `equalityFn`.
  */
 
-import React, { useCallback, useRef } from "react";
-import { useSyncExternalStore as useSyncExternalStoreShim } from "use-sync-external-store/shim/index.js";
+import { useSyncExternalStoreWithSelector } from "use-sync-external-store/with-selector.js";
 import { useStore } from "./useStore";
-
-/** Choose the right `useSyncExternalStore` (React 17 uses the shim). */
-const useSyncExternalStore: typeof React.useSyncExternalStore =
-  (
-    React as unknown as {
-      useSyncExternalStore?: typeof React.useSyncExternalStore;
-    }
-  ).useSyncExternalStore ?? useSyncExternalStoreShim;
 
 /**
  * Select a slice and subscribe to changes.
@@ -36,32 +29,11 @@ export function useSelector<RootState, Selected>(
   equalityFn?: (left: Selected, right: Selected) => boolean,
 ): Selected {
   const store = useStore<RootState>();
-
-  // Cache the last selected value to ensure `getSnapshot` returns a stable
-  // reference when the selected slice is equal, preventing infinite loops.
-  const lastSelectedRef = useRef<Selected | symbol>(UNINITIALIZED);
-  const compare = equalityFn ?? Object.is;
-
-  // Pure snapshot returns previous ref when values compare equal.
-  const computeSelected = useCallback((): Selected => {
-    const nextSelected = selector(store.getState());
-    const lastSelected = lastSelectedRef.current;
-    if (
-      lastSelected !== UNINITIALIZED &&
-      compare(nextSelected as Selected, lastSelected as Selected)
-    ) {
-      return lastSelected as Selected;
-    }
-    lastSelectedRef.current = nextSelected as Selected;
-    return nextSelected;
-  }, [store, selector, compare]);
-
-  return useSyncExternalStore(
+  return useSyncExternalStoreWithSelector(
     store.subscribe,
-    computeSelected,
-    computeSelected,
+    store.getState,
+    store.getState,
+    selector,
+    equalityFn,
   );
 }
-
-// Sentinel to distinguish “no cached value yet” from valid falsy values.
-const UNINITIALIZED = Symbol("useSelector.uninitialized");


### PR DESCRIPTION
Replaces the custom `useSelector` implementation with `useSyncExternalStoreWithSelector` from `use-sync-external-store/with-selector` — the same utility `react-redux` uses internally. This fixes a concurrent-rendering bug reported by a consumer where `showLauncher` remained truthy after the chat was closed, causing the launcher to stay rendered.

The previous implementation had two concurrent-safety issues:

1. `getSnapshot` was not pure — it mutated `lastSelectedRef.current` during render. React may call `getSnapshot` multiple times per render for tearing detection, and mutation during that call could freeze the cached reference on a stale value.
2. `getSnapshot` identity changed across renders (via `useCallback` with a `selector` dep), which can cause `useSyncExternalStore` to treat each render's snapshot as independent, opening the door to stale reads under transitions / StrictMode.

Delegating to `useSyncExternalStoreWithSelector` eliminates the class of bug entirely while preserving the public `useSelector` signature, so no call sites need to change.

#### Changelog

**Changed**

- `useSelector` hook now delegates to `useSyncExternalStoreWithSelector` from `use-sync-external-store/with-selector`, making store reads safe under concurrent rendering.

**Removed**

- Custom `computeSelected` / `lastSelectedRef` caching logic inside `useSelector` (no longer needed — the upstream utility handles equality-based reference stabilization).
- Unused `UNINITIALIZED` sentinel.

#### Testing / Reviewing

We are going to have to publish a new rc and have the consumer test
