### PR TITLE
fix: cds-aichat-card-max-width wasnt applying

### DIFF
--- a/packages/ai-chat/src/chat/components-legacy/responseTypes/card/CardItemComponent.scss
+++ b/packages/ai-chat/src/chat/components-legacy/responseTypes/card/CardItemComponent.scss
@@ -8,4 +8,17 @@
 .cds-aichat--card-message-component {
   overflow: hidden;
   padding: 0;
+  max-inline-size: var(--cds-aichat-card-max-width, auto);
+}
+
+.cds-aichat--card-message-component.cds-aichat--max-width-small {
+  max-inline-size: min(291px, var(--cds-aichat-card-max-width, 291px));
+}
+
+.cds-aichat--card-message-component.cds-aichat--max-width-medium {
+  max-inline-size: min(438px, var(--cds-aichat-card-max-width, 438px));
+}
+
+.cds-aichat--card-message-component.cds-aichat--max-width-large {
+  max-inline-size: min(585px, var(--cds-aichat-card-max-width, 585px));
 }


### PR DESCRIPTION
Constrain card message preset widths by `--cds-aichat-card-max-width` when that custom property is set.

#### Changelog

**New**

- None

**Changed**

- Updated [`packages/ai-chat/src/chat/components-legacy/responseTypes/card/CardItemComponent.scss`](packages/ai-chat/src/chat/components-legacy/responseTypes/card/CardItemComponent.scss) so the small, medium, and large card width presets use `min()` with `--cds-aichat-card-max-width`
- Fixed the base fallback for `max-inline-size` on card messages to use `auto` instead of a quoted string

**Removed**

- None

#### Testing / Reviewing

1. In [`demo/src/framework/utils.ts`](demo/src/framework/utils.ts), temporarily add the demo config change back under the fullscreen layout so [`layout.customProperties`](demo/src/framework/utils.ts:210) includes:
   - `'card-max-width': '500px'`
   - `'messages-max-width': '1100px'`
2. Run the demo with [`npm run aiChat:start`](AGENTS.md).
3. Open the demo and navigate to the card example.
4. Verify card responses using [`cds-aichat--max-width-small`](packages/ai-chat/src/chat/components-legacy/responseTypes/maxWidth.scss:8), [`cds-aichat--max-width-medium`](packages/ai-chat/src/chat/components-legacy/responseTypes/maxWidth.scss:12), and [`cds-aichat--max-width-large`](packages/ai-chat/src/chat/components-legacy/responseTypes/maxWidth.scss:16) do not grow beyond the value supplied by `--cds-aichat-card-max-width`.
5. Verify the behavior specifically matches the expected constraint:
   - small remains capped at 291px
   - medium is capped by the custom property when it is below 438px
   - large is capped by the custom property when it is below 585px
6. Revert the temporary demo change in [`demo/src/framework/utils.ts`](demo/src/framework/utils.ts) after verification.