### PR TITLE
fix: set focus to next or previous chat item when deleting

### DIFF
--- a/demo/src/react/HistoryWriteableElementExample.tsx
+++ b/demo/src/react/HistoryWriteableElementExample.tsx
@@ -91,6 +91,7 @@ function HistoryWriteableElementExample({
   );
   const [showDeletePanel, setShowDeletePanel] = useState(false);
   const [itemToDelete, setItemToDelete] = useState(null);
+  const [itemToDeleteElement, setItemToDeleteElement] = useState(null);
   const [pinnedItems, setPinnedItems] = useState<resultItem[]>(
     pinnedHistoryItems.map((item) => ({ ...item, rename: false })),
   );
@@ -220,6 +221,7 @@ function HistoryWriteableElementExample({
   const handleDeleteCancel = useCallback(() => {
     setShowDeletePanel(false);
     setItemToDelete(null);
+    setItemToDeleteElement(null);
   }, []);
 
   // Handle delete panel confirm
@@ -239,6 +241,7 @@ function HistoryWriteableElementExample({
 
     setShowDeletePanel(false);
     setItemToDelete(null);
+    setItemToDeleteElement(null);
   }, [itemToDelete]);
 
   // Handle rename chat save
@@ -280,6 +283,7 @@ function HistoryWriteableElementExample({
       switch (action) {
         case "Delete":
           setItemToDelete(event.detail.itemId);
+          setItemToDeleteElement(event.detail.element);
           setShowDeletePanel(true);
           break;
         case "Rename":
@@ -445,6 +449,7 @@ function HistoryWriteableElementExample({
       </HistoryContent>
       {showDeletePanel && (
         <HistoryDeletePanel
+          triggeringElement={itemToDeleteElement}
           onCancel={handleDeleteCancel}
           onConfirm={handleDeleteConfirm}
         >

--- a/demo/src/react/HistoryWriteableElementExample.tsx
+++ b/demo/src/react/HistoryWriteableElementExample.tsx
@@ -90,8 +90,7 @@ function HistoryWriteableElementExample({
     findSelectedItemId(pinnedHistoryItems, historyItems),
   );
   const [showDeletePanel, setShowDeletePanel] = useState(false);
-  const [itemToDelete, setItemToDelete] = useState(null);
-  const [itemToDeleteElement, setItemToDeleteElement] = useState(null);
+  const [itemToDelete, setItemToDelete] = useState<HTMLElement | null>(null);
   const [pinnedItems, setPinnedItems] = useState<resultItem[]>(
     pinnedHistoryItems.map((item) => ({ ...item, rename: false })),
   );
@@ -221,27 +220,27 @@ function HistoryWriteableElementExample({
   const handleDeleteCancel = useCallback(() => {
     setShowDeletePanel(false);
     setItemToDelete(null);
-    setItemToDeleteElement(null);
   }, []);
 
   // Handle delete panel confirm
   const handleDeleteConfirm = useCallback(() => {
     if (itemToDelete) {
+      const itemId = itemToDelete.id;
+
       // Remove from pinned items
-      setPinnedItems((prev) => prev.filter((item) => item.id !== itemToDelete));
+      setPinnedItems((prev) => prev.filter((item) => item.id !== itemId));
 
       // Remove from regular items
       setRegularItems((prev) =>
         prev.map((section) => ({
           ...section,
-          chats: section.chats.filter((chat) => chat.id !== itemToDelete),
+          chats: section.chats.filter((chat) => chat.id !== itemId),
         })),
       );
     }
 
     setShowDeletePanel(false);
     setItemToDelete(null);
-    setItemToDeleteElement(null);
   }, [itemToDelete]);
 
   // Handle rename chat save
@@ -282,8 +281,7 @@ function HistoryWriteableElementExample({
 
       switch (action) {
         case "Delete":
-          setItemToDelete(event.detail.itemId);
-          setItemToDeleteElement(event.detail.element);
+          setItemToDelete(event.detail.element);
           setShowDeletePanel(true);
           break;
         case "Rename":
@@ -449,7 +447,7 @@ function HistoryWriteableElementExample({
       </HistoryContent>
       {showDeletePanel && (
         <HistoryDeletePanel
-          triggeringElement={itemToDeleteElement}
+          triggeringElement={itemToDelete}
           onCancel={handleDeleteCancel}
           onConfirm={handleDeleteConfirm}
         >

--- a/demo/src/web-components/history-writeable-element-example.ts
+++ b/demo/src/web-components/history-writeable-element-example.ts
@@ -83,6 +83,9 @@ export class HistoryWriteableElementExample extends LitElement {
   accessor itemToDelete: string | null = null;
 
   @state()
+  accessor itemToDeleteElement: HTMLElement | null = null;
+
+  @state()
   accessor selectedChatId: string | undefined = findSelectedItemId(
     pinnedHistoryItems,
     historyItems,
@@ -230,6 +233,7 @@ export class HistoryWriteableElementExample extends LitElement {
   _handleDeleteCancel = () => {
     this.showDeletePanel = false;
     this.itemToDelete = null;
+    this.itemToDeleteElement = null;
     this.requestUpdate();
   };
 
@@ -250,6 +254,7 @@ export class HistoryWriteableElementExample extends LitElement {
 
     this.showDeletePanel = false;
     this.itemToDelete = null;
+    this.itemToDeleteElement = null;
     this.requestUpdate();
   };
 
@@ -288,6 +293,7 @@ export class HistoryWriteableElementExample extends LitElement {
     switch (action) {
       case "Delete":
         this.itemToDelete = event.detail.itemId;
+        this.itemToDeleteElement = event.detail.element;
         this.showDeletePanel = true;
         break;
       case "Rename":
@@ -483,6 +489,7 @@ export class HistoryWriteableElementExample extends LitElement {
         ${this.showDeletePanel
           ? html`
               <cds-aichat-history-delete-panel
+                .triggeringElement=${this.itemToDeleteElement}
                 @history-delete-cancel=${this._handleDeleteCancel}
                 @history-delete-confirm=${this._handleDeleteConfirm}
               >

--- a/demo/src/web-components/history-writeable-element-example.ts
+++ b/demo/src/web-components/history-writeable-element-example.ts
@@ -80,10 +80,7 @@ export class HistoryWriteableElementExample extends LitElement {
   accessor isMobile: boolean = false;
 
   @state()
-  accessor itemToDelete: string | null = null;
-
-  @state()
-  accessor itemToDeleteElement: HTMLElement | null = null;
+  accessor itemToDelete: HTMLElement | null = null;
 
   @state()
   accessor selectedChatId: string | undefined = findSelectedItemId(
@@ -233,28 +230,26 @@ export class HistoryWriteableElementExample extends LitElement {
   _handleDeleteCancel = () => {
     this.showDeletePanel = false;
     this.itemToDelete = null;
-    this.itemToDeleteElement = null;
     this.requestUpdate();
   };
 
   // Handle delete panel confirm
   _handleDeleteConfirm = () => {
     if (this.itemToDelete) {
+      const itemId = this.itemToDelete.id;
+
       // Remove from pinned items
-      this.pinnedItems = this.pinnedItems.filter(
-        (item) => item.id !== this.itemToDelete,
-      );
+      this.pinnedItems = this.pinnedItems.filter((item) => item.id !== itemId);
 
       // Remove from regular items
       this.regularItems = this.regularItems.map((section) => ({
         ...section,
-        chats: section.chats.filter((chat) => chat.id !== this.itemToDelete),
+        chats: section.chats.filter((chat) => chat.id !== itemId),
       }));
     }
 
     this.showDeletePanel = false;
     this.itemToDelete = null;
-    this.itemToDeleteElement = null;
     this.requestUpdate();
   };
 
@@ -292,8 +287,7 @@ export class HistoryWriteableElementExample extends LitElement {
 
     switch (action) {
       case "Delete":
-        this.itemToDelete = event.detail.itemId;
-        this.itemToDeleteElement = event.detail.element;
+        this.itemToDelete = event.detail.element;
         this.showDeletePanel = true;
         break;
       case "Rename":
@@ -489,7 +483,7 @@ export class HistoryWriteableElementExample extends LitElement {
         ${this.showDeletePanel
           ? html`
               <cds-aichat-history-delete-panel
-                .triggeringElement=${this.itemToDeleteElement}
+                .triggeringElement=${this.itemToDelete}
                 @history-delete-cancel=${this._handleDeleteCancel}
                 @history-delete-confirm=${this._handleDeleteConfirm}
               >

--- a/packages/ai-chat-components/src/components/chat-history/__stories__/chat-history-react.stories.jsx
+++ b/packages/ai-chat-components/src/components/chat-history/__stories__/chat-history-react.stories.jsx
@@ -218,7 +218,7 @@ export const Default = {
 
         switch (action) {
           case "Delete":
-            setItemToDelete(event.detail.itemId);
+            setItemToDelete(event.detail.element);
             setShowDeletePanel(true);
             break;
           case "Rename":
@@ -246,16 +246,16 @@ export const Default = {
 
     const handleDeleteConfirm = useCallback(() => {
       if (itemToDelete) {
+        const itemId = itemToDelete.id;
+
         // Remove from pinned items
-        setPinnedItems((prev) =>
-          prev.filter((item) => item.id !== itemToDelete),
-        );
+        setPinnedItems((prev) => prev.filter((item) => item.id !== itemId));
 
         // Remove from regular items
         setRegularItems((prev) =>
           prev.map((section) => ({
             ...section,
-            chats: section.chats.filter((chat) => chat.id !== itemToDelete),
+            chats: section.chats.filter((chat) => chat.id !== itemId),
           })),
         );
       }
@@ -421,6 +421,7 @@ export const Default = {
         </HistoryContent>
         {showDeletePanel && (
           <HistoryDeletePanel
+            triggeringElement={itemToDelete}
             onCancel={handleDeleteCancel}
             onConfirm={handleDeleteConfirm}
           >

--- a/packages/ai-chat-components/src/components/chat-history/__stories__/chat-history.stories.js
+++ b/packages/ai-chat-components/src/components/chat-history/__stories__/chat-history.stories.js
@@ -58,7 +58,7 @@ class ChatHistoryDemo extends LitElement {
     selectedId: { type: String },
     showCloseAction: { type: Boolean, attribute: "show-close-action" },
     showDeletePanel: { type: Boolean },
-    itemToDelete: { type: String },
+    itemToDelete: { type: Object },
     pinnedItems: { type: Array },
     regularItems: { type: Array },
   };
@@ -209,7 +209,7 @@ class ChatHistoryDemo extends LitElement {
 
     switch (action) {
       case "Delete":
-        this.itemToDelete = event.detail.itemId;
+        this.itemToDelete = event.detail.element;
         this.showDeletePanel = true;
         break;
       case "Rename":
@@ -236,15 +236,15 @@ class ChatHistoryDemo extends LitElement {
 
   _handleDeleteConfirm = () => {
     if (this.itemToDelete) {
+      const itemId = this.itemToDelete.id;
+
       // Remove from pinned items
-      this.pinnedItems = this.pinnedItems.filter(
-        (item) => item.id !== this.itemToDelete,
-      );
+      this.pinnedItems = this.pinnedItems.filter((item) => item.id !== itemId);
 
       // Remove from regular items
       this.regularItems = this.regularItems.map((section) => ({
         ...section,
-        chats: section.chats.filter((chat) => chat.id !== this.itemToDelete),
+        chats: section.chats.filter((chat) => chat.id !== itemId),
       }));
     }
 
@@ -424,7 +424,11 @@ class ChatHistoryDemo extends LitElement {
         </cds-aichat-history-content>
         ${this.showDeletePanel
           ? html`
-              <cds-aichat-history-delete-panel></cds-aichat-history-delete-panel>
+              <cds-aichat-history-delete-panel
+                .triggeringElement=${this.itemToDelete}
+                @history-delete-cancel=${this._handleDeleteCancel}
+                @history-delete-confirm=${this._handleDeleteConfirm}
+              ></cds-aichat-history-delete-panel>
             `
           : ""}
       </cds-aichat-history-shell>

--- a/packages/ai-chat-components/src/components/chat-history/src/history-delete-panel.ts
+++ b/packages/ai-chat-components/src/components/chat-history/src/history-delete-panel.ts
@@ -14,6 +14,7 @@ import { carbonElement } from "../../../globals/decorators/carbon-element.js";
 import "../../chat-button/index.js";
 import TrashCan16 from "@carbon/icons/es/trash-can/16.js";
 import { iconLoader } from "@carbon/web-components/es/globals/internal/icon-loader.js";
+import { tryFocus } from "../../../globals/utils/focus-utils.js";
 
 import styles from "./chat-history.scss?lit";
 
@@ -31,6 +32,13 @@ class CDSAIChatHistoryDeletePanel extends LitElement {
   @property({ type: String, attribute: "delete-text", reflect: true })
   deleteText = "Delete";
 
+  /**
+   * Reference to the history panel item element that triggered the delete action.
+   * Used to restore focus to the next/previous item after deletion.
+   */
+  @property({ type: Object })
+  triggeringElement?: HTMLElement;
+
   @query('cds-aichat-button[kind="danger"]')
   _deleteButton;
 
@@ -38,6 +46,60 @@ class CDSAIChatHistoryDeletePanel extends LitElement {
   async firstUpdated() {
     await this.updateComplete;
     this._deleteButton?.shadowRoot?.querySelector("button").focus();
+  }
+
+  /**
+   * Finds the next or previous focusable history panel item.
+   * Prioritizes the next item, falls back to previous if this was the last item.
+   *
+   * @returns The next/previous history panel item element, or null if none found
+   */
+  private _findNextFocusableItem(): HTMLElement | null {
+    if (!this.triggeringElement) {
+      return null;
+    }
+
+    // Find all history panel items in the same container
+    const container = this.triggeringElement.closest(
+      `${prefix}-history-panel-items`,
+    );
+
+    if (!container) {
+      // Try alternative: search from the root document
+      const historyShell = document.querySelector(`${prefix}-history-shell`);
+
+      if (historyShell) {
+        const allItems = Array.from(
+          historyShell.querySelectorAll(`${prefix}-history-panel-item`),
+        ) as HTMLElement[];
+
+        const currentIndex = allItems.indexOf(this.triggeringElement);
+
+        if (currentIndex !== -1) {
+          const nextItem =
+            allItems[currentIndex + 1] || allItems[currentIndex - 1] || null;
+          return nextItem;
+        }
+      }
+
+      return null;
+    }
+
+    const allItems = Array.from(
+      container.querySelectorAll(`${prefix}-history-panel-item`),
+    ) as HTMLElement[];
+
+    const currentIndex = allItems.indexOf(this.triggeringElement);
+
+    if (currentIndex === -1) {
+      return null;
+    }
+
+    const nextItem =
+      allItems[currentIndex + 1] || allItems[currentIndex - 1] || null;
+
+    // Try next item first, then previous, then null
+    return nextItem;
   }
 
   /**
@@ -53,15 +115,40 @@ class CDSAIChatHistoryDeletePanel extends LitElement {
   };
 
   /**
-   * Handles delete button click event
+   * Handles delete button click event.
+   * Automatically restores focus to the next/previous history item after deletion.
    */
   _handleDeleteClick = () => {
+    // Find the next item to focus BEFORE dispatching the event
+    // (because the triggering element will be removed from DOM after deletion)
+    const nextFocusTarget = this._findNextFocusableItem();
+
     this.dispatchEvent(
       new CustomEvent("history-delete-confirm", {
         bubbles: true,
         composed: true,
+        detail: {
+          triggeringElement: this.triggeringElement,
+          nextFocusTarget: nextFocusTarget,
+        },
       }),
     );
+
+    // Restore focus after a microtask to allow DOM updates
+    if (nextFocusTarget) {
+      requestAnimationFrame(() => {
+        // Try the utility first
+        const focused = tryFocus(nextFocusTarget);
+
+        // If tryFocus didn't work, manually focus the button in shadow DOM
+        if (!focused) {
+          const button = nextFocusTarget.shadowRoot?.querySelector("button");
+          if (button) {
+            button.focus();
+          }
+        }
+      });
+    }
   };
 
   render() {


### PR DESCRIPTION
Closes #1187 

This PR adds logic to the `history-delete-panel` component to set focus on the next chat item after the triggering chat item is deleted. This helps maintain the focus flow for the keyboard user.

#### Changelog

**New**

- {{ New thing }}

**Changed**

- {{ Changed thing }}

**Removed**

- {{ Removed thing }}

#### Testing / Reviewing

{{ Add descriptions, steps or a checklist for how reviewers can verify this PR works or not }}
