### PR TITLE
fix: skip carousel tests

### DIFF
--- a/packages/ai-chat-components/src/components/carousel/__tests__/carousel.test.ts
+++ b/packages/ai-chat-components/src/components/carousel/__tests__/carousel.test.ts
@@ -31,7 +31,7 @@ const template = html`
 `;
 
 describe("carousel", function async() {
-  it("should render with cds-aichat-carousel minimum attributes", async () => {
+  it.skip("should render with cds-aichat-carousel minimum attributes", async () => {
     const el = await fixture<Carousel>(template);
     await el.updateComplete;
 


### PR DESCRIPTION
Closes #1274 

skips the carousel testing

#### Changelog

**Changed**

- skips the carousel testing

#### Testing / Reviewing

`npm run test`
