### PR TITLE
fix: view sources accessibility

### DIFF
--- a/packages/ai-chat/src/chat/components-legacy/responseTypes/conversationalSearch/ConversationalSearchText.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/responseTypes/conversationalSearch/ConversationalSearchText.tsx
@@ -1,5 +1,5 @@
 /*
- *  Copyright IBM Corp. 2025
+ *  Copyright IBM Corp. 2025, 2026
  *
  *  This source code is licensed under the Apache-2.0 license found in the
  *  LICENSE file in the root directory of this source tree.
@@ -104,6 +104,7 @@ function ConversationalSearchText(props: ConversationalSearchTextProps) {
             <OperationalTag
               id={toggleID}
               onClick={onToggleCitations}
+              onKeyDown={onToggleCitations}
               aria-expanded={citationsOpen}
               text={languagePack.conversationalSearch_citationsLabel}
               aria-label={languagePack.conversationalSearch_toggleCitations}


### PR DESCRIPTION
Closes #1323 

Adds keyboard support for the citations button in conversational search

#### Changelog

**New**

- Adds keyboard support for the citations button in conversational search

#### Testing / Reviewing

1. open demo
2. view conversational search response
3. tab to the citations button and verify it can be toggled with the keyboard
