### PR TITLE
fix(markdown): apply margin to only non-nested list items in ol 

### DIFF
--- a/packages/ai-chat-components/src/components/markdown/src/markdown.scss
+++ b/packages/ai-chat-components/src/components/markdown/src/markdown.scss
@@ -1,5 +1,5 @@
 /*
- *  Copyright IBM Corp. 2025
+ *  Copyright IBM Corp. 2025, 2026
  *
  *  This source code is licensed under the Apache-2.0 license found in the
  *  LICENSE file in the root directory of this source tree.
@@ -254,8 +254,8 @@
     --#{$prefix}-border-radius-end-end: 0;
   }
 
-  cds-ordered-list:not([nested]) cds-list-item {
-    margin-inline-start: layout.$spacing-06;
+  cds-ordered-list cds-list-item:not([nested]) {
+    margin-inline-start: layout.$spacing-05;
   }
 
   cds-aichat-code-snippet {


### PR DESCRIPTION
cherry-picks fix(markdown): apply margin to only non-nested list items in ol (#1387) to release branch