### PR TITLE
fix: misaligned public types

### DIFF
--- a/packages/ai-chat/src/aiChatEntry.tsx
+++ b/packages/ai-chat/src/aiChatEntry.tsx
@@ -106,7 +106,10 @@ export {
   ViewChangeReason,
 } from "./types/events/eventBusTypes";
 
-export { PersistedState } from "./types/state/AppState";
+export {
+  CatastrophicErrorPanelState,
+  PersistedState,
+} from "./types/state/AppState";
 
 export { readCarbonChatSession } from "./globals/utils/readCarbonChatSession";
 

--- a/packages/ai-chat/src/serverEntry.ts
+++ b/packages/ai-chat/src/serverEntry.ts
@@ -102,7 +102,10 @@ export {
   ViewChangeReason,
 } from "./types/events/eventBusTypes";
 
-export { PersistedState } from "./types/state/AppState";
+export {
+  CatastrophicErrorPanelState,
+  PersistedState,
+} from "./types/state/AppState";
 
 export { PersistedHumanAgentState } from "./types/state/PersistedHumanAgentState";
 

--- a/packages/ai-chat/src/types/state/AppState.ts
+++ b/packages/ai-chat/src/types/state/AppState.ts
@@ -215,10 +215,10 @@ export enum PendingUploadStatus {
 }
 
 /**
- * Internal state for a single file that is being (or has been) uploaded via
- * {@link UploadConfig.onFileUpload}.  Stored in {@link InputState.pendingUploads}.
- *
- * This type is **internal** — it is not part of the public API surface.
+ * State for a single file that is being (or has been) uploaded via
+ * {@link UploadConfig.onFileUpload}. The chat widget tracks one of these per
+ * in-flight or completed upload and uses them to build the
+ * `pendingStructuredData` attached to the outgoing message.
  *
  * @experimental
  */


### PR DESCRIPTION
Forgot to export types for new catasrophic error api