### PR TITLE
fix: announce chat history updates

### DIFF
--- a/packages/ai-chat-components/src/components/chat-history/src/history-content.ts
+++ b/packages/ai-chat-components/src/components/chat-history/src/history-content.ts
@@ -44,17 +44,19 @@ class CDSAIChatHistoryContent extends LitElement {
 
   render() {
     return html`
-      ${this._hasResultsCount
-        ? html`<span class="${prefix}--history-content__results-count">
-            <slot
+      <div class="${prefix}--history-content__container" aria-live="polite">
+        ${this._hasResultsCount
+          ? html`<span class="${prefix}--history-content__results-count">
+              <slot
+                name="results-count"
+                @slotchange=${this._handleResultsCountSlotChange}
+              ></slot>
+            </span>`
+          : html`<slot
               name="results-count"
               @slotchange=${this._handleResultsCountSlotChange}
-            ></slot>
-          </span>`
-        : html`<slot
-            name="results-count"
-            @slotchange=${this._handleResultsCountSlotChange}
-          ></slot>`}
+            ></slot>`}
+      </div>
       <slot></slot>
     `;
   }


### PR DESCRIPTION
Closes #1321 

adds `aria-live` to the search results slot in the chat history component.

#### Changelog

**New**

- adds `aria-live` to the search results slot in the chat history component

#### Testing / Reviewing

1. enable VO or your screenreader of choice
2. open the chat history component in storybook or in the demo app
3. enter in a search
4. verify that results are being announced
