### PR TITLE
fix(history): overflow menu visible for active chat

### DIFF
--- a/packages/ai-chat-components/src/components/chat-history/src/chat-history.scss
+++ b/packages/ai-chat-components/src/components/chat-history/src/chat-history.scss
@@ -279,6 +279,10 @@
   visibility: hidden;
 }
 
+:host(#{$prefix}-history-panel-item[selected]) #{$cds-prefix}-overflow-menu {
+  visibility: visible;
+}
+
 :host(#{$prefix}-history-panel-item:hover) #{$cds-prefix}-overflow-menu,
 :host(#{$prefix}-history-panel-item:focus) #{$cds-prefix}-overflow-menu,
 :host(#{$prefix}-history-panel-item:focus-within) #{$cds-prefix}-overflow-menu,


### PR DESCRIPTION
Closes #1158 

This PR makes the overflow menu which currently is not visible until user hovers or focuses on the chat item, visible for the active chat item. This lets the user know that there is an overflow menu available. 

<img width="389" height="369" alt="Screenshot 2026-04-16 at 10 56 22 AM" src="https://github.com/user-attachments/assets/9fd0888e-7d1e-4bc2-a61f-26720e0081c9" />

#### Changelog

**New**

- add style for selected chat item

#### Testing / Reviewing

check demo deploy preview and enable chat history. Confirm that the overflow menu is visible for the active chat item.
