### PR TITLE
fix: workspaceshell subtitle heading

### DIFF
--- a/packages/ai-chat-components/src/components/workspace-shell/src/workspace-shell-header.ts
+++ b/packages/ai-chat-components/src/components/workspace-shell/src/workspace-shell-header.ts
@@ -1,5 +1,5 @@
 /*
- *  Copyright IBM Corp. 2025
+ *  Copyright IBM Corp. 2025, 2026
  *
  *  This source code is licensed under the Apache-2.0 license found in the
  *  LICENSE file in the root directory of this source tree.
@@ -96,9 +96,9 @@ class CDSAIChatWorkspaceShellHeader extends LitElement {
     const headerContent = html`
       ${subTitleText &&
       html`
-        <h3 class="${prefix}-workspace-shell__header-sub-title">
+        <h2 class="${prefix}-workspace-shell__header-sub-title">
           ${subTitleText}
-        </h3>
+        </h2>
       `}
       <slot name="header-description"></slot>
       <slot name="header-action"></slot>


### PR DESCRIPTION
Closes #1364 

resolves accessibility issue where workspaceshell has incorrect heading order

#### Changelog

**Changed**

- workspaceshell header subtitle now h2 up from h3

#### Testing / Reviewing

accessibility checker passed
