### PR TITLE
chore: chromatic web components storybook set up

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,12 +153,7 @@ jobs:
           buildScriptName: storybook:build
           zip: true # Runs Chromatic with the option to compress the build output
           autoAcceptChanges: 'main' # Option to accept all changes on main
-          # TODO: set up TurboSnap via onlyChanged w/ externals
-          # https://www.chromatic.com/docs/github-actions/#enable-turbosnap
-          # onlyChanged: true # 👈 Required option to enable TurboSnap
-          # externals: |
-          #   packages/(colors|elements|feature-flags|grid|icons|icons-react|layout|motion|pictograms|pictograms-react|styles|themes|type|utilities|utilities-react)/**
-          #   *.sass
+          onlyChanged: true # 👈 Required option to enable TurboSnap
         env:
           # 👇 Set to the PR branch if it's a PR; otherwise, falls back to the pushed branch name
           CHROMATIC_BRANCH:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,9 @@
 name: ci-check
 on:
   push:
-    branches: [ main, release/v*, feat/integrate-chat-history ]
+    branches: [ main, release/v* ]
   pull_request:
-    branches: [ main, release/v*, feat/integrate-chat-history ]
+    branches: [ main, release/v* ]
   merge_group:
     types: [checks_requested]
 
@@ -105,3 +105,65 @@ jobs:
         run: npm ci --prefer-offline
       - name: Validate agents files
         run: npm run validate:agents
+
+  chromatic-wc-storybook:
+    if:
+      ${{ github.repository == 'carbon-design-system/carbon-ai-chat' &&
+      github.event.pull_request.draft == false }}
+    runs-on: ubuntu-latest
+    outputs:
+      buildUrl: ${{ steps.chromatic.outputs.buildUrl }}
+      storybookUrl: ${{ steps.chromatic.outputs.storybookUrl }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+          # 👇 Tells the checkout which commit hash to reference
+          # https://www.chromatic.com/docs/github-actions/#recommended-configuration-for-build-events
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Use Node.js version from .nvmrc
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version-file: '.nvmrc'
+          cache: "npm"
+      - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        if: github.event_name != 'merge_group'
+        id: cache
+        with:
+          path: |
+            node_modules
+            */**/node_modules
+          key:
+            ${{ runner.os }}-npm-${{ hashFiles('package-lock.json',
+            'packages/**/package-lock.json') }}
+      - name: Install dependencies
+        run: npm ci --prefer-offline
+      - name: Build project
+        run: npm run build
+      - name: Build storybook
+        run: npm run storybook:build --workspace=@carbon/ai-chat-components
+      - id: chromatic
+        name: Run Chromatic
+        uses: chromaui/action@3378c92d26c32353e53166beac732e2edc14213c # v13.0.0
+        with:
+          # 👇 Token is intentionally plaintext
+          # https://www.chromatic.com/docs/github-actions/#run-chromatic-on-external-forks-of-open-source-projects
+          projectToken: chpt_bdf649378875471
+          workingDir: packages/ai-chat-components
+          buildScriptName: storybook:build
+          zip: true # Runs Chromatic with the option to compress the build output
+          autoAcceptChanges: 'main' # Option to accept all changes on main
+          # TODO: set up TurboSnap via onlyChanged w/ externals
+          # https://www.chromatic.com/docs/github-actions/#enable-turbosnap
+          # onlyChanged: true # 👈 Required option to enable TurboSnap
+          # externals: |
+          #   packages/(colors|elements|feature-flags|grid|icons|icons-react|layout|motion|pictograms|pictograms-react|styles|themes|type|utilities|utilities-react)/**
+          #   *.sass
+        env:
+          # 👇 Set to the PR branch if it's a PR; otherwise, falls back to the pushed branch name
+          CHROMATIC_BRANCH:
+            ${{ github.event.pull_request.head.ref || github.ref_name }}
+          # 👇 Set to the PR head commit if it's a PR; otherwise to the ref (which typically resolves to the latest commit SHA)
+          CHROMATIC_SHA: ${{ github.event.pull_request.head.sha || github.ref }}
+          # 👇 Makes sure this is always set to the corect owner/repo
+          CHROMATIC_SLUG: ${{ github.repository }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,8 +138,8 @@ jobs:
             'packages/**/package-lock.json') }}
       - name: Install dependencies
         run: npm ci --prefer-offline
-      - name: Build project
-        run: npm run build
+      - name: Build @carbon/ai-chat-components package
+        run: npm run build --workspace=@carbon/ai-chat-components
       - name: Build storybook
         run: npm run storybook:build --workspace=@carbon/ai-chat-components
       - id: chromatic

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "@types/react": "^19.2.2",
         "@types/react-dom": "^19.2.1",
         "babel-preset-carbon": "^0.8.0",
+        "chromatic": "^16.10.0",
         "commander": "^14.0.0",
         "concurrently": "^9.2.0",
         "cross-env": "^10.0.0",
@@ -20066,6 +20067,50 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/chromatic": {
+      "version": "16.10.0",
+      "resolved": "https://registry.npmjs.org/chromatic/-/chromatic-16.10.0.tgz",
+      "integrity": "sha512-nFsztmnu7rFiGafUJgXvLUNpqmRylz92eNvzBoJNTKKQj4EQUyxznwnfpf1dTs7hXtWD8JwcH92jADydaHA1sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "bin": {
+        "chroma": "dist/bin.cjs",
+        "chromatic": "dist/bin.cjs",
+        "chromatic-cli": "dist/bin.cjs"
+      },
+      "peerDependencies": {
+        "@chromatic-com/cypress": "^0.*.* || ^1.0.0",
+        "@chromatic-com/playwright": "^0.*.* || ^1.0.0",
+        "@chromatic-com/vitest": "^0.*.* || ^1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@chromatic-com/cypress": {
+          "optional": true
+        },
+        "@chromatic-com/playwright": {
+          "optional": true
+        },
+        "@chromatic-com/vitest": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/chromatic/node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/chrome-launcher": {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "@types/react": "^19.2.2",
     "@types/react-dom": "^19.2.1",
     "babel-preset-carbon": "^0.8.0",
+    "chromatic": "^16.10.0",
     "commander": "^14.0.0",
     "concurrently": "^9.2.0",
     "cross-env": "^10.0.0",


### PR DESCRIPTION
Contributes to #1233

Set up chromatic for our `@carbon/ai-chat-components` Web Components storybook in our ci workflow

#### Changelog

**New**

- add chromatic step to our ci workflow

**Removed**

- remove `feat/integrate-chat-history` branch from the trigger branch list as it's no longer needed

#### Testing / Reviewing

The `ci-check / chromatic-wc-storybook (pull_request)` check should pass
