### PR TITLE
fix: minor visual bugs on cards stories and toolbar

### DIFF
--- a/packages/ai-chat-components/src/components/card/__stories__/preview-card-react.stories.jsx
+++ b/packages/ai-chat-components/src/components/card/__stories__/preview-card-react.stories.jsx
@@ -1,3 +1,12 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2025, 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 /* eslint-disable */
 import React, { useState, useEffect } from "react";
 import { ICON_INDICATOR_KIND } from "@carbon/web-components/es/components/icon-indicator/defs.js";
@@ -9,7 +18,7 @@ import {
   CardSteps as CardStepsWC,
 } from "./preview-card.stories";
 import { Card, CardFooter, CardSteps } from "../../../react/card";
-import { AILabel } from "@carbon/react";
+import { AILabel, AILabelContent } from "@carbon/react";
 import Toolbar from "../../../react/toolbar";
 import "./story-styles.scss";
 import { action } from "storybook/actions";
@@ -17,13 +26,15 @@ import { name } from "@carbon/icons/lib/caret--down";
 import { previewCardFooterPresets, toolbarActions } from "./story-data";
 
 const aiContent = (
-  <div slot="body-text" class="ai-label-body">
-    <h4>Powered by IBM watsonx</h4>
+  <AILabelContent>
     <div>
-      IBM watsonx is powered by the latest AI models to intelligently process
-      conversations and provide help whenever and wherever you may need it.
+      <h4>Powered by IBM watsonx</h4>
+      <div>
+        IBM watsonx is powered by the latest AI models to intelligently process
+        conversations and provide help whenever and wherever you may need it.
+      </div>
     </div>
-  </div>
+  </AILabelContent>
 );
 
 const Wrapper = ({ width, children }) => {
@@ -67,14 +78,16 @@ export const Small = {
         />
       </div>
       {args.aiLabel && (
-        <AILabel
-          size="mini"
-          autoalign
-          alignment="bottom-right"
-          slot="decorator"
-        >
-          {aiContent}
-        </AILabel>
+        <div slot="decorator">
+          <AILabel
+            size="mini"
+            autoalign
+            alignment="bottom-right"
+            slot="decorator"
+          >
+            {aiContent}
+          </AILabel>
+        </div>
       )}
     </Card>
   ),
@@ -115,14 +128,11 @@ export const Default = {
       )}
 
       {args.aiLabel && (
-        <AILabel
-          size="mini"
-          autoalign
-          alignment="bottom-right"
-          slot="decorator"
-        >
-          {aiContent}
-        </AILabel>
+        <div slot="decorator">
+          <AILabel size="mini" autoalign alignment="bottom-right">
+            {aiContent}
+          </AILabel>
+        </div>
       )}
     </Card>
   ),
