### PR TITLE
feat: add onViewChange, onViewPreChange, renderCustomMessageFooter

### DIFF
--- a/packages/ai-chat/docs/React.md
+++ b/packages/ai-chat/docs/React.md
@@ -63,6 +63,8 @@ This component requires a `className` prop that defines the size and positioning
 
 If you don't want these behaviors, you can also listen for {@link BusEventType.VIEW_PRE_CHANGE} and {@link BusEventType.VIEW_CHANGE} events directly. These events fire in sequence (PRE_CHANGE -> view state update -> CHANGE), and both are awaited, making async handlers ideal for animations. See the event type documentation for complete details on timing and usage. Just be aware that the {@link ChatCustomElementProps.onViewChange} default behavior will still run if you don't replace that function with your own.
 
+{@link ChatContainerProps.onViewChange} and {@link ChatContainerProps.onViewPreChange} are also available on {@link ChatContainer} as opt-in observation hooks — useful for analytics or mirroring the chat's open state into your own UI. The float container has no wrapping element to size, so there is no default visibility behavior on the container: the callbacks simply fire when provided.
+
 See {@link ChatCustomElementProps} for an explanation of the various accepted props.
 
 ```javascript

--- a/packages/ai-chat/docs/WebComponent.md
+++ b/packages/ai-chat/docs/WebComponent.md
@@ -78,6 +78,8 @@ If you don't want these behaviors, then provide your own `onViewChange` prop to 
 
 Just be aware that the `onViewChange` default behavior will still run if you don't replace that function with your own.
 
+`onViewChange` and `onViewPreChange` are also available on `cds-aichat-container` as opt-in observation hooks — useful for analytics or mirroring the chat's open state into your own UI. Because the float container has no wrapping element to size, there is no default visibility behavior on the container: the callbacks simply fire when provided.
+
 See {@link CdsAiChatCustomElementAttributes} for an explanation of the various accepted properties and attributes.
 
 ```typescript
