### PR TITLE
fix(markdown): apply margin to only non-nested list items in ol

### DIFF
--- a/packages/ai-chat-components/src/components/markdown/src/markdown.scss
+++ b/packages/ai-chat-components/src/components/markdown/src/markdown.scss
@@ -227,7 +227,7 @@
   ul ol,
   ol ul {
     margin-block-start: layout.$spacing-03;
-    margin-inline-start: layout.$spacing-03;
+    margin-inline-start: layout.$spacing-07;
   }
 
   // Nested unordered lists use square bullets

--- a/packages/ai-chat-components/src/components/markdown/src/markdown.scss
+++ b/packages/ai-chat-components/src/components/markdown/src/markdown.scss
@@ -1,5 +1,5 @@
 /*
- *  Copyright IBM Corp. 2025
+ *  Copyright IBM Corp. 2025, 2026
  *
  *  This source code is licensed under the Apache-2.0 license found in the
  *  LICENSE file in the root directory of this source tree.
@@ -227,7 +227,7 @@
   ul ol,
   ol ul {
     margin-block-start: layout.$spacing-03;
-    margin-inline-start: layout.$spacing-07;
+    margin-inline-start: layout.$spacing-03;
   }
 
   // Nested unordered lists use square bullets
@@ -254,8 +254,8 @@
     --#{$prefix}-border-radius-end-end: 0;
   }
 
-  cds-ordered-list:not([nested]) cds-list-item {
-    margin-inline-start: layout.$spacing-06;
+  cds-ordered-list cds-list-item:not([nested]) {
+    margin-inline-start: layout.$spacing-05;
   }
 
   cds-aichat-code-snippet {


### PR DESCRIPTION
Closes #1281

`cds-ordered-list:not([nested]) cds-list-item` selector was still adding margin to nested list-items, increasing the indent spacing. Replace with more specific `cds-ordered-list cds-list-item:not([nested])` instead.

BEFORE:
<img width="300"  alt="Screenshot 2026-05-13 at 4 42 42 PM" src="https://github.com/user-attachments/assets/27eeea25-99e9-4757-9548-6a2a0248cd1c" />

AFTER:
<img width="300"  alt="Screenshot 2026-05-13 at 4 42 05 PM" src="https://github.com/user-attachments/assets/6dc7b3f8-999a-42ce-8f9e-3032bf3f29c5" />

#### Changelog

**Changed**

- fix selector so margin is applied to only non-nested list items
- make the margin smaller to align with the avatar line better

#### Testing / Reviewing

You can test locally by replacing in `constants.ts` of the demo app and running demo locally

```
const ORDERED_LIST = `
1. Carbon bonding types
  a. Single bonds (sp³)
  b. Double bonds (sp²)
2. Triple bonds (sp)
3. Aromatic bonding
4. Metallic carbides
`;
```

with 
```
const ORDERED_LIST = `
1. **Carbon is the sixth element on the periodic table with atomic number 6.**\n   - **Confidence**: HIGH\n   - **Reasoning**: Derived from the standard periodic table classification of non-metallic elements.\n   - **Recommendation**: Reference carbon's atomic number when performing chemical bonding and valence electron calculations.\n\n2. **Carbon has four valence electrons, making it capable of forming up to four covalent bonds.**\n   - **Confidence**: HIGH\n   - **Reasoning**: Based on carbon's electron configuration of 2, 4 placing it in Group 14 of the periodic table.\n   - **Recommendation**: Leverage carbon's tetravalency when designing organic molecular structures and polymer chains.\n`;
```
