### PR TITLE
chore: chromatic audio player snapshots + chromatic set up for React wrapper storybook

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,3 +162,61 @@ jobs:
           CHROMATIC_SHA: ${{ github.event.pull_request.head.sha || github.ref }}
           # 👇 Makes sure this is always set to the corect owner/repo
           CHROMATIC_SLUG: ${{ github.repository }}
+
+
+  chromatic-react-wrapper-storybook:
+    if:
+      ${{ github.repository == 'carbon-design-system/carbon-ai-chat' &&
+      github.event.pull_request.draft == false }}
+    runs-on: ubuntu-latest
+    outputs:
+      buildUrl: ${{ steps.chromatic.outputs.buildUrl }}
+      storybookUrl: ${{ steps.chromatic.outputs.storybookUrl }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          # 👇 Tells the checkout which commit hash to reference
+          # https://www.chromatic.com/docs/github-actions/#recommended-configuration-for-build-events
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Use Node.js version from .nvmrc
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: '.nvmrc'
+          cache: "npm"
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        if: github.event_name != 'merge_group'
+        id: cache
+        with:
+          path: |
+            node_modules
+            */**/node_modules
+          key:
+            ${{ runner.os }}-npm-${{ hashFiles('package-lock.json',
+            'packages/**/package-lock.json') }}
+      - name: Install dependencies
+        run: npm ci --prefer-offline
+      - name: Build @carbon/ai-chat-components package
+        run: npm run build --workspace=@carbon/ai-chat-components
+      - name: Build storybook
+        run: npm run storybook:build --workspace=@carbon/ai-chat-components
+      - id: chromatic
+        name: Run Chromatic
+        uses: chromaui/action@e3eb8ec36101d8f0253c7c3ae66e5a2b4e2197ba # v16.10.0
+        with:
+          # 👇 Token is intentionally plaintext
+          # https://www.chromatic.com/docs/github-actions/#run-chromatic-on-external-forks-of-open-source-projects
+          projectToken: chpt_b20070be5bf15ee
+          workingDir: packages/ai-chat-components
+          buildScriptName: storybook:react:build
+          zip: true # Runs Chromatic with the option to compress the build output
+          autoAcceptChanges: 'main' # Option to accept all changes on main
+          onlyChanged: true # 👈 Required option to enable TurboSnap
+        env:
+          # 👇 Set to the PR branch if it's a PR; otherwise, falls back to the pushed branch name
+          CHROMATIC_BRANCH:
+            ${{ github.event.pull_request.head.ref || github.ref_name }}
+          # 👇 Set to the PR head commit if it's a PR; otherwise to the ref (which typically resolves to the latest commit SHA)
+          CHROMATIC_SHA: ${{ github.event.pull_request.head.sha || github.ref }}
+          # 👇 Makes sure this is always set to the corect owner/repo
+          CHROMATIC_SLUG: ${{ github.repository }}

--- a/packages/ai-chat-components/src/components/audio-player/__stories__/audio-player-react.stories.jsx
+++ b/packages/ai-chat-components/src/components/audio-player/__stories__/audio-player-react.stories.jsx
@@ -11,6 +11,7 @@ import React from "react";
 import AudioPlayer from "../../../react/audio-player";
 import { Transcript } from "../../../react/transcript";
 import Card from "../../../react/card";
+import { waitForAudioReadyForSnapshot } from "./audio-player-story-helpers.js";
 import "./audio-player-react.stories.css";
 
 export default {
@@ -226,6 +227,9 @@ export const WithTranscript = {
         </div>
       </Card>
     );
+  },
+  play: async ({ canvasElement }) => {
+    await waitForAudioReadyForSnapshot(canvasElement);
   },
 };
 

