### PR TITLE
chore(chat-history): use attributes for results count and label instead of slot

### DIFF
--- a/demo/src/react/HistoryWriteableElementExample.tsx
+++ b/demo/src/react/HistoryWriteableElementExample.tsx
@@ -378,10 +378,14 @@ function HistoryWriteableElementExample({
         onNewChatClick={handleNewChat}
         onSearchInput={handleSearchInput}
       />
-      <HistoryContent>
-        {(showSearchResults || noSearchResults) && (
-          <div slot="results-count">Results: {searchResults.length}</div>
-        )}
+      <HistoryContent
+        resultsLabel="Results"
+        resultsCount={
+          showSearchResults || noSearchResults
+            ? searchResults.length
+            : undefined
+        }
+      >
         <HistoryPanel aria-label="Chat history">
           <HistoryPanelItems>
             {noSearchResults && (

--- a/demo/src/web-components/history-writeable-element-example.ts
+++ b/demo/src/web-components/history-writeable-element-example.ts
@@ -387,12 +387,12 @@ export class HistoryWriteableElementExample extends LitElement {
           @chat-history-new-chat-click=${this._handleNewChat}
           @cds-search-input=${this._handleSearchInput}
         ></cds-aichat-history-toolbar>
-        <cds-aichat-history-content>
-          ${this.showSearchResults || this.noSearchResults
-            ? html`<div slot="results-count">
-                Results: ${this.searchResults.length}
-              </div>`
-            : ""}
+        <cds-aichat-history-content
+          results-label="Results"
+          results-count="${this.showSearchResults || this.noSearchResults
+            ? this.searchResults.length
+            : ""}"
+        >
           <cds-aichat-history-panel aria-label="Chat history">
             <cds-aichat-history-panel-items>
               ${this.noSearchResults

--- a/examples/react/chat-history-float/src/ChatHistoryExample.tsx
+++ b/examples/react/chat-history-float/src/ChatHistoryExample.tsx
@@ -363,10 +363,12 @@ function ChatHistoryExample({
         onNewChatClick={handleNewChat}
         onSearchInput={handleSearchInput}
       />
-      <HistoryContent>
-        {(showSearchResults || noSearchResults) && (
-          <div slot="results-count">Results: {searchResults.length}</div>
-        )}
+      <HistoryContent
+        resultsLabel="Results"
+        resultsCount={
+          showSearchResults || noSearchResults ? searchResults.length : ""
+        }
+      >
         <HistoryPanel aria-label="Chat history">
           <HistoryPanelItems>
             {noSearchResults && (

--- a/examples/react/chat-history-fullscreen/src/ChatHistoryExample.tsx
+++ b/examples/react/chat-history-fullscreen/src/ChatHistoryExample.tsx
@@ -370,10 +370,12 @@ function ChatHistoryExample({
         onNewChatClick={handleNewChat}
         onSearchInput={handleSearchInput}
       />
-      <HistoryContent>
-        {(showSearchResults || noSearchResults) && (
-          <div slot="results-count">Results: {searchResults.length}</div>
-        )}
+      <HistoryContent
+        resultsLabel="Results"
+        resultsCount={
+          showSearchResults || noSearchResults ? searchResults.length : ""
+        }
+      >
         <HistoryPanel aria-label="Chat history">
           <HistoryPanelItems>
             {noSearchResults && (

--- a/examples/web-components/chat-history-float/src/history-writeable-element-example.ts
+++ b/examples/web-components/chat-history-float/src/history-writeable-element-example.ts
@@ -380,12 +380,12 @@ export class HistoryWriteableElementExample extends LitElement {
           @chat-history-new-chat-click=${this._handleNewChat}
           @cds-search-input=${this._handleSearchInput}
         ></cds-aichat-history-toolbar>
-        <cds-aichat-history-content>
-          ${this.showSearchResults || this.noSearchResults
-            ? html`<div slot="results-count">
-                Results: ${this.searchResults.length}
-              </div>`
-            : ""}
+        <cds-aichat-history-content
+          results-label="Results"
+          results-count="${this.showSearchResults || this.noSearchResults
+            ? this.searchResults.length
+            : ""}"
+        >
           <cds-aichat-history-panel aria-label="Chat history">
             <cds-aichat-history-panel-items>
               ${this.noSearchResults

--- a/examples/web-components/chat-history-fullscreen/src/history-writeable-element-example.ts
+++ b/examples/web-components/chat-history-fullscreen/src/history-writeable-element-example.ts
@@ -396,12 +396,12 @@ export class HistoryWriteableElementExample extends LitElement {
           @chat-history-new-chat-click=${this._handleNewChat}
           @cds-search-input=${this._handleSearchInput}
         ></cds-aichat-history-toolbar>
-        <cds-aichat-history-content>
-          ${this.showSearchResults || this.noSearchResults
-            ? html`<div slot="results-count">
-                Results: ${this.searchResults.length}
-              </div>`
-            : ""}
+        <cds-aichat-history-content
+          results-label="Results"
+          results-count="${this.showSearchResults || this.noSearchResults
+            ? this.searchResults.length
+            : ""}"
+        >
           <cds-aichat-history-panel aria-label="Chat history">
             <cds-aichat-history-panel-items>
               ${this.noSearchResults

--- a/packages/ai-chat-components/src/components/chat-history/__stories__/chat-history-react.mdx
+++ b/packages/ai-chat-components/src/components/chat-history/__stories__/chat-history-react.mdx
@@ -55,8 +55,7 @@ function ChatHistory() {
     <HistoryShell>
       <HistoryHeader headerTitle="Chats" />
       <HistoryToolbar onSearchInput={handleSearchInput} />
-      <HistoryContent>
-        <div slot="results-count">Results: 10</div>
+      <HistoryContent resultsLabel="Results" resultsCount="10">
         <HistoryPanel aria-label="Chat history">
           <HistoryPanelItems>
             <HistoryPanelMenu expanded title="Pinned">
@@ -102,8 +101,7 @@ function ChatHistory() {
 <HistoryShell>
   <HistoryHeader headerTitle="Chats" />
   <HistoryToolbar />
-  <HistoryContent>
-    <div slot="results-count">Results: 4</div>
+  <HistoryContent resultsLabel="Results" resultsCount="4">
     <HistoryPanel aria-label="Search results">
       <HistoryPanelItems>
         <HistoryPanelMenu expanded title="Search results">
@@ -126,7 +124,6 @@ function ChatHistory() {
   <HistoryHeader headerTitle="Chats" />
   <HistoryToolbar />
   <HistoryContent>
-    <div slot="results-count">No available chats</div>
   </HistoryContent>
 </HistoryShell>
 ```

--- a/packages/ai-chat-components/src/components/chat-history/__stories__/chat-history-react.stories.jsx
+++ b/packages/ai-chat-components/src/components/chat-history/__stories__/chat-history-react.stories.jsx
@@ -356,10 +356,12 @@ export const Default = {
           searchOff={args.searchOff}
           onSearchInput={handleSearchInput}
         />
-        <HistoryContent>
-          {(showSearchResults || noSearchResults) && (
-            <div slot="results-count">Results: {searchTotalCount}</div>
-          )}
+        <HistoryContent
+          resultsLabel="Results"
+          resultsCount={
+            showSearchResults || noSearchResults ? searchTotalCount : ""
+          }
+        >
           <HistoryPanel aria-label="Chat history">
             <HistoryPanelItems>
               {noSearchResults && (
@@ -457,8 +459,7 @@ export const SearchResults = {
       <HistoryShell>
         <HistoryHeader headerTitle={args.HeaderTitle} />
         <HistoryToolbar />
-        <HistoryContent>
-          <div slot="results-count">Results: 4</div>
+        <HistoryContent resultsLabel="Results" resultsCount="4">
           <HistoryPanel aria-label="Search results">
             <HistoryPanelItems>
               <HistoryPanelMenu expanded title="Search results">
@@ -509,9 +510,7 @@ export const EmptyState = {
       <HistoryShell>
         <HistoryHeader headerTitle={args.HeaderTitle} />
         <HistoryToolbar />
-        <HistoryContent>
-          <div slot="results-count">No available chats</div>
-        </HistoryContent>
+        <HistoryContent></HistoryContent>
       </HistoryShell>
     );
   },

--- a/packages/ai-chat-components/src/components/chat-history/__stories__/chat-history.mdx
+++ b/packages/ai-chat-components/src/components/chat-history/__stories__/chat-history.mdx
@@ -162,8 +162,7 @@ Using these subcomponents ensures visual consistency and predictable structure w
 <cds-aichat-history-shell>
   <cds-aichat-history-header header-title="Chats"></cds-aichat-history-header>
   <cds-aichat-history-toolbar></cds-aichat-history-toolbar>
-  <cds-aichat-history-content>
-    <div slot="results-count">Results: 4</div>
+  <cds-aichat-history-content results-label="Results" results-count="4">
     <cds-aichat-history-panel aria-label="Search results">
       <cds-aichat-history-panel-items>
         <cds-aichat-history-panel-menu expanded title="Search results">
@@ -199,7 +198,6 @@ Using these subcomponents ensures visual consistency and predictable structure w
   <cds-aichat-history-header header-title="Chats"></cds-aichat-history-header>
   <cds-aichat-history-toolbar></cds-aichat-history-toolbar>
   <cds-aichat-history-content>
-    <div slot="results-count">No available chats</div>
   </cds-aichat-history-content>
 </cds-aichat-history-shell>
 ```

--- a/packages/ai-chat-components/src/components/chat-history/__stories__/chat-history.stories.js
+++ b/packages/ai-chat-components/src/components/chat-history/__stories__/chat-history.stories.js
@@ -337,12 +337,12 @@ class ChatHistoryDemo extends LitElement {
         ></cds-aichat-history-header>
         <cds-aichat-history-toolbar ?search-off=${this.searchOff}>
         </cds-aichat-history-toolbar>
-        <cds-aichat-history-content>
-          ${showSearchResults || noSearchResults
-            ? html`<div slot="results-count">
-                Results: ${this.searchTotalCount}
-              </div>`
-            : ""}
+        <cds-aichat-history-content
+          results-label="Results"
+          results-count="${showSearchResults || noSearchResults
+            ? this.searchTotalCount
+            : ""}"
+        >
           <cds-aichat-history-panel aria-label="Chat history">
             <cds-aichat-history-panel-items>
               ${noSearchResults
@@ -501,8 +501,10 @@ export const SearchResults = {
         header-title="Chats"
       ></cds-aichat-history-header>
       <cds-aichat-history-toolbar></cds-aichat-history-toolbar>
-      <cds-aichat-history-content>
-        <div slot="results-count">Results: 4</div>
+      <cds-aichat-history-content
+        results-label="Results"
+        results-count="4"
+      >
         <cds-aichat-history-panel aria-label="Search results">
         <cds-aichat-history-panel-items>
           <cds-aichat-history-panel-menu expanded title="Search results">
@@ -559,9 +561,7 @@ export const EmptyState = {
           header-title="${args.HeaderTitle}"
         ></cds-aichat-history-header>
         <cds-aichat-history-toolbar></cds-aichat-history-toolbar>
-        <cds-aichat-history-content>
-          <div slot="results-count">No available chats</div>
-        </cds-aichat-history-content>
+        <cds-aichat-history-content> </cds-aichat-history-content>
       </cds-aichat-history-shell>
     `;
   },

--- a/packages/ai-chat-components/src/components/chat-history/src/history-content.ts
+++ b/packages/ai-chat-components/src/components/chat-history/src/history-content.ts
@@ -9,7 +9,7 @@
 
 import { LitElement, html } from "lit";
 import prefix from "../../../globals/settings.js";
-import { property, state } from "lit/decorators.js";
+import { property } from "lit/decorators.js";
 import { carbonElement } from "../../../globals/decorators/carbon-element.js";
 
 import styles from "./chat-history.scss?lit";
@@ -29,33 +29,30 @@ class CDSAIChatHistoryContent extends LitElement {
   slot = "content";
 
   /**
-   * Tracks whether the results-count slot has content
+   * Label to display before the results count
    */
-  @state()
-  private _hasResultsCount = false;
+  @property({ type: String, attribute: "results-label" })
+  resultsLabel = "Results";
 
   /**
-   * Handle slot change to detect if results-count has content
+   * The results count to display
    */
-  private _handleResultsCountSlotChange(e: Event) {
-    const slot = e.target as HTMLSlotElement;
-    this._hasResultsCount = slot.assignedNodes().length > 0;
-  }
+  @property({ type: Number, attribute: "results-count" })
+  resultsCount?: number;
 
   render() {
+    const displayText =
+      this.resultsCount !== undefined && this.resultsLabel
+        ? `${this.resultsLabel}: ${this.resultsCount}`
+        : this.resultsCount;
+
     return html`
       <div class="${prefix}--history-content__container" aria-live="polite">
-        ${this._hasResultsCount
+        ${this.resultsCount !== undefined
           ? html`<span class="${prefix}--history-content__results-count">
-              <slot
-                name="results-count"
-                @slotchange=${this._handleResultsCountSlotChange}
-              ></slot>
+              ${displayText}
             </span>`
-          : html`<slot
-              name="results-count"
-              @slotchange=${this._handleResultsCountSlotChange}
-            ></slot>`}
+          : ""}
       </div>
       <slot></slot>
     `;


### PR DESCRIPTION
Closes #1321

Currently for the chat history component, when typing into the search input field, the screen reader will read just the results count number (ie. 0) instead of "Results: 0". This can be confusing to the user. Instead of having the results label and number come through the slot, have these as attributes in the `history-content` component instead - the screen reader will then pick up on the 'Results' as well as the results count number.

#### Changelog

**Changed**

- in `history-content.ts`, set up two new properties (`results-label` and `results-count`)
- update demo and examples to reflect the property change instead of passing the information through the slots.

#### Testing / Reviewing

- Go to demo deploy preview and enable chat history
- enable screen reader
- input string in search field
- screen reader should read out "results" with number