### PR TITLE
fix: set focus flow when deleting / unpinning / pinning history chat item

### DIFF
--- a/demo/src/react/HistoryWriteableElementExample.tsx
+++ b/demo/src/react/HistoryWriteableElementExample.tsx
@@ -29,9 +29,10 @@ import {
   resultItemSection,
 } from "../fixtures/history/chatHistoryData";
 import { customLoadHistory } from "../fixtures/history/customLoadHistory";
+import { focusElementAfterRepaint } from "@carbon/ai-chat-components/es/globals/utils/focus-utils";
 
 import { PinFilled, Search, Time } from "@carbon/icons-react";
-import React, { useState, useCallback } from "react";
+import React, { useState, useCallback, useRef } from "react";
 import { ChatInstance, PanelType } from "@carbon/ai-chat";
 
 interface HistoryExampleProps {
@@ -84,6 +85,7 @@ function HistoryWriteableElementExample({
   parentStateText: _parentStateText,
   isMobile,
 }: HistoryExampleProps) {
+  const historyShellRef = useRef<HTMLElement | null>(null);
   const [searchResults, setSearchResults] = useState<resultItem[]>([]);
   const [searchValue, setSearchValue] = useState("");
   const [selectedId, setSelectedId] = useState<string | undefined>(
@@ -166,6 +168,11 @@ function HistoryWriteableElementExample({
 
         // Add to start of pinned items
         setPinnedItems((prev) => [{ ...itemToPin, isPinned: true }, ...prev]);
+
+        focusElementAfterRepaint(
+          historyShellRef.current ?? document,
+          `cds-aichat-history-panel-item[id="${CSS.escape(itemId)}"]`,
+        );
       }
     },
     [regularItems],
@@ -211,6 +218,11 @@ function HistoryWriteableElementExample({
             return item;
           });
         });
+
+        focusElementAfterRepaint(
+          historyShellRef.current ?? document,
+          `cds-aichat-history-panel-item[id="${CSS.escape(itemId)}"]`,
+        );
       }
     },
     [pinnedItems],
