### PR TITLE
chore: add chat history set up docs to example READMEs

### DIFF
--- a/demo/src/react/HistoryWriteableElementExample.tsx
+++ b/demo/src/react/HistoryWriteableElementExample.tsx
@@ -142,12 +142,12 @@ function HistoryWriteableElementExample({
 
         loadChat(event, instance);
 
-        if (instance?.customPanels) {
+        if (isMobile && instance?.customPanels) {
           instance.customPanels.getPanel(PanelType.HISTORY)?.close();
         }
       }
     },
-    [selectedId, pinnedItems, regularItems, instance],
+    [selectedId, pinnedItems, regularItems, instance, isMobile],
   );
 
   // Handle pin chat

--- a/demo/src/web-components/history-writeable-element-example.ts
+++ b/demo/src/web-components/history-writeable-element-example.ts
@@ -156,7 +156,7 @@ export class HistoryWriteableElementExample extends LitElement {
 
       this._loadChat(event, this.instance);
 
-      if (this.instance?.customPanels) {
+      if (this.isMobile && this.instance?.customPanels) {
         this.instance.customPanels.getPanel(PanelType.HISTORY)?.close();
       }
     }

--- a/examples/react/chat-history-float/README.md
+++ b/examples/react/chat-history-float/README.md
@@ -32,6 +32,10 @@
 | `instance.messaging.clearConversation`        | instance method             | Clears the current conversation before inserting history.    |
 | `instance.messaging.insertHistory`            | instance method             | Inserts the loaded history payload.                          |
 
+## Chat history configuration
+
+For information on how to set up chat history view the [chat-history-fullscreen/README.md](../chat-history-fullscreen/README.md) guide.
+
 ## Run it
 
 **Prerequisite — build the core packages first.** Examples consume the built output of `@carbon/ai-chat-components` and `@carbon/ai-chat`; without this step the dev server will fail with missing-module errors. Rebuild whenever you change anything under `packages/`.

--- a/examples/react/chat-history-fullscreen/README.md
+++ b/examples/react/chat-history-fullscreen/README.md
@@ -138,7 +138,7 @@ if (historyPanel?.isOpen) {
 
 See [`ChatHistoryExample.tsx`](../chat-history-fullscreen/src/ChatHistoryExample.tsx) for a full implementation. Key patterns:
 
-```typescript
+````typescript
 // 1. Configure history in PublicConfig
 const config: PublicConfig = {
   history: {
@@ -154,14 +154,6 @@ const handleHistoryClose = useCallback(() => {
     instance.customPanels.getPanel(PanelType.HISTORY)?.close();
   }
 }, [instance]);
-
-// 3. Use the handler in your history UI
-<HistoryHeader
-  headerTitle="Conversations"
-  onClose={handleHistoryClose}
-  showCloseAction={true}
-/>
-```
 
 ### When to use `startClosed: true`
 
@@ -189,6 +181,6 @@ npm run build --workspace=@carbon/ai-chat-components
 npm run build --workspace=@carbon/ai-chat
 
 npm run start --workspace=@carbon/ai-chat-examples-react-chat-history-fullscreen
-```
+````
 
 See [../README.md](../README.md) for the full setup walkthrough.

--- a/examples/react/chat-history-fullscreen/README.md
+++ b/examples/react/chat-history-fullscreen/README.md
@@ -38,6 +38,145 @@
 | `instance.messaging.clearConversation`        | instance method             | Clears the conversation before insertion.             |
 | `instance.messaging.insertHistory`            | instance method             | Inserts the loaded history.                           |
 
+## Chat history configuration
+
+### Default setup
+
+The simplest way to enable chat history is to set `history.isOn: true`:
+
+```typescript
+const config: PublicConfig = {
+  history: {
+    isOn: true,
+  },
+};
+```
+
+With this default configuration:
+
+- **Desktop**: History panel starts open on the left side
+- **Mobile**: History panel starts closed; users access it via the mobile menu in the header
+- **Mobile menu**: "New chat" and "View chats" options appear in the header on small screens
+- **State behavior**: Resizing between desktop and mobile resets to the default state for each mode
+
+This is the recommended setup if you want the standard chat history experience without custom controls.
+
+## Setting up chat history with external controls
+
+### configuration
+
+To enable chat history with an external control, configure these key properties:
+
+```typescript
+const config: PublicConfig = {
+  history: {
+    isOn: true, // Enables history feature and renders slots
+    showMobileMenu: false, // Hide mobile menu if using external controls
+    startClosed: true, // Optional: control initial state and preserve state across resizes
+  },
+};
+```
+
+### Understanding history configuration properties
+
+#### `history.isOn`
+
+- **Purpose**: Enables the history feature and renders the history panel slots
+- **Does NOT control**: Panel visibility in mobile breakpoints
+- **Use when**: You want to enable the history feature
+
+#### `history.showMobileMenu`
+
+- **Purpose**: Controls whether mobile menu options (New chat, View chats) appear in the header
+- **Default**: `true`
+- **Set to `false` when**: You're implementing external controls (like a custom button) to toggle history
+- **Important**: If you're using external actions to control history visibility, set this to `false` to prevent duplicate controls
+
+#### `history.startClosed`
+
+- **Purpose**: Controls initial state and state preservation behavior
+- **Default**: `false`
+- **When `false` (default)**:
+  - Desktop: history starts open
+  - Mobile: history starts closed
+  - Resizing between modes resets to default state
+- **When `true`**:
+  - Both desktop and mobile start closed
+  - User's open/closed state is preserved when resizing between desktop and mobile
+  - Enables reliable external control via instance methods
+
+### Controlling history panel visibility
+
+**❌ Incorrect approach** - Don't toggle `history.isOn`:
+
+```typescript
+// This will cause issues - don't do this!
+config.history.isOn = !config.history.isOn;
+```
+
+**✅ Correct approach** - Use the panel instance methods:
+
+```typescript
+import { PanelType } from "@carbon/ai-chat";
+
+// To close the history panel
+instance.customPanels.getPanel(PanelType.HISTORY)?.close();
+
+// To open the history panel
+instance.customPanels.getPanel(PanelType.HISTORY)?.open();
+
+// To toggle the history panel
+const historyPanel = instance.customPanels.getPanel(PanelType.HISTORY);
+if (historyPanel?.isOpen) {
+  historyPanel.close();
+} else {
+  historyPanel?.open();
+}
+```
+
+### Complete example with external control
+
+See [`ChatHistoryExample.tsx`](../chat-history-fullscreen/src/ChatHistoryExample.tsx) for a full implementation. Key patterns:
+
+```typescript
+// 1. Configure history in PublicConfig
+const config: PublicConfig = {
+  history: {
+    isOn: true,
+    showMobileMenu: false,  // Hide built-in mobile menu
+    startClosed: true,      // Start closed, preserve state
+  },
+};
+
+// 2. Implement close handler in your custom history component
+const handleHistoryClose = useCallback(() => {
+  if (instance?.customPanels) {
+    instance.customPanels.getPanel(PanelType.HISTORY)?.close();
+  }
+}, [instance]);
+
+// 3. Use the handler in your history UI
+<HistoryHeader
+  headerTitle="Conversations"
+  onClose={handleHistoryClose}
+  showCloseAction={true}
+/>
+```
+
+### When to use `startClosed: true`
+
+Use `startClosed: true` when:
+
+- You want consistent initial state across desktop and mobile
+- You're implementing external controls (buttons, menu items) to open/close history
+- You want the user's open/closed preference to persist when they resize their browser
+- You need predictable behavior for programmatic control
+
+Use the default (`false`) when:
+
+- You want the standard behavior (open on desktop, closed on mobile)
+- You don't need state preservation across viewport changes
+
 ## Run it
 
 **Prerequisite — build the core packages first.** Examples consume the built output of `@carbon/ai-chat-components` and `@carbon/ai-chat`; without this step the dev server will fail with missing-module errors. Rebuild whenever you change anything under `packages/`.

--- a/examples/web-components/chat-history-float/README.md
+++ b/examples/web-components/chat-history-float/README.md
@@ -30,6 +30,10 @@ Float-layout chat that exposes a custom history panel slot backed by `customLoad
 | `historyPanelElement`                  | slot           | Writeable-element slot hosting the custom history panel.         |
 | `history-panel-load-chat`              | custom event   | Dispatched by the slot element when a user picks a conversation. |
 
+## Chat history configuration
+
+For information on how to set up chat history view the [chat-history-fullscreen/README.md](../chat-history-fullscreen/README.md) guide.
+
 ## Run it
 
 **Prerequisite — build the core packages first.** Examples consume the built output of `@carbon/ai-chat-components` and `@carbon/ai-chat`; without this step the dev server will fail with missing-module errors. Rebuild whenever you change anything under `packages/`.

--- a/examples/web-components/chat-history-fullscreen/README.md
+++ b/examples/web-components/chat-history-fullscreen/README.md
@@ -34,6 +34,138 @@ Fullscreen chat driven by `<cds-aichat-custom-element>` that exposes a custom hi
 | `historyPanelElement`                  | slot           | Writeable-element slot hosting the custom history panel.  |
 | `history-panel-load-chat`              | custom event   | Listened for on the host element to drive the loader.     |
 
+## Chat history configuration
+
+### Default setup
+
+The simplest way to enable chat history is to set `history.isOn: true`:
+
+```javascript
+const config = {
+  history: {
+    isOn: true,
+  },
+};
+```
+
+With this default configuration:
+
+- **Desktop**: History panel starts open on the left side
+- **Mobile**: History panel starts closed; users access it via the mobile menu in the header
+- **Mobile menu**: "New chat" and "View chats" options appear in the header on small screens
+- **State behavior**: Resizing between desktop and mobile resets to the default state for each mode
+
+This is the recommended setup if you want the standard chat history experience without custom controls.
+
+### Setting up chat history with external controls
+
+#### Basic configuration
+
+To enable chat history with external controls, configure these key properties:
+
+```javascript
+const config = {
+  history: {
+    isOn: true, // Enables history feature and renders slots
+    showMobileMenu: false, // Hide mobile menu if using external controls
+    startClosed: true, // Optional: control initial state and preserve state across resizes
+  },
+};
+```
+
+#### Understanding history configuration properties
+
+##### `history.isOn`
+
+- **Purpose**: Enables the history feature and renders the history panel slots
+- **Does NOT control**: Panel visibility in mobile breakpoints
+- **Use when**: You want to enable the history feature
+
+##### `history.showMobileMenu`
+
+- **Purpose**: Controls whether mobile menu options (New chat, View chats) appear in the header
+- **Default**: `true`
+- **Set to `false` when**: You're implementing external controls (like a custom button) to toggle history
+- **Important**: If you're using external actions to control history visibility, set this to `false` to prevent duplicate controls
+
+##### `history.startClosed`
+
+- **Purpose**: Controls initial state and state preservation behavior
+- **Default**: `false`
+- **When `false` (default)**:
+  - Desktop: history starts open
+  - Mobile: history starts closed
+  - Resizing between modes resets to default state
+- **When `true`**:
+  - Both desktop and mobile start closed
+  - User's open/closed state is preserved when resizing between desktop and mobile
+  - Enables reliable external control via instance methods
+
+#### Controlling history panel visibility
+
+**❌ Incorrect approach** - Don't toggle `history.isOn`:
+
+```javascript
+// This will cause issues - don't do this!
+config.history.isOn = !config.history.isOn;
+```
+
+**✅ Correct approach** - Use the panel instance methods:
+
+```javascript
+import { PanelType } from "@carbon/ai-chat";
+
+// To close the history panel
+instance.customPanels.getPanel(PanelType.HISTORY)?.close();
+
+// To open the history panel
+instance.customPanels.getPanel(PanelType.HISTORY)?.open();
+
+// To toggle the history panel
+const historyPanel = instance.customPanels.getPanel(PanelType.HISTORY);
+if (historyPanel?.isOpen) {
+  historyPanel.close();
+} else {
+  historyPanel?.open();
+}
+```
+
+#### Complete example with external control
+
+See [`history-writeable-element-example.ts`](../../../demo/src/web-components/history-writeable-element-example.ts) for a full implementation. Key patterns:
+
+```javascript
+// 1. Configure history in config object
+const config = {
+  history: {
+    isOn: true,
+    showMobileMenu: false, // Hide built-in mobile menu
+    startClosed: true, // Start closed, preserve state
+  },
+};
+
+// 2. Implement close handler in your custom history component
+_handleHistoryClose = () => {
+  if (this.instance?.customPanels) {
+    this.instance.customPanels.getPanel(PanelType.HISTORY)?.close();
+  }
+};
+```
+
+#### When to use `startClosed: true`
+
+Use `startClosed: true` when:
+
+- You want consistent initial state across desktop and mobile
+- You're implementing external controls (buttons, menu items) to open/close history
+- You want the user's open/closed preference to persist when they resize their browser
+- You need predictable behavior for programmatic control
+
+Use the default (`false`) when:
+
+- You want the standard behavior (open on desktop, closed on mobile)
+- You don't need state preservation across viewport changes
+
 ## Run it
 
 **Prerequisite — build the core packages first.** Examples consume the built output of `@carbon/ai-chat-components` and `@carbon/ai-chat`; without this step the dev server will fail with missing-module errors. Rebuild whenever you change anything under `packages/`.


### PR DESCRIPTION
Closes #1296

Updates the chat history example READMEs with instructions on how to set up chat history.

Adds a `isMobile` check for the demo to the event handler for when user selects a chat from the history panel in desktop - it should only close the history panel in mobile.

#### Changelog

**New**

- New "chat history configuration" documentation to the example READMEs

**Changed**

- Add `isMobile` check to the demo for the select chat handler

#### Testing / Reviewing

- Read through the README doc changes to confirm they make sense
- Go to the demo deploy preview, enable chat history, and select a chat item from the history panel in desktop breakpoint - confirm the history panel stays open