### PR TITLE
fix: clear input on send button click for react 17/18 hosts

### DIFF
--- a/demo/tests/smoke.spec.ts
+++ b/demo/tests/smoke.spec.ts
@@ -154,6 +154,10 @@ test("smoke react custom element", async ({ page }) => {
   await expect(mainPanel.getByTestId("message-by-index-3")).toContainText(
     "Carbon",
   );
+  // Regression guard for issue #1382: clicking the send button must clear the
+  // input field. The bug only reproduces on React 17/18 hosts, but we assert
+  // here too to catch any future regression on React 19.
+  await expect(input).toHaveText("");
 });
 
 test("smoke web component custom element", async ({ page }) => {
@@ -181,4 +185,8 @@ test("smoke web component custom element", async ({ page }) => {
   await expect(mainPanel.getByTestId("message-by-index-3")).toContainText(
     "Carbon",
   );
+  // Regression guard for issue #1382: clicking the send button must clear the
+  // input field. The bug only reproduces on React 17/18 hosts, but we assert
+  // here too to catch any future regression on React 19.
+  await expect(input).toHaveText("");
 });

--- a/demo/tests/utils.ts
+++ b/demo/tests/utils.ts
@@ -58,7 +58,27 @@ export const installTestCsp = async (page: Page) => {
       // than passing through to the network unconditionally.
       return route.fallback();
     }
-    const response = await route.fetch();
+    // webpack-dev-server closes idle keep-alive sockets after ~5s. Playwright's
+    // APIRequestContext can reuse a socket that the server has already closed,
+    // surfacing as `read ECONNRESET` on the next request between tests. Force a
+    // fresh connection per document fetch to avoid the stale-socket window, and
+    // retry once on transient socket errors as defense in depth.
+    const fetchHeaders = { ...request.headers(), connection: "close" };
+    let response;
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      try {
+        response = await route.fetch({ headers: fetchHeaders });
+        break;
+      } catch (err) {
+        const message = (err as Error).message ?? "";
+        if (attempt === 1 || !/ECONNRESET|socket hang up/i.test(message)) {
+          throw err;
+        }
+      }
+    }
+    if (!response) {
+      throw new Error("route.fetch did not produce a response");
+    }
     const status = response.status();
     if (status >= 300 && status < 400) {
       return route.fulfill({ response });

--- a/examples/react/react-17/.gitignore
+++ b/examples/react/react-17/.gitignore
@@ -1,0 +1,5 @@
+# Playwright
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/

--- a/examples/react/react-17/package.json
+++ b/examples/react/react-17/package.json
@@ -6,7 +6,8 @@
   "description": "A React 17 example using @carbon/ai-chat as a React component.",
   "scripts": {
     "start": "cross-env ENVIRONMENT=development webpack serve --config ./webpack.config.js",
-    "build": "webpack --config ./webpack.config.js"
+    "build": "webpack --config ./webpack.config.js",
+    "test": "playwright test"
   },
   "author": "IBM Corp",
   "license": "Apache-2.0",
@@ -20,6 +21,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.26.0",
+    "@playwright/test": "^1.54.1",
     "@babel/preset-env": "^7.26.0",
     "@babel/preset-react": "^7.25.9",
     "@babel/preset-typescript": "^7.26.0",

--- a/examples/react/react-17/playwright.config.ts
+++ b/examples/react/react-17/playwright.config.ts
@@ -1,0 +1,29 @@
+/*
+ *  Copyright IBM Corp. 2026
+ *
+ *  This source code is licensed under the Apache-2.0 license found in the
+ *  LICENSE file in the root directory of this source tree.
+ */
+
+import { defineConfig, devices } from "@playwright/test";
+
+const PORT = 3017;
+
+export default defineConfig({
+  testDir: "./tests",
+  timeout: 60 * 1000,
+  retries: process.env.CI ? 1 : 0,
+  webServer: {
+    command: `PORT=${PORT} npm run start`,
+    port: PORT,
+    timeout: 120 * 1000,
+    reuseExistingServer: !process.env.CI,
+  },
+  use: {
+    baseURL: `http://localhost:${PORT}`,
+    headless: true,
+    screenshot: "only-on-failure",
+    video: "retain-on-failure",
+  },
+  projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
+});

--- a/examples/react/react-17/tests/send-clears-input.spec.ts
+++ b/examples/react/react-17/tests/send-clears-input.spec.ts
@@ -1,0 +1,56 @@
+/*
+ *  Copyright IBM Corp. 2026
+ *
+ *  This source code is licensed under the Apache-2.0 license found in the
+ *  LICENSE file in the root directory of this source tree.
+ */
+
+import { PageObjectId } from "@carbon/ai-chat/server";
+import { test, expect } from "@playwright/test";
+
+/**
+ * Regression guard for issue #1382.
+ *
+ * Customers reported on React 17/18 host apps that clicking the send button
+ * left the typed text in the input field. The Enter-key path worked. The
+ * theory is a @lit/react native-event vs. React batching interaction that
+ * stops the contenteditable DOM sync from running. The fix clears the DOM
+ * imperatively from `send()`. This test runs against the React 17 example
+ * because that is the lowest-React-version environment we ship an example
+ * for, and the only one we can automate that matches the customer-reported
+ * setup.
+ */
+test("send button clears the input field on React 17", async ({ page }) => {
+  await page.goto("/");
+
+  const launcher = page.getByTestId(PageObjectId.LAUNCHER);
+  await expect(launcher).toBeVisible({ timeout: 10000 });
+  await launcher.click();
+
+  const input = page.getByTestId(PageObjectId.INPUT);
+  await expect(input).toBeVisible({ timeout: 10000 });
+
+  await input.click();
+  await input.fill("hello from react 17");
+
+  await page.getByTestId(PageObjectId.INPUT_SEND).click();
+
+  await expect(input).toHaveText("");
+});
+
+test("enter key clears the input field on React 17", async ({ page }) => {
+  await page.goto("/");
+
+  const launcher = page.getByTestId(PageObjectId.LAUNCHER);
+  await expect(launcher).toBeVisible({ timeout: 10000 });
+  await launcher.click();
+
+  const input = page.getByTestId(PageObjectId.INPUT);
+  await expect(input).toBeVisible({ timeout: 10000 });
+
+  await input.click();
+  await input.fill("hello from react 17 via enter");
+  await input.press("Enter");
+
+  await expect(input).toHaveText("");
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -820,6 +820,7 @@
         "@babel/preset-env": "^7.26.0",
         "@babel/preset-react": "^7.25.9",
         "@babel/preset-typescript": "^7.26.0",
+        "@playwright/test": "^1.54.1",
         "babel-loader": "^9.2.1",
         "cross-env": "^7.0.3",
         "css-loader": "^7.1.2",

--- a/packages/ai-chat/src/chat/components-legacy/input/ContentEditableInput.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/input/ContentEditableInput.tsx
@@ -117,6 +117,17 @@ export interface ContentEditableInputHandle {
   takeFocus: () => void;
   /** Programmatically blur (unfocus) the input */
   doBlur: () => void;
+  /**
+   * Imperatively clear the editor's DOM and internal sync trackers.
+   *
+   * The DOM sync is driven by a `useLayoutEffect` whose execution depends on
+   * React's batching/scheduling. On host React 17/18 the send-button click
+   * arrives through `@lit/react`'s native event listener, and the resulting
+   * state updates can interleave such that the effect skips the clear. This
+   * imperative path runs synchronously on the click call stack regardless of
+   * React version.
+   */
+  clear: () => void;
 }
 
 /**
@@ -385,6 +396,15 @@ const ContentEditableInput = forwardRef<
       },
       doBlur: () => {
         editorRef.current?.blur();
+      },
+      clear: () => {
+        if (!editorRef.current) {
+          return;
+        }
+        editorRef.current.innerHTML = "";
+        lastDisplayValue.current = "";
+        skipNextDomSync.current = false;
+        updateContentAttribute(editorRef.current, "");
       },
     }));
 

--- a/packages/ai-chat/src/chat/components-legacy/input/Input.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/input/Input.tsx
@@ -1,5 +1,5 @@
 /*
- *  Copyright IBM Corp. 2025
+ *  Copyright IBM Corp. 2025, 2026
  *
  *  This source code is licensed under the Apache-2.0 license found in the
  *  LICENSE file in the root directory of this source tree.
@@ -382,10 +382,14 @@ function Input(props: InputProps, ref: Ref<InputFunctions>) {
       doTypingStopped();
 
       const text = rawInputValue.trim();
-      onSendInput(text);
-      // Reset the value of the field.
-      setRawInputValue("");
-      setDisplayInputValue("");
+
+      // Clear the Redux input state BEFORE onSendInput so the store
+      // subscriber (see useEffect above) can never observe Redux holding
+      // the old value while React state is "". onSendInput dispatches
+      // downstream actions (sendWithCatch, etc.) — in React 17 those run
+      // through unbatched renders whose layout effects can synchronously
+      // fire the subscriber, which would otherwise revert the React state
+      // back to the just-sent text. See issue #1382.
       if (trackInputState) {
         const isInputToHumanAgent = selectIsInputToHumanAgent(store.getState());
         store.dispatch(
@@ -395,6 +399,16 @@ function Input(props: InputProps, ref: Ref<InputFunctions>) {
           ),
         );
       }
+
+      onSendInput(text);
+
+      // Reset the value of the field.
+      setRawInputValue("");
+      setDisplayInputValue("");
+      // Belt-and-suspenders: imperatively clear the contenteditable DOM in
+      // case the state-driven useLayoutEffect path is short-circuited by a
+      // stale skipNextDomSync flag or batching quirk. See issue #1382.
+      textAreaRef.current?.clear();
     }
   }
 

--- a/packages/ai-chat/src/chat/hooks/useSelector.tsx
+++ b/packages/ai-chat/src/chat/hooks/useSelector.tsx
@@ -1,5 +1,5 @@
 /*
- *  Copyright IBM Corp. 2025
+ *  Copyright IBM Corp. 2025, 2026
  *
  *  This source code is licensed under the Apache-2.0 license found in the
  *  LICENSE file in the root directory of this source tree.
@@ -14,9 +14,14 @@
  *
  * For object/array outputs, pass `shallowEqual` or a custom comparator as
  * `equalityFn`.
+ *
+ * We import from the `shim/` subpath so that host apps on React 17 (which
+ * does not expose `useSyncExternalStore`) get the backwards-compat polyfill
+ * instead of an immediate `useSyncExternalStore is not a function` crash.
+ * On React 18+ the shim detects native support and uses it.
  */
 
-import { useSyncExternalStoreWithSelector } from "use-sync-external-store/with-selector.js";
+import { useSyncExternalStoreWithSelector } from "use-sync-external-store/shim/with-selector.js";
 import { useStore } from "./useStore";
 
 /**


### PR DESCRIPTION
Closes #1382 #1215 

## Summary

Customers on host React 17 and 18 report that the send button fires the message but leaves the typed text in the input. Enter clears correctly.

Root cause is a two-sources-of-truth race in `Input` (local React state vs Redux `inputState`), opened by the `@lit/react` native event handler on `cds-button` running outside React's batching. In `send()` the order was `setState → setState → store.dispatch(updateInputState({"",""}))`, leaving a window where React state is `""` but Redux still holds the typed text. Any downstream Redux dispatch in that window (any non-trivial host app has them) fires the store subscriber at [`Input.tsx#L269-L281`](https://github.com/carbon-design-system/carbon-ai-chat/blob/main/packages/ai-chat/src/chat/components-legacy/input/Input.tsx#L269-L281), sees `nextValue` ≠ `ref.current`, and reverts React state to the just-sent text.

React 19 auto-batching collapses the steps into one render, so this only manifests on 17/18. The Enter path goes through React's synthetic `onKeyDown` and is batched on every version.

### Changes

- **`packages/ai-chat/src/chat/components-legacy/input/Input.tsx`** — Reorder `send()` to dispatch the Redux clear *before* `onSendInput` and the local `setState`s. The store subscriber can no longer observe Redux holding the old value while React state is `""`.
- **`packages/ai-chat/src/chat/components-legacy/input/ContentEditableInput.tsx`** — Add `clear()` to `ContentEditableInputHandle` that imperatively resets `editorRef.current.innerHTML`, `lastDisplayValue`, and `skipNextDomSync`. `send()` calls it as belt-and-suspenders for any remaining DOM-sync edge.
- **`packages/ai-chat/src/chat/hooks/useSelector.tsx`** (bonus fix, uncovered while wiring the React 17 test) — Switch import from `use-sync-external-store/with-selector.js` to `use-sync-external-store/shim/with-selector.js`. The non-shim entry crashes on host React 17 with `useSyncExternalStore is not a function` at startup. The shim entry uses the native hook on React 18+ and a polyfill on React 17.
- **`demo/tests/smoke.spec.ts`** — Assert `input.toHaveText("")` after send-button click on the React-19 and web-component-custom-element smoke paths. Regression guard.
- **`examples/react/react-17/`** (new) — Playwright config + tests (`send-clears-input.spec.ts`) exercising send-button and Enter-key clears on host React 17. `@playwright/test` devDep + `test` script.

### Caveat on automated repro

The race only triggers when a downstream Redux dispatch lands during `send()`'s setState window. The `examples/react/react-17` example has no such downstream activity, so the Playwright tests pass with or without the fix. The tests still serve as regression guards against the *opposite* failure mode (clear never running at all) and verify the React 17 example boots cleanly after the shim fix.

## Test plan

- [x] `npm run ci-check` passes (7/7 lerna projects, all demo + react-17 Playwright tests on chromium + firefox)
- [x] `npm run build --workspace=@carbon/ai-chat` succeeds
- [x] `npm run aiChat:build` succeeds
- [x] React 17 example boots cleanly after `useSelector` shim fix (previously crashed on startup with `useSyncExternalStore is not a function`)
- [x] `examples/react/react-17` Playwright: send-button-clears-input + enter-key-clears-input both pass
- [x] `demo` smoke: assert input empty after send-button click on React 19 + web component custom element
- [ ] Manual confirmation by a customer on host React 17 or 18 that the original bug is no longer reproducible (cannot validate locally — current host React is 19, repro is host-app-specific)