@@ -151,9 +161,11 @@ export const WithToolbar = {
           </div>
 
           {args.aiLabel && (
-            <AILabel size="2xs" autoalign alignment="bottom" slot="decorator">
-              {aiContent}
-            </AILabel>
+            <div slot="decorator">
+              <AILabel size="2xs" autoalign alignment="bottom">
+                {aiContent}
+              </AILabel>
+            </div>
           )}
         </Toolbar>
       </div>
@@ -258,7 +270,7 @@ export const WithSteps = {
 
     return (
       <Card isLayered={args.isLayered} isFlush={args.isFlush}>
-        <div slot="header" className="preview-card preview-card-toolbar">
+        <div slot="header" className="preview-card">
           <Toolbar className="preview-card-toolbar">
             <div slot="title">
               <div className="title-container">
@@ -268,14 +280,11 @@ export const WithSteps = {
             </div>
 
             {args.aiLabel && (
-              <AILabel
-                size="mini"
-                autoalign
-                alignment="bottom"
-                slot="decorator"
-              >
-                {aiContent}
-              </AILabel>
+              <div slot="decorator">
+                <AILabel size="mini" autoalign alignment="bottom">
+                  {aiContent}
+                </AILabel>
+              </div>
             )}
           </Toolbar>
         </div>

--- a/packages/ai-chat-components/src/components/card/__stories__/preview-card-react.stories.jsx
+++ b/packages/ai-chat-components/src/components/card/__stories__/preview-card-react.stories.jsx
@@ -28,7 +28,8 @@ import { previewCardFooterPresets, toolbarActions } from "./story-data";
 const aiContent = (
   <AILabelContent>
     <div>
-      <h4>Powered by IBM watsonx</h4>
+      <div>Powered by IBM watsonx</div>
+      <br />
       <div>
         IBM watsonx is powered by the latest AI models to intelligently process
         conversations and provide help whenever and wherever you may need it.

--- a/packages/ai-chat-components/src/components/card/__stories__/preview-card-react.stories.jsx
+++ b/packages/ai-chat-components/src/components/card/__stories__/preview-card-react.stories.jsx
@@ -80,12 +80,7 @@ export const Small = {
       </div>
       {args.aiLabel && (
         <div slot="decorator">
-          <AILabel
-            size="mini"
-            autoalign
-            alignment="bottom-right"
-            slot="decorator"
-          >
+          <AILabel size="mini" autoalign alignment="bottom-right">
             {aiContent}
           </AILabel>
         </div>

--- a/packages/ai-chat-components/src/components/card/__stories__/preview-card.stories.js
+++ b/packages/ai-chat-components/src/components/card/__stories__/preview-card.stories.js
@@ -1,7 +1,7 @@
 /**
  * @license
  *
- * Copyright IBM Corp. 2025
+ * Copyright IBM Corp. 2025, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -188,7 +188,7 @@ export const WithToolbar = {
           ?is-layered=${args.isLayered}
           ?is-flush=${args.isFlush}
         >
-          <div slot="header" class="preview-card preview-card-toolbar">
+          <div slot="header" class="preview-card">
             <cds-aichat-toolbar
               class="preview-card-toolbar"
               overflow
@@ -324,7 +324,7 @@ export const WithSteps = {
           ?is-layered=${args.isLayered}
           ?is-flush=${args.isFlush}
         >
-          <div slot="header" class="preview-card preview-card-toolbar">
+          <div slot="header" class="preview-card">
             <cds-aichat-toolbar class="preview-card-toolbar">
               <div slot="title">
                 <div class="title-container">

--- a/packages/ai-chat-components/src/components/card/__stories__/preview-card.stories.js
+++ b/packages/ai-chat-components/src/components/card/__stories__/preview-card.stories.js
@@ -23,7 +23,8 @@ import { previewCardFooterPresets, toolbarActions } from "./story-data";
 
 const aiContent = html`
   <div slot="body-text" class="ai-label-body">
-    <h4>Powered by IBM watsonx</h4>
+    <div>Powered by IBM watsonx</div>
+    <br />
     <div>
       IBM watsonx is powered by the latest AI models to intelligently process
       conversations and provide help whenever and wherever you may need it.

--- a/packages/ai-chat-components/src/components/card/__stories__/story-styles.scss
+++ b/packages/ai-chat-components/src/components/card/__stories__/story-styles.scss
@@ -1,5 +1,5 @@
 /*
- *  Copyright IBM Corp. 2025
+ *  Copyright IBM Corp. 2025, 2026
  *
  *  This source code is licensed under the Apache-2.0 license found in the
  *  LICENSE file in the root directory of this source tree.
@@ -85,10 +85,6 @@
 
   .preview-card-toolbar {
     border-block-end: to-rem(1px) solid theme.$chat-bubble-border;
-  }
-
-  .ai-label-body h4 {
-    margin-block-end: layout.$spacing-05;
   }
 
   .title-container {

--- a/packages/ai-chat-components/src/components/toolbar/__stories__/toolbar-react.stories.jsx
+++ b/packages/ai-chat-components/src/components/toolbar/__stories__/toolbar-react.stories.jsx
@@ -1,3 +1,12 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2025, 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 /* eslint-disable */
 import React from "react";
 import Toolbar from "../../../react/toolbar";
@@ -48,8 +57,9 @@ export default {
       options: ["home", "back", "custom 1", "custom 2", "none"],
       mapping: {
         home: (
-          <div slot="navigation" data-rounded="top-left">
+          <div slot="navigation">
             <IconButton
+              data-rounded="top-left"
               size="md"
               kind="ghost"
               align="bottom-start"
@@ -63,8 +73,9 @@ export default {
           </div>
         ),
         back: (
-          <div slot="navigation" data-rounded="top-left">
+          <div slot="navigation">
             <IconButton
+              data-rounded="top-left"
               size="md"
               kind="ghost"
               align="bottom-start"

--- a/packages/ai-chat-components/src/components/toolbar/src/toolbar.scss
+++ b/packages/ai-chat-components/src/components/toolbar/src/toolbar.scss
@@ -1,5 +1,5 @@
 /*
- *  Copyright IBM Corp. 2025
+ *  Copyright IBM Corp. 2025, 2026
  *
  *  This source code is licensed under the Apache-2.0 license found in the
  *  LICENSE file in the root directory of this source tree.
@@ -28,7 +28,6 @@ $block-class: #{$prefix}-toolbar;
 
   .#{$block-class} {
     display: flex;
-    align-items: center;
     block-size: 100%;
     inline-size: 100%;
     max-inline-size: 100%;

--- a/packages/ai-chat-components/src/components/toolbar/src/toolbar.ts
+++ b/packages/ai-chat-components/src/components/toolbar/src/toolbar.ts
@@ -1,5 +1,5 @@
 /*
- *  Copyright IBM Corp. 2025
+ *  Copyright IBM Corp. 2025, 2026
  *
  *  This source code is licensed under the Apache-2.0 license found in the
  *  LICENSE file in the root directory of this source tree.
@@ -332,7 +332,7 @@ class CDSAIChatToolbar extends LitElement {
           </div>
         </div>
 
-        <div data-fixed class="${blockClass}__end">
+        <div data-fixed class="${blockClass}__end" data-rounded="top-right">
           <div data-fixed class="${blockClass}__fixed-actions">
             <slot name="fixed-actions"></slot>
           </div>


### PR DESCRIPTION
Closes N/A

Story updates

Fixes AILabel not rendering in react stories, previously WC ai-label is re-exported with Lit-React wrapper as AILabel. which used to accept `slot="decorator"`. now that the re-exports are removed. the React AILabel is wrapped in div with `slot="decorator"`

Fixes duplicate classname adding additional border in preview card stories

This PR also fixes toolbar styles for rounded border radius on corners. which should also be fixed in the app.

#### Changelog

**Changed**

- added data-rounded="top-right" to the right element of toolbar
- story fixes after all the re-exports of lit-react wrappers are removed

#### Testing / Reviewing

all card stories and toolbar stories should be looking good, with all operational controls.
the toolbar component border radius changes must be reflecting in the app.
