### PR TITLE
chore: update chat history status label to preview

### DIFF
--- a/packages/ai-chat-components/src/components/chat-history/__stories__/chat-history-react.stories.jsx
+++ b/packages/ai-chat-components/src/components/chat-history/__stories__/chat-history-react.stories.jsx
@@ -35,7 +35,7 @@ import { focusElementAfterRepaint } from "../../../globals/utils/focus-utils";
 import { PinFilled, Search, Time } from "@carbon/icons-react";
 
 export default {
-  title: "Unstable/Chat History",
+  title: "Preview/Chat History",
   component: HistoryShell,
   decorators: [
     (Story) => (

--- a/packages/ai-chat-components/src/components/chat-history/__stories__/chat-history.stories.js
+++ b/packages/ai-chat-components/src/components/chat-history/__stories__/chat-history.stories.js
@@ -451,7 +451,7 @@ if (!customElements.get("cds-aichat-history-demo")) {
 }
 
 export default {
-  title: "Unstable/Chat History",
+  title: "Preview/Chat History",
   component: "cds-aichat-history-shell",
   decorators: [
     (story) => html`


### PR DESCRIPTION
This PR updates Chat history components to be under the `Preview` section of storybook

#### Changelog

**Changed**

- update chat history section from "Unstable" to "Preview"


#### Testing / Reviewing
Check both WC and React storybooks to make sure chat history appears under "Preview"