@@ -356,7 +368,7 @@ function HistoryWriteableElementExample({
   const noSearchResults = searchResults.length === 0 && searchValue;
 
   return (
-    <HistoryShell>
+    <HistoryShell ref={historyShellRef}>
       <HistoryHeader
         headerTitle="Chats"
         onClose={handleHistoryClose}

--- a/demo/src/react/HistoryWriteableElementExample.tsx
+++ b/demo/src/react/HistoryWriteableElementExample.tsx
@@ -445,6 +445,7 @@ function HistoryWriteableElementExample({
       </HistoryContent>
       {showDeletePanel && (
         <HistoryDeletePanel
+          itemId={itemToDelete ?? ""}
           onCancel={handleDeleteCancel}
           onConfirm={handleDeleteConfirm}
         >

--- a/demo/src/web-components/history-writeable-element-example.ts
+++ b/demo/src/web-components/history-writeable-element-example.ts
@@ -10,6 +10,7 @@ import "@carbon/ai-chat-components/es/components/chat-history/index.js";
 import "@carbon/web-components/es/components/icon-button/index.js";
 
 import { ChatInstance, PanelType } from "@carbon/ai-chat";
+import { focusElementAfterRepaint } from "@carbon/ai-chat-components/es/globals/utils/focus-utils";
 import { css, html, LitElement } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { iconLoader } from "@carbon/web-components/es/globals/internal/icon-loader.js";
@@ -180,6 +181,12 @@ export class HistoryWriteableElementExample extends LitElement {
         ...this.pinnedItems,
       ];
       this.requestUpdate();
+
+      // Restore focus to the item that was unpinned for accessibility
+      focusElementAfterRepaint(
+        this.renderRoot,
+        `cds-aichat-history-panel-item#${CSS.escape(itemId)}`,
+      );
     }
   };
 
@@ -223,6 +230,12 @@ export class HistoryWriteableElementExample extends LitElement {
 
       this.regularItems = newRegularItems;
       this.requestUpdate();
+
+      // Restore focus to the item that was unpinned for accessibility
+      focusElementAfterRepaint(
+        this.renderRoot,
+        `cds-aichat-history-panel-item#${CSS.escape(itemId)}`,
+      );
     }
   };
 

--- a/demo/src/web-components/history-writeable-element-example.ts
+++ b/demo/src/web-components/history-writeable-element-example.ts
@@ -483,6 +483,7 @@ export class HistoryWriteableElementExample extends LitElement {
         ${this.showDeletePanel
           ? html`
               <cds-aichat-history-delete-panel
+                item-id=${this.itemToDelete ?? ""}
                 @history-delete-cancel=${this._handleDeleteCancel}
                 @history-delete-confirm=${this._handleDeleteConfirm}
               >

--- a/examples/react/chat-history-float/src/ChatHistoryExample.tsx
+++ b/examples/react/chat-history-float/src/ChatHistoryExample.tsx
@@ -426,6 +426,7 @@ function ChatHistoryExample({
       </HistoryContent>
       {showDeletePanel && (
         <HistoryDeletePanel
+          itemId={itemToDelete ?? ""}
           onCancel={handleDeleteCancel}
           onConfirm={handleDeleteConfirm}
         >

--- a/examples/react/chat-history-float/src/ChatHistoryExample.tsx
+++ b/examples/react/chat-history-float/src/ChatHistoryExample.tsx
@@ -7,7 +7,7 @@
  *  @license
  */
 
-import React, { useState, useCallback } from "react";
+import React, { useState, useCallback, useRef } from "react";
 import {
   HistoryShell,
   HistoryHeader,
@@ -20,6 +20,7 @@ import {
   HistorySearchItem,
   HistoryDeletePanel,
 } from "@carbon/ai-chat-components/es/react/history";
+import { focusElementAfterRepaint } from "@carbon/ai-chat-components/es/globals/utils/focus-utils";
 import {
   historyItemActions,
   pinnedHistoryItemActions,
@@ -71,6 +72,7 @@ function ChatHistoryExample({
   parentStateText: _parentStateText,
   loadChat,
 }: ChatHistoryExampleProps) {
+  const historyShellRef = useRef<HTMLElement | null>(null);
   const [searchResults, setSearchResults] = useState<resultItem[]>([]);
   const [searchValue, setSearchValue] = useState("");
   const [selectedId, setSelectedId] = useState<string | undefined>(
@@ -159,6 +161,11 @@ function ChatHistoryExample({
 
         // Add to start of pinned items
         setPinnedItems((prev) => [{ ...itemToPin, isPinned: true }, ...prev]);
+
+        focusElementAfterRepaint(
+          historyShellRef.current ?? document,
+          `cds-aichat-history-panel-item[id="${CSS.escape(itemId)}"]`,
+        );
       }
     },
     [regularItems],
@@ -204,6 +211,11 @@ function ChatHistoryExample({
             return item;
           });
         });
+
+        focusElementAfterRepaint(
+          historyShellRef.current ?? document,
+          `cds-aichat-history-panel-item[id="${CSS.escape(itemId)}"]`,
+        );
       }
     },
     [pinnedItems],
@@ -341,7 +353,7 @@ function ChatHistoryExample({
   const noSearchResults = searchResults.length === 0 && searchValue;
 
   return (
-    <HistoryShell className="history-writeable-element">
+    <HistoryShell className="history-writeable-element" ref={historyShellRef}>
       <HistoryHeader
         headerTitle="Conversations"
         onClose={handleHistoryClose}

--- a/examples/react/chat-history-fullscreen/src/ChatHistoryExample.tsx
+++ b/examples/react/chat-history-fullscreen/src/ChatHistoryExample.tsx
@@ -438,6 +438,7 @@ function ChatHistoryExample({
       </HistoryContent>
       {showDeletePanel && (
         <HistoryDeletePanel
+          itemId={itemToDelete ?? ""}
           onCancel={handleDeleteCancel}
           onConfirm={handleDeleteConfirm}
         >

--- a/examples/react/chat-history-fullscreen/src/ChatHistoryExample.tsx
+++ b/examples/react/chat-history-fullscreen/src/ChatHistoryExample.tsx
@@ -7,7 +7,7 @@
  *  @license
  */
 
-import React, { useState, useCallback } from "react";
+import React, { useState, useCallback, useRef } from "react";
 import {
   HistoryShell,
   HistoryHeader,
@@ -20,6 +20,7 @@ import {
   HistorySearchItem,
   HistoryDeletePanel,
 } from "@carbon/ai-chat-components/es/react/history";
+import { focusElementAfterRepaint } from "@carbon/ai-chat-components/es/globals/utils/focus-utils";
 import {
   historyItemActions,
   pinnedHistoryItemActions,
@@ -73,6 +74,7 @@ function ChatHistoryExample({
   isMobile,
   loadChat,
 }: ChatHistoryExampleProps) {
+  const historyShellRef = useRef<HTMLElement | null>(null);
   const [searchResults, setSearchResults] = useState<resultItem[]>([]);
   const [searchValue, setSearchValue] = useState("");
   const [selectedId, setSelectedId] = useState<string | undefined>(
@@ -171,6 +173,11 @@ function ChatHistoryExample({
 
         // Add to start of pinned items
         setPinnedItems((prev) => [{ ...itemToPin, isPinned: true }, ...prev]);
+
+        focusElementAfterRepaint(
+          historyShellRef.current ?? document,
+          `cds-aichat-history-panel-item[id="${CSS.escape(itemId)}"]`,
+        );
       }
     },
     [regularItems],
@@ -353,7 +360,7 @@ function ChatHistoryExample({
   const noSearchResults = searchResults.length === 0 && searchValue;
 
   return (
-    <HistoryShell>
+    <HistoryShell ref={historyShellRef}>
       <HistoryHeader
         headerTitle="Conversations"
         onClose={handleHistoryClose}

--- a/examples/web-components/chat-history-float/src/history-writeable-element-example.ts
+++ b/examples/web-components/chat-history-float/src/history-writeable-element-example.ts
@@ -10,6 +10,7 @@ import "@carbon/ai-chat-components/es/components/chat-history/index.js";
 import "@carbon/web-components/es/components/icon-button/index.js";
 
 import { ChatInstance, PanelType } from "@carbon/ai-chat";
+import { focusElementAfterRepaint } from "@carbon/ai-chat-components/es/globals/utils/focus-utils.js";
 import { css, html, LitElement } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { iconLoader } from "@carbon/web-components/es/globals/internal/icon-loader.js";
@@ -173,6 +174,12 @@ export class HistoryWriteableElementExample extends LitElement {
         ...this.pinnedItems,
       ];
       this.requestUpdate();
+
+      // Restore focus to the item that was pinned for accessibility
+      focusElementAfterRepaint(
+        this.renderRoot,
+        `cds-aichat-history-panel-item#${CSS.escape(itemId)}`,
+      );
     }
   };
 
@@ -216,6 +223,12 @@ export class HistoryWriteableElementExample extends LitElement {
 
       this.regularItems = newRegularItems;
       this.requestUpdate();
+
+      // Restore focus to the item that was unpinned for accessibility
+      focusElementAfterRepaint(
+        this.renderRoot,
+        `cds-aichat-history-panel-item#${CSS.escape(itemId)}`,
+      );
     }
   };
 

--- a/examples/web-components/chat-history-float/src/history-writeable-element-example.ts
+++ b/examples/web-components/chat-history-float/src/history-writeable-element-example.ts
@@ -465,6 +465,7 @@ export class HistoryWriteableElementExample extends LitElement {
         ${this.showDeletePanel
           ? html`
               <cds-aichat-history-delete-panel
+                item-id=${this.itemToDelete ?? ""}
                 @history-delete-cancel=${this._handleDeleteCancel}
                 @history-delete-confirm=${this._handleDeleteConfirm}
               >

--- a/examples/web-components/chat-history-fullscreen/src/history-writeable-element-example.ts
+++ b/examples/web-components/chat-history-fullscreen/src/history-writeable-element-example.ts
@@ -10,6 +10,7 @@ import "@carbon/ai-chat-components/es/components/chat-history/index.js";
 import "@carbon/web-components/es/components/icon-button/index.js";
 
 import { ChatInstance, PanelType } from "@carbon/ai-chat";
+import { focusElementAfterRepaint } from "@carbon/ai-chat-components/es/globals/utils/focus-utils.js";
 import { css, html, LitElement } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { iconLoader } from "@carbon/web-components/es/globals/internal/icon-loader.js";
@@ -188,6 +189,12 @@ export class HistoryWriteableElementExample extends LitElement {
         ...this.pinnedItems,
       ];
       this.requestUpdate();
+
+      // Restore focus to the item that was pinned for accessibility
+      focusElementAfterRepaint(
+        this.renderRoot,
+        `cds-aichat-history-panel-item#${CSS.escape(itemId)}`,
+      );
     }
   };
 
@@ -231,6 +238,12 @@ export class HistoryWriteableElementExample extends LitElement {
 
       this.regularItems = newRegularItems;
       this.requestUpdate();
+
+      // Restore focus to the item that was unpinned for accessibility
+      focusElementAfterRepaint(
+        this.renderRoot,
+        `cds-aichat-history-panel-item#${CSS.escape(itemId)}`,
+      );
     }
   };
 

--- a/examples/web-components/chat-history-fullscreen/src/history-writeable-element-example.ts
+++ b/examples/web-components/chat-history-fullscreen/src/history-writeable-element-example.ts
@@ -481,6 +481,7 @@ export class HistoryWriteableElementExample extends LitElement {
         ${this.showDeletePanel
           ? html`
               <cds-aichat-history-delete-panel
+                item-id=${this.itemToDelete ?? ""}
                 @history-delete-cancel=${this._handleDeleteCancel}
                 @history-delete-confirm=${this._handleDeleteConfirm}
               >

--- a/packages/ai-chat-components/src/components/chat-history/__stories__/chat-history-react.mdx
+++ b/packages/ai-chat-components/src/components/chat-history/__stories__/chat-history-react.mdx
@@ -232,6 +232,42 @@ function ChatHistory() {
 }
 ```
 
+#### Focus Management Utility
+
+When performing actions that reorder or move history items (such as pinning/unpinning), you may need to restore focus to the item after the DOM updates for accessibility reasons. Use the `focusElementAfterRepaint` utility to handle this:
+
+```javascript
+import { focusElementAfterRepaint } from "@carbon/ai-chat-components/es/globals/utils/focus-utils";
+```
+
+**Example with Pin/Unpin:**
+```jsx
+import { focusElementAfterRepaint } from "@carbon/ai-chat-components/es/globals/utils/focus-utils";
+
+function ChatHistory() {
+  const historyShellRef = useRef(null);
+
+  const handlePin = (itemId) => {
+    // Move item from regular to pinned list
+    const itemToPin = regularItems.find(chat => chat.id === itemId);
+    setPinnedItems(prev => [itemToPin, ...prev]);
+    setRegularItems(prev => prev.filter(chat => chat.id !== itemId));
+
+    // Restore focus to the item after DOM updates
+    focusElementAfterRepaint(
+      historyShellRef.current ?? document,
+      `cds-aichat-history-panel-item[id="${CSS.escape(itemId)}"]`
+    );
+  };
+
+  return (
+    <HistoryShell ref={historyShellRef}>
+      {/* ... history content */}
+    </HistoryShell>
+  );
+}
+```
+
 ### `<HistorySearchItem>` Events
 
 <table style={{width: '100%'}}>

--- a/packages/ai-chat-components/src/components/chat-history/__stories__/chat-history-react.mdx
+++ b/packages/ai-chat-components/src/components/chat-history/__stories__/chat-history-react.mdx
@@ -133,7 +133,7 @@ function ChatHistory() {
 
 ### Delete confirmation panel
 
-Render **`HistoryDeletePanel`** when the user chooses **Delete** from a chat item’s overflow menu. Pass **`itemId`** (maps to **`item-id`** on the host) for the chat item being removed. 
+Render **`HistoryDeletePanel`** when the user chooses **Delete** from a chat item’s overflow menu. Pass **`itemId`** for the chat item being removed.
 Combined with **`HistoryShell`**, focus moves to the next chat item after delete, and **`history-item-selected`** fires on that chat item when the deleted chat item was the active one.
 
 Use **`onCancel`** to dismiss the panel without deleting, and **`onConfirm`** to remove the chat from your state and hide the panel.

--- a/packages/ai-chat-components/src/components/chat-history/__stories__/chat-history-react.mdx
+++ b/packages/ai-chat-components/src/components/chat-history/__stories__/chat-history-react.mdx
@@ -5,6 +5,8 @@ import * as ChatHistoryStories from "./chat-history-react.stories";
 <Meta of={ChatHistoryStories} />
 
 # AI Chat History
+
+
 ## Getting started
 
 Here's a quick example to get you started.

--- a/packages/ai-chat-components/src/components/chat-history/__stories__/chat-history-react.mdx
+++ b/packages/ai-chat-components/src/components/chat-history/__stories__/chat-history-react.mdx
@@ -5,8 +5,6 @@ import * as ChatHistoryStories from "./chat-history-react.stories";
 <Meta of={ChatHistoryStories} />
 
 # AI Chat History
-
-
 ## Getting started
 
 Here's a quick example to get you started.
@@ -129,6 +127,28 @@ function ChatHistory() {
     <div slot="results-count">No available chats</div>
   </HistoryContent>
 </HistoryShell>
+```
+
+### Delete confirmation panel
+
+Render **`HistoryDeletePanel`** when the user chooses **Delete** from a chat item’s overflow menu. Pass **`itemId`** (maps to **`item-id`** on the host) for the chat item being removed. 
+Combined with **`HistoryShell`**, focus moves to the next chat item after delete, and **`history-item-selected`** fires on that chat item when the deleted chat item was the active one.
+
+Use **`onCancel`** to dismiss the panel without deleting, and **`onConfirm`** to remove the chat from your state and hide the panel.
+
+```jsx
+{showDeletePanel && (
+  <HistoryDeletePanel
+    itemId={itemToDelete ?? ""}
+    onCancel={handleDeleteCancel}
+    onConfirm={handleDeleteConfirm}
+  >
+    <div slot="title">Confirm Delete</div>
+    <div slot="description">
+      This conversation will be permanently deleted.
+    </div>
+  </HistoryDeletePanel>
+)}
 ```
 
 ## Custom Events
@@ -454,7 +474,9 @@ function ChatHistory() {
       <td><code>onConfirm</code></td>
       <td><code>history-delete-confirm</code></td>
       <td>Fired when the delete button is clicked or Enter is pressed on the delete button.</td>
-      <td>None</td>
+      <td>
+        When <code>itemId</code> is set: <code>itemId</code>, optional <code>nextItemId</code>, and <code>deletedItemWasSelected</code>.
+      </td>
     </tr>
   </tbody>
 </table>
@@ -463,12 +485,12 @@ function ChatHistory() {
 ```jsx
 function ChatHistory() {
   const [showDeletePanel, setShowDeletePanel] = useState(false);
-  const [selectedChatId, setSelectedChatId] = useState(null);
+  const [itemToDelete, setItemToDelete] = useState(null);
 
   const handleDeleteAction = (event) => {
     const { action, itemId } = event.detail;
     if (action === 'Delete') {
-      setSelectedChatId(itemId);
+      setItemToDelete(itemId);
       setShowDeletePanel(true);
     }
   };
@@ -476,15 +498,14 @@ function ChatHistory() {
   const handleDeleteCancel = () => {
     console.log('Delete cancelled');
     setShowDeletePanel(false);
-    setSelectedChatId(null);
+    setItemToDelete(null);
   };
 
   const handleDeleteConfirm = () => {
-    console.log('Delete confirmed for chat:', selectedChatId);
-    // Delete the selected chat item
-    deleteChat(selectedChatId);
+    console.log('Delete confirmed for chat:', itemToDelete);
+    deleteChat(itemToDelete);
     setShowDeletePanel(false);
-    setSelectedChatId(null);
+    setItemToDelete(null);
   };
 
   return (
@@ -507,6 +528,7 @@ function ChatHistory() {
 
         {showDeletePanel && (
           <HistoryDeletePanel
+            itemId={itemToDelete ?? ''}
             onCancel={handleDeleteCancel}
             onConfirm={handleDeleteConfirm}
           >

--- a/packages/ai-chat-components/src/components/chat-history/__stories__/chat-history-react.stories.jsx
+++ b/packages/ai-chat-components/src/components/chat-history/__stories__/chat-history-react.stories.jsx
@@ -8,7 +8,7 @@
  */
 
 /* eslint-disable */
-import React, { useState, useCallback } from "react";
+import React, { useState, useCallback, useRef } from "react";
 import {
   HistoryShell,
   HistoryHeader,
@@ -30,6 +30,7 @@ import {
   pinnedHistoryItems,
   historyItems,
 } from "./story-data";
+import { focusElementAfterRepaint } from "../../../globals/utils/focus-utils";
 
 import { PinFilled, Search, Time } from "@carbon/icons-react";
 
@@ -83,6 +84,7 @@ export const Default = {
     showCloseAction: true,
   },
   render: (args) => {
+    const historyShellRef = useRef(null);
     const [searchResults, setSearchResults] = useState([]);
     const [searchTotalCount, setSearchTotalCount] = useState(0);
     const [searchValue, setSearchValue] = useState("");
@@ -163,6 +165,11 @@ export const Default = {
 
           // Add to start of pinned items
           setPinnedItems((prev) => [{ ...itemToPin, isPinned: true }, ...prev]);
+
+          focusElementAfterRepaint(
+            historyShellRef.current ?? document,
+            `cds-aichat-history-panel-item[id="${CSS.escape(itemId)}"]`,
+          );
         }
       },
       [regularItems],
@@ -207,6 +214,11 @@ export const Default = {
               return item;
             });
           });
+
+          focusElementAfterRepaint(
+            historyShellRef.current ?? document,
+            `cds-aichat-history-panel-item[id="${CSS.escape(itemId)}"]`,
+          );
         }
       },
       [pinnedItems],
@@ -335,7 +347,7 @@ export const Default = {
     const noSearchResults = searchTotalCount === 0 && searchValue;
 
     return (
-      <HistoryShell>
+      <HistoryShell ref={historyShellRef}>
         <HistoryHeader
           headerTitle={args.HeaderTitle}
           showCloseAction={args.showCloseAction}

--- a/packages/ai-chat-components/src/components/chat-history/__stories__/chat-history-react.stories.jsx
+++ b/packages/ai-chat-components/src/components/chat-history/__stories__/chat-history-react.stories.jsx
@@ -421,6 +421,7 @@ export const Default = {
         </HistoryContent>
         {showDeletePanel && (
           <HistoryDeletePanel
+            itemId={itemToDelete ?? ""}
             onCancel={handleDeleteCancel}
             onConfirm={handleDeleteConfirm}
           >
@@ -548,7 +549,7 @@ export const DeleteFlow = {
             </HistoryPanelItems>
           </HistoryPanel>
         </HistoryContent>
-        <HistoryDeletePanel>
+        <HistoryDeletePanel itemId="today-0">
           <div slot="title">Confirm Delete</div>
           <div slot="description">
             This conversation will be permanently deleted.

--- a/packages/ai-chat-components/src/components/chat-history/__stories__/chat-history.mdx
+++ b/packages/ai-chat-components/src/components/chat-history/__stories__/chat-history.mdx
@@ -248,7 +248,7 @@ Using these subcomponents ensures visual consistency and predictable structure w
 
 ### Delete confirmation panel
 
-Render **`<cds-aichat-history-delete-panel>`** when the user chooses **Delete** from a chat item’s overflow menu. Set **`item-id`** to the id of the chat item being removed; **`cds-aichat-history-shell`** uses this (with **`history-delete-confirm`**) 
+Render **`<cds-aichat-history-delete-panel>`** when the user chooses **Delete** from a chat item’s overflow menu. Set **`item-id`** to the id of the chat item being removed; **`cds-aichat-history-shell`** uses this (with **`history-delete-confirm`**)
 to move keyboard focus to the next or previous chat item after your handler deletes the item, and to fire **`history-item-selected`** on that item when the deleted chat item was the active/selected one.
 
 Listen for **`history-delete-cancel`** to dismiss the panel without changes, and **`history-delete-confirm`** to remove the chat from your data store and hide the panel.
@@ -332,6 +332,36 @@ document.addEventListener('history-item-action', (event) => {
     case 'Pin':
       console.log(`Pinning chat: ${itemName}`);
       break;
+  }
+});
+```
+
+#### Focus Management Utility
+
+When performing actions that reorder or move history items (such as pinning/unpinning), you may need to restore focus to the item after the DOM updates for accessibility reasons. Use the `focusElementAfterRepaint` utility to handle this:
+
+```javascript
+import { focusElementAfterRepaint } from "@carbon/ai-chat-components/es/globals/utils/focus-utils";
+```
+
+**Example with Pin/Unpin:**
+```javascript
+import { focusElementAfterRepaint } from "@carbon/ai-chat-components/es/globals/utils/focus-utils";
+
+// Listen for pin action
+document.addEventListener('history-item-action', (event) => {
+  const { action, itemId } = event.detail;
+
+  if (action === 'Pin') {
+    // Move item from regular to pinned list in your data
+    const itemToPin = regularItems.find(chat => chat.id === itemId);
+    pinnedItems.unshift(itemToPin);
+    regularItems = regularItems.filter(chat => chat.id !== itemId);
+
+    focusElementAfterRepaint(
+      this.renderRoot,
+      `cds-aichat-history-panel-item[id="${CSS.escape(itemId)}"]`
+    );
   }
 });
 ```

--- a/packages/ai-chat-components/src/components/chat-history/__stories__/chat-history.mdx
+++ b/packages/ai-chat-components/src/components/chat-history/__stories__/chat-history.mdx
@@ -48,10 +48,6 @@ The **`<cds-aichat-history-shell>`** component provides a structured layout for 
 Each of these slots can accept **any element or component**, allowing users to freely construct and customize the chat history layout as needed.
 Alternatively, adopters can use the **provided subcomponents**, which are designed specifically for each section. These subcomponents offer consistent styling and default behaviors that align with the AI Chat design patterns.
 
-When you use **`<cds-aichat-history-delete-panel>`** inside **`<cds-aichat-history-shell>`**, set the **`item-id`** attribute to the id of the chat row being deleted. The shell listens for **`history-delete-confirm`**, then restores 
-keyboard focus to the next or previous chat item after your handler removes the item. If the deleted chat item was **selected** / active, the shell also dispatches **`history-item-selected`** on the target row so your existing selection handler can update state.
-
-
 <table style={{width: '100%'}}>
   <thead>
     <tr>
@@ -253,7 +249,7 @@ Using these subcomponents ensures visual consistency and predictable structure w
 ### Delete confirmation panel
 
 Render **`<cds-aichat-history-delete-panel>`** when the user chooses **Delete** from a chat item’s overflow menu. Set **`item-id`** to the id of the chat item being removed; **`cds-aichat-history-shell`** uses this (with **`history-delete-confirm`**) 
-to move keyboard focus to the next or previous chat item after your handler deletes the item, and to fire **`history-item-selected`** on that row when the deleted chat item was the active/selected one.
+to move keyboard focus to the next or previous chat item after your handler deletes the item, and to fire **`history-item-selected`** on that item when the deleted chat item was the active/selected one.
 
 Listen for **`history-delete-cancel`** to dismiss the panel without changes, and **`history-delete-confirm`** to remove the chat from your data store and hide the panel.
 

--- a/packages/ai-chat-components/src/components/chat-history/__stories__/chat-history.mdx
+++ b/packages/ai-chat-components/src/components/chat-history/__stories__/chat-history.mdx
@@ -48,6 +48,9 @@ The **`<cds-aichat-history-shell>`** component provides a structured layout for 
 Each of these slots can accept **any element or component**, allowing users to freely construct and customize the chat history layout as needed.
 Alternatively, adopters can use the **provided subcomponents**, which are designed specifically for each section. These subcomponents offer consistent styling and default behaviors that align with the AI Chat design patterns.
 
+When you use **`<cds-aichat-history-delete-panel>`** inside **`<cds-aichat-history-shell>`**, set the **`item-id`** attribute to the id of the chat row being deleted. The shell listens for **`history-delete-confirm`**, then restores 
+keyboard focus to the next or previous chat item after your handler removes the item. If the deleted chat item was **selected** / active, the shell also dispatches **`history-item-selected`** on the target row so your existing selection handler can update state.
+
 
 <table style={{width: '100%'}}>
   <thead>
@@ -245,6 +248,31 @@ Using these subcomponents ensures visual consistency and predictable structure w
     // Implement search logic here
   });
 </script>
+```
+
+### Delete confirmation panel
+
+Render **`<cds-aichat-history-delete-panel>`** when the user chooses **Delete** from a chat item’s overflow menu. Set **`item-id`** to the id of the chat item being removed; **`cds-aichat-history-shell`** uses this (with **`history-delete-confirm`**) 
+to move keyboard focus to the next or previous chat item after your handler deletes the item, and to fire **`history-item-selected`** on that row when the deleted chat item was the active/selected one.
+
+Listen for **`history-delete-cancel`** to dismiss the panel without changes, and **`history-delete-confirm`** to remove the chat from your data store and hide the panel.
+
+```html
+<cds-aichat-history-shell>
+  <cds-aichat-history-header header-title="Chats"></cds-aichat-history-header>
+  <cds-aichat-history-toolbar></cds-aichat-history-toolbar>
+  <cds-aichat-history-content>
+    <cds-aichat-history-panel aria-label="Chat history">
+      <cds-aichat-history-panel-items>
+        <!-- Panel items; overflow Delete opens the delete panel -->
+      </cds-aichat-history-panel-items>
+    </cds-aichat-history-panel>
+  </cds-aichat-history-content>
+  <cds-aichat-history-delete-panel item-id="chat-to-delete">
+    <div slot="title">Confirm Delete</div>
+    <div slot="description">This conversation will be permanently deleted.</div>
+  </cds-aichat-history-delete-panel>
+</cds-aichat-history-shell>
 ```
 
 ### Custom Events
@@ -479,10 +507,17 @@ document.addEventListener('history-panel-item-input-cancel', () => {
     <tr>
       <td><code>history-delete-confirm</code></td>
       <td>Fired when the delete button is clicked or Enter is pressed on the delete button.</td>
-      <td>None</td>
+      <td>
+        When <code>item-id</code> is set, includes:<br/>
+        • <code>itemId</code> (string) - The chat item being removed<br/>
+        • <code>nextItemId</code> (string, optional) - Next chat item to move focus to after delete<br/>
+        • <code>deletedItemWasSelected</code> (boolean) - Whether that chat item was selected before removal
+      </td>
     </tr>
   </tbody>
 </table>
+
+Set the **`item-id`** attribute (or `itemId` property) whenever the delete panel is shown so **`cds-aichat-history-shell`** can restore focus (and fire **`history-item-selected`** when appropriate).
 
 **Example:**
 ```javascript
@@ -494,11 +529,11 @@ document.addEventListener('history-delete-cancel', () => {
 });
 
 // Listen for delete confirmation
-document.addEventListener('history-delete-confirm', () => {
-  console.log('Delete confirmed');
-  // Delete the selected chat item
-  deleteSelectedChat();
-  // Hide the delete panel
+document.addEventListener('history-delete-confirm', (event) => {
+  const { itemId, nextItemId, deletedItemWasSelected } = event.detail ?? {};
+  console.log('Delete confirmed', { itemId, nextItemId, deletedItemWasSelected });
+  // Remove the chat item from your data store; the shell handles focus if item-id was set
+  deleteChatFromStore(itemId);
   document.querySelector('cds-aichat-history-delete-panel').remove();
 });
 ```
@@ -514,7 +549,7 @@ document.addEventListener('history-delete-confirm', () => {
     </cds-aichat-history-panel>
 
     <!-- Delete confirmation panel (shown when delete action is triggered) -->
-    <cds-aichat-history-delete-panel>
+    <cds-aichat-history-delete-panel item-id="chat-item-to-delete">
       <div slot="title">Confirm Delete</div>
       <div slot="description">This conversation will be permanently deleted.</div>
     </cds-aichat-history-delete-panel>

--- a/packages/ai-chat-components/src/components/chat-history/__stories__/chat-history.stories.js
+++ b/packages/ai-chat-components/src/components/chat-history/__stories__/chat-history.stories.js
@@ -424,7 +424,9 @@ class ChatHistoryDemo extends LitElement {
         </cds-aichat-history-content>
         ${this.showDeletePanel
           ? html`
-              <cds-aichat-history-delete-panel></cds-aichat-history-delete-panel>
+              <cds-aichat-history-delete-panel
+                item-id=${this.itemToDelete ?? ""}
+              ></cds-aichat-history-delete-panel>
             `
           : ""}
       </cds-aichat-history-shell>
@@ -606,7 +608,9 @@ export const DeleteFlow = {
             </cds-aichat-history-panel-items>
           </cds-aichat-history-panel>
         </cds-aichat-history-content>
-        <cds-aichat-history-delete-panel></cds-aichat-history-delete-panel>
+        <cds-aichat-history-delete-panel
+          item-id="today-0"
+        ></cds-aichat-history-delete-panel>
       </cds-aichat-history-shell>
     `;
   },

--- a/packages/ai-chat-components/src/components/chat-history/__stories__/chat-history.stories.js
+++ b/packages/ai-chat-components/src/components/chat-history/__stories__/chat-history.stories.js
@@ -9,6 +9,7 @@
 import "../index";
 import { LitElement, html, css } from "lit";
 import styles from "./story-styles.scss?lit";
+import { focusElementAfterRepaint } from "../../../globals/utils/focus-utils";
 
 import {
   historyItemActions,
@@ -159,6 +160,11 @@ class ChatHistoryDemo extends LitElement {
         ...this.pinnedItems,
       ];
       this.requestUpdate();
+
+      focusElementAfterRepaint(
+        this.renderRoot,
+        `cds-aichat-history-panel-item#${CSS.escape(itemId)}`,
+      );
     }
   };
 
@@ -201,6 +207,11 @@ class ChatHistoryDemo extends LitElement {
 
       this.regularItems = newRegularItems;
       this.requestUpdate();
+
+      focusElementAfterRepaint(
+        this.renderRoot,
+        `cds-aichat-history-panel-item#${CSS.escape(itemId)}`,
+      );
     }
   };
 

--- a/packages/ai-chat-components/src/components/chat-history/__tests__/chat-history.test.ts
+++ b/packages/ai-chat-components/src/components/chat-history/__tests__/chat-history.test.ts
@@ -1,0 +1,104 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { html, fixture, expect } from "@open-wc/testing";
+import "../index.js";
+
+describe("history delete focus restore", () => {
+  it("delete panel _getFocusDetailForDeletedItem picks next row and selected state", async () => {
+    const host = await fixture(html`
+      <cds-aichat-history-shell>
+        <cds-aichat-history-content>
+          <cds-aichat-history-panel>
+            <cds-aichat-history-panel-items>
+              <cds-aichat-history-panel-menu expanded title="T">
+                <cds-aichat-history-panel-item
+                  id="a"
+                  name="A"
+                  selected
+                ></cds-aichat-history-panel-item>
+                <cds-aichat-history-panel-item
+                  id="b"
+                  name="B"
+                ></cds-aichat-history-panel-item>
+              </cds-aichat-history-panel-menu>
+            </cds-aichat-history-panel-items>
+          </cds-aichat-history-panel>
+        </cds-aichat-history-content>
+        <cds-aichat-history-delete-panel></cds-aichat-history-delete-panel>
+      </cds-aichat-history-shell>
+    `);
+
+    const deletePanel = host.querySelector(
+      "cds-aichat-history-delete-panel",
+    ) as HTMLElement;
+    const detail = (deletePanel as any)._getFocusDetailForDeletedItem("a");
+    expect(detail.itemId).to.equal("a");
+    expect(detail.nextItemId).to.equal("b");
+    expect(detail.deletedItemWasSelected).to.be.true;
+  });
+
+  it("cds-aichat-history-shell dispatches history-item-selected on next item after delete", async () => {
+    const shell = await fixture(html`
+      <cds-aichat-history-shell>
+        <cds-aichat-history-content>
+          <cds-aichat-history-panel>
+            <cds-aichat-history-panel-items>
+              <cds-aichat-history-panel-menu expanded title="T">
+                <cds-aichat-history-panel-item
+                  id="first"
+                  name="First"
+                  selected
+                ></cds-aichat-history-panel-item>
+                <cds-aichat-history-panel-item
+                  id="second"
+                  name="Second"
+                ></cds-aichat-history-panel-item>
+              </cds-aichat-history-panel-menu>
+            </cds-aichat-history-panel-items>
+          </cds-aichat-history-panel>
+        </cds-aichat-history-content>
+        <cds-aichat-history-delete-panel
+          item-id="first"
+        ></cds-aichat-history-delete-panel>
+      </cds-aichat-history-shell>
+    `);
+
+    const deletePanel = shell.querySelector("cds-aichat-history-delete-panel")!;
+
+    deletePanel.addEventListener("history-delete-confirm", () => {
+      shell
+        .querySelector(`cds-aichat-history-panel-item[id="first"]`)
+        ?.remove();
+    });
+
+    let selectedDetail;
+    const onSelected = (e: Event) => {
+      selectedDetail = (e as CustomEvent).detail;
+    };
+    shell.addEventListener("history-item-selected", onSelected);
+
+    const dangerBtn = deletePanel.shadowRoot?.querySelector(
+      "cds-aichat-button[kind=danger]",
+    ) as HTMLElement;
+    expect(dangerBtn).to.exist;
+    dangerBtn.click();
+
+    await new Promise<void>((resolve) => {
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => resolve());
+      });
+    });
+
+    expect(selectedDetail?.itemId).to.equal("second");
+    expect(selectedDetail?.itemName).to.equal("Second");
+
+    shell.removeEventListener("history-item-selected", onSelected);
+  });
+});

--- a/packages/ai-chat-components/src/components/chat-history/src/history-delete-panel.ts
+++ b/packages/ai-chat-components/src/components/chat-history/src/history-delete-panel.ts
@@ -31,8 +31,44 @@ class CDSAIChatHistoryDeletePanel extends LitElement {
   @property({ type: String, attribute: "delete-text", reflect: true })
   deleteText = "Delete";
 
+  /**
+   * Id of the chat item being deleted.
+   */
+  @property({ type: String, attribute: "item-id", reflect: true })
+  itemId = "";
+
   @query('cds-aichat-button[kind="danger"]')
   _deleteButton;
+
+  /**
+   * Next panel item id after deleting `itemId`, and whether the removed row was selected.
+   * Call before updating data so the DOM still reflects the row being removed.
+   */
+  private _getFocusDetailForDeletedItem(itemId: string) {
+    const shell = this.closest(`${prefix}-history-shell`);
+    const scope = shell ?? document;
+    const tag = `${prefix}-history-panel-item`;
+    const nodes = Array.from(scope.querySelectorAll(tag));
+    const index = nodes.findIndex((el) => el.id === itemId);
+    const deletedHost = index === -1 ? undefined : nodes[index];
+    const deletedItemWasSelected =
+      deletedHost !== undefined && (deletedHost as any).selected === true;
+
+    let nextItemId;
+    if (index !== -1) {
+      const next =
+        nodes[index + 1] ?? (index > 0 ? nodes[index - 1] : undefined);
+      const nextId = next?.id;
+      nextItemId =
+        typeof nextId === "string" && nextId.length > 0 ? nextId : undefined;
+    }
+
+    return {
+      itemId,
+      nextItemId,
+      deletedItemWasSelected,
+    };
+  }
 
   // auto focus on delete button when delete panel first renders.
   async firstUpdated() {
@@ -56,10 +92,18 @@ class CDSAIChatHistoryDeletePanel extends LitElement {
    * Handles delete button click event
    */
   _handleDeleteClick = () => {
+    const focusDetail =
+      this.itemId.length > 0
+        ? this._getFocusDetailForDeletedItem(this.itemId)
+        : {};
+
     this.dispatchEvent(
       new CustomEvent("history-delete-confirm", {
         bubbles: true,
         composed: true,
+        detail: {
+          ...focusDetail,
+        },
       }),
     );
   };

--- a/packages/ai-chat-components/src/components/chat-history/src/history-delete-panel.ts
+++ b/packages/ai-chat-components/src/components/chat-history/src/history-delete-panel.ts
@@ -41,8 +41,9 @@ class CDSAIChatHistoryDeletePanel extends LitElement {
   _deleteButton;
 
   /**
-   * Next panel item id after deleting `itemId`, and whether the removed row was selected.
-   * Call before updating data so the DOM still reflects the row being removed.
+   * Finds the next chat item id after deleting `itemId`, and whether the removed chat item was * selected / active.
+   *
+   * Call before updating data so the DOM still reflects the chat item being removed.
    */
   private _getFocusDetailForDeletedItem(itemId: string) {
     const shell = this.closest(`${prefix}-history-shell`);

--- a/packages/ai-chat-components/src/components/chat-history/src/history-panel-item.ts
+++ b/packages/ai-chat-components/src/components/chat-history/src/history-panel-item.ts
@@ -53,7 +53,7 @@ class CDSAIChatHistoryPanelItem extends HostListenerMixin(
   /**
    * id of chat history item element
    */
-  @property({ type: String })
+  @property({ type: String, reflect: true })
   id;
 
   /**

--- a/packages/ai-chat-components/src/components/chat-history/src/history-shell.ts
+++ b/packages/ai-chat-components/src/components/chat-history/src/history-shell.ts
@@ -23,6 +23,64 @@ import styles from "./chat-history.scss?lit";
  */
 @carbonElement(`${prefix}-history-shell`)
 class CDSAIChatHistoryShell extends LitElement {
+  connectedCallback() {
+    super.connectedCallback();
+    this.addEventListener(
+      "history-delete-confirm",
+      this._handleHistoryDeleteConfirm,
+    );
+  }
+
+  disconnectedCallback() {
+    this.removeEventListener(
+      "history-delete-confirm",
+      this._handleHistoryDeleteConfirm,
+    );
+    super.disconnectedCallback();
+  }
+
+  /**
+   * After the app removes the deleted row, move focus to the next row and optionally fire `history-item-selected`
+   * when the deleted row was selected (detail from `cds-aichat-history-delete-panel` with `item-id` set).
+   */
+  private _handleHistoryDeleteConfirm = (event: Event) => {
+    const detail = (event as CustomEvent).detail ?? {};
+    const { nextItemId, deletedItemWasSelected } = detail;
+
+    if (!nextItemId) {
+      return;
+    }
+
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        const tag = `${prefix}-history-panel-item`;
+        const nextHost = Array.from(this.querySelectorAll(tag)).find(
+          (el) => (el as HTMLElement).id === nextItemId,
+        ) as HTMLElement | undefined;
+
+        if (!nextHost) {
+          return;
+        }
+
+        if (deletedItemWasSelected) {
+          nextHost.dispatchEvent(
+            new CustomEvent("history-item-selected", {
+              bubbles: true,
+              composed: true,
+              detail: {
+                itemId: nextHost.id,
+                itemName: (nextHost as any).name,
+                element: nextHost,
+              },
+            }),
+          );
+        }
+
+        nextHost.focus();
+      });
+    });
+  };
+
   render() {
     return html` <slot name="header"></slot>
       <slot name="toolbar"></slot>

--- a/packages/ai-chat-components/src/globals/utils/__tests__/focus-utils.test.ts
+++ b/packages/ai-chat-components/src/globals/utils/__tests__/focus-utils.test.ts
@@ -15,6 +15,7 @@ import {
   tryFocus,
   walkComposedTree,
   getFirstAndLastFocusableChildren,
+  focusElementAfterRepaint,
 } from "../focus-utils.js";
 
 /**
@@ -731,6 +732,44 @@ describe("focus-utils", function () {
       expect(last).to.not.be.null;
       expect(first?.id).to.equal("first");
       expect(last?.id).to.equal("last");
+    });
+  });
+
+  describe("focusElementAfterRepaint", function () {
+    it("should focus the matching element after paint", async function () {
+      const root = await fixture(html`
+        <div>
+          <button id="other">Other</button>
+          <button id="target">Target</button>
+        </div>
+      `);
+      (root.querySelector("#other") as HTMLElement).focus();
+      expect(document.activeElement?.id).to.equal("other");
+
+      focusElementAfterRepaint(root, "#target");
+      await new Promise<void>((resolve) => {
+        requestAnimationFrame(() => {
+          requestAnimationFrame(() => resolve());
+        });
+      });
+
+      expect(document.activeElement?.id).to.equal("target");
+    });
+
+    it("should leave focus unchanged when selector matches nothing", async function () {
+      const root = await fixture(
+        html`<div><button id="stay">Stay</button></div>`,
+      );
+      (root.querySelector("#stay") as HTMLElement).focus();
+
+      focusElementAfterRepaint(root, "#nope");
+      await new Promise<void>((resolve) => {
+        requestAnimationFrame(() => {
+          requestAnimationFrame(() => resolve());
+        });
+      });
+
+      expect(document.activeElement?.id).to.equal("stay");
     });
   });
 });

--- a/packages/ai-chat-components/src/globals/utils/focus-utils.ts
+++ b/packages/ai-chat-components/src/globals/utils/focus-utils.ts
@@ -219,6 +219,34 @@ function getFirstAndLastFocusableChildren(
   return [firstFocusableChild, lastFocusableChild];
 }
 
+/**
+ * Finds a descendant of `searchRoot` via `selector` and focuses it after the next
+ * two animation frames. Use when DOM updates (Lit, React, reorder) replace or move
+ * nodes so the previous focused element is detached (e.g. list pin/unpin).
+ *
+ * Tries {@link tryFocus} first for visibility/focusability checks; if that does
+ * not take focus (e.g. some custom element hosts), falls back to {@link HTMLElement.focus}.
+ *
+ * @param searchRoot - Root to query (`Element`, `ShadowRoot`, `Document`, or `DocumentFragment`, e.g. Lit `renderRoot`)
+ * @param selector - CSS selector that resolves to the node to focus.
+ */
+function focusElementAfterRepaint(
+  searchRoot: Document | Element | ShadowRoot | DocumentFragment,
+  selector: string,
+): void {
+  requestAnimationFrame(() => {
+    requestAnimationFrame(() => {
+      const el = searchRoot.querySelector(selector);
+      if (!(el instanceof HTMLElement)) {
+        return;
+      }
+      if (!tryFocus(el)) {
+        el.focus();
+      }
+    });
+  });
+}
+
 export {
   getDeepActiveElement,
   isElementInvisible,
@@ -226,4 +254,5 @@ export {
   tryFocus,
   walkComposedTree,
   getFirstAndLastFocusableChildren,
+  focusElementAfterRepaint,
 };


### PR DESCRIPTION
Closes #1187

Currently when performing the delete / pin / unpin actions on the chat items, the focus disappears and user has to tab through all the chat history components again from the top. This PR sets the focus states for those actions.

Expected focus behaviors:
After delete → Move focus to the next available chat item (or previous if it was the last item)
After pin/unpin → Maintain focus on the same item (updated state)

https://github.com/user-attachments/assets/28409e51-d4f9-4e9a-9056-c2c87216d4d4

For the delete action, `_getFocusDetailForDeletedItem()` is added to determine the next focusable item and is added to the event details when the "history-delete-confirm" custom event is dispatched. Then in `history-shell` we have event listeners for the "history-delete-confirm" custom event which then handles the focus management to the next item. Also handles the case where the active / selected chat is deleted, it will move the active state to the next chat item that is focused.

For the pin / unpin actions, we provide a utility `focusElementAfterRepaint()` for users to implement on their end. Since these actions are customizable, I didn't want to build in that logic into our chat history components.

```
_handlePinToTop = () => {
    .......
    
    focusElementAfterRepaint(
        this.renderRoot,
        `cds-aichat-history-panel-item#${CSS.escape(itemId)}`,
      );
}
```

#### Changelog

**New**

- `focusElementAfterRepaint` focus utility
- Added documentation for the delete panel and focus utility usage in the storybook `*.mdx` files
- chat-history.test.ts file

**Changed**

- Added the delete and pin / unpin focus changes to the examples

#### Testing / Reviewing

Check the demo deploy preview and storybooks (both React and Web Components):

- turn on chat history
- tab to options for a chat item and delete item - confirm that focus goes to the next chat item
- tab to options for the last chat item and delete item - confirm that focus goes to the previous chat item
- tab to options for a chat item and select pin / unpin - confirm that focus stays with the same chat item
