### PR TITLE
fix: adds clear search label support to chat history

### DIFF
--- a/packages/ai-chat-components/src/components/chat-history/src/history-toolbar.ts
+++ b/packages/ai-chat-components/src/components/chat-history/src/history-toolbar.ts
@@ -44,6 +44,9 @@ class CDSAIChatHistoryToolbar extends LitElement {
   @property({ type: Boolean, attribute: "search-off", reflect: true })
   searchOff;
 
+  @property({ type: String, attribute: "close-button-label-text" })
+  closeButtonLabelText = "Clear search";
+
   /**
    * Handles new chat button click event
    */
@@ -58,13 +61,18 @@ class CDSAIChatHistoryToolbar extends LitElement {
 
   render() {
     const {
+      closeButtonLabelText,
       newChatLabel,
       searchOff,
       _handleNewChatButtonClick: handleNewChatButtonClick,
     } = this;
 
     return html` <slot name="actions-start"></slot>
-      ${!searchOff ? html`<cds-search></cds-search>` : nothing}
+      ${!searchOff
+        ? html`<cds-search
+            close-button-label-text=${closeButtonLabelText}
+          ></cds-search>`
+        : nothing}
       <slot name="actions-end"></slot>
       <cds-icon-button align="top-right" @click=${handleNewChatButtonClick}>
         ${iconLoader(AddComment16, {


### PR DESCRIPTION
Closes #1325 

adds support for the search clear in chat history

#### Changelog

**New**

- adds new prop `close-button-label-text` to `history-toolbar` to support the search close button label

#### Testing / Reviewing

1. access chat history via the demo or storybook
2. type something into the search / filter area
3. inspect the close button and verify that it's using the default label for the close button `aria-label="Clear search"`
