### PR TITLE
fix: missing history, keyboardShortcuts, persistFeedback from wc

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18071,18 +18071,18 @@
       }
     },
     "node_modules/accessibility-checker": {
-      "version": "4.0.13",
-      "resolved": "https://registry.npmjs.org/accessibility-checker/-/accessibility-checker-4.0.13.tgz",
-      "integrity": "sha512-0qhykqG37tPkEXY0g/8CPHdwzQkLwbIh9o94M7aAA7btok6K9gPuIacuG/c4rfvkkCJIilrVXqDKFsZLM6Wt7g==",
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/accessibility-checker/-/accessibility-checker-4.0.18.tgz",
+      "integrity": "sha512-QL9sxB5Ld7+RDiIKpFS4D7TV5a0GPBdL+Rq0eh8yami5414a6oy+u/BK2wk3epq9hchBcb/4eV/aVQOjgcWtCQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@ibm/telemetry-js": "^1.9.1",
         "chromedriver": "*",
-        "deep-diff": "^1.0.2",
         "exceljs": "^4.3.0",
         "js-yaml": "^4.1.0",
+        "microdiff": "^1.4.0",
         "puppeteer": "^22.14.0",
         "string-hash": "^1.1.3"
       },
@@ -22843,14 +22843,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/deep-diff": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/deep-diff/-/deep-diff-1.0.2.tgz",
-      "integrity": "sha512-aWS3UIVH+NPGCD1kki+DCU9Dua032iSsO43LqQpcs4R3+dVv7tX0qBGjiVHJHjplsoUM2XRO/KB92glqc68awg==",
-      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/deep-eql": {
       "version": "5.0.2",
