### PR TITLE
fix: card response size

### DIFF
--- a/packages/ai-chat-components/src/components/carousel/src/carousel.ts
+++ b/packages/ai-chat-components/src/components/carousel/src/carousel.ts
@@ -88,6 +88,7 @@ class CDSAICarousel extends LitElement {
           this._currentIndex = endData.currentIndex;
           this._dispatchChange(endData);
         },
+        useMaxHeight: true,
       };
       this.carousel = initCarousel(this.container[0], config);
       this._lastIndex = Object.keys(this.carousel.allViews).length - 1;

--- a/packages/ai-chat/src/chat/components-legacy/responseTypes/card/CardItemComponent.scss
+++ b/packages/ai-chat/src/chat/components-legacy/responseTypes/card/CardItemComponent.scss
@@ -6,9 +6,15 @@
  */
 
 .cds-aichat--card-message-component {
+  display: flex;
   overflow: hidden;
+  flex-direction: column;
   padding: 0;
   max-inline-size: var(--cds-aichat-card-max-width, auto);
+
+  [slot="body"] {
+    flex: 1;
+  }
 }
 
 .cds-aichat--card-message-component.cds-aichat--max-width-small {


### PR DESCRIPTION
Closes #1294

fixes discrepancy in card sizes when rendered in the carousel

#### Changelog

**Changed**

- fixes discrepancy in card sizes when rendered in the carousel

#### Testing / Reviewing

manual testing