@@ -426,11 +428,11 @@ export class MyApp extends LitElement {
 
 ### Custom Message Footer
 
-This component allows you to insert a `custom_footer_slot` in chatbot messages. The Carbon AI Chat throws a {@link BusEventType.CUSTOM_FOOTER_SLOT} event when it receives a message from your custom backend with `custom_footer_slot` configured. The event contains an `additional_data` object where you can pass in custom data needed to render the footer.
+This component is capable of managing custom message footers — extra content rendered beneath an assistant message. The recommended approach is to use the `renderCustomMessageFooter` callback property, which handles all event listening, slot tracking, and element lifecycle for you.
 
-Then, you dynamically generate the custom slot content and pass it to the correct message footer slot inside the Carbon AI Chat.
+The Carbon AI Chat fires a {@link BusEventType.CUSTOM_FOOTER_SLOT} event when it receives a message from your custom backend with `custom_footer_slot` configured. The event carries an `additional_data` object where you can pass in custom data needed to render the footer.
 
-Refer to the following example.
+The examples below share a `custom-footer-example` component for the footer UI:
 
 ```typescript
 import { GenericItem } from "@carbon/ai-chat";
@@ -510,6 +512,69 @@ class CustomFooterExample extends LitElement {
 
 export default CustomFooterExample;
 ```
+
+#### Using the `renderCustomMessageFooter` callback
+
+Provide a callback that receives the accumulated state for a custom footer slot and returns an `HTMLElement` (or `null`). The library subscribes to the footer event, tracks each slot, and manages the rendered elements for you.
+
+```typescript
+import "@carbon/ai-chat/dist/es/web-components/cds-aichat-container/index.js";
+
+import {
+  type ChatInstance,
+  type PublicConfig,
+  type RenderCustomMessageFooterState,
+} from "@carbon/ai-chat";
+import { html, LitElement } from "lit";
+import { customElement, state } from "lit/decorators.js";
+
+// The side-effect import registers the <custom-footer-example> custom element;
+// the `import type` only supplies the class for typing the created element.
+import "./custom-footer-example";
+import type CustomFooterExample from "./custom-footer-example";
+import { customSendMessage } from "./customSendMessage";
+
+const config: PublicConfig = {
+  messaging: {
+    customSendMessage,
+  },
+};
+
+@customElement("my-app")
+export class Demo extends LitElement {
+  @state()
+  accessor instance!: ChatInstance;
+
+  onBeforeRender = (instance: ChatInstance) => {
+    this.instance = instance;
+  };
+
+  renderCustomMessageFooterCallback = (
+    state: RenderCustomMessageFooterState,
+    instance: ChatInstance,
+  ): HTMLElement | null => {
+    const footer = document.createElement("custom-footer-example");
+    (footer as CustomFooterExample).messageItem = state.messageItem;
+    (footer as CustomFooterExample).additionalData = state.additionalData;
+    return footer;
+  };
+
+  render() {
+    return html`
+      <h1>Welcome!</h1>
+      <cds-aichat-container
+        .onBeforeRender=${this.onBeforeRender}
+        .messaging=${config.messaging}
+        .renderCustomMessageFooter=${this.renderCustomMessageFooterCallback}
+      ></cds-aichat-container>
+    `;
+  }
+}
+```
+
+#### Legacy: Manual event handling
+
+If you need fine-grained control over event handling and slot management, you can subscribe to the {@link BusEventType.CUSTOM_FOOTER_SLOT} event directly, maintain your own slot map, and render slotted content manually.
 
 ```typescript
 import "@carbon/ai-chat/dist/es/web-components/cds-aichat-container/index.js";

--- a/packages/ai-chat/src/aiChatEntry.tsx
+++ b/packages/ai-chat/src/aiChatEntry.tsx
@@ -278,9 +278,11 @@ export { CdsAiChatCustomElementAttributes } from "./web-components/cds-aichat-cu
 
 export {
   RenderCustomMessageFooter,
+  RenderCustomMessageFooterState,
   RenderUserDefinedResponse,
   RenderUserDefinedState,
   RenderWriteableElementResponse,
+  WCRenderCustomMessageFooter,
   WCRenderUserDefinedResponse,
 } from "./types/component/ChatContainer";
 

--- a/packages/ai-chat/src/chat/components/CustomFooterPortalsContainer.tsx
+++ b/packages/ai-chat/src/chat/components/CustomFooterPortalsContainer.tsx
@@ -11,38 +11,18 @@ import React, { ReactNode, useRef, useEffect } from "react";
 import ReactDOM from "react-dom";
 
 import { ChatInstance } from "../../types/instance/ChatInstance";
-import { RenderCustomMessageFooter } from "../../types/component/ChatContainer";
-import { MessageResponse, GenericItem } from "../../types/messaging/Messages";
+import {
+  RenderCustomMessageFooter,
+  RenderCustomMessageFooterState,
+} from "../../types/component/ChatContainer";
 
 /**
  * Internal state object used by CustomFooterPortalsContainer to track each custom footer slot.
+ *
+ * Structurally identical to the public {@link RenderCustomMessageFooterState}; aliased here so the
+ * type has a single source of truth while keeping the name `ChatAppEntry` imports.
  */
-interface CustomFooterSlotState {
-  /**
-   * The unique identifier for this footer slot (e.g., "footer-msg-123").
-   * Used as the key in the customFooterSlotsByName record and passed to renderCustomMessageFooter.
-   */
-  slotName: string;
-
-  /**
-   * The complete assistant response message that contains the messageItem.
-   * Passed to renderCustomMessageFooter as the second parameter.
-   */
-  message: MessageResponse;
-
-  /**
-   * The specific message item (text, card, etc.) that has the custom footer.
-   * Passed to renderCustomMessageFooter as the third parameter.
-   */
-  messageItem: GenericItem;
-
-  /**
-   * Optional custom data from message_item_options.custom_footer_slot.additional_data.
-   * Can contain any application-specific data needed to render the footer.
-   * Passed to renderCustomMessageFooter as the fifth parameter.
-   */
-  additionalData?: Record<string, unknown>;
-}
+type CustomFooterSlotState = RenderCustomMessageFooterState;
 
 interface CustomFooterPortalsContainerProps {
   /**

--- a/packages/ai-chat/src/react/ChatContainer.tsx
+++ b/packages/ai-chat/src/react/ChatContainer.tsx
@@ -23,6 +23,7 @@ import ChatAppEntry from "../chat/ChatAppEntry";
 import { carbonElement } from "@carbon/ai-chat-components/es/globals/decorators/index.js";
 import { ChatContainerProps } from "../types/component/ChatContainer";
 import { ChatInstance } from "../types/instance/ChatInstance";
+import { BusEventType } from "../types/events/eventBusTypes";
 import { PublicConfig } from "../types/config/PublicConfig";
 import { isBrowser } from "../chat/utils/browserUtils";
 
@@ -78,6 +79,8 @@ function ChatContainer(
   const {
     onBeforeRender,
     onAfterRender,
+    onViewChange,
+    onViewPreChange,
     strings,
     serviceDeskFactory,
     serviceDesk,
@@ -268,10 +271,27 @@ function ChatContainer(
         };
 
         addWriteableElementSlots();
+
+        // Opt-in view-change observation hooks. The float container manages
+        // its own visibility, so there is no default handler — a prop is only
+        // subscribed when the consumer provides it.
+        if (onViewPreChange) {
+          instance.on({
+            type: BusEventType.VIEW_PRE_CHANGE,
+            handler: onViewPreChange,
+          });
+        }
+        if (onViewChange) {
+          instance.on({
+            type: BusEventType.VIEW_CHANGE,
+            handler: onViewChange,
+          });
+        }
+
         onBeforeRender?.(instance);
       }
     },
-    [onBeforeRender],
+    [onBeforeRender, onViewChange, onViewPreChange],
   );
 
   // If we are in SSR mode, just short circuit here. This prevents all of our window.* and document.* stuff from trying

--- a/packages/ai-chat/src/serverEntry.ts
+++ b/packages/ai-chat/src/serverEntry.ts
@@ -267,6 +267,7 @@ export {
 
 export {
   RenderCustomMessageFooter,
+  RenderCustomMessageFooterState,
   RenderUserDefinedResponse,
   RenderUserDefinedState,
   RenderWriteableElementResponse,

--- a/packages/ai-chat/src/types/component/ChatContainer.ts
+++ b/packages/ai-chat/src/types/component/ChatContainer.ts
@@ -12,6 +12,10 @@ import { type ChatInstance, WriteableElements } from "../instance/ChatInstance";
 import { GenericItem, Message, MessageResponse } from "../messaging/Messages";
 import { PublicConfig } from "../config/PublicConfig";
 import { DeepPartial } from "../utilities/DeepPartial";
+import {
+  BusEventViewChange,
+  BusEventViewPreChange,
+} from "../events/eventBusTypes";
 
 /**
  * The user_defined message object passed into the renderUserDefinedResponse property on the main chat components.
@@ -95,6 +99,45 @@ type WCRenderUserDefinedResponse = (
 ) => HTMLElement | null;
 
 /**
+ * The accumulated state for one custom message footer slot, passed to the
+ * web component {@link WCRenderCustomMessageFooter} callback.
+ *
+ * @category Web component
+ */
+interface RenderCustomMessageFooterState {
+  /** The unique identifier for this footer slot. */
+  slotName: string;
+
+  /** The assistant response object that contains the messageItem. */
+  message: MessageResponse;
+
+  /** The message item that the footer is attached to. */
+  messageItem: GenericItem;
+
+  /** Optional application data supplied with the footer slot. */
+  additionalData?: Record<string, unknown>;
+}
+
+/**
+ * The render function used to render a custom message footer in web
+ * components. When provided, the library manages all event listening, slot
+ * tracking, and element lifecycle. The callback receives the accumulated state
+ * and should return an HTMLElement to display, or null to render nothing.
+ *
+ * This is the web component analogue of {@link RenderCustomMessageFooter} and
+ * mirrors the contract of {@link WCRenderUserDefinedResponse}.
+ *
+ * @param state The accumulated state for this custom footer slot.
+ * @param instance The current instance of Carbon AI Chat.
+ *
+ * @category Web component
+ */
+type WCRenderCustomMessageFooter = (
+  state: RenderCustomMessageFooterState,
+  instance: ChatInstance,
+) => HTMLElement | null;
+
+/**
  * A map of writeable element keys to a ReactNode to render to them.
  *
  * @category React
@@ -128,6 +171,28 @@ interface ChatContainerProps extends PublicConfig {
   onAfterRender?: (instance: ChatInstance) => Promise<void> | void;
 
   /**
+   * Called before a view change (the chat opening or closing). Async — return a
+   * Promise to defer the view change until it resolves.
+   *
+   * This is an opt-in observation hook. Unlike {@link ChatCustomElementProps},
+   * the container has no wrapping element to size, so no default visibility
+   * behavior runs when this prop is omitted.
+   */
+  onViewPreChange?: (
+    event: BusEventViewPreChange,
+    instance: ChatInstance,
+  ) => Promise<void> | void;
+
+  /**
+   * Called when a view change (the chat opening or closing) is complete.
+   *
+   * This is an opt-in observation hook. Unlike {@link ChatCustomElementProps},
+   * the container has no wrapping element to size, so no default visibility
+   * behavior runs when this prop is omitted.
+   */
+  onViewChange?: (event: BusEventViewChange, instance: ChatInstance) => void;
+
+  /**
    * This is the function that this component will call when a custom footer should be rendered.
    */
   renderCustomMessageFooter?: RenderCustomMessageFooter;
@@ -152,8 +217,10 @@ interface ChatContainerProps extends PublicConfig {
 export {
   ChatContainerProps,
   RenderCustomMessageFooter,
+  RenderCustomMessageFooterState,
   RenderUserDefinedResponse,
   RenderWriteableElementResponse,
   RenderUserDefinedState,
+  WCRenderCustomMessageFooter,
   WCRenderUserDefinedResponse,
 };

--- a/packages/ai-chat/src/web-components/cds-aichat-container/index.ts
+++ b/packages/ai-chat/src/web-components/cds-aichat-container/index.ts
@@ -1,5 +1,5 @@
 /*
- *  Copyright IBM Corp. 2025
+ *  Copyright IBM Corp. 2025, 2026
  *
  *  This source code is licensed under the Apache-2.0 license found in the
  *  LICENSE file in the root directory of this source tree.
@@ -44,9 +44,13 @@ import {
   BusEventCustomFooterSlot,
   BusEventType,
   BusEventUserDefinedResponse,
+  BusEventViewChange,
+  BusEventViewPreChange,
 } from "../../types/events/eventBusTypes";
 import type {
+  RenderCustomMessageFooterState,
   RenderUserDefinedState,
+  WCRenderCustomMessageFooter,
   WCRenderUserDefinedResponse,
 } from "../../types/component/ChatContainer";
 
@@ -195,6 +199,27 @@ class ChatContainer extends LitElement {
   onAfterRender: (instance: ChatInstance) => Promise<void> | void;
 
   /**
+   * Called before a view change (the chat opening or closing). Async — return a
+   * Promise to defer the view change until it resolves.
+   *
+   * This is an opt-in observation hook. Unlike `cds-aichat-custom-element`, the
+   * container has no wrapping element to size, so no default visibility
+   * behavior runs when this property is omitted.
+   */
+  @property()
+  onViewPreChange?: (event: BusEventViewPreChange) => Promise<void> | void;
+
+  /**
+   * Called when a view change (the chat opening or closing) is complete.
+   *
+   * This is an opt-in observation hook. Unlike `cds-aichat-custom-element`, the
+   * container has no wrapping element to size, so no default visibility
+   * behavior runs when this property is omitted.
+   */
+  @property()
+  onViewChange?: (event: BusEventViewChange, instance: ChatInstance) => void;
+
+  /**
    * Optional callback to render user defined responses. When provided, the library manages all event listening,
    * slot tracking, streaming state, and element lifecycle. The callback receives the accumulated state and should
    * return an HTMLElement or null.
@@ -203,6 +228,16 @@ class ChatContainer extends LitElement {
    */
   @property({ attribute: false })
   renderUserDefinedResponse?: WCRenderUserDefinedResponse;
+
+  /**
+   * Optional callback to render custom message footers. When provided, the library manages all event listening,
+   * slot tracking, and element lifecycle. The callback receives the accumulated state and should
+   * return an HTMLElement or null.
+   *
+   * When this property is not set, the existing event + manual slot approach continues to work.
+   */
+  @property({ attribute: false })
+  renderCustomMessageFooter?: WCRenderCustomMessageFooter;
 
   /**
    * The existing array of slot names for all user_defined components.
@@ -235,9 +270,20 @@ class ChatContainer extends LitElement {
   _userDefinedStateBySlot: Record<string, RenderUserDefinedState> = {};
 
   /**
+   * Accumulated state per slot for custom message footers when renderCustomMessageFooter is provided.
+   */
+  @state()
+  _customFooterStateBySlot: Record<string, RenderCustomMessageFooterState> = {};
+
+  /**
    * Tracks the wrapper elements created by the callback rendering path.
    */
   private _callbackElements = new Map<string, HTMLElement>();
+
+  /**
+   * Tracks the wrapper elements created by the custom-footer callback rendering path.
+   */
+  private _callbackFooterElements = new Map<string, HTMLElement>();
 
   /**
    * Adds the slot attribute to the element for the user_defined response type and then injects it into the component by
@@ -263,6 +309,26 @@ class ChatContainer extends LitElement {
     if (!this._customFooterSlotNames.includes(slotName)) {
       this._customFooterSlotNames = [...this._customFooterSlotNames, slotName];
     }
+  };
+
+  /**
+   * Enhanced handler for CUSTOM_FOOTER_SLOT when the renderCustomMessageFooter callback is provided.
+   * Tracks both slot names and the full per-slot state used by the callback rendering path.
+   */
+  private enhancedCustomFooterHandler = (event: BusEventCustomFooterSlot) => {
+    const { slotName, message, messageItem, additionalData } = event.data;
+    if (!this._customFooterSlotNames.includes(slotName)) {
+      this._customFooterSlotNames = [...this._customFooterSlotNames, slotName];
+    }
+    this._customFooterStateBySlot = {
+      ...this._customFooterStateBySlot,
+      [slotName]: {
+        slotName,
+        message,
+        messageItem,
+        additionalData: additionalData as Record<string, unknown> | undefined,
+      },
+    };
   };
 
   /**
@@ -313,8 +379,11 @@ class ChatContainer extends LitElement {
   };
 
   /**
-   * Handles RESTART_CONVERSATION when renderUserDefinedResponse callback is provided.
-   * Clears all accumulated state and removes callback-rendered elements from the DOM.
+   * Handles RESTART_CONVERSATION when the renderUserDefinedResponse and/or renderCustomMessageFooter
+   * callback is provided. Clears all accumulated state and removes callback-rendered elements from the DOM.
+   *
+   * The custom-footer cleanup is guarded by renderCustomMessageFooter so the legacy footer passthrough
+   * path (which the host clears itself) is left untouched.
    */
   private restartHandler = () => {
     this._userDefinedStateBySlot = {};
@@ -323,6 +392,15 @@ class ChatContainer extends LitElement {
       el.remove();
     }
     this._callbackElements.clear();
+
+    if (this.renderCustomMessageFooter) {
+      this._customFooterStateBySlot = {};
+      this._customFooterSlotNames = [];
+      for (const el of this._callbackFooterElements.values()) {
+        el.remove();
+      }
+      this._callbackFooterElements.clear();
+    }
   };
 
   /**
@@ -361,6 +439,47 @@ class ChatContainer extends LitElement {
       if (!(slot in this._userDefinedStateBySlot)) {
         el.remove();
         this._callbackElements.delete(slot);
+      }
+    }
+  }
+
+  /**
+   * Synchronizes custom-footer callback-rendered elements in the light DOM based on current state.
+   * Called from render() when renderCustomMessageFooter is provided. Direct analogue of
+   * syncCallbackRenderedElements().
+   */
+  private syncCallbackRenderedFooterElements() {
+    for (const [slotName, slotState] of Object.entries(
+      this._customFooterStateBySlot,
+    )) {
+      const newContent =
+        this.renderCustomMessageFooter?.(slotState, this._instance) ?? null;
+
+      if (!newContent) {
+        const existing = this._callbackFooterElements.get(slotName);
+        if (existing) {
+          existing.remove();
+          this._callbackFooterElements.delete(slotName);
+        }
+        continue;
+      }
+
+      let wrapper = this._callbackFooterElements.get(slotName);
+      if (!wrapper) {
+        wrapper = document.createElement("div");
+        wrapper.setAttribute("slot", slotName);
+        this._callbackFooterElements.set(slotName, wrapper);
+        this.appendChild(wrapper);
+      }
+
+      wrapper.replaceChildren(newContent);
+    }
+
+    // Clean up wrappers for slots that no longer exist in state
+    for (const [slotName, el] of this._callbackFooterElements.entries()) {
+      if (!(slotName in this._customFooterStateBySlot)) {
+        el.remove();
+        this._callbackFooterElements.delete(slotName);
       }
     }
   }
@@ -457,6 +576,22 @@ class ChatContainer extends LitElement {
   onBeforeRenderOverride = async (instance: ChatInstance) => {
     this._instance = instance;
 
+    // Opt-in view-change observation hooks. The float container manages its own
+    // visibility, so there is no default handler — a prop is only subscribed
+    // when the consumer provides it.
+    if (this.onViewPreChange) {
+      this._instance.on({
+        type: BusEventType.VIEW_PRE_CHANGE,
+        handler: this.onViewPreChange,
+      });
+    }
+    if (this.onViewChange) {
+      this._instance.on({
+        type: BusEventType.VIEW_CHANGE,
+        handler: this.onViewChange,
+      });
+    }
+
     if (this.renderUserDefinedResponse) {
       // Enhanced path: library manages full state for callback rendering
       this._instance.on({
@@ -466,10 +601,6 @@ class ChatContainer extends LitElement {
       this._instance.on({
         type: BusEventType.CHUNK_USER_DEFINED_RESPONSE,
         handler: this.enhancedUserDefinedChunkHandler,
-      });
-      this._instance.on({
-        type: BusEventType.RESTART_CONVERSATION,
-        handler: this.restartHandler,
       });
     } else {
       // Legacy path: container only tracks slot names
@@ -483,10 +614,25 @@ class ChatContainer extends LitElement {
       });
     }
 
+    // Enhanced path manages full per-slot state for callback rendering; the
+    // legacy path only tracks slot names for manual slotting.
     this._instance.on({
       type: BusEventType.CUSTOM_FOOTER_SLOT,
-      handler: this.customFooterHandler,
+      handler: this.renderCustomMessageFooter
+        ? this.enhancedCustomFooterHandler
+        : this.customFooterHandler,
     });
+
+    // A single RESTART_CONVERSATION subscription clears whichever callback
+    // paths are active. Registered once so the handler does not fire twice
+    // when both callbacks are provided.
+    if (this.renderUserDefinedResponse || this.renderCustomMessageFooter) {
+      this._instance.on({
+        type: BusEventType.RESTART_CONVERSATION,
+        handler: this.restartHandler,
+      });
+    }
+
     this.addWriteableElementSlots();
     this.attachWriteableElements();
     await this.onBeforeRender?.(instance);
@@ -528,6 +674,9 @@ class ChatContainer extends LitElement {
     if (this.renderUserDefinedResponse) {
       this.syncCallbackRenderedElements();
     }
+    if (this.renderCustomMessageFooter) {
+      this.syncCallbackRenderedFooterElements();
+    }
 
     return html`<cds-aichat-internal
       .config=${this.resolvedConfig}
@@ -541,9 +690,13 @@ class ChatContainer extends LitElement {
       ${this._userDefinedSlotNames.map(
         (slot) => html`<slot name=${slot} slot=${slot}></slot>`,
       )}
-      ${this._customFooterSlotNames.map(
-        (slot) => html`<div slot=${slot}><slot name=${slot}></slot></div>`,
-      )}
+      ${this.renderCustomMessageFooter
+        ? this._customFooterSlotNames.map(
+            (slot) => html`<slot name=${slot} slot=${slot}></slot>`,
+          )
+        : this._customFooterSlotNames.map(
+            (slot) => html`<div slot=${slot}><slot name=${slot}></slot></div>`,
+          )}
     </cds-aichat-internal>`;
   }
 }
@@ -574,10 +727,28 @@ interface CdsAiChatContainerAttributes extends PublicConfig {
   onAfterRender?: (instance: ChatInstance) => Promise<void> | void;
 
   /**
+   * Called before a view change (the chat opening or closing). Async — return a Promise to defer the view
+   * change until it resolves. This is an opt-in observation hook with no default visibility behavior.
+   */
+  onViewPreChange?: (event: BusEventViewPreChange) => Promise<void> | void;
+
+  /**
+   * Called when a view change (the chat opening or closing) is complete. This is an opt-in observation hook
+   * with no default visibility behavior.
+   */
+  onViewChange?: (event: BusEventViewChange, instance: ChatInstance) => void;
+
+  /**
    * Optional callback to render user defined responses. When provided, the library manages all event listening,
    * slot tracking, streaming state, and element lifecycle.
    */
   renderUserDefinedResponse?: WCRenderUserDefinedResponse;
+
+  /**
+   * Optional callback to render custom message footers. When provided, the library manages all event listening,
+   * slot tracking, and element lifecycle. When omitted, the legacy event + manual slot approach continues to work.
+   */
+  renderCustomMessageFooter?: WCRenderCustomMessageFooter;
 }
 
 export { CdsAiChatContainerAttributes };

--- a/packages/ai-chat/src/web-components/cds-aichat-custom-element/index.ts
+++ b/packages/ai-chat/src/web-components/cds-aichat-custom-element/index.ts
@@ -1,5 +1,5 @@
 /*
- *  Copyright IBM Corp. 2025
+ *  Copyright IBM Corp. 2025, 2026
  *
  *  This source code is licensed under the Apache-2.0 license found in the
  *  LICENSE file in the root directory of this source tree.
@@ -48,7 +48,10 @@ import {
   BusEventViewChange,
   BusEventViewPreChange,
 } from "../../types/events/eventBusTypes";
-import type { WCRenderUserDefinedResponse } from "../../types/component/ChatContainer";
+import type {
+  WCRenderCustomMessageFooter,
+  WCRenderUserDefinedResponse,
+} from "../../types/component/ChatContainer";
 
 /**
  * cds-aichat-custom-element will is a pass through to cds-aichat-container. It takes any user_defined and writeable element
@@ -270,6 +273,13 @@ class ChatCustomElement extends LitElement {
   @property({ attribute: false })
   renderUserDefinedResponse?: WCRenderUserDefinedResponse;
 
+  /**
+   * Optional callback to render custom message footers. When provided, the inner cds-aichat-container
+   * manages all event listening, slot tracking, and element lifecycle.
+   */
+  @property({ attribute: false })
+  renderCustomMessageFooter?: WCRenderCustomMessageFooter;
+
   @state()
   private _userDefinedSlotNames: string[] = [];
 
@@ -421,10 +431,14 @@ class ChatCustomElement extends LitElement {
       });
     }
 
-    this._instance.on({
-      type: BusEventType.CUSTOM_FOOTER_SLOT,
-      handler: this.customFooterHandler,
-    });
+    if (!this.renderCustomMessageFooter) {
+      // Legacy path: custom-element tracks slot names for manual slotting.
+      // When renderCustomMessageFooter is set, the inner cds-aichat-container handles everything.
+      this._instance.on({
+        type: BusEventType.CUSTOM_FOOTER_SLOT,
+        handler: this.customFooterHandler,
+      });
+    }
     this.addWriteableElementSlots();
     await this.onBeforeRender?.(instance);
   };
@@ -441,6 +455,7 @@ class ChatCustomElement extends LitElement {
         .onBeforeRender=${this.onBeforeRenderOverride}
         .element=${this}
         .renderUserDefinedResponse=${this.renderUserDefinedResponse}
+        .renderCustomMessageFooter=${this.renderCustomMessageFooter}
       >
         ${this._writeableElementSlots.map(
           (slot) => html`<slot name=${slot} slot=${slot}></slot>`,
@@ -450,9 +465,12 @@ class ChatCustomElement extends LitElement {
           : this._userDefinedSlotNames.map(
               (slot) => html`<slot name=${slot} slot=${slot}></slot>`,
             )}
-        ${this._customFooterSlotNames.map(
-          (slot) => html`<div slot=${slot}><slot name=${slot}></slot></div>`,
-        )}
+        ${this.renderCustomMessageFooter
+          ? null
+          : this._customFooterSlotNames.map(
+              (slot) =>
+                html`<div slot=${slot}><slot name=${slot}></slot></div>`,
+            )}
       </cds-aichat-container>
     `;
   }
@@ -460,7 +478,7 @@ class ChatCustomElement extends LitElement {
 
 /**
  * Attributes interface for the cds-aichat-custom-element web component.
- * This interface extends {@link CdsAiChatContainerAttributes} and {@link PublicConfig} with additional component-specific props,
+ * This interface extends {@link PublicConfig} with additional component-specific props,
  * flattening all config properties as top-level properties for better TypeScript IntelliSense.
  *
  * @category Web component
@@ -496,6 +514,12 @@ interface CdsAiChatCustomElementAttributes extends PublicConfig {
    * manages all event listening, slot tracking, streaming state, and element lifecycle.
    */
   renderUserDefinedResponse?: WCRenderUserDefinedResponse;
+
+  /**
+   * Optional callback to render custom message footers. When provided, the inner cds-aichat-container
+   * manages all event listening, slot tracking, and element lifecycle.
+   */
+  renderCustomMessageFooter?: WCRenderCustomMessageFooter;
 }
 
 export { CdsAiChatCustomElementAttributes };


### PR DESCRIPTION
Closes #1379 #1380 

Adds opt-in view-change observation hooks (`onViewChange` / `onViewPreChange`) to the float `ChatContainer` and `cds-aichat-container`, and a managed `renderCustomMessageFooter` callback to the web components so custom message footers can be rendered with the same library-managed contract already used for user-defined responses.

#### Changelog

**New**

- `onViewChange` and `onViewPreChange` props on the React `ChatContainer` and matching properties on the `cds-aichat-container` web component. These are pure observation hooks — useful for analytics or mirroring the chat's open/closed state into your own UI. Unlike `cds-aichat-custom-element`, the float container has no wrapping element to size, so there is no default visibility behavior; a handler is only subscribed when the consumer provides the prop.
- `renderCustomMessageFooter` callback property on `cds-aichat-container` and `cds-aichat-custom-element`. When provided, the library handles all `CUSTOM_FOOTER_SLOT` event listening, per-slot state tracking, and element lifecycle (including `RESTART_CONVERSATION` cleanup) — the web component analogue of the React `RenderCustomMessageFooter`.
- New exported types `RenderCustomMessageFooterState` (accumulated per-slot state) and `WCRenderCustomMessageFooter` (the callback signature), surfaced from both `aiChatEntry` and `serverEntry`.
- Documentation: a `renderCustomMessageFooter` section in `WebComponent.md` (with the prior manual-event approach kept as a "Legacy" subsection), plus `onViewChange` / `onViewPreChange` notes in `React.md` and `WebComponent.md`.

**Changed**

- `cds-aichat-custom-element` now delegates custom-footer rendering to the inner `cds-aichat-container` when `renderCustomMessageFooter` is set, and skips its own `CUSTOM_FOOTER_SLOT` subscription / manual slot wrappers in that case.
- The internal `CustomFooterSlotState` interface in `CustomFooterPortalsContainer.tsx` is now a type alias of the public `RenderCustomMessageFooterState`, giving the shape a single source of truth.
- The `RESTART_CONVERSATION` subscription on `cds-aichat-container` is registered once and clears whichever callback paths are active (user-defined and/or custom-footer), instead of being tied to `renderUserDefinedResponse` alone — avoiding a double-fire when both callbacks are provided.
- Copyright year headers on the two web-component `index.ts` files bumped to `2025, 2026`.

**Removed**

- Nothing user-facing. The legacy event + manual-slot path for custom footers is fully preserved as the default when `renderCustomMessageFooter` is omitted.

#### Testing / Reviewing

- Check the rendered `WebComponent.md` / `React.md` docs and the example snippets compile against the exported types.