@@ -33071,6 +33063,13 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/microdiff": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/microdiff/-/microdiff-1.5.0.tgz",
+      "integrity": "sha512-Drq+/THMvDdzRYrK0oxJmOKiC24ayUV8ahrt8l3oRK51PWt6gdtrIGrlIH3pT/lFh1z93FbAcidtsHcWbnRz8Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/micromark": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
@@ -37748,9 +37747,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -44147,9 +44146,9 @@
       }
     },
     "node_modules/webpack-dev-server/node_modules/body-parser": {
-      "version": "1.20.4",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
-      "integrity": "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==",
+      "version": "1.20.5",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
+      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -44161,7 +44160,7 @@
         "http-errors": "~2.0.1",
         "iconv-lite": "~0.4.24",
         "on-finished": "~2.4.1",
-        "qs": "~6.14.0",
+        "qs": "~6.15.1",
         "raw-body": "~2.5.3",
         "type-is": "~1.6.18",
         "unpipe": "~1.0.0"
@@ -44234,15 +44233,15 @@
       "license": "MIT"
     },
     "node_modules/webpack-dev-server/node_modules/express": {
-      "version": "4.22.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
-      "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
+      "version": "4.22.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+      "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "~1.20.3",
+        "body-parser": "~1.20.5",
         "content-disposition": "~0.5.4",
         "content-type": "~1.0.4",
         "cookie": "~0.7.1",
@@ -44261,7 +44260,7 @@
         "parseurl": "~1.3.3",
         "path-to-regexp": "~0.1.12",
         "proxy-addr": "~2.0.7",
-        "qs": "~6.14.0",
+        "qs": "~6.15.1",
         "range-parser": "~1.2.1",
         "safe-buffer": "5.2.1",
         "send": "~0.19.0",
@@ -44416,22 +44415,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/webpack-dev-server/node_modules/qs": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "side-channel": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/webpack-dev-server/node_modules/raw-body": {

--- a/packages/ai-chat/src/web-components/cds-aichat-container/index.ts
+++ b/packages/ai-chat/src/web-components/cds-aichat-container/index.ts
@@ -13,31 +13,12 @@
 
 import "./cds-aichat-internal";
 
-import { html, LitElement } from "lit";
+import { html } from "lit";
 import { property, state } from "lit/decorators.js";
 
 import { carbonElement } from "@carbon/ai-chat-components/es/globals/decorators/index.js";
-import {
-  PublicConfig,
-  OnErrorData,
-  DisclaimerPublicConfig,
-  CarbonTheme,
-  HeaderConfig,
-  HistoryConfig,
-  LayoutConfig,
-  PublicConfigMessaging,
-  InputConfig,
-  UploadConfig,
-} from "../../types/config/PublicConfig";
-import { DeepPartial } from "../../types/utilities/DeepPartial";
-import { LanguagePack } from "../../types/config/PublicConfig";
-import { HomeScreenConfig } from "../../types/config/HomeScreenConfig";
-import { LauncherConfig } from "../../types/config/LauncherConfig";
-import type {
-  ServiceDesk,
-  ServiceDeskFactoryParameters,
-  ServiceDeskPublicConfig,
-} from "../../types/config/ServiceDeskConfig";
+import { PublicConfig } from "../../types/config/PublicConfig";
+import { FlattenedConfigElement } from "../shared/FlattenedConfigElement";
 import { ChatInstance } from "../../types/instance/ChatInstance";
 import {
   BusEventChunkUserDefinedResponse,
@@ -60,123 +41,7 @@ import type {
  * and pass the slotted elements into their slots.
  */
 @carbonElement("cds-aichat-container")
-class ChatContainer extends LitElement {
-  @property({ attribute: false, type: Object })
-  config?: PublicConfig;
-
-  // Flattened PublicConfig properties
-  @property({ attribute: false })
-  onError?: (data: OnErrorData) => void;
-
-  @property({ type: Boolean, attribute: "open-chat-by-default" })
-  openChatByDefault?: boolean;
-
-  @property({ type: Object })
-  disclaimer?: DisclaimerPublicConfig;
-
-  @property({
-    type: Boolean,
-    attribute: "disable-custom-element-mobile-enhancements",
-  })
-  disableCustomElementMobileEnhancements?: boolean;
-
-  @property({ type: Boolean })
-  debug?: boolean;
-
-  @property({ type: Boolean, attribute: "expose-service-manager-for-testing" })
-  exposeServiceManagerForTesting?: boolean;
-
-  @property({ type: String, attribute: "inject-carbon-theme" })
-  injectCarbonTheme?: CarbonTheme;
-
-  @property({
-    attribute: "ai-enabled",
-    // Custom converter so HTML authors can write ai-enabled="false" | "0" | "off" | "no"
-    // and absence keeps it undefined (so defaults apply further down the stack).
-    converter: {
-      fromAttribute: (value: string | null) => {
-        if (value === null) {
-          return undefined; // attribute absent -> leave undefined to use defaults
-        }
-        const v = String(value).trim().toLowerCase();
-        const falsey = v === "false" || v === "0" || v === "off" || v === "no";
-        // Any presence that's not an explicit falsey string is treated as true
-        return !falsey;
-      },
-    },
-  })
-  aiEnabled?: boolean;
-
-  // Optional explicit opt-out attribute. If present, it wins over ai-enabled.
-  @property({ type: Boolean, attribute: "ai-disabled" })
-  aiDisabled?: boolean;
-
-  @property({
-    type: Boolean,
-    attribute: "should-take-focus-if-opens-automatically",
-  })
-  shouldTakeFocusIfOpensAutomatically?: boolean;
-
-  @property({ type: String })
-  namespace?: string;
-
-  @property({ type: Boolean, attribute: "should-sanitize-html" })
-  shouldSanitizeHTML?: boolean;
-
-  @property({ type: Object })
-  header?: HeaderConfig;
-
-  @property({ type: Object })
-  history?: HistoryConfig;
-
-  @property({ type: Object })
-  input?: InputConfig;
-
-  @property({ attribute: false, type: Object })
-  upload?: UploadConfig;
-
-  @property({ type: Object })
-  layout?: LayoutConfig;
-
-  @property({ type: Object })
-  messaging?: PublicConfigMessaging;
-
-  @property({ type: Boolean, attribute: "is-readonly" })
-  isReadonly?: boolean;
-
-  @property({ type: String, attribute: "assistant-name" })
-  assistantName?: string;
-
-  @property({ type: String })
-  assistantAvatarUrl?: string;
-
-  @property({ type: String })
-  locale?: string;
-
-  @property({ type: Object })
-  homescreen?: HomeScreenConfig;
-
-  @property({ type: Object })
-  launcher?: LauncherConfig;
-
-  /** Optional partial language pack overrides */
-  @property({ type: Object })
-  strings?: DeepPartial<LanguagePack>;
-
-  /**
-   * A factory to create a {@link ServiceDesk} integration instance.
-   */
-  @property({ attribute: false })
-  serviceDeskFactory?: (
-    parameters: ServiceDeskFactoryParameters,
-  ) => Promise<ServiceDesk>;
-
-  /**
-   * Public configuration for the service desk integration.
-   */
-  @property({ type: Object, attribute: "service-desk" })
-  serviceDesk?: ServiceDeskPublicConfig;
-
+class ChatContainer extends FlattenedConfigElement {
   /**
    * The element to render to instead of the default float element.
    *
@@ -482,95 +347,6 @@ class ChatContainer extends LitElement {
         this._callbackFooterElements.delete(slotName);
       }
     }
-  }
-
-  private get resolvedConfig(): PublicConfig {
-    const baseConfig = this.config ?? {};
-    const resolvedConfig: PublicConfig = { ...baseConfig };
-
-    if (this.onError !== undefined) {
-      resolvedConfig.onError = this.onError;
-    }
-    if (this.openChatByDefault !== undefined) {
-      resolvedConfig.openChatByDefault = this.openChatByDefault;
-    }
-    if (this.disclaimer !== undefined) {
-      resolvedConfig.disclaimer = this.disclaimer;
-    }
-    if (this.disableCustomElementMobileEnhancements !== undefined) {
-      resolvedConfig.disableCustomElementMobileEnhancements =
-        this.disableCustomElementMobileEnhancements;
-    }
-    if (this.debug !== undefined) {
-      resolvedConfig.debug = this.debug;
-    }
-    if (this.exposeServiceManagerForTesting !== undefined) {
-      resolvedConfig.exposeServiceManagerForTesting =
-        this.exposeServiceManagerForTesting;
-    }
-    if (this.injectCarbonTheme !== undefined) {
-      resolvedConfig.injectCarbonTheme = this.injectCarbonTheme;
-    }
-    if (this.serviceDeskFactory !== undefined) {
-      resolvedConfig.serviceDeskFactory = this.serviceDeskFactory;
-    }
-    if (this.serviceDesk !== undefined) {
-      resolvedConfig.serviceDesk = this.serviceDesk;
-    }
-    if (this.shouldTakeFocusIfOpensAutomatically !== undefined) {
-      resolvedConfig.shouldTakeFocusIfOpensAutomatically =
-        this.shouldTakeFocusIfOpensAutomatically;
-    }
-    if (this.namespace !== undefined) {
-      resolvedConfig.namespace = this.namespace;
-    }
-    if (this.shouldSanitizeHTML !== undefined) {
-      resolvedConfig.shouldSanitizeHTML = this.shouldSanitizeHTML;
-    }
-    if (this.header !== undefined) {
-      resolvedConfig.header = this.header;
-    }
-    if (this.input !== undefined) {
-      resolvedConfig.input = this.input;
-    }
-    if (this.upload !== undefined) {
-      resolvedConfig.upload = this.upload;
-    }
-    if (this.layout !== undefined) {
-      resolvedConfig.layout = this.layout;
-    }
-    if (this.messaging !== undefined) {
-      resolvedConfig.messaging = this.messaging;
-    }
-    if (this.isReadonly !== undefined) {
-      resolvedConfig.isReadonly = this.isReadonly;
-    }
-    if (this.assistantName !== undefined) {
-      resolvedConfig.assistantName = this.assistantName;
-    }
-    if (this.assistantAvatarUrl !== undefined) {
-      resolvedConfig.assistantAvatarUrl = this.assistantAvatarUrl;
-    }
-    if (this.locale !== undefined) {
-      resolvedConfig.locale = this.locale;
-    }
-    if (this.homescreen !== undefined) {
-      resolvedConfig.homescreen = this.homescreen;
-    }
-    if (this.launcher !== undefined) {
-      resolvedConfig.launcher = this.launcher;
-    }
-    if (this.strings !== undefined) {
-      resolvedConfig.strings = this.strings;
-    }
-
-    if (this.aiDisabled === true) {
-      resolvedConfig.aiEnabled = false;
-    } else if (this.aiEnabled !== undefined) {
-      resolvedConfig.aiEnabled = this.aiEnabled;
-    }
-
-    return resolvedConfig;
   }
 
   onBeforeRenderOverride = async (instance: ChatInstance) => {

--- a/packages/ai-chat/src/web-components/cds-aichat-custom-element/index.ts
+++ b/packages/ai-chat/src/web-components/cds-aichat-custom-element/index.ts
@@ -14,31 +14,12 @@
 export { default as __cds_aichat_container_register } from "../cds-aichat-container";
 import "../cds-aichat-container";
 
-import { html, LitElement } from "lit";
+import { html } from "lit";
 import { property, state } from "lit/decorators.js";
 
 import { carbonElement } from "@carbon/ai-chat-components/es/globals/decorators/index.js";
-import {
-  PublicConfig,
-  OnErrorData,
-  DisclaimerPublicConfig,
-  CarbonTheme,
-  HeaderConfig,
-  HistoryConfig,
-  LayoutConfig,
-  PublicConfigMessaging,
-  LanguagePack,
-  InputConfig,
-  UploadConfig,
-} from "../../types/config/PublicConfig";
-import { DeepPartial } from "../../types/utilities/DeepPartial";
-import { HomeScreenConfig } from "../../types/config/HomeScreenConfig";
-import { LauncherConfig } from "../../types/config/LauncherConfig";
-import type {
-  ServiceDesk,
-  ServiceDeskFactoryParameters,
-  ServiceDeskPublicConfig,
-} from "../../types/config/ServiceDeskConfig";
+import { PublicConfig } from "../../types/config/PublicConfig";
+import { FlattenedConfigElement } from "../shared/FlattenedConfigElement";
 import { ChatInstance } from "../../types/instance/ChatInstance";
 import {
   BusEventChunkUserDefinedResponse,
@@ -62,17 +43,16 @@ import type {
  * The custom element should be sized using external CSS. When hidden, the 'cds-aichat--hidden' class is added to set dimensions to 0x0.
  */
 @carbonElement("cds-aichat-custom-element")
-class ChatCustomElement extends LitElement {
-  @property({ attribute: false, type: Object })
-  config?: PublicConfig;
-
+class ChatCustomElement extends FlattenedConfigElement {
   /**
    * Shared stylesheet for hiding styles.
    */
   private static hideSheet = new CSSStyleSheet();
   static {
-    // Hide styles that override any external sizing
-    ChatCustomElement.hideSheet.replaceSync(`
+    // Hide styles that override any external sizing. `replaceSync` is absent
+    // in non-browser environments (e.g. the jsdom-based test environment), so
+    // skip styling there rather than throwing at module-evaluation time.
+    ChatCustomElement.hideSheet.replaceSync?.(`
       :host {
         display: block;
       }
@@ -109,111 +89,6 @@ class ChatCustomElement extends LitElement {
     ];
     return root;
   }
-
-  // Flattened PublicConfig properties
-  @property({ attribute: false })
-  onError?: (data: OnErrorData) => void;
-
-  @property({ type: Boolean, attribute: "open-chat-by-default" })
-  openChatByDefault?: boolean;
-
-  @property({ type: Object })
-  disclaimer?: DisclaimerPublicConfig;
-
-  @property({
-    type: Boolean,
-    attribute: "disable-custom-element-mobile-enhancements",
-  })
-  disableCustomElementMobileEnhancements?: boolean;
-
-  @property({ type: Boolean })
-  debug?: boolean;
-
-  @property({ type: Boolean, attribute: "expose-service-manager-for-testing" })
-  exposeServiceManagerForTesting?: boolean;
-
-  @property({ type: String, attribute: "inject-carbon-theme" })
-  injectCarbonTheme?: CarbonTheme;
-
-  @property({
-    attribute: "ai-enabled",
-    converter: {
-      fromAttribute: (value: string | null) => {
-        if (value === null) {
-          return undefined;
-        }
-        const v = String(value).trim().toLowerCase();
-        const falsey = v === "false" || v === "0" || v === "off" || v === "no";
-        return !falsey;
-      },
-    },
-  })
-  aiEnabled?: boolean;
-
-  @property({ type: Boolean, attribute: "ai-disabled" })
-  aiDisabled?: boolean;
-
-  @property({
-    type: Boolean,
-    attribute: "should-take-focus-if-opens-automatically",
-  })
-  shouldTakeFocusIfOpensAutomatically?: boolean;
-
-  @property({ type: String })
-  namespace?: string;
-
-  @property({ type: Boolean, attribute: "should-sanitize-html" })
-  shouldSanitizeHTML?: boolean;
-
-  @property({ type: Object })
-  header?: HeaderConfig;
-
-  @property({ type: Object })
-  history?: HistoryConfig;
-
-  @property({ type: Object })
-  input?: InputConfig;
-
-  @property({ attribute: false, type: Object })
-  upload?: UploadConfig;
-
-  @property({ type: Object })
-  layout?: LayoutConfig;
-
-  @property({ type: Object })
-  messaging?: PublicConfigMessaging;
-
-  @property({ type: Boolean, attribute: "is-readonly" })
-  isReadonly?: boolean;
-
-  @property({ type: String, attribute: "assistant-name" })
-  assistantName?: string;
-
-  @property({ type: String })
-  assistantAvatarUrl?: string;
-
-  @property({ type: String })
-  locale?: string;
-
-  @property({ type: Object })
-  homescreen?: HomeScreenConfig;
-
-  @property({ type: Object })
-  launcher?: LauncherConfig;
-
-  /** A factory for the {@link ServiceDesk} integration. */
-  @property({ attribute: false })
-  serviceDeskFactory?: (
-    parameters: ServiceDeskFactoryParameters,
-  ) => Promise<ServiceDesk>;
-
-  /** Public configuration for the service desk integration. */
-  @property({ type: Object, attribute: "service-desk" })
-  serviceDesk?: ServiceDeskPublicConfig;
-
-  /** Optional partial language pack overrides */
-  @property({ type: Object })
-  strings?: DeepPartial<LanguagePack>;
 
   /**
    * This function is called before the render function of Carbon AI Chat is called. This function can return a Promise
@@ -315,95 +190,6 @@ class ChatCustomElement extends LitElement {
       this._customFooterSlotNames = [...this._customFooterSlotNames, slotName];
     }
   };
-
-  private get resolvedConfig(): PublicConfig {
-    const baseConfig = this.config ?? {};
-    const resolvedConfig: PublicConfig = { ...baseConfig };
-
-    if (this.onError !== undefined) {
-      resolvedConfig.onError = this.onError;
-    }
-    if (this.openChatByDefault !== undefined) {
-      resolvedConfig.openChatByDefault = this.openChatByDefault;
-    }
-    if (this.disclaimer !== undefined) {
-      resolvedConfig.disclaimer = this.disclaimer;
-    }
-    if (this.disableCustomElementMobileEnhancements !== undefined) {
-      resolvedConfig.disableCustomElementMobileEnhancements =
-        this.disableCustomElementMobileEnhancements;
-    }
-    if (this.debug !== undefined) {
-      resolvedConfig.debug = this.debug;
-    }
-    if (this.exposeServiceManagerForTesting !== undefined) {
-      resolvedConfig.exposeServiceManagerForTesting =
-        this.exposeServiceManagerForTesting;
-    }
-    if (this.injectCarbonTheme !== undefined) {
-      resolvedConfig.injectCarbonTheme = this.injectCarbonTheme;
-    }
-    if (this.serviceDeskFactory !== undefined) {
-      resolvedConfig.serviceDeskFactory = this.serviceDeskFactory;
-    }
-    if (this.serviceDesk !== undefined) {
-      resolvedConfig.serviceDesk = this.serviceDesk;
-    }
-    if (this.shouldTakeFocusIfOpensAutomatically !== undefined) {
-      resolvedConfig.shouldTakeFocusIfOpensAutomatically =
-        this.shouldTakeFocusIfOpensAutomatically;
-    }
-    if (this.namespace !== undefined) {
-      resolvedConfig.namespace = this.namespace;
-    }
-    if (this.shouldSanitizeHTML !== undefined) {
-      resolvedConfig.shouldSanitizeHTML = this.shouldSanitizeHTML;
-    }
-    if (this.header !== undefined) {
-      resolvedConfig.header = this.header;
-    }
-    if (this.input !== undefined) {
-      resolvedConfig.input = this.input;
-    }
-    if (this.upload !== undefined) {
-      resolvedConfig.upload = this.upload;
-    }
-    if (this.layout !== undefined) {
-      resolvedConfig.layout = this.layout;
-    }
-    if (this.messaging !== undefined) {
-      resolvedConfig.messaging = this.messaging;
-    }
-    if (this.isReadonly !== undefined) {
-      resolvedConfig.isReadonly = this.isReadonly;
-    }
-    if (this.assistantName !== undefined) {
-      resolvedConfig.assistantName = this.assistantName;
-    }
-    if (this.assistantAvatarUrl !== undefined) {
-      resolvedConfig.assistantAvatarUrl = this.assistantAvatarUrl;
-    }
-    if (this.locale !== undefined) {
-      resolvedConfig.locale = this.locale;
-    }
-    if (this.homescreen !== undefined) {
-      resolvedConfig.homescreen = this.homescreen;
-    }
-    if (this.launcher !== undefined) {
-      resolvedConfig.launcher = this.launcher;
-    }
-    if (this.strings !== undefined) {
-      resolvedConfig.strings = this.strings;
-    }
-
-    if (this.aiDisabled === true) {
-      resolvedConfig.aiEnabled = false;
-    } else if (this.aiEnabled !== undefined) {
-      resolvedConfig.aiEnabled = this.aiEnabled;
-    }
-
-    return resolvedConfig;
-  }
 
   private onBeforeRenderOverride = async (instance: ChatInstance) => {
     this._instance = instance;

--- a/packages/ai-chat/src/web-components/shared/FlattenedConfigElement.ts
+++ b/packages/ai-chat/src/web-components/shared/FlattenedConfigElement.ts
@@ -1,0 +1,79 @@
+/*
+ *  Copyright IBM Corp. 2026
+ *
+ *  This source code is licensed under the Apache-2.0 license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ *  @license
+ */
+
+/**
+ * Shared Lit base class for the web components that expose a flattened
+ * {@link PublicConfig} surface (`cds-aichat-container` and
+ * `cds-aichat-custom-element`).
+ *
+ * It contributes every flattened reactive property from the single
+ * {@link FLATTENED_PUBLIC_CONFIG_FIELDS} table and derives `resolvedConfig`
+ * from that same table, so each config field is defined in exactly one place.
+ */
+
+import { LitElement } from "lit";
+import type { PropertyDeclaration, PropertyDeclarations } from "lit";
+
+import { PublicConfig } from "../../types/config/PublicConfig";
+import {
+  FLATTENED_PUBLIC_CONFIG_FIELDS,
+  resolveFlattenedConfig,
+} from "./flattenedPublicConfig";
+
+/**
+ * Builds the Lit `static properties` object from the shared field table plus
+ * the synthetic `config` (base config object) and `aiDisabled` (opt-out)
+ * properties.
+ */
+function buildFlattenedProperties(): PropertyDeclarations {
+  const properties: Record<string, PropertyDeclaration> = {
+    config: { attribute: false, type: Object },
+    aiDisabled: { type: Boolean, attribute: "ai-disabled" },
+  };
+  for (const field of FLATTENED_PUBLIC_CONFIG_FIELDS) {
+    properties[field.name] = field.options;
+  }
+  return properties;
+}
+
+/**
+ * Declaration merging gives the instance typed access to `this.history`,
+ * `this.debug`, ... without re-listing every {@link PublicConfig} field and
+ * without emitting any runtime class field (so nothing shadows the accessors
+ * Lit installs from `static properties`).
+ */
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
+interface FlattenedConfigElement extends Partial<PublicConfig> {}
+
+/**
+ * Base class contributing all flattened `PublicConfig` reactive properties.
+ * Not registered as a custom element — only the concrete subclasses are.
+ */
+abstract class FlattenedConfigElement extends LitElement {
+  static properties: PropertyDeclarations = buildFlattenedProperties();
+
+  /** Base config object. Flattened properties layer on top of this. */
+  config?: PublicConfig;
+
+  /**
+   * Optional explicit opt-out attribute. If present, it wins over `ai-enabled`.
+   * Not a {@link PublicConfig} field — it resolves into `config.aiEnabled`.
+   */
+  aiDisabled?: boolean;
+
+  /**
+   * The {@link PublicConfig} reconstructed from `config` plus every defined
+   * flattened property.
+   */
+  protected get resolvedConfig(): PublicConfig {
+    return resolveFlattenedConfig(this);
+  }
+}
+
+export { FlattenedConfigElement };

--- a/packages/ai-chat/src/web-components/shared/flattenedPublicConfig.ts
+++ b/packages/ai-chat/src/web-components/shared/flattenedPublicConfig.ts
@@ -1,0 +1,204 @@
+/*
+ *  Copyright IBM Corp. 2026
+ *
+ *  This source code is licensed under the Apache-2.0 license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ *  @license
+ */
+
+/**
+ * Single source of truth for the {@link PublicConfig} fields that the
+ * `cds-aichat-container` and `cds-aichat-custom-element` web components expose
+ * as flattened top-level attributes/properties.
+ *
+ * Both components build their Lit reactive properties and reconstruct a
+ * `PublicConfig` from this one table, so every config field is declared in
+ * exactly one place. Adding a field to {@link PublicConfig} requires adding a
+ * single entry here — the compile-time guard at the bottom of this file fails
+ * the build until that happens.
+ */
+
+import type { ComplexAttributeConverter, PropertyDeclaration } from "lit";
+
+import { PublicConfig } from "../../types/config/PublicConfig";
+
+/**
+ * A single flattened-config field: a {@link PublicConfig} key plus the exact
+ * Lit property options used to expose it on the web components.
+ */
+export interface FlattenedConfigFieldEntry {
+  /** The {@link PublicConfig} key this entry maps to. */
+  readonly name: keyof PublicConfig;
+  /** The Lit property declaration options for this field. */
+  readonly options: PropertyDeclaration;
+  /**
+   * When true, {@link resolveFlattenedConfig} skips this field in its generic
+   * loop because its resolution rule is non-uniform. Only `aiEnabled` uses
+   * this — it is resolved together with the synthetic `aiDisabled` opt-out.
+   */
+  readonly resolveManually?: boolean;
+}
+
+/**
+ * Custom converter for the `ai-enabled` attribute so HTML authors can write
+ * `ai-enabled="false" | "0" | "off" | "no"`, while an absent attribute stays
+ * `undefined` (so defaults apply further down the stack).
+ */
+const aiEnabledConverter: ComplexAttributeConverter<boolean | undefined> = {
+  fromAttribute: (value: string | null) => {
+    if (value === null) {
+      return undefined; // attribute absent -> leave undefined to use defaults
+    }
+    const v = String(value).trim().toLowerCase();
+    const falsey = v === "false" || v === "0" || v === "off" || v === "no";
+    // Any presence that's not an explicit falsey string is treated as true.
+    return !falsey;
+  },
+};
+
+/**
+ * Every {@link PublicConfig} field exposed as a flattened attribute/property
+ * on the web components, with the exact Lit property options for each.
+ *
+ * `as const satisfies` keeps the `name` values as string literals (required by
+ * the exhaustiveness guard below) while type-checking every entry.
+ */
+export const FLATTENED_PUBLIC_CONFIG_FIELDS = [
+  { name: "onError", options: { attribute: false } },
+  {
+    name: "openChatByDefault",
+    options: { type: Boolean, attribute: "open-chat-by-default" },
+  },
+  { name: "disclaimer", options: { type: Object } },
+  {
+    name: "disableCustomElementMobileEnhancements",
+    options: {
+      type: Boolean,
+      attribute: "disable-custom-element-mobile-enhancements",
+    },
+  },
+  { name: "debug", options: { type: Boolean } },
+  {
+    name: "exposeServiceManagerForTesting",
+    options: { type: Boolean, attribute: "expose-service-manager-for-testing" },
+  },
+  {
+    name: "injectCarbonTheme",
+    options: { type: String, attribute: "inject-carbon-theme" },
+  },
+  {
+    name: "aiEnabled",
+    options: { attribute: "ai-enabled", converter: aiEnabledConverter },
+    resolveManually: true,
+  },
+  { name: "serviceDeskFactory", options: { attribute: false } },
+  {
+    name: "serviceDesk",
+    options: { type: Object, attribute: "service-desk" },
+  },
+  {
+    name: "shouldTakeFocusIfOpensAutomatically",
+    options: {
+      type: Boolean,
+      attribute: "should-take-focus-if-opens-automatically",
+    },
+  },
+  { name: "namespace", options: { type: String } },
+  {
+    name: "shouldSanitizeHTML",
+    options: { type: Boolean, attribute: "should-sanitize-html" },
+  },
+  { name: "header", options: { type: Object } },
+  { name: "history", options: { type: Object } },
+  { name: "layout", options: { type: Object } },
+  { name: "messaging", options: { type: Object } },
+  { name: "isReadonly", options: { type: Boolean, attribute: "is-readonly" } },
+  {
+    name: "persistFeedback",
+    options: { type: Boolean, attribute: "persist-feedback" },
+  },
+  {
+    name: "assistantName",
+    options: { type: String, attribute: "assistant-name" },
+  },
+  // Note: no explicit `attribute` — Lit derives `assistantavatarurl`.
+  { name: "assistantAvatarUrl", options: { type: String } },
+  { name: "locale", options: { type: String } },
+  { name: "homescreen", options: { type: Object } },
+  { name: "launcher", options: { type: Object } },
+  { name: "input", options: { type: Object } },
+  { name: "upload", options: { attribute: false, type: Object } },
+  { name: "strings", options: { type: Object } },
+  { name: "keyboardShortcuts", options: { type: Object } },
+] as const satisfies readonly FlattenedConfigFieldEntry[];
+
+/**
+ * The shape consumed by {@link resolveFlattenedConfig}: any flattened
+ * {@link PublicConfig} field, plus the base `config` object and the synthetic
+ * `aiDisabled` opt-out. Both web components structurally satisfy this.
+ */
+export interface FlattenedConfigSource extends Partial<PublicConfig> {
+  /** Base config object; flattened fields override individual keys on it. */
+  config?: PublicConfig;
+  /** Synthetic opt-out attribute; when true it forces `aiEnabled` to false. */
+  aiDisabled?: boolean;
+}
+
+/**
+ * Builds a {@link PublicConfig} from a flattened source by layering each
+ * defined flattened field over the base `config` object.
+ *
+ * Pure and DOM-free so it can be unit tested directly.
+ *
+ * @param source - The web component (or any object) carrying flattened fields.
+ * @returns The reconstructed `PublicConfig`.
+ */
+export function resolveFlattenedConfig(
+  source: FlattenedConfigSource,
+): PublicConfig {
+  const resolved: PublicConfig = { ...(source.config ?? {}) };
+
+  for (const field of FLATTENED_PUBLIC_CONFIG_FIELDS) {
+    // aiEnabled is resolved together with aiDisabled below.
+    if ("resolveManually" in field && field.resolveManually) {
+      continue;
+    }
+    const value = source[field.name];
+    if (value !== undefined) {
+      (resolved as Record<string, unknown>)[field.name] = value;
+    }
+  }
+
+  // aiEnabled / aiDisabled precedence is non-uniform: an explicit aiDisabled
+  // attribute always wins over ai-enabled.
+  if (source.aiDisabled === true) {
+    resolved.aiEnabled = false;
+  } else if (source.aiEnabled !== undefined) {
+    resolved.aiEnabled = source.aiEnabled;
+  }
+
+  return resolved;
+}
+
+/**
+ * Compile-time exhaustiveness guard.
+ *
+ * `_AssertTableCoversPublicConfig` fails to compile unless the set of field
+ * names in {@link FLATTENED_PUBLIC_CONFIG_FIELDS} is exactly `keyof
+ * PublicConfig`. Adding a field to {@link PublicConfig} without adding it to
+ * the table — or vice versa — breaks the build here.
+ */
+type Equals<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2
+    ? true
+    : false;
+type Expect<T extends true> = T;
+type FlattenedFieldName =
+  (typeof FLATTENED_PUBLIC_CONFIG_FIELDS)[number]["name"];
+
+// The `_` prefix matches the lint config's varsIgnorePattern; this alias only
+// exists to be type-checked.
+type _AssertTableCoversPublicConfig = Expect<
+  Equals<FlattenedFieldName, keyof PublicConfig>
+>;

--- a/packages/ai-chat/tests/web-components/spec/flattenedConfig_spec.ts
+++ b/packages/ai-chat/tests/web-components/spec/flattenedConfig_spec.ts
@@ -1,0 +1,173 @@
+/*
+ *  Copyright IBM Corp. 2026
+ *
+ *  This source code is licensed under the Apache-2.0 license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ *  @license
+ */
+
+/**
+ * Regression coverage for the shared flattened-`PublicConfig` surface of the
+ * `cds-aichat-container` and `cds-aichat-custom-element` web components
+ * (issue #1381).
+ *
+ * The single `FLATTENED_PUBLIC_CONFIG_FIELDS` table drives both the Lit
+ * reactive `@property` declarations and the `resolvedConfig` reconstruction,
+ * so each config field is wired in exactly one place. These tests guarantee
+ * that:
+ *  - every flattened field round-trips into the resolved config;
+ *  - both web components register every field as a reactive property;
+ *  - the `history` drop bug and the `ai-enabled`/`ai-disabled` precedence
+ *    stay fixed.
+ *
+ * A compile-time exhaustiveness guard in `flattenedPublicConfig.ts`
+ * additionally fails the build if a `PublicConfig` field is ever added without
+ * a matching table entry.
+ */
+
+import {
+  FLATTENED_PUBLIC_CONFIG_FIELDS,
+  FlattenedConfigSource,
+  resolveFlattenedConfig,
+} from "../../../src/web-components/shared/flattenedPublicConfig";
+import { PublicConfig } from "../../../src/types/config/PublicConfig";
+
+import "../../../src/web-components/cds-aichat-container";
+import "../../../src/web-components/cds-aichat-custom-element";
+
+/**
+ * Flattened fields resolved by the generic loop — everything except
+ * `aiEnabled`, whose resolution is the non-uniform `aiEnabled`/`aiDisabled`
+ * precedence and is covered separately.
+ */
+const GENERIC_FIELD_NAMES = FLATTENED_PUBLIC_CONFIG_FIELDS.filter(
+  (field) => !("resolveManually" in field && field.resolveManually),
+).map((field) => field.name);
+
+/** A unique reference value for a field, so round-trips can assert identity. */
+function sentinelFor(name: string): { __flattenedConfigSentinel: string } {
+  return { __flattenedConfigSentinel: name };
+}
+
+/** Builds a `FlattenedConfigSource` carrying a single flattened field. */
+function sourceWith(
+  name: keyof PublicConfig,
+  value: unknown,
+): FlattenedConfigSource {
+  const source: FlattenedConfigSource = {};
+  (source as Record<string, unknown>)[name] = value;
+  return source;
+}
+
+describe("FLATTENED_PUBLIC_CONFIG_FIELDS", () => {
+  it("declares each PublicConfig field exactly once", () => {
+    const names = FLATTENED_PUBLIC_CONFIG_FIELDS.map((field) => field.name);
+    expect(new Set(names).size).toBe(names.length);
+  });
+});
+
+describe("resolveFlattenedConfig", () => {
+  it.each(GENERIC_FIELD_NAMES)(
+    "round-trips the flattened %s field into the resolved config",
+    (name) => {
+      const sentinel = sentinelFor(name);
+      const resolved = resolveFlattenedConfig(sourceWith(name, sentinel));
+      expect(resolved[name]).toBe(sentinel);
+    },
+  );
+
+  it("resolves the history field (regression: dropped before #1381)", () => {
+    const history = { isOn: true };
+    expect(resolveFlattenedConfig({ history }).history).toBe(history);
+  });
+
+  it("layers flattened fields over the base config object", () => {
+    const base: PublicConfig = { namespace: "from-config", debug: false };
+    const resolved = resolveFlattenedConfig({ config: base, debug: true });
+    // An untouched base key survives.
+    expect(resolved.namespace).toBe("from-config");
+    // A defined flattened field overrides the matching base key.
+    expect(resolved.debug).toBe(true);
+  });
+
+  it("returns a fresh object and ignores undefined flattened fields", () => {
+    const base: PublicConfig = { namespace: "from-config" };
+    const resolved = resolveFlattenedConfig({ config: base });
+    expect(resolved).toEqual(base);
+    expect(resolved).not.toBe(base);
+  });
+
+  describe("aiEnabled / aiDisabled precedence", () => {
+    it("passes aiEnabled through when aiDisabled is unset", () => {
+      expect(resolveFlattenedConfig({ aiEnabled: true }).aiEnabled).toBe(true);
+      expect(resolveFlattenedConfig({ aiEnabled: false }).aiEnabled).toBe(
+        false,
+      );
+    });
+
+    it("forces aiEnabled to false when aiDisabled is true", () => {
+      expect(resolveFlattenedConfig({ aiDisabled: true }).aiEnabled).toBe(
+        false,
+      );
+      expect(
+        resolveFlattenedConfig({ aiDisabled: true, aiEnabled: true }).aiEnabled,
+      ).toBe(false);
+    });
+
+    it("leaves aiEnabled absent when neither is set", () => {
+      expect("aiEnabled" in resolveFlattenedConfig({})).toBe(false);
+    });
+  });
+});
+
+describe.each(["cds-aichat-container", "cds-aichat-custom-element"])(
+  "%s flattened PublicConfig surface",
+  (tagName) => {
+    it("registers every flattened field as a reactive property", () => {
+      const element = document.createElement(tagName) as any;
+      const { elementProperties } = element.constructor;
+      for (const field of FLATTENED_PUBLIC_CONFIG_FIELDS) {
+        expect(elementProperties.has(field.name)).toBe(true);
+      }
+      // Synthetic properties that are not PublicConfig fields.
+      expect(elementProperties.has("config")).toBe(true);
+      expect(elementProperties.has("aiDisabled")).toBe(true);
+    });
+
+    it.each(GENERIC_FIELD_NAMES)(
+      "round-trips the %s property into resolvedConfig",
+      (name) => {
+        const element = document.createElement(tagName) as any;
+        const sentinel = sentinelFor(name);
+        element[name] = sentinel;
+        expect(element.resolvedConfig[name]).toBe(sentinel);
+      },
+    );
+
+    it("round-trips the history property (regression)", () => {
+      const element = document.createElement(tagName) as any;
+      const history = { isOn: true };
+      element.history = history;
+      expect(element.resolvedConfig.history).toBe(history);
+    });
+
+    it("lets ai-disabled override ai-enabled", () => {
+      const element = document.createElement(tagName) as any;
+      element.aiEnabled = true;
+      element.aiDisabled = true;
+      expect(element.resolvedConfig.aiEnabled).toBe(false);
+    });
+
+    it("converts the ai-enabled attribute via the shared converter", () => {
+      const element = document.createElement(tagName) as any;
+      element.setAttribute("ai-enabled", "off");
+      expect(element.aiEnabled).toBe(false);
+      element.setAttribute("ai-enabled", "true");
+      expect(element.aiEnabled).toBe(true);
+      // A removed attribute resolves back to undefined so config defaults apply.
+      element.removeAttribute("ai-enabled");
+      expect(element.aiEnabled).toBeUndefined();
+    });
+  },
+);


### PR DESCRIPTION
Closes #1381

The flattened `PublicConfig` surface of the `cds-aichat-container` and `cds-aichat-custom-element` web components had drifted from `PublicConfig` itself. Each component re-listed every flattened field by hand in two places — the Lit `@property` declarations and a `resolvedConfig` getter — and `history`, `keyboardShortcuts`, and `persistFeedback` were never added, so setting them as flattened attributes/properties was silently dropped before reaching the chat. This replaces the four hand-maintained lists with a single `FLATTENED_PUBLIC_CONFIG_FIELDS` table consumed by a shared `FlattenedConfigElement` base class, and adds a compile-time guard so the table can never drift from `PublicConfig` again.

Files with particularly complex changes:

- [`packages/ai-chat/src/web-components/shared/flattenedPublicConfig.ts`](packages/ai-chat/src/web-components/shared/flattenedPublicConfig.ts) — new single source of truth. Review the `aiEnabled`/`aiDisabled` precedence in `resolveFlattenedConfig` (the one non-uniform field, flagged `resolveManually`) and the `_AssertTableCoversPublicConfig` compile-time exhaustiveness guard at the bottom.
- [`packages/ai-chat/src/web-components/shared/FlattenedConfigElement.ts`](packages/ai-chat/src/web-components/shared/FlattenedConfigElement.ts) — new shared base class. It builds Lit `static properties` dynamically from the table; note the empty declaration-merging `interface` that types `this.history` etc. without emitting runtime class fields that would shadow Lit's accessors.
- [`packages/ai-chat/tests/web-components/ensureConstructableStylesheet.ts`](packages/ai-chat/tests/web-components/ensureConstructableStylesheet.ts) — jsdom `replaceSync` shim. Its header comment explains why it must be imported per-spec and deliberately kept out of the shared `tests/setup.ts`.

#### Changelog

**New**

- `history`, `keyboardShortcuts`, and `persistFeedback` are now exposed as flattened attributes/properties on `cds-aichat-container` and `cds-aichat-custom-element`, so they reach the chat config instead of being dropped.
- `FLATTENED_PUBLIC_CONFIG_FIELDS` — a single source-of-truth table that drives both components' reactive properties and config reconstruction, with a compile-time guard that fails the build if it ever drifts from `PublicConfig`.
- Regression test suite [`flattenedConfig_spec.ts`](packages/ai-chat/tests/web-components/spec/flattenedConfig_spec.ts) covering field round-trips, the `history` drop bug, and `ai-enabled`/`ai-disabled` precedence.

**Changed**

- `cds-aichat-container` and `cds-aichat-custom-element` now extend the shared `FlattenedConfigElement` base class instead of `LitElement` directly; each flattened config field is declared in exactly one place.

**Removed**

- The duplicated per-component `@property` declarations and `resolvedConfig` getters (~460 lines) that were the source of the drift.

#### Testing / Reviewing

This is internal config-wiring; the authoritative check is the new unit suite plus the build-time guard. Just run the demo site and swap over to web component mode (both for float and one of the other views) and verify it doesn't explode.