--- a/packages/ai-chat-components/src/components/audio-player/__stories__/audio-player-story-helpers.js
+++ b/packages/ai-chat-components/src/components/audio-player/__stories__/audio-player-story-helpers.js
@@ -1,0 +1,35 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const wait = (timeoutMs) =>
+  new Promise((resolve) => {
+    setTimeout(resolve, timeoutMs);
+  });
+
+// Audio can finish drawing at slightly different times, so we pause before
+// taking snapshots to keep results more consistent.
+const SNAPSHOT_AUDIO_WAIT_MS = 3000;
+const SNAPSHOT_FINAL_SETTLE_MS = 500;
+
+export const waitForAudioReadyForSnapshot = async (canvasElement) => {
+  const audioPlayer = canvasElement.querySelector("cds-aichat-audio-player");
+
+  if (!audioPlayer) {
+    return;
+  }
+
+  await audioPlayer.updateComplete;
+  // We use a fixed wait here because "ready" can happen before the bar looks
+  // fully loaded.
+  await wait(SNAPSHOT_AUDIO_WAIT_MS);
+
+  await new Promise((resolve) => requestAnimationFrame(resolve));
+  await new Promise((resolve) => requestAnimationFrame(resolve));
+  await wait(SNAPSHOT_FINAL_SETTLE_MS);
+};

--- a/packages/ai-chat-components/src/components/audio-player/__stories__/audio-player.stories.js
+++ b/packages/ai-chat-components/src/components/audio-player/__stories__/audio-player.stories.js
@@ -10,6 +10,7 @@
 import "../index";
 import "../../card/index.js";
 import { html } from "lit";
+import { waitForAudioReadyForSnapshot } from "./audio-player-story-helpers.js";
 
 export default {
   title: "Preview/Audio player",
@@ -235,6 +236,9 @@ export const WithTranscript = {
         </div>
       </cds-aichat-card>
     `;
+  },
+  play: async ({ canvasElement }) => {
+    await waitForAudioReadyForSnapshot(canvasElement);
   },
 };
 

--- a/packages/ai-chat-components/src/components/audio-player/__stories__/transcript-react.stories.jsx
+++ b/packages/ai-chat-components/src/components/audio-player/__stories__/transcript-react.stories.jsx
@@ -11,6 +11,7 @@ import React from "react";
 import { Transcript } from "../../../react/transcript";
 import { AudioPlayer } from "../../../react/audio-player";
 import { Card } from "../../../react/card";
+import { waitForAudioReadyForSnapshot } from "./audio-player-story-helpers.js";
 import "./transcript-react.stories.css";
 
 export default {
@@ -112,6 +113,9 @@ export const WithAudioPlayer = {
         </div>
       </Card>
     );
+  },
+  play: async ({ canvasElement }) => {
+    await waitForAudioReadyForSnapshot(canvasElement);
   },
 };
 

--- a/packages/ai-chat-components/src/components/audio-player/__stories__/transcript.stories.js
+++ b/packages/ai-chat-components/src/components/audio-player/__stories__/transcript.stories.js
@@ -9,6 +9,7 @@
 
 import "../index";
 import { html } from "lit";
+import { waitForAudioReadyForSnapshot } from "./audio-player-story-helpers.js";
 
 export default {
   title: "Preview/Audio player/Transcript",
@@ -122,6 +123,9 @@ export const WithAudioPlayer = {
         </div>
       </cds-aichat-card>
     `;
+  },
+  play: async ({ canvasElement }) => {
+    await waitForAudioReadyForSnapshot(canvasElement);
   },
 };
 


### PR DESCRIPTION
Contributes to #1233

The audio player chromatic snapshots tests were unstable as we're fetching from an external mp3 source which causes the load bar in the audio player to render differently depending on the network timing. This PR adds a wait to allow for the mp3 to fully load in the audio player before taking a snapshot.

<img width="2786" height="412" alt="Screenshot 2026-05-14 at 1 22 45 PM" src="https://github.com/user-attachments/assets/d93f9cb9-0bd4-443f-b78e-5bca338a1642" />

Add chromatic testing for our React wrapper `@carbon/ai-chat-components` storybook as well.

#### Changelog

**New**

- `audio-player-story-helpers.js` to add wait for the audio player stories that are unstable
- chromatic step for react wrapper storybook in `ci.yml`

#### Testing / Reviewing

ci checks should pass