### PR TITLE
feat(chat-history):  add `show-actions` option  to display actions for all chat items

### DIFF
--- a/packages/ai-chat-components/src/components/chat-history/__stories__/chat-history-react.stories.jsx
+++ b/packages/ai-chat-components/src/components/chat-history/__stories__/chat-history-react.stories.jsx
@@ -77,11 +77,16 @@ export const Default = {
       control: "boolean",
       description: "renders close chat history action in header.",
     },
+    showActions: {
+      control: "boolean",
+      description: "Show actions on all history panel items.",
+    },
   },
   args: {
     HeaderTitle: "Chats",
     searchOff: false,
     showCloseAction: true,
+    showActions: false,
   },
   render: (args) => {
     const historyShellRef = useRef(null);
@@ -362,7 +367,10 @@ export const Default = {
             showSearchResults || noSearchResults ? searchTotalCount : ""
           }
         >
-          <HistoryPanel aria-label="Chat history">
+          <HistoryPanel
+            showActions={args.showActions}
+            aria-label="Chat history"
+          >
             <HistoryPanelItems>
               {noSearchResults && (
                 <HistoryPanelMenu expanded title="Search results">

--- a/packages/ai-chat-components/src/components/chat-history/__stories__/chat-history.stories.js
+++ b/packages/ai-chat-components/src/components/chat-history/__stories__/chat-history.stories.js
@@ -58,6 +58,7 @@ class ChatHistoryDemo extends LitElement {
     searchOff: { type: Boolean, attribute: "search-off" },
     selectedId: { type: String },
     showCloseAction: { type: Boolean, attribute: "show-close-action" },
+    showActions: { type: Boolean, attribute: "show-actions" },
     showDeletePanel: { type: Boolean },
     itemToDelete: { type: String },
     pinnedItems: { type: Array },
@@ -76,6 +77,7 @@ class ChatHistoryDemo extends LitElement {
     this.headerTitle = "Chats";
     this.searchOff = false;
     this.showCloseAction = true;
+    this.showActions = false;
     this.startPanel = false;
     this.searchResults = [];
     this.searchTotalCount = 0;
@@ -343,7 +345,10 @@ class ChatHistoryDemo extends LitElement {
             ? this.searchTotalCount
             : ""}"
         >
-          <cds-aichat-history-panel aria-label="Chat history">
+          <cds-aichat-history-panel
+            ?show-actions=${this.showActions}
+            aria-label="Chat history"
+          >
             <cds-aichat-history-panel-items>
               ${noSearchResults
                 ? html`
@@ -478,17 +483,23 @@ export const Default = {
       control: "boolean",
       description: "renders close chat history action in header.",
     },
+    showActions: {
+      control: "boolean",
+      description: "Show actions on all history panel items.",
+    },
   },
   args: {
     HeaderTitle: "Chats",
     searchOff: false,
     showCloseAction: true,
+    showActions: false,
   },
   render: (args) => html`
     <cds-aichat-history-demo
       header-title="${args.HeaderTitle}"
       ?search-off=${args.searchOff}
       ?show-close-action=${args.showCloseAction}
+      ?show-actions=${args.showActions}
     ></cds-aichat-history-demo>
   `,
 };

--- a/packages/ai-chat-components/src/components/chat-history/src/chat-history.scss
+++ b/packages/ai-chat-components/src/components/chat-history/src/chat-history.scss
@@ -290,6 +290,11 @@
   visibility: visible;
 }
 
+:host(#{$prefix}-history-panel-item[show-actions])
+  #{$cds-prefix}-overflow-menu {
+  visibility: visible;
+}
+
 :host(#{$prefix}-history-panel-item[parent-has-icon])
   button.#{$prefix}--side-nav__link {
   padding-inline-start: 4.5rem;

--- a/packages/ai-chat-components/src/components/chat-history/src/history-content.ts
+++ b/packages/ai-chat-components/src/components/chat-history/src/history-content.ts
@@ -37,18 +37,23 @@ class CDSAIChatHistoryContent extends LitElement {
   /**
    * The results count to display
    */
-  @property({ type: Number, attribute: "results-count" })
-  resultsCount?: number;
+  @property({ type: String, attribute: "results-count" })
+  resultsCount?: string | number;
 
   render() {
+    const shouldDisplay =
+      this.resultsCount !== undefined &&
+      this.resultsCount !== null &&
+      this.resultsCount !== "";
+
     const displayText =
-      this.resultsCount !== undefined && this.resultsLabel
+      shouldDisplay && this.resultsLabel
         ? `${this.resultsLabel}: ${this.resultsCount}`
         : this.resultsCount;
 
     return html`
       <div class="${prefix}--history-content__container" aria-live="polite">
-        ${this.resultsCount !== undefined
+        ${shouldDisplay
           ? html`<span class="${prefix}--history-content__results-count">
               ${displayText}
             </span>`

--- a/packages/ai-chat-components/src/components/chat-history/src/history-panel-item.ts
+++ b/packages/ai-chat-components/src/components/chat-history/src/history-panel-item.ts
@@ -101,13 +101,6 @@ class CDSAIChatHistoryPanelItem extends HostListenerMixin(
   private _overflowMenuBodyFlippedClass = `${prefix}--history-overflow-menu-body--flipped`;
   private _overflowMenuBodyFlippedSelector = `cds-overflow-menu-body.${this._overflowMenuBodyFlippedClass}`;
 
-  disconnectedCallback() {
-    this._overflowMenuBodyElement?.classList.remove(
-      this._overflowMenuBodyFlippedClass,
-    );
-    super.disconnectedCallback();
-  }
-
   private _adoptOverflowMenuBodyStyles(overflowMenuBody: HTMLElement) {
     const root = overflowMenuBody.getRootNode();
     if (root instanceof Document || root instanceof ShadowRoot) {
@@ -337,6 +330,10 @@ class CDSAIChatHistoryPanelItem extends HostListenerMixin(
   }
 
   disconnectedCallback() {
+    this._overflowMenuBodyElement?.classList.remove(
+      this._overflowMenuBodyFlippedClass,
+    );
+
     super.disconnectedCallback();
     this._parentObserver?.disconnect();
   }

--- a/packages/ai-chat-components/src/components/chat-history/src/history-panel-item.ts
+++ b/packages/ai-chat-components/src/components/chat-history/src/history-panel-item.ts
@@ -80,10 +80,23 @@ class CDSAIChatHistoryPanelItem extends HostListenerMixin(
   @property({ type: String, attribute: "overflow-menu-label" })
   overflowMenuLabel = "Options";
 
+  /**
+   * `true` to always show the actions menu for this item.
+   * When set, the actions menu will be visible without requiring hover or selection.
+   * Can be set directly on the item or inherited from the parent panel's `show-actions` attribute.
+   */
+  @property({ type: Boolean, reflect: true, attribute: "show-actions" })
+  showActions = false;
+
   @query(`${prefix}-history-panel-item-input`) input!: HTMLElement;
 
   @query("cds-overflow-menu") overflowMenu!: HTMLElement;
   @query("cds-overflow-menu-body") overflowMenuBody!: HTMLElement;
+
+  /**
+   * MutationObserver to watch for changes to parent panel's always-show-actions attribute
+   */
+  private _parentObserver?: MutationObserver;
 
   /**
    *
@@ -265,7 +278,36 @@ class CDSAIChatHistoryPanelItem extends HostListenerMixin(
     }
   };
 
-  updated() {
+  connectedCallback() {
+    super.connectedCallback();
+
+    // Inherit show-actions from parent panel if not explicitly set on this item
+    const parentPanel = this.closest(`${prefix}-history-panel`);
+    if (parentPanel && !this.hasAttribute("show-actions")) {
+      // Set initial value
+      this.showActions = parentPanel.hasAttribute("show-actions");
+
+      // Watch for changes to parent's show-actions attribute
+      this._parentObserver = new MutationObserver(() => {
+        const parentHasAttribute = parentPanel.hasAttribute("show-actions");
+        this.showActions = parentHasAttribute;
+      });
+
+      this._parentObserver.observe(parentPanel, {
+        attributes: true,
+        attributeFilter: ["show-actions"],
+      });
+    }
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    this._parentObserver?.disconnect();
+  }
+
+  updated(changedProperties: Map<string, any>) {
+    super.updated(changedProperties);
+
     if (this.input) {
       this.input.addEventListener("history-panel-item-input-cancel", () => {
         this.rename = false;

--- a/packages/ai-chat-components/src/components/chat-history/src/history-panel.ts
+++ b/packages/ai-chat-components/src/components/chat-history/src/history-panel.ts
@@ -34,6 +34,14 @@ class CDSAIChatHistoryPanel extends CDSSideNav {
   @property({ type: Boolean })
   expanded = true;
 
+  /**
+   * `true` to always show the actions menu on all child history panel items.
+   * When set, the actions menu will be visible without requiring hover or selection.
+   * Individual items can override this with their own `show-actions` attribute.
+   */
+  @property({ type: Boolean, reflect: true, attribute: "show-actions" })
+  showActions = false;
+
   connectedCallback() {
     this.setAttribute("collapse-mode", "fixed");
     super.connectedCallback();

--- a/packages/ai-chat-components/src/components/markdown/src/utils/html-helpers.ts
+++ b/packages/ai-chat-components/src/components/markdown/src/utils/html-helpers.ts
@@ -173,7 +173,9 @@ export function combineConsecutiveHtmlInline(
     }
 
     if (!success) {
-      return combinedChildren;
+      // If we couldn't successfully combine, just add the original token and continue
+      combinedChildren.push(startNode);
+      continue;
     }
 
     if (stack.length === 0 && endIndex > index) {


### PR DESCRIPTION
Closes #1339

This PR adds a new `showActions` property to the chat history panel components that allows actions menus to be persistently visible on history items without requiring hover or selection.

Also fixes an issue with the recently merged [chore(chat-history): use attributes for results count and label instead of slot](https://github.com/carbon-design-system/carbon-ai-chat/pull/1330) PR where the "Results: 0" shows in Web Components even when user has not input anything in the search field.

#### Changelog

**New**

- Added `showActions` property to `HistoryPanel` component to control visibility of action menus across all child items
- Added `showActions` property to `HistoryPanelItem` component to control visibility of action menu on individual items
- Added MutationObserver in `HistoryPanelItem` to automatically inherit `showActions` from parent panel
- Added CSS rule to make overflow menu visible when `show-actions` attribute is present
- Added `showActions` control to Storybook stories for both React and web components

**Changed**

- Updated `resultsCount` property type in `HistoryContent` from `Number` to `String | Number` to handle empty string values
- Improved `resultsCount` display logic to properly handle undefined, null, and empty string values

#### Testing / Reviewing

- [ ] Verify that the `showActions` toggle in Storybook controls the visibility of action menus on history items
- [ ] Verify that action menus still appear on hover/selection when `showActions` is disabled (default behavior)
- [ ] Verify that the results count displays correctly (only visible when user types in search input)