### PR TITLE
fix(markdown): merge the split tokens for markdown table cells

### DIFF
--- a/demo/src/customSendMessage/constants.ts
+++ b/demo/src/customSendMessage/constants.ts
@@ -1,5 +1,5 @@
 /*
- *  Copyright IBM Corp. 2025
+ *  Copyright IBM Corp. 2025, 2026
  *
  *  This source code is licensed under the Apache-2.0 license found in the
  *  LICENSE file in the root directory of this source tree.
@@ -10,21 +10,8 @@
 const TABLE = `
 | Element      | Symbol | Atomic Number | Group | Period | Atomic Mass (u) | Electron Config | Bonding | Melting Point (°C) | Boiling Point (°C) |
 |--------------|--------|---------------|-------|--------|-----------------|-----------------|---------|--------------------|--------------------|
-| [Carbon](https://www.ibm.com)      | C      | 6             | 14    | 2      | 12.011          | [He] 2s² 2p²    | Covalent| 3550               | 4027               |
-| Silicon      | Si     | 14            | 14    | 3      | 28.085          | [Ne] 3s² 3p²    | Covalent| 1414               | 3265               |
-| Germanium    | Ge     | 32            | 14    | 4      | 72.630          | [Ar] 3d¹⁰ 4s² 4p²| Covalent| 938                | 2833               |
-| Tin          | Sn     | 50            | 14    | 5      | 118.710         | [Kr] 4d¹⁰ 5s² 5p²| Metallic| 232                | 2602               |
-| Lead         | Pb     | 82            | 14    | 6      | 207.200         | [Xe] 4f¹⁴ 5d¹⁰ 6s² 6p²| Metallic| 327          | 1749               |
-| Flerovium    | Fl     | 114           | 14    | 7      | 289             | [Rn] 5f¹⁴ 6d¹⁰ 7s² 7p²| Unknown | Unknown      | Unknown            |
-| Hydrogen     | H      | 1             | 1     | 1      | 1.008           | 1s¹             | Covalent| -259               | -253               |
-| Helium       | He     | 2             | 18    | 1      | 4.003           | 1s²             | Noble   | -272               | -269               |
-| Lithium      | Li     | 3             | 1     | 2      | 6.940           | [He] 2s¹        | Metallic| 180                | 1342               |
-| Beryllium    | Be     | 4             | 2     | 2      | 9.012           | [He] 2s²        | Metallic| 1287               | 2468               |
-| Boron        | B      | 5             | 13    | 2      | 10.810          | [He] 2s² 2p¹    | Covalent| 2075               | 4000               |
-| Nitrogen     | N      | 7             | 15    | 2      | 14.007          | [He] 2s² 2p³    | Covalent| -210               | -196               |
-| Oxygen       | O      | 8             | 16    | 2      | 15.999          | [He] 2s² 2p⁴    | Covalent| -218               | -183               |
-| Fluorine     | F      | 9             | 17    | 2      | 18.998          | [He] 2s² 2p⁵    | Covalent| -220               | -188               |
-| Neon         | Ne     | 10            | 18    | 2      | 20.180          | [He] 2s² 2p⁶    | Noble   | -249               | -246               |`;
+| <a href="https://www.ibm.com">Carbon</a>     | C      | 6             | 14    | 2      | 12.011          | [He] 2s² 2p²    | Covalent| 3550               | 4027               |
+| [covalent bonds](https://ibm.com)      | Si     | 14            | 14    | 3      | 28.085          | [Ne] 3s² 3p²    | Covalent| 1414               | 3265               |`;
 
 const UNORDERED_LIST = `
 - Carbon allotropes
@@ -50,7 +37,7 @@ const ORDERED_LIST = `
 4. Metallic carbides
 `;
 
-const TEXT = `Carbon is a **chemical element** with the *atomic number* 6 and symbol **C**. \`C + O₂ → CO₂\` represents one of carbon's most fundamental reactions.
+const TEXT = `Carbon is a **chemical element** with <a href="https://www.ibm.com">Carbon</a> the *atomic number* 6</a> and symbol **C**. \`C + O₂ → CO₂\` represents one of carbon's most fundamental reactions.
 
 Carbon forms [covalent bonds](https://ibm.com) through electron sharing and creates [carbon chains](https://ibm.com){{target="_self"}} that are essential for organic molecules.
 `;

--- a/demo/src/customSendMessage/constants.ts
+++ b/demo/src/customSendMessage/constants.ts
@@ -10,8 +10,21 @@
 const TABLE = `
 | Element      | Symbol | Atomic Number | Group | Period | Atomic Mass (u) | Electron Config | Bonding | Melting Point (°C) | Boiling Point (°C) |
 |--------------|--------|---------------|-------|--------|-----------------|-----------------|---------|--------------------|--------------------|
-| <a href="https://www.ibm.com">Carbon</a>     | C      | 6             | 14    | 2      | 12.011          | [He] 2s² 2p²    | Covalent| 3550               | 4027               |
-| [covalent bonds](https://ibm.com)      | Si     | 14            | 14    | 3      | 28.085          | [Ne] 3s² 3p²    | Covalent| 1414               | 3265               |`;
+| [Carbon](https://www.ibm.com)      | C      | 6             | 14    | 2      | 12.011          | [He] 2s² 2p²    | Covalent| 3550               | 4027               |
+| <a href="https://www.ibm.com">Silicon</a>      | Si     | 14            | 14    | 3      | 28.085          | [Ne] 3s² 3p²    | Covalent| 1414               | 3265               |
+| Germanium    | Ge     | 32            | 14    | 4      | 72.630          | [Ar] 3d¹⁰ 4s² 4p²| Covalent| 938                | 2833               |
+| Tin          | Sn     | 50            | 14    | 5      | 118.710         | [Kr] 4d¹⁰ 5s² 5p²| Metallic| 232                | 2602               |
+| Lead         | Pb     | 82            | 14    | 6      | 207.200         | [Xe] 4f¹⁴ 5d¹⁰ 6s² 6p²| Metallic| 327          | 1749               |
+| Flerovium    | Fl     | 114           | 14    | 7      | 289             | [Rn] 5f¹⁴ 6d¹⁰ 7s² 7p²| Unknown | Unknown      | Unknown            |
+| Hydrogen     | H      | 1             | 1     | 1      | 1.008           | 1s¹             | Covalent| -259               | -253               |
+| Helium       | He     | 2             | 18    | 1      | 4.003           | 1s²             | Noble   | -272               | -269               |
+| Lithium      | Li     | 3             | 1     | 2      | 6.940           | [He] 2s¹        | Metallic| 180                | 1342               |
+| Beryllium    | Be     | 4             | 2     | 2      | 9.012           | [He] 2s²        | Metallic| 1287               | 2468               |
+| Boron        | B      | 5             | 13    | 2      | 10.810          | [He] 2s² 2p¹    | Covalent| 2075               | 4000               |
+| Nitrogen     | N      | 7             | 15    | 2      | 14.007          | [He] 2s² 2p³    | Covalent| -210               | -196               |
+| Oxygen       | O      | 8             | 16    | 2      | 15.999          | [He] 2s² 2p⁴    | Covalent| -218               | -183               |
+| Fluorine     | F      | 9             | 17    | 2      | 18.998          | [He] 2s² 2p⁵    | Covalent| -220               | -188               |
+| Neon         | Ne     | 10            | 18    | 2      | 20.180          | [He] 2s² 2p⁶    | Noble   | -249               | -246               |`;
 
 const UNORDERED_LIST = `
 - Carbon allotropes
@@ -37,7 +50,7 @@ const ORDERED_LIST = `
 4. Metallic carbides
 `;
 
-const TEXT = `Carbon is a **chemical element** with <a href="https://www.ibm.com">Carbon</a> the *atomic number* 6</a> and symbol **C**. \`C + O₂ → CO₂\` represents one of carbon's most fundamental reactions.
+const TEXT = `Carbon is a **chemical element** with the *atomic number* 6 and symbol **C**. \`C + O₂ → CO₂\` represents one of carbon's most fundamental reactions.
 
 Carbon forms [covalent bonds](https://ibm.com) through electron sharing and creates [carbon chains](https://ibm.com){{target="_self"}} that are essential for organic molecules.
 `;

--- a/packages/ai-chat-components/src/components/markdown/__tests__/markdown.test.ts
+++ b/packages/ai-chat-components/src/components/markdown/__tests__/markdown.test.ts
@@ -7,7 +7,7 @@
  *  @license
  */
 
-import { expect, fixture, html } from "@open-wc/testing";
+import { expect, fixture, html, waitUntil } from "@open-wc/testing";
 import CDSAIChatMarkdownElement from "../src/markdown.js";
 const MARKDOWN_ELEMENT_TAG = "cds-aichat-markdown";
 
@@ -196,13 +196,14 @@ describe("cds-aichat-markdown smoke test", () => {
     }
 
     await table.updateComplete;
+    await waitUntil(
+      () => !!table.shadowRoot?.querySelector('a[href="https://www.ibm.com"]'),
+      "Expected table link to render",
+    );
 
-    const tableShadow = table.shadowRoot;
-    if (!tableShadow) {
-      throw new Error("Expected table shadow root");
-    }
-
-    const link = tableShadow.querySelector('a[href="https://www.ibm.com"]');
+    const link = table.shadowRoot?.querySelector(
+      'a[href="https://www.ibm.com"]',
+    );
     expect(link).to.not.equal(null);
     expect(link?.textContent?.trim()).to.equal("Carbon");
   });

--- a/packages/ai-chat-components/src/components/markdown/__tests__/markdown.test.ts
+++ b/packages/ai-chat-components/src/components/markdown/__tests__/markdown.test.ts
@@ -1,5 +1,5 @@
 /*
- *  Copyright IBM Corp. 2025
+ *  Copyright IBM Corp. 2025, 2026
  *
  *  This source code is licensed under the Apache-2.0 license found in the
  *  LICENSE file in the root directory of this source tree.
@@ -172,6 +172,39 @@ describe("cds-aichat-markdown smoke test", () => {
     if (!link) {
       throw new Error(`Link did not get target="_self" applied`);
     }
+  });
+
+  it("keeps raw HTML anchor text inside the link in a table cell", async () => {
+    const markdown = `| Name |
+| ---- |
+| <a href="https://www.ibm.com">Carbon</a> |`;
+    const el = await fixture<MarkdownElementInstance>(
+      html`<cds-aichat-markdown .markdown=${markdown}></cds-aichat-markdown>`,
+    );
+
+    await el.updateComplete;
+
+    const root = el.shadowRoot;
+    if (!root) {
+      throw new Error("Expected shadow root to exist");
+    }
+
+    const table = root.querySelector("cds-aichat-table");
+    expect(table).to.not.equal(null);
+    if (!table) {
+      throw new Error("Expected cds-aichat-table");
+    }
+
+    await table.updateComplete;
+
+    const tableShadow = table.shadowRoot;
+    if (!tableShadow) {
+      throw new Error("Expected table shadow root");
+    }
+
+    const link = tableShadow.querySelector('a[href="https://www.ibm.com"]');
+    expect(link).to.not.equal(null);
+    expect(link?.textContent?.trim()).to.equal("Carbon");
   });
 
   describe("linkify functionality", () => {

--- a/packages/ai-chat-components/src/components/markdown/src/markdown-renderer.ts
+++ b/packages/ai-chat-components/src/components/markdown/src/markdown-renderer.ts
@@ -1,5 +1,5 @@
 /*
- *  Copyright IBM Corp. 2025
+ *  Copyright IBM Corp. 2025, 2026
  *
  *  This source code is licensed under the Apache-2.0 license found in the
  *  LICENSE file in the root directory of this source tree.
@@ -469,9 +469,12 @@ function renderWithStaticTag(
         isLoading = !hasNodesAfterTable;
       }
 
-      const renderCellTokens = (tokens: TokenTree[], contextOverrides = {}) =>
-        html`${repeat(
-          tokens,
+      const renderCellTokens = (tokens: TokenTree[], contextOverrides = {}) => {
+        // Same as block/inline rendering: merge split raw HTML (e.g. `<a>…</a>`)
+        // so each cell is not rendered as separate unsafeHTML + text chunks.
+        const normalizedTokens = combineConsecutiveHtmlInline(tokens);
+        return html`${repeat(
+          normalizedTokens,
           (child, index) =>
             `cell-${index}:${child.token.type}:${child.token.tag}`,
           (child, index) =>
@@ -480,11 +483,12 @@ function renderWithStaticTag(
               context: {
                 ...options.context,
                 ...contextOverrides,
-                parentChildren: tokens,
+                parentChildren: normalizedTokens,
                 currentIndex: index,
               },
             }),
         )}`;
+      };
 
       const createCellContent = (
         cell: TableCellData,

--- a/packages/ai-chat-components/src/components/markdown/src/utils/html-helpers.ts
+++ b/packages/ai-chat-components/src/components/markdown/src/utils/html-helpers.ts
@@ -173,8 +173,7 @@ export function combineConsecutiveHtmlInline(
     }
 
     if (!success) {
-      combinedChildren.push(startNode);
-      continue;
+      return combinedChildren;
     }
 
     if (stack.length === 0 && endIndex > index) {

--- a/packages/ai-chat-components/src/components/markdown/src/utils/html-helpers.ts
+++ b/packages/ai-chat-components/src/components/markdown/src/utils/html-helpers.ts
@@ -1,5 +1,5 @@
 /*
- *  Copyright IBM Corp. 2025
+ *  Copyright IBM Corp. 2025, 2026
  *
  *  This source code is licensed under the Apache-2.0 license found in the
  *  LICENSE file in the root directory of this source tree.
@@ -173,7 +173,8 @@ export function combineConsecutiveHtmlInline(
     }
 
     if (!success) {
-      return combinedChildren;
+      combinedChildren.push(startNode);
+      continue;
     }
 
     if (stack.length === 0 && endIndex > index) {


### PR DESCRIPTION
Closes #1361

Currently when using the anchor element inside a markdown table, it doesn't render the link correctly as the raw inline HTML gets split. The link text gets render outside of the anchor tags (ie. `<a href="www.ibm.com"></a>Carbon`)

<img width="300" alt="Image" src="https://github.com/user-attachments/assets/1c308318-70f5-4614-a4a9-113cd42e83c8" />

In `markdown-render.ts`, use `combineConsecutiveHtmlInline` which is used for regular markdown text already for the `renderCellTokens()` to merge the tokens together when rendering the markdown table cells so the link text stays inside the anchor tags. 

AFTER:
<img width="558" alt="Screenshot 2026-05-08 at 4 35 48 PM" src="https://github.com/user-attachments/assets/b9d6f1b4-b1fa-450d-bcdf-f3890d64b44c" />

#### Changelog

**New**

- add test case for markdown table cell rendering anchor element

**Changed**

- use `combineConsecutiveHtmlInline` in `renderCellTokens()`
- updated markdown table in demo app `constants.ts` file to render anchor element

#### Testing / Reviewing

type `table` in the demo deploy preview, see that the second row of the table (Silicon) renders correctly as an anchor link
