### PR TITLE
fix: adjust auto-scroll to show previous messages

### DIFF
--- a/packages/ai-chat/src/chat/utils/messagesAutoScrollController.ts
+++ b/packages/ai-chat/src/chat/utils/messagesAutoScrollController.ts
@@ -1,5 +1,5 @@
 /*
- *  Copyright IBM Corp. 2025
+ *  Copyright IBM Corp. 2025, 2026
  *
  *  This source code is licensed under the Apache-2.0 license found in the
  *  LICENSE file in the root directory of this source tree.
@@ -72,7 +72,7 @@ function applySpacerDeficit(spacerElem: HTMLElement, deficit: number): void {
  * Note: A negative value will leave more of the previous message visible above the target message.
  * For example, -60 will show approximately 60px of the previous conversation above the new message.
  */
-const AUTO_SCROLL_EXTRA = -60; 
+const AUTO_SCROLL_EXTRA = -60;
 
 /**
  * The visible portion (in pixels) to show at the bottom of a tall message when auto-scrolling.

--- a/packages/ai-chat/src/chat/utils/messagesAutoScrollController.ts
+++ b/packages/ai-chat/src/chat/utils/messagesAutoScrollController.ts
@@ -68,10 +68,11 @@ function applySpacerDeficit(spacerElem: HTMLElement, deficit: number): void {
 
 /**
  * When we auto-scroll to a message, we want to scroll a bit more than necessary because messages have a lot of
- * padding on the top that we want to cut off when scrolling. This is the extra amount we scroll by. There's 28px of
- * padding above the message and we want to cut that down to just 8 so we scroll an extra 20px (28 - 8).
+ * padding on the top that we want to cut off when scrolling. This is the extra amount we scroll by.
+ * Note: A negative value will leave more of the previous message visible above the target message.
+ * For example, -60 will show approximately 60px of the previous conversation above the new message.
  */
-const AUTO_SCROLL_EXTRA = 28 - 8;
+const AUTO_SCROLL_EXTRA = -60; 
 
 /**
  * The visible portion (in pixels) to show at the bottom of a tall message when auto-scrolling.

--- a/packages/ai-chat/tests/utils/spec/messagesAutoScrollController_spec.ts
+++ b/packages/ai-chat/tests/utils/spec/messagesAutoScrollController_spec.ts
@@ -327,11 +327,11 @@ describe("pinMessageAndScroll", () => {
    *   spacer:    top=400
    *
    *   targetOffsetWithinScroller = 100 - 0 + 0 = 100
-   *   baseScrollTop = floor(100 + 20) = 120     (AUTO_SCROLL_EXTRA = 20)
-   *   finalScrollTop = 120                      (no tall adjustment)
+   *   baseScrollTop = floor(100 + (-60)) = 40   (AUTO_SCROLL_EXTRA = -60)
+   *   finalScrollTop = 40                       (no tall adjustment)
    *   spacerOffset = 400 - 0 + 0 = 400
-   *   visibleBottom = 120 + 500 = 620
-   *   deficit = ceil(620 - 400) = 220
+   *   visibleBottom = 40 + 500 = 540
+   *   deficit = ceil(540 - 400) = 140
    */
   it("returns null when spacerElem is null", () => {
     const scrollElement = createMockScrollElement() as any;
@@ -372,15 +372,15 @@ describe("pinMessageAndScroll", () => {
     });
 
     expect(applyDynamicStylesSpy).toHaveBeenCalledWith(spacerElem, "spacer", {
-      "min-block-size": "220px",
+      "min-block-size": "140px",
     });
     expect(spacerElem.getAttribute("data-cds-aichat-spacer-id")).toBe(
       "spacer-1",
     );
-    expect(scrollElement.scrollTop).toBe(120);
+    expect(scrollElement.scrollTop).toBe(40);
     expect(result).not.toBeNull();
-    expect(result.currentSpacerHeight).toBe(220);
-    expect(result.scrollTop).toBe(120);
+    expect(result.currentSpacerHeight).toBe(140);
+    expect(result.scrollTop).toBe(40);
     expect(result.pinnedMessageComponent).toBe(messageComponent);
     // lastScrollHeight reflects the scrollElement.scrollHeight at time of call.
     expect(result.lastScrollHeight).toBe(scrollElement.scrollHeight);
@@ -390,12 +390,12 @@ describe("pinMessageAndScroll", () => {
     /**
      *   message: top=50, height=200    (200 > 500 * 0.25 = 125 → TALL)
      *
-     *   baseScrollTop = floor(50 + 20) = 70
+     *   baseScrollTop = floor(50 + (-60)) = -10 → max(0, -10) = 0
      *   tallAdjustment = max(0, 200 - 100) = 100   (VISIBLE_BOTTOM_PORTION_PX = 100)
-     *   finalScrollTop = 70 + 100 = 170
+     *   finalScrollTop = 0 + 100 = 100
      *   spacerOffset = 400
-     *   visibleBottom = 170 + 500 = 670
-     *   deficit = ceil(670 - 400) = 270
+     *   visibleBottom = 100 + 500 = 600
+     *   deficit = ceil(600 - 400) = 200
      */
     const scrollElement = createMockScrollElement({
       scrollTop: 0,
@@ -412,14 +412,14 @@ describe("pinMessageAndScroll", () => {
     });
 
     expect(applyDynamicStylesSpy).toHaveBeenCalledWith(spacerElem, "spacer", {
-      "min-block-size": "270px",
+      "min-block-size": "200px",
     });
     expect(spacerElem.getAttribute("data-cds-aichat-spacer-id")).toBe(
       "spacer-2",
     );
-    expect(scrollElement.scrollTop).toBe(170);
-    expect(result.currentSpacerHeight).toBe(270);
-    expect(result.scrollTop).toBe(170);
+    expect(scrollElement.scrollTop).toBe(100);
+    expect(result.currentSpacerHeight).toBe(200);
+    expect(result.scrollTop).toBe(100);
   });
 });
 


### PR DESCRIPTION
Closes #1290

#### Changelog

**Changed**

- Modified `AUTO_SCROLL_EXTRA` constant from `20` to `-60` in `messagesAutoScrollController.ts`
- This keeps ~60px of previous conversation visible when scrolling to new messages


#### Testing / Reviewing

- Manually tested by sending messages and verifying scroll behavior
- Previous messages remain partially visible above new messages

#### After screenshot
<img width="1495" height="951" alt="Screenshot 2026-05-05 at 4 10 32 PM" src="https://github.com/user-attachments/assets/5f9fc36c-7c10-41c3-bedc-627dc7fb839b" />

#### Before screenshot
<img width="1704" height="837" alt="Screenshot 2026-05-05 at 4 42 49 PM" src="https://github.com/user-attachments/assets/11c986a4-0445-490a-aded-811ce0bcebb8" />
