### PR TITLE
fix: reduced animations launcher bug

### DIFF
--- a/packages/ai-chat/src/chat/components-legacy/launcher/Launcher.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/launcher/Launcher.tsx
@@ -30,8 +30,15 @@ import Button, {
   BUTTON_TYPE,
 } from "../../components/carbon/Button";
 import { doFocusRef } from "../../utils/domUtils";
+import { prefersReducedMotion } from "../../utils/prefersReducedMotion";
 import { HasRequestFocus } from "../../../types/utilities/HasRequestFocus";
 import { uuid } from "../../utils/lang/uuid";
+
+// Upper bound for the launcher extended open/close animations
+// (`$duration-moderate-01` = 150ms, plus a fade stage) with a generous buffer.
+// Used as a safety net in case `animationend` never fires — most often under
+// `prefers-reduced-motion: reduce`, where the CSS animation is never declared.
+const LAUNCHER_ANIMATION_TIMEOUT_MS = 600;
 
 const AiLaunch = carbonIconToReact(AiLaunch24);
 const ChatLaunch = carbonIconToReact(ChatLaunch24);
@@ -208,8 +215,10 @@ function Launcher(props: LauncherProps) {
     if (callToActionOpenState === LauncherOpenState.Opening) {
       const element = greetingMessageRef.current;
 
-      if (!element) {
-        // Fail-safe: if no element, just snap to open
+      // Snap straight to Open when the element is missing or when reduced
+      // motion is active (the CSS animation is not declared, so `animationend`
+      // will never fire — see Launcher.scss `prefers-reduced-motion` gating).
+      if (!element || prefersReducedMotion()) {
         setCallToActionOpenState(LauncherOpenState.Open);
       } else {
         const handleAnimationEnd = (event: AnimationEvent) => {
@@ -220,10 +229,17 @@ function Launcher(props: LauncherProps) {
 
         element.addEventListener("animationend", handleAnimationEnd);
         element.addEventListener("animationcancel", handleAnimationEnd);
+        // Safety net: if `animationend` is never dispatched (e.g. element
+        // re-parented, display hidden mid-animation, future CSS edit drops
+        // the animation), still advance the state machine.
+        const timeoutId = setTimeout(() => {
+          setCallToActionOpenState(LauncherOpenState.Open);
+        }, LAUNCHER_ANIMATION_TIMEOUT_MS);
 
         cleanup = () => {
           element.removeEventListener("animationend", handleAnimationEnd);
           element.removeEventListener("animationcancel", handleAnimationEnd);
+          clearTimeout(timeoutId);
         };
       }
     }
@@ -238,8 +254,9 @@ function Launcher(props: LauncherProps) {
     if (callToActionOpenState === LauncherOpenState.Closing) {
       const element = textHolderRef.current;
 
-      if (!element) {
-        // Fail-safe: if no element, just snap to closed
+      // See Opening branch above — same rationale for the reduced-motion and
+      // null-element short-circuits.
+      if (!element || prefersReducedMotion()) {
         setCallToActionOpenState(LauncherOpenState.Closed);
       } else {
         const handleAnimationEnd = (event: AnimationEvent) => {
@@ -250,10 +267,14 @@ function Launcher(props: LauncherProps) {
 
         element.addEventListener("animationend", handleAnimationEnd);
         element.addEventListener("animationcancel", handleAnimationEnd);
+        const timeoutId = setTimeout(() => {
+          setCallToActionOpenState(LauncherOpenState.Closed);
+        }, LAUNCHER_ANIMATION_TIMEOUT_MS);
 
         cleanup = () => {
           element.removeEventListener("animationend", handleAnimationEnd);
           element.removeEventListener("animationcancel", handleAnimationEnd);
+          clearTimeout(timeoutId);
         };
       }
     }

--- a/packages/ai-chat/src/chat/hooks/useWindowOpenState.tsx
+++ b/packages/ai-chat/src/chat/hooks/useWindowOpenState.tsx
@@ -9,6 +9,7 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import { usePrevious } from "./usePrevious";
+import { prefersReducedMotion } from "../utils/prefersReducedMotion";
 
 interface UseWindowOpenStateProps {
   viewStateMainWindow: boolean;
@@ -25,6 +26,12 @@ interface UseWindowOpenStateReturn {
   widgetContainerRef: React.MutableRefObject<HTMLElement | null>;
 }
 
+// Upper bound for the widget close animation (`$duration-fast-02` = 110ms) plus
+// a generous buffer. Used as a safety net in case `animationend` never fires —
+// e.g. when the browser reports `prefers-reduced-motion: reduce` and the CSS
+// `animation` is never declared, or if the element is re-parented mid-animation.
+const CLOSE_ANIMATION_TIMEOUT_MS = 500;
+
 /**
  * Custom hook to manage window open/close state and animations
  */
@@ -39,6 +46,7 @@ export function useWindowOpenState({
   const [isHydrationAnimationComplete, setIsHydrationAnimationComplete] =
     useState(isHydrated);
   const widgetContainerRef = useRef<HTMLElement | null>(null);
+  const closeTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const prevIsHydrated = usePrevious(isHydrated);
   const prevViewState = usePrevious({ mainWindow: viewStateMainWindow });
 
@@ -46,6 +54,10 @@ export function useWindowOpenState({
     const widgetEl = widgetContainerRef.current;
     if (widgetEl) {
       widgetEl.removeEventListener("animationend", removeChatFromDom);
+    }
+    if (closeTimeoutRef.current !== null) {
+      clearTimeout(closeTimeoutRef.current);
+      closeTimeoutRef.current = null;
     }
     setOpen(false);
     setClosing(false);
@@ -69,12 +81,18 @@ export function useWindowOpenState({
       requestFocus();
     } else if (!viewStateMainWindow && previouslyOpen && open) {
       setClosing(true);
-      if (useCustomHostElement) {
+      const widgetEl = widgetContainerRef.current;
+      // When the user's OS has reduced motion enabled, the SCSS close animation
+      // is gated behind `prefers-reduced-motion: no-preference` and never
+      // declares an `animation`. That means `animationend` will never fire, so
+      // fall back to an immediate snap. Mirrors the custom-host-element path.
+      if (useCustomHostElement || prefersReducedMotion() || !widgetEl) {
         removeChatFromDom();
       } else {
-        widgetContainerRef.current?.addEventListener(
-          "animationend",
+        widgetEl.addEventListener("animationend", removeChatFromDom);
+        closeTimeoutRef.current = setTimeout(
           removeChatFromDom,
+          CLOSE_ANIMATION_TIMEOUT_MS,
         );
         requestFocus();
       }

--- a/packages/ai-chat/src/chat/utils/prefersReducedMotion.ts
+++ b/packages/ai-chat/src/chat/utils/prefersReducedMotion.ts
@@ -1,0 +1,26 @@
+/*
+ *  Copyright IBM Corp. 2025
+ *
+ *  This source code is licensed under the Apache-2.0 license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ *  @license
+ */
+
+/**
+ * Returns whether the user agent currently reports
+ * `prefers-reduced-motion: reduce`. Safe to call in non-browser environments.
+ *
+ * Prefer this over inlining `matchMedia` so all call sites stay consistent and
+ * any future change (e.g. reacting to `MediaQueryList` change events) has a
+ * single place to live.
+ */
+export function prefersReducedMotion(): boolean {
+  if (
+    typeof window === "undefined" ||
+    typeof window.matchMedia !== "function"
+  ) {
+    return false;
+  }
+  return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+}


### PR DESCRIPTION
Consumers reported that after closing the chat on Windows, the launcher renders on top of a still-visible main window. The bug reproduces on the demo site across Firefox, Chrome, and Edge on Windows, on both React 18 and 19, but does not reproduce on macOS with default settings. Regression between 1.8.0 and 1.9.0.

Root cause: [`useWindowOpenState`](packages/ai-chat/src/chat/hooks/useWindowOpenState.tsx) drives `setOpen(false)` off an `animationend` listener attached to the widget container. The GA-reorg commit [`ece468c`](https://github.com/carbon-design-system/carbon-ai-chat/commit/ece468c) gated the widget close animation in [`AppShellStyles.scss`](packages/ai-chat/src/chat/AppShellStyles.scss) behind `@media (prefers-reduced-motion: no-preference)` and removed the reduced-motion fallback. Under reduced motion no `animation` property is declared, so `animationend` never fires, `open` never flips to `false`, and the main window stays mounted while `viewState.launcher` independently flips to `true` and renders the launcher. [`Launcher.tsx`](packages/ai-chat/src/chat/components-legacy/launcher/Launcher.tsx) has the same pattern for the extended-launcher open/close transitions.

Why Windows specifically: corporate Windows images (including common IBM builds) ship with *Settings → Accessibility → Visual effects → Animation effects = Off*, which browsers surface as `prefers-reduced-motion: reduce`. macOS defaults it OFF, which is why it doesn't reproduce on a typical dev machine.

Fix: decouple the terminal state transition from `animationend` with two layers of defense — a reduced-motion short-circuit (snap to the terminal state immediately) and a safety timeout (covers any other reason `animationend` might not fire, like element re-parenting or future CSS edits).

#### Changelog

**New**

- `prefersReducedMotion()` utility in [`packages/ai-chat/src/chat/utils/prefersReducedMotion.ts`](packages/ai-chat/src/chat/utils/prefersReducedMotion.ts) for consistent `matchMedia` checks across hooks.

**Changed**

- [`useWindowOpenState`](packages/ai-chat/src/chat/hooks/useWindowOpenState.tsx): when closing the main window, snap `open` to `false` immediately if `prefers-reduced-motion: reduce` matches. Added a `setTimeout`-backed safety net (`CLOSE_ANIMATION_TIMEOUT_MS = 500`) that un-mounts the widget if `animationend` never fires.
- [`Launcher`](packages/ai-chat/src/chat/components-legacy/launcher/Launcher.tsx): both the `Opening → Open` and `Closing → Closed` `useEffect`s now short-circuit to the terminal state under reduced motion, and install a `setTimeout` fallback (`LAUNCHER_ANIMATION_TIMEOUT_MS = 600`) alongside the `animationend` listener.

**Removed**

- Nothing removed.

#### Testing / Reviewing

Existing Jest suite still green (`cd packages/ai-chat && npm test` — 823 tests, 74 suites).

**Manual repro (works on macOS — no Windows machine needed):**

Since all reviewers are on macOS (including Tahoe/26), you can reproduce the original bug by enabling the OS-level reduced-motion setting. The browsers will immediately report `prefers-reduced-motion: reduce` without a restart.

1. Open *System Settings → Accessibility → Display*.
2. Turn **Reduce motion** ON. (On macOS Tahoe: the setting is in the same place — *Accessibility → Display → Reduce motion*. No restart required.)
3. Open a fresh browser tab (Chrome, Safari, or Firefox) and load the demo site.
4. Open the chat via the launcher, then close it using the main window's close button.

**Expected on `main` (bug present):** both the main window and the launcher remain visible after close.

**Expected on this branch (fix applied):** the main window un-mounts immediately on close and only the launcher is visible, matching the normal-motion behavior.

5. Turn *Reduce motion* **OFF** and re-run the flow to confirm the normal close animation still plays end-to-end.

**Alternative without changing OS settings:** in Chrome DevTools open the *Rendering* drawer (⋮ menu → More tools → Rendering) and set *Emulate CSS media feature prefers-reduced-motion* → `reduce`. Same repro steps.

**Secondary check — extended launcher:** with *Reduce motion* ON, toggle an `extended: true` launcher greeting (via the launcher demo scenarios or by configuring `launcher.isOn = true, launcher.mainButton.text = "..."`). Before the fix, opening/closing the greeting would stick; after, the state snaps cleanly.

**Review checklist:**

- [ ] Reproduce the original bug with *Reduce motion* ON on `main`.
- [ ] Confirm the fix closes the bug on this branch.
- [ ] Confirm normal-motion close still animates as before.
- [ ] Sanity-check that the new `setTimeout` values are comfortably longer than the SCSS durations (`$duration-fast-02 = 110ms`, `$duration-moderate-01 = 150ms`) so they never fire ahead of a legitimate animation.
