### PR TITLE
fix(chat-history): actions overflow menu positioning logic under CSP

### DIFF
--- a/packages/ai-chat-components/src/components/chat-history/__tests__/chat-history.test.ts
+++ b/packages/ai-chat-components/src/components/chat-history/__tests__/chat-history.test.ts
@@ -102,3 +102,62 @@ describe("history delete focus restore", () => {
     shell.removeEventListener("history-item-selected", onSelected);
   });
 });
+
+describe("history panel item overflow menu positioning", () => {
+  it("flips the overflow menu body upward when there is not enough space below", async () => {
+    const createRect = (rect: Partial<DOMRect>): DOMRect =>
+      ({
+        x: 0,
+        y: 0,
+        width: 0,
+        height: 0,
+        top: 0,
+        right: 0,
+        bottom: 0,
+        left: 0,
+        toJSON: () => rect,
+        ...rect,
+      }) as DOMRect;
+
+    const host = await fixture(html`
+      <cds-aichat-history-content>
+        <cds-aichat-history-panel-item
+          id="with-menu"
+          name="With menu"
+        ></cds-aichat-history-panel-item>
+      </cds-aichat-history-content>
+    `);
+    const item = host.querySelector(
+      "cds-aichat-history-panel-item",
+    ) as HTMLElement & {
+      actions: unknown[];
+      updateComplete: Promise<boolean>;
+      _adjustMenuPosition: () => void;
+    };
+    item.actions = [{ text: "Delete" }, { text: "Rename" }];
+    await item.updateComplete;
+
+    const overflowMenu = item.shadowRoot?.querySelector(
+      "cds-overflow-menu",
+    ) as HTMLElement;
+    const overflowMenuBody = item.shadowRoot?.querySelector(
+      "cds-overflow-menu-body",
+    ) as HTMLElement;
+    const flippedClass = "cds-aichat--history-overflow-menu-body--flipped";
+
+    host.getBoundingClientRect = () => createRect({ top: 0, bottom: 120 });
+    overflowMenu.getBoundingClientRect = () =>
+      createRect({ top: 80, bottom: 112 });
+    overflowMenuBody.getBoundingClientRect = () => createRect({ height: 80 });
+
+    item._adjustMenuPosition();
+
+    expect(overflowMenuBody.classList.contains(flippedClass)).to.be.true;
+
+    host.getBoundingClientRect = () => createRect({ top: 0, bottom: 240 });
+
+    item._adjustMenuPosition();
+
+    expect(overflowMenuBody.classList.contains(flippedClass)).to.be.false;
+  });
+});

--- a/packages/ai-chat-components/src/components/chat-history/src/chat-history.scss
+++ b/packages/ai-chat-components/src/components/chat-history/src/chat-history.scss
@@ -342,11 +342,3 @@
     }
   }
 }
-
-// Flip the overflow menu upward when there isn't enough room below the
-// trigger. -100% rotates around the trigger; the additional 32px is the
-// trigger's own block-size (kept in sync with `actualMenuHeight` math in
-// history-panel-item.ts::_adjustMenuPosition).
-cds-overflow-menu-body.#{$prefix}--history-overflow-menu-body--flipped {
-  transform: translateY(calc(-100% - 32px));
-}

--- a/packages/ai-chat-components/src/components/chat-history/src/history-panel-item.ts
+++ b/packages/ai-chat-components/src/components/chat-history/src/history-panel-item.ts
@@ -23,6 +23,10 @@ import OverflowMenuVertical16 from "@carbon/icons/es/overflow-menu--vertical/16.
 import { iconLoader } from "@carbon/web-components/es/globals/internal/icon-loader.js";
 import "@carbon/web-components/es/components/overflow-menu/index.js";
 import "@carbon/web-components/es/components/icon-button/index.js";
+import {
+  adoptOnRoot,
+  setVarsForSelector,
+} from "../../shared/dynamic-css-var-sheet.js";
 
 import styles from "./chat-history.scss?lit";
 
@@ -85,6 +89,41 @@ class CDSAIChatHistoryPanelItem extends HostListenerMixin(
   @query("cds-overflow-menu") overflowMenu!: HTMLElement;
   @query("cds-overflow-menu-body") overflowMenuBody!: HTMLElement;
 
+  private _overflowMenuBodyElement?: HTMLElement;
+  private _overflowMenuBodyFlippedClass = `${prefix}--history-overflow-menu-body--flipped`;
+  private _overflowMenuBodyFlippedSelector = `cds-overflow-menu-body.${this._overflowMenuBodyFlippedClass}`;
+
+  connectedCallback() {
+    super.connectedCallback();
+
+    const menuTriggerHeight = 32;
+    setVarsForSelector(this._overflowMenuBodyFlippedSelector, {
+      transform: `translateY(calc(-100% - ${menuTriggerHeight}px))`,
+    });
+  }
+
+  disconnectedCallback() {
+    this._overflowMenuBodyElement?.classList.remove(
+      this._overflowMenuBodyFlippedClass,
+    );
+    super.disconnectedCallback();
+  }
+
+  private _adoptOverflowMenuBodyStyles(overflowMenuBody: HTMLElement) {
+    const root = overflowMenuBody.getRootNode();
+    if (root instanceof Document || root instanceof ShadowRoot) {
+      adoptOnRoot(root);
+    }
+  }
+
+  private _adoptOverflowMenuBodyStylesAfterPortal(
+    overflowMenuBody: HTMLElement,
+  ) {
+    requestAnimationFrame(() => {
+      this._adoptOverflowMenuBodyStyles(overflowMenuBody);
+    });
+  }
+
   /**
    *
    * The current cds-overflow-menu doesn't support opening the menu body in different
@@ -98,9 +137,12 @@ class CDSAIChatHistoryPanelItem extends HostListenerMixin(
     if (!this.overflowMenu || !this.overflowMenuBody) {
       return;
     }
+    const overflowMenuBody = this.overflowMenuBody;
+    this._overflowMenuBodyElement = overflowMenuBody;
+    this._adoptOverflowMenuBodyStyles(overflowMenuBody);
 
     const menuRect = this.overflowMenu.getBoundingClientRect();
-    const menuBodyRect = this.overflowMenuBody.getBoundingClientRect();
+    const menuBodyRect = overflowMenuBody.getBoundingClientRect();
     const actualMenuHeight = menuBodyRect.height || this.actions.length * 40; // fallback
 
     const parentContainer = this.closest(`${prefix}-history-content`);
@@ -112,14 +154,13 @@ class CDSAIChatHistoryPanelItem extends HostListenerMixin(
     const spaceBelow = containerRect.bottom - menuRect.bottom;
     const spaceAbove = menuRect.top - containerRect.top;
 
-    // Class-based flip (paired with a rule in chat-history.scss) so a strict
-    // CSP can drop style-src-attr 'unsafe-inline'. The trigger height is
-    // hardcoded in the rule to match this branch's geometry.
+    // Class-based flip so a strict CSP can drop style-src-attr 'unsafe-inline'.
     const flipUp = spaceBelow < actualMenuHeight && spaceAbove > spaceBelow;
-    this.overflowMenuBody.classList.toggle(
-      `${prefix}--history-overflow-menu-body--flipped`,
+    overflowMenuBody.classList.toggle(
+      this._overflowMenuBodyFlippedClass,
       flipUp,
     );
+    this._adoptOverflowMenuBodyStylesAfterPortal(overflowMenuBody);
   }
 
   /**

--- a/packages/ai-chat-components/src/components/chat-history/src/history-panel-item.ts
+++ b/packages/ai-chat-components/src/components/chat-history/src/history-panel-item.ts
@@ -93,15 +93,6 @@ class CDSAIChatHistoryPanelItem extends HostListenerMixin(
   private _overflowMenuBodyFlippedClass = `${prefix}--history-overflow-menu-body--flipped`;
   private _overflowMenuBodyFlippedSelector = `cds-overflow-menu-body.${this._overflowMenuBodyFlippedClass}`;
 
-  connectedCallback() {
-    super.connectedCallback();
-
-    const menuTriggerHeight = 32;
-    setVarsForSelector(this._overflowMenuBodyFlippedSelector, {
-      transform: `translateY(calc(-100% - ${menuTriggerHeight}px))`,
-    });
-  }
-
   disconnectedCallback() {
     this._overflowMenuBodyElement?.classList.remove(
       this._overflowMenuBodyFlippedClass,
@@ -142,6 +133,10 @@ class CDSAIChatHistoryPanelItem extends HostListenerMixin(
     this._adoptOverflowMenuBodyStyles(overflowMenuBody);
 
     const menuRect = this.overflowMenu.getBoundingClientRect();
+    const menuTriggerHeight = menuRect.height;
+    setVarsForSelector(this._overflowMenuBodyFlippedSelector, {
+      transform: `translateY(calc(-100% - ${menuTriggerHeight}px))`,
+    });
     const menuBodyRect = overflowMenuBody.getBoundingClientRect();
     const actualMenuHeight = menuBodyRect.height || this.actions.length * 40; // fallback
 


### PR DESCRIPTION
Closes #1358


https://github.com/user-attachments/assets/1446e7bd-b25f-4731-a738-11b5a103db7f

The PR fixes a regression with the chat history overflow menu positioning. When opening the chat history actions menu, there is logic to determine if there is enough space for the menu to open below the trigger element, if not styles are applied to the menu to open upwards. 

The `cds-overflow-menu-body` is rendered outside of the `history-panel-item` component so the style rule in the `chat-history.scss` file isn't applied to it as `cds-overflow-menu-body` is out of scope. Solution is to use the utilities from the `dynamic-css-var-sheet.ts` to add the necessary style rule to the shadowRoot of the overflow-menu-body.

#### Changelog

**New**

- add test case for the menu positioning logic

**Changed**

- use ` adoptOnRoot` and `setVarsForSelector` to set the css rule at the root of the overflow menu body

**Removed**

- css rule in `chat-history.scss`

#### Testing / Reviewing

- Go to demo and storybooks for React and WC
- check that when opening the chat history item overflow menu, the menu opens either upwards or downwards depending on space and all options are visible
