### PR TITLE
fix: align feedback component with design specs

### DIFF
--- a/packages/ai-chat-components/src/components/feedback/__stories__/feedback-react.mdx
+++ b/packages/ai-chat-components/src/components/feedback/__stories__/feedback-react.mdx
@@ -35,7 +35,6 @@ function FeedbackExample() {
       title="Provide feedback"
       body="Help us improve this response"
       categories={["Accurate", "Helpful", "Too verbose", "Inappropriate"]}
-      secondaryLabel="Cancel"
       primaryLabel="Submit"
       showTextArea={true}
       showBody={true}
@@ -126,7 +125,6 @@ All button labels and text can be customized:
 - `title`: Panel title
 - `body`: Instructions for the user
 - `placeholder`: Text area placeholder
-- `secondaryLabel`: Secondary button text
 - `primaryLabel`: Primary button text
 
 #### Optional Elements

--- a/packages/ai-chat-components/src/components/feedback/__stories__/feedback-react.stories.jsx
+++ b/packages/ai-chat-components/src/components/feedback/__stories__/feedback-react.stories.jsx
@@ -43,10 +43,6 @@ export default {
       control: "text",
       description: "Placeholder for the text area",
     },
-    secondaryLabel: {
-      control: "text",
-      description: "Label for the secondary button",
-    },
     primaryLabel: {
       control: "text",
       description: "Label for the primary button",
@@ -89,12 +85,12 @@ const renderFeedback = (args, options) => {
         title={args.title}
         body={args.body}
         placeholder={args.placeholder}
-        secondaryLabel={args.secondaryLabel}
         primaryLabel={args.primaryLabel}
         showTextArea={args.showTextArea}
         showBody={args.showBody}
         categories={options?.categories}
         disclaimer={options?.disclaimer}
+        disclaimerCheckbox={options?.disclaimerCheckbox}
         initialValues={options?.initialValues}
         onSubmit={(event) => {
           const details = event.detail;
@@ -115,7 +111,6 @@ export const Default = {
     title: "Provide feedback",
     body: "Help us improve by sharing your thoughts",
     placeholder: "Tell us more...",
-    secondaryLabel: "Cancel",
     primaryLabel: "Submit",
     showTextArea: true,
     showBody: true,
@@ -145,8 +140,7 @@ export const WithCategories = {
     title: "What went wrong?",
     body: "Select all that apply and provide details",
     placeholder: "Please describe the issue...",
-    secondaryLabel: "Cancel",
-    primaryLabel: "Submit feedback",
+    primaryLabel: "Submit",
     showTextArea: true,
     showBody: true,
   },
@@ -173,10 +167,9 @@ export const WithDisclaimer = {
   args: {
     isOpen: true,
     isReadonly: false,
-    title: "Share your feedback",
+    title: "Additional feedback",
     body: "Help us improve by sharing your thoughts",
     placeholder: "Your feedback...",
-    secondaryLabel: "Cancel",
     primaryLabel: "Submit",
     showTextArea: true,
     showBody: true,
@@ -185,7 +178,9 @@ export const WithDisclaimer = {
     renderFeedback(args, {
       categories: positiveCategories,
       disclaimer:
-        "By submitting feedback, you agree to our [Privacy Policy](https://example.com/privacy). Your feedback may be used to improve our services.",
+        "To better understand your feedback, a dedicated IBM team may review additional information (such as your prompt and the model output) to drive improvement of AI-powered features. Your content will not be used to train or enhance the AI model.",
+      disclaimerCheckbox:
+        "I agree to IBM collecting information related to my feedback.",
       onSubmit: (details) => {
         console.log("Feedback submitted:", details);
         if (typeof window !== "undefined") {

--- a/packages/ai-chat-components/src/components/feedback/__stories__/feedback-react.stories.jsx
+++ b/packages/ai-chat-components/src/components/feedback/__stories__/feedback-react.stories.jsx
@@ -39,6 +39,16 @@ export default {
       control: "text",
       description: "Body text for the user",
     },
+    disclaimer: {
+      control: "text",
+      description: "Legal disclaimer text",
+      table: { type: { summary: "string" } },
+    },
+    disclaimerCheckbox: {
+      control: "text",
+      description: "Label text to display with disclaimer checkbox",
+      table: { type: { summary: "string" } },
+    },
     placeholder: {
       control: "text",
       description: "Placeholder for the text area",
@@ -89,8 +99,8 @@ const renderFeedback = (args, options) => {
         showTextArea={args.showTextArea}
         showBody={args.showBody}
         categories={options?.categories}
-        disclaimer={options?.disclaimer}
-        disclaimerCheckbox={options?.disclaimerCheckbox}
+        disclaimer={args.disclaimer}
+        disclaimerCheckbox={args.disclaimerCheckbox}
         initialValues={options?.initialValues}
         onSubmit={(event) => {
           const details = event.detail;
@@ -170,6 +180,10 @@ export const WithDisclaimer = {
     title: "Additional feedback",
     body: "Help us improve by sharing your thoughts",
     placeholder: "Your feedback...",
+    disclaimer:
+      "To better understand your feedback, a dedicated IBM team may review additional information (such as your prompt and the model output) to drive improvement of AI-powered features. Your content will not be used to train or enhance the AI model.",
+    disclaimerCheckbox:
+      "I agree to IBM collecting information related to my feedback.",
     primaryLabel: "Submit",
     showTextArea: true,
     showBody: true,
@@ -177,10 +191,6 @@ export const WithDisclaimer = {
   render: (args) =>
     renderFeedback(args, {
       categories: positiveCategories,
-      disclaimer:
-        "To better understand your feedback, a dedicated IBM team may review additional information (such as your prompt and the model output) to drive improvement of AI-powered features. Your content will not be used to train or enhance the AI model.",
-      disclaimerCheckbox:
-        "I agree to IBM collecting information related to my feedback.",
       onSubmit: (details) => {
         console.log("Feedback submitted:", details);
         if (typeof window !== "undefined") {

--- a/packages/ai-chat-components/src/components/feedback/__stories__/feedback.stories.js
+++ b/packages/ai-chat-components/src/components/feedback/__stories__/feedback.stories.js
@@ -55,10 +55,6 @@ export default {
       control: "text",
       description: "Accessible label for the categories listbox",
     },
-    secondaryLabel: {
-      control: "text",
-      description: "Label for the secondary button",
-    },
     primaryLabel: {
       control: "text",
       description: "Label for the primary button",
@@ -85,7 +81,6 @@ export const Default = {
     title: "Provide feedback",
     body: "Help us improve by sharing your thoughts",
     placeholder: "Tell us more...",
-    secondaryLabel: "Cancel",
     primaryLabel: "Submit",
     showTextArea: true,
     showBody: true,
@@ -98,7 +93,6 @@ export const Default = {
         title=${args.title}
         body=${args.body}
         text-area-placeholder=${args.placeholder}
-        secondary-label=${args.secondaryLabel}
         primary-label=${args.primaryLabel}
         .showTextArea=${args.showTextArea}
         ?show-body=${args.showBody}
@@ -126,8 +120,7 @@ export const WithCategories = {
     body: "Select all that apply and provide details",
     placeholder: "Please describe the issue...",
     categoriesLabel: "Feedback categories",
-    secondaryLabel: "Cancel",
-    primaryLabel: "Submit feedback",
+    primaryLabel: "Submit",
     showTextArea: true,
     showBody: true,
   },
@@ -140,7 +133,6 @@ export const WithCategories = {
         body=${args.body}
         text-area-placeholder=${args.placeholder}
         categories-label=${args.categoriesLabel}
-        secondary-label=${args.secondaryLabel}
         primary-label=${args.primaryLabel}
         .showTextArea=${args.showTextArea}
         ?show-body=${args.showBody}
@@ -165,10 +157,9 @@ export const WithDisclaimer = {
   args: {
     isOpen: true,
     isReadonly: false,
-    title: "Share your feedback",
+    title: "Additional feedback",
     body: "Help us improve by sharing your thoughts",
     placeholder: "Your feedback...",
-    secondaryLabel: "Cancel",
     primaryLabel: "Submit",
     showTextArea: true,
     showBody: true,
@@ -181,12 +172,12 @@ export const WithDisclaimer = {
         title=${args.title}
         body=${args.body}
         text-area-placeholder=${args.placeholder}
-        secondary-label=${args.secondaryLabel}
         primary-label=${args.primaryLabel}
         .showTextArea=${args.showTextArea}
         ?show-body=${args.showBody}
         .categories=${positiveCategories}
-        disclaimer="By submitting feedback, you agree to our [Privacy Policy](https://example.com/privacy). Your feedback may be used to improve our services."
+        disclaimer="To better understand your feedback, a dedicated IBM team may review additional information (such as your prompt and the model output) to drive improvement of AI-powered features. Your content will not be used to train or enhance the AI model."
+        disclaimer-checkbox="I agree to IBM collecting information related to my feedback."
         @feedback-submit=${(event) => {
           const details = event.detail;
           console.log("Feedback submitted:", details);

--- a/packages/ai-chat-components/src/components/feedback/__stories__/feedback.stories.js
+++ b/packages/ai-chat-components/src/components/feedback/__stories__/feedback.stories.js
@@ -51,6 +51,14 @@ export default {
       control: "text",
       description: "Placeholder for the text area",
     },
+    disclaimer: {
+      control: "text",
+      description: "Legal disclaimer text",
+    },
+    disclaimerCheckbox: {
+      control: "text",
+      description: "Label text to display with disclaimer checkbox",
+    },
     categoriesLabel: {
       control: "text",
       description: "Accessible label for the categories listbox",
@@ -163,6 +171,10 @@ export const WithDisclaimer = {
     primaryLabel: "Submit",
     showTextArea: true,
     showBody: true,
+    disclaimer:
+      "To better understand your feedback, a dedicated IBM team may review additional information (such as your prompt and the model output) to drive improvement of AI-powered features. Your content will not be used to train or enhance the AI model.",
+    disclaimerCheckbox:
+      "I agree to IBM collecting information related to my feedback.",
   },
   render: (args) => html`
     <div style="padding: 1rem; max-width: 24rem;">
@@ -176,8 +188,8 @@ export const WithDisclaimer = {
         .showTextArea=${args.showTextArea}
         ?show-body=${args.showBody}
         .categories=${positiveCategories}
-        disclaimer="To better understand your feedback, a dedicated IBM team may review additional information (such as your prompt and the model output) to drive improvement of AI-powered features. Your content will not be used to train or enhance the AI model."
-        disclaimer-checkbox="I agree to IBM collecting information related to my feedback."
+        disclaimer=${args.disclaimer}
+        disclaimer-checkbox=${args.disclaimerCheckbox}
         @feedback-submit=${(event) => {
           const details = event.detail;
           console.log("Feedback submitted:", details);

--- a/packages/ai-chat-components/src/components/feedback/src/feedback.scss
+++ b/packages/ai-chat-components/src/components/feedback/src/feedback.scss
@@ -23,6 +23,7 @@
 }
 
 .#{$prefix}--container {
+  position: relative;
   box-sizing: border-box;
   border: 1px solid theme.$chat-bubble-border;
   animation: cds-aichat-fade-in 600ms forwards;
@@ -33,41 +34,48 @@
   border-start-start-radius: var(--cds-aichat-border-radius-start-start, 0);
   container-type: inline-size;
   inline-size: 100%;
-  margin-block-start: layout.$spacing-02;
 }
 
 .#{$prefix}--is-closed {
   display: none;
 }
 
+.#{$prefix}--close {
+  position: absolute;
+  inset-block-start: 0;
+  inset-inline-end: 0;
+}
+
 .#{$prefix}--title-row {
   display: flex;
   margin-block-start: layout.$spacing-04;
-  margin-inline: layout.$spacing-05 layout.$spacing-03;
+  margin-inline: layout.$spacing-05;
 }
 
 .#{$prefix}--title {
-  @include type.type-style("heading-compact-01");
+  @include type.type-style("heading-03");
 
   flex: 1;
 }
 
-.#{$prefix}--close {
-  margin-inline-start: layout.$spacing-03;
+.#{$prefix}--body-content {
+  display: flex;
+  flex-direction: column;
+  gap: layout.$spacing-05;
+  margin-block-start: layout.$spacing-05;
+  margin-inline: layout.$spacing-05;
 }
 
-.#{$prefix}--disclaimer,
+.#{$prefix}--prompt-categories {
+  display: flex;
+  flex-direction: column;
+  gap: layout.$spacing-03;
+}
+
 .#{$prefix}--prompt {
-  @include type.type-style("body-compact-01");
+  @include type.type-style("label-01");
 
   color: theme.$text-secondary;
-  margin-block-start: layout.$spacing-03;
-  margin-inline: layout.$spacing-05;
-}
-
-.#{$prefix}--categories {
-  margin-block-start: layout.$spacing-03;
-  margin-inline: layout.$spacing-05;
 }
 
 .#{$prefix}--tag-list-container {
@@ -78,8 +86,15 @@
 }
 
 .#{$prefix}--feedback-text {
-  margin-block-start: layout.$spacing-03;
-  margin-inline: layout.$spacing-05;
+  display: flex;
+  flex-direction: column;
+  gap: layout.$spacing-02;
+}
+
+.#{$prefix}--disclaimer {
+  @include type.type-style("helper-text-01");
+
+  color: theme.$text-secondary;
 }
 
 .#{$prefix}--buttons {
@@ -88,25 +103,16 @@
   margin-block-start: layout.$spacing-05;
 }
 
-.#{$prefix}--submit,
-.#{$prefix}--cancel {
+.#{$prefix}--submit {
   display: flex;
   overflow: hidden;
   flex: 1;
   align-items: stretch;
+  margin-inline-start: 50%;
   min-inline-size: 0;
 }
 
-.#{$prefix}--submit {
-  border-end-end-radius: layout.$spacing-03;
-}
-
-.#{$prefix}--cancel {
-  border-end-start-radius: layout.$spacing-03;
-}
-
-.#{$prefix}--submit cds-button,
-.#{$prefix}--cancel cds-button {
+.#{$prefix}--submit cds-button {
   flex: 1;
   inline-size: 100%;
 }

--- a/packages/ai-chat-components/src/components/feedback/src/feedback.ts
+++ b/packages/ai-chat-components/src/components/feedback/src/feedback.ts
@@ -9,11 +9,14 @@
 
 import "../../markdown/index.js";
 import "@carbon/web-components/es/components/button/index.js";
-import "@carbon/web-components/es/components/chat-button/index.js";
+import "@carbon/web-components/es/components/checkbox/index.js";
+import "@carbon/web-components/es/components/tag/index.js";
 import "@carbon/web-components/es/components/icon-button/index.js";
 import "@carbon/web-components/es/components/layer/index.js";
 import "@carbon/web-components/es/components/textarea/index.js";
 
+import { iconLoader } from "@carbon/web-components/es/globals/internal/icon-loader.js";
+import Close16 from "@carbon/icons/es/close/16.js";
 import { html, LitElement, PropertyValues } from "lit";
 import { property, state } from "lit/decorators.js";
 import { classMap } from "lit/directives/class-map.js";
@@ -89,16 +92,16 @@ class CDSAIChatFeedback extends LitElement {
   disclaimer?: string;
 
   /**
+   * The label text to display with the disclaimer checkbox. If this value is not provided, no checkbox or label text will be displayed.
+   */
+  @property({ type: String, attribute: "disclaimer-checkbox", reflect: true })
+  disclaimerCheckbox?: string;
+
+  /**
    * The placeholder to show in the text area. A default value will be used if no value is provided here.
    */
   @property({ type: String, attribute: "text-area-placeholder", reflect: true })
   placeholder = "Provide additional feedback...";
-
-  /**
-   * The label for the secondary button. A default value will be used if no value is provided here.
-   */
-  @property({ type: String, attribute: "secondary-label", reflect: true })
-  secondaryLabel?: string;
 
   /**
    * The label for the primary button. A default value will be used if no value is provided here.
@@ -141,12 +144,30 @@ class CDSAIChatFeedback extends LitElement {
   _selectedCategories: Set<string> = new Set();
 
   /**
+   * Indicates if the submit feedback button is disabled.
+   */
+  @state()
+  _isSubmitDisabled = false;
+
+  /**
    * Called when the properties of the component have changed.
    */
   protected updated(changedProperties: PropertyValues<this>) {
     if (changedProperties.has("initialValues")) {
       this._setInitialValues(this.initialValues);
     }
+
+    if (changedProperties.has("disclaimerCheckbox")) {
+      this._isSubmitDisabled = Boolean(this.disclaimerCheckbox);
+    }
+  }
+
+  /**
+   * Called when the component is connected to the document.
+   */
+  connectedCallback() {
+    super.connectedCallback();
+    this._isSubmitDisabled = Boolean(this.disclaimerCheckbox);
   }
 
   /**
@@ -221,6 +242,13 @@ class CDSAIChatFeedback extends LitElement {
     this._selectedCategories = nextSelection;
   }
 
+  /**
+   * Called when the disclaimer checkbox state changes.
+   */
+  _handleDisclaimerCheckboxChange(event: Event) {
+    this._isSubmitDisabled = !(event.currentTarget as HTMLInputElement).checked;
+  }
+
   render() {
     const containerClasses = {
       [`${prefix}--container`]: true,
@@ -228,80 +256,94 @@ class CDSAIChatFeedback extends LitElement {
     };
 
     return html`<div class="${classMap(containerClasses)}">
+      <div class="${prefix}--close" data-rounded="top-right">
+        <cds-icon-button
+          size="lg"
+          align="top-right"
+          kind="ghost"
+          ?disabled=${this.isReadonly}
+          @click=${this._handleCancel}
+        >
+          <span slot="icon">${iconLoader(Close16)}</span>
+          <span slot="tooltip-content">Close</span>
+        </cds-icon-button>
+      </div>
       <div class="${prefix}--title-row">
         <div class="${prefix}--title">${this.title}</div>
       </div>
-      ${this.showBody
-        ? html`<div class="${prefix}--prompt">${this.body}</div>`
-        : ""}
-      ${this.categories?.length
-        ? html`<div class="${prefix}--categories">
-            <div
-              class="${prefix}--tag-list-container"
-              role="group"
-              aria-label="${this.categoriesLabel || "Feedback categories"}"
-            >
-              ${this.categories.map(
-                (value) =>
-                  html`<cds-chat-button
-                    class="${prefix}--tag-list-button"
-                    kind="primary"
-                    size="sm"
-                    type="button"
-                    is-quick-action
-                    aria-pressed="${this._selectedCategories.has(value)}"
-                    ?is-selected=${this._selectedCategories.has(value)}
-                    data-content="${value}"
-                    ?disabled=${this.isReadonly}
-                    @click=${this._handleCategoryClick}
+      <div class="${prefix}--body">
+        <div class="${prefix}--body-content">
+          <div class="${prefix}--prompt-categories">
+            ${this.showBody
+              ? html`<div class="${prefix}--prompt">${this.body}</div>`
+              : ""}
+            ${this.categories?.length
+              ? html`<div class="${prefix}--categories">
+                  <div
+                    class="${prefix}--tag-list-container"
+                    role="group"
+                    aria-label="${this.categoriesLabel ||
+                    "Feedback categories"}"
                   >
-                    ${value}
-                  </cds-chat-button>`,
-              )}
-            </div>
-          </div>`
-        : ""}
-      ${this.showTextArea
-        ? html`<div class="${prefix}--feedback-text">
-            <cds-textarea
-              id="${this.id}-text-area"
-              value="${this._textInput}"
-              class="${prefix}--feedback-text-area"
-              ?disabled=${this.isReadonly}
-              placeholder="${this.placeholder}"
-              rows="3"
-              max-count="${MAX_TEXT_COUNT}"
-              @input=${this._handleTextInput}
-            ></cds-textarea>
-          </div>`
-        : ""}
-      ${this.disclaimer
-        ? html`<div class="${prefix}--disclaimer">
-            <cds-aichat-markdown
-              .markdown=${this.disclaimer}
-            ></cds-aichat-markdown>
-          </div>`
-        : ""}
-      <div class="${prefix}--buttons">
-        <div class="${prefix}--cancel" data-rounded="bottom-left">
-          <cds-button
-            ?disabled=${this.isReadonly}
-            size="lg"
-            kind="secondary"
-            @click=${this._handleCancel}
-          >
-            ${this.secondaryLabel || "Cancel"}
-          </cds-button>
+                    ${this.categories.map(
+                      (value) =>
+                        html`<cds-selectable-tag
+                          class="${prefix}--tag-list-button"
+                          size="md"
+                          text="${value}"
+                          ?selected=${this._selectedCategories.has(value)}
+                          ?disabled=${this.isReadonly}
+                          @click=${this._handleCategoryClick}
+                        ></cds-selectable-tag>`,
+                    )}
+                  </div>
+                </div>`
+              : ""}
+          </div>
+          <div class="${prefix}--feedback-text">
+            ${this.showTextArea
+              ? html`<div class="${prefix}--feedback-input">
+                  <cds-textarea
+                    id="${this.id}-text-area"
+                    value="${this._textInput}"
+                    class="${prefix}--feedback-text-area"
+                    ?disabled=${this.isReadonly}
+                    placeholder="${this.placeholder}"
+                    rows="3"
+                    max-count="${MAX_TEXT_COUNT}"
+                    @input=${this._handleTextInput}
+                  ></cds-textarea>
+                </div>`
+              : ""}
+            ${this.disclaimer
+              ? html`<div class="${prefix}--disclaimer">
+                  <cds-aichat-markdown
+                    .markdown=${this.disclaimer}
+                  ></cds-aichat-markdown>
+                </div>`
+              : ""}
+          </div>
+          ${this.disclaimerCheckbox
+            ? html`<cds-checkbox
+                class="${prefix}--disclaimer-checkbox"
+                ?disabled=${this.isReadonly}
+                @cds-checkbox-changed=${this._handleDisclaimerCheckboxChange}
+              >
+                ${this.disclaimerCheckbox}
+              </cds-checkbox>`
+            : ""}
         </div>
-        <div class="${prefix}--submit" data-rounded="bottom-right">
-          <cds-button
-            ?disabled=${this.isReadonly}
-            size="lg"
-            kind="primary"
-            @click=${this._handleSubmit}
-          >
-            ${this.primaryLabel || "Submit"}
-          </cds-button>
+        <div class="${prefix}--buttons">
+          <div class="${prefix}--submit" data-rounded="bottom-right">
+            <cds-button
+              ?disabled=${this.isReadonly || this._isSubmitDisabled}
+              size="lg"
+              kind="primary"
+              @click=${this._handleSubmit}
+            >
+              ${this.primaryLabel || "Submit"}
+            </cds-button>
+          </div>
         </div>
       </div>
     </div>`;

--- a/packages/ai-chat/src/chat/components-legacy/MessageTypeComponent.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/MessageTypeComponent.tsx
@@ -937,7 +937,6 @@ function MessageTypeComponent(props: MessageTypeComponentProps) {
           placeholder={placeholder || languagePack.feedback_defaultPlaceholder}
           disclaimer={disclaimer}
           primaryLabel={languagePack.feedback_submitLabel}
-          secondaryLabel={languagePack.feedback_cancelLabel}
         />
       );
     }

--- a/packages/ai-chat/src/types/messaging/Messages.ts
+++ b/packages/ai-chat/src/types/messaging/Messages.ts
@@ -841,6 +841,12 @@ export interface GenericItemMessageFeedbackOptions {
    * value is not provided, no text will be shown.
    */
   disclaimer?: string;
+
+  /**
+   * The label text to display with the legal disclaimer checkbox. If this value is not provided, no disclaimer checkbox
+   * or label text will be displayed.
+   */
+  disclaimerCheckbox?: string;
 }
 
 /**


### PR DESCRIPTION
Closes #1103

Updates `Feedback` component to match Design [specs](https://www.figma.com/design/j6Wh5Ud6cDLwlx1i4pmQo7/Carbon-AI---Universal-Chat?node-id=2712-115268&t=poXV9LVLhw13KcT7-0)

#### Changelog

**New**

- Checkbox for user to agree to legal disclaimer. This can be added by providing label text in the `disclaimerCheckbox` prop 

**Changed**

- Close button is now an Icon button in top right corner instead of secondary button in footer
- Category buttons are now `cds-selectable-tag`
- Updated styles in `feedback.scss` to match designs
- Updated React & WC stories to reflect changes

**Removed**

- `secondaryLabel` prop. This was used for the cancel button text which has been moved to an Icon Button

#### Testing / Reviewing

- Go to Storybook deploy preview (React & WC)
- Verify that the Feedback component with Disclaimer matches the design specs
- Toggle disclaimer checkbox and ensure Submit button is disabled appropriately
- Verify Feedback still works properly in demo app deploy preview ("text with feedback")