### PR TITLE
chore: fix copyright license year check

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,12 +112,18 @@
   },
   "lint-staged": {
     "**/*.{js,jsx,ts,tsx}": [
+      "tools/check-license.js -w",
       "prettier --cache --write",
       "eslint"
     ],
     "**/*.scss": [
+      "tools/check-license.js -w",
       "prettier --cache --write",
       "stylelint --report-needless-disables --report-invalid-scope-disables --allow-empty-input"
+    ],
+    "**/*.html": [
+      "tools/check-license.js -w",
+      "prettier --cache --write"
     ],
     "!(*sass).md": [
       "prettier --cache --write"

--- a/tools/check-license.js
+++ b/tools/check-license.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 /**
- * Copyright IBM Corp. 2025
+ * Copyright IBM Corp. 2025, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -13,13 +13,24 @@ const fs = require("fs");
 const { promisify } = require("util");
 const { program } = require("commander");
 const { exec } = require("child_process");
-const gitignoreToGlob = require("gitignore-to-glob");
 const path = require("path");
 const reLicense = require("./license-text.js");
 
 const readFile = promisify(fs.readFile);
 const writeFile = promisify(fs.writeFile);
 const execPromise = promisify(exec);
+const projectRoot = path.resolve(__dirname, "..");
+const sourceFilePattern = "**/*.{js,jsx,ts,tsx,scss,html}";
+const allFilesSourceFilePattern = "**/*.{js,ts,tsx,scss,html}";
+const ignoredFilePatterns = ["!**/*.snap.js", "!examples/**"];
+const sourceFileExtensions = new Set([
+  ".html",
+  ".js",
+  ".jsx",
+  ".scss",
+  ".ts",
+  ".tsx",
+]);
 const {
   currentYear,
   reLicenseTextCurrentYear,
@@ -36,7 +47,8 @@ program
     "-w, --write-current-year",
     "Updates the license header to represent the current year",
   )
-  .option("-a, --check-all-files", "Grabs all files in the project to check");
+  .option("-a, --check-all-files", "Grabs all files in the project to check")
+  .argument("[paths...]", "Files or directories to check");
 
 program.parse();
 
@@ -46,6 +58,55 @@ program.parse();
  * @type {{}}
  */
 const options = program.opts();
+
+/**
+ * Converts a path from the CLI or git into a project-relative path for globby.
+ *
+ * @param {string} filePath The path to normalize.
+ * @returns {string} The normalized project-relative path.
+ */
+const toProjectRelativePath = (filePath) =>
+  path
+    .relative(
+      projectRoot,
+      path.isAbsolute(filePath)
+        ? filePath
+        : path.resolve(process.cwd(), filePath),
+    )
+    .replace(/\\/g, "/");
+
+/**
+ * Checks whether a path is a source file that should have a license header.
+ *
+ * @param {string} filePath The project-relative file path.
+ * @returns {boolean} `true` if the file should be checked.
+ */
+const isSupportedSourceFile = (filePath) =>
+  sourceFileExtensions.has(path.extname(filePath)) &&
+  !filePath.endsWith(".snap.js") &&
+  !filePath.includes(".yarn/");
+
+/**
+ * Resolves CLI or git paths to source files that should be checked.
+ *
+ * @param {string[]} paths The paths to resolve.
+ * @returns {Promise<string[]>} The project-relative source file paths.
+ */
+const resolveSourceFiles = async (paths) => {
+  const { globby } = await import("globby");
+  const normalizedPaths = paths.map(toProjectRelativePath);
+  const files = await globby(normalizedPaths, {
+    cwd: projectRoot,
+    gitignore: true,
+    onlyFiles: true,
+    expandDirectories: {
+      files: [sourceFilePattern],
+      exclude: ["**/*.snap.js"],
+    },
+  });
+
+  return [...new Set(files.filter(isSupportedSourceFile))];
+};
 
 /**
  * Checks files with the given paths for valid license text.
@@ -62,46 +123,33 @@ const check = async (paths, options) => {
   const { globby } = await import("globby");
 
   if (options.checkAllFiles) {
-    const gitIgnorePath = await globby(
-      path.resolve(__dirname, "../.gitignore"),
-      {
-        cwd: path.resolve(__dirname, ".."),
-        gitignore: true,
-      },
-    );
-
     checkPaths = await globby(
-      gitIgnorePath.reduce(
-        (acc, item) => acc.concat(gitignoreToGlob(item)),
-        ["**/*.{js,ts,tsx,scss,html}", "!**/*.snap.js", "!examples"],
-      ),
+      [allFilesSourceFilePattern, ...ignoredFilePatterns],
+      {
+        cwd: projectRoot,
+        gitignore: true,
+        onlyFiles: true,
+      },
     );
   } else if (options.writeCurrentYear) {
-    // Get the list of staged files
-    const { stdout } = await execPromise("git diff --cached --name-only");
-    const allPaths = stdout.split("\n").filter(Boolean);
+    let pathsToCheck = paths;
+    if (pathsToCheck.length === 0) {
+      // Fall back to staged files when the command is run directly.
+      const { stdout } = await execPromise("git diff --cached --name-only");
+      pathsToCheck = stdout.split("\n").filter(Boolean);
+    }
 
-    checkPaths = await globby(
-      allPaths.map((file) => path.relative(__dirname, file)),
-      {
-        cwd: path.resolve(__dirname, ".."),
-        gitignore: true,
-        expandDirectories: {
-          files: ["**/*.{js,ts,tsx,scss,html}"],
-          exclude: ["**/*.snap.js"],
-        },
-      },
-    );
+    checkPaths = await resolveSourceFiles(pathsToCheck);
+  } else {
+    checkPaths = await resolveSourceFiles(paths);
   }
 
-  const checkFiles = checkPaths || paths;
+  const checkFiles = [...new Set(checkPaths.filter(isSupportedSourceFile))];
   const filesWithErrors = (
     await Promise.all(
       checkFiles.map(async (item) => {
-        if (item.indexOf(".yarn") !== -1) {
-          return;
-        }
-        const contents = await readFile(item, "utf8");
+        const filePath = path.resolve(projectRoot, item);
+        const contents = await readFile(filePath, "utf8");
         const result = (
           options.testCurrentYear || options.writeCurrentYear
             ? reLicenseTextCurrentYear
@@ -121,7 +169,7 @@ const check = async (paths, options) => {
             if (!reLicenseTextCurrentYear.test(newContents)) {
               return item;
             }
-            await writeFile(item, newContents, "utf8");
+            await writeFile(filePath, newContents, "utf8");
           } else {
             return item;
           }

--- a/tools/license-text.js
+++ b/tools/license-text.js
@@ -1,5 +1,5 @@
 /**
- * Copyright IBM Corp. 2025
+ * Copyright IBM Corp. 2025, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -8,13 +8,12 @@
 "use strict";
 
 const currentYear = new Date().getFullYear();
-const licenseText = `Copyright IBM Corp\\..* \\d+.*This source code is licensed under the Apache-2\\.0 license found in the
+const licenseText = `Copyright IBM Corp\\.\\s+\\d{4}(?:,\\s*\\d{4})*.*This source code is licensed under the Apache-2\\.0 license found in the
 .*LICENSE file in the root directory of this source tree.`;
-const licenseTextCurrentYear = `Copyright IBM Corp\\. (\\d+, +)?${currentYear}
-.*This source code is licensed under the Apache-2\\.0 license found in the
+const licenseTextCurrentYear = `Copyright IBM Corp\\.\\s+(?:\\d{4},\\s*)*${currentYear}(?:,\\s*\\d{4})*(?=\\s).*This source code is licensed under the Apache-2\\.0 license found in the
 .*LICENSE file in the root directory of this source tree.`;
-const licenseTextSingleYear = `Copyright IBM Corp\\. \\d+(?=\\s)`;
-const licenseTextRange = `(Copyright IBM Corp\\. \\d+, )\\d+(?=\\s)`;
+const licenseTextSingleYear = `Copyright IBM Corp\\.\\s+\\d{4}(?=\\s)(?!\\s*,)`;
+const licenseTextRange = `(Copyright IBM Corp\\.\\s+(?:\\d{4},\\s*)+)\\d{4}(?=\\s)`;
 const reLicenseText = new RegExp(licenseText, "s");
 reLicenseText.currentYear = currentYear;
 reLicenseText.reLicenseTextCurrentYear = new RegExp(


### PR DESCRIPTION
Closes #1203

We have existing scripts that check the copyright license year and updates them but the pathing was not working so they never updated the files.

This PR corrects the pathing and updates the regex. Adds to the husky commands to update the staged files when committing.

#### Changelog

**Changed**

- update husky commands to update the copyright license year on git commit
- update `check-license` script with correct pathing
- update regex in the `license-text` script

#### Testing / Reviewing

You can test by pulling in this branch, modifying a file that does not have an updated copyright year (ie.` Copyright IBM Corp. 2025`) and doing a git commit. You should see the copyright year for the file updated to `Copyright IBM Corp. 2025, 2026`
