### PR TITLE
fix(markdown): add helper to detect html block pattern in markdown

### DIFF
--- a/demo/src/customSendMessage/constants.ts
+++ b/demo/src/customSendMessage/constants.ts
@@ -160,8 +160,23 @@ const BLOCKQUOTE = `
 > The [carbon cycle](https://ibm.com) describes how carbon moves between Earth's atmosphere, oceans, and [living organisms](https://ibm.com){{target="_self"}} through photosynthesis and respiration. Carbon dating uses the radioactive isotope ¹⁴C to determine the age of organic materials. Diamond and graphite demonstrate carbon's structural versatility through different bonding arrangements.
  `;
 
+const MARKDOWN_WITH_HTML = `
+<details open>
+
+### Carbon elements
+| Allotrope | Form | Notes |
+|----------|------|-------|
+| Diamond | Crystalline | Hardest natural material |
+| Graphite | Layered | Used in pencils and lubricants |
+| Graphene | Single layer | Excellent conductivity |
+
+</details>
+`;
+
 const MARKDOWN = `
 ${TEXT}
+---
+${MARKDOWN_WITH_HTML}
 ---
 ${HEADERS}
 ---

--- a/packages/ai-chat-components/src/components/markdown/__tests__/markdown.test.ts
+++ b/packages/ai-chat-components/src/components/markdown/__tests__/markdown.test.ts
@@ -622,6 +622,53 @@ HTTP: http://example.com
     });
   });
 
+  describe("markdown between HTML tags", () => {
+    const detailsWithTableMarkdown = `<details open>
+
+### Carbon elements
+| Allotrope | Form | Notes |
+|----------|------|-------|
+| Diamond | Crystalline | Hardest natural material |
+| Graphite | Layered | Used in pencils and lubricants |
+| Graphene | Single layer | Excellent conductivity |
+
+</details>`;
+
+    async function renderMarkdown(markdown: string) {
+      const el = await fixture<MarkdownElementInstance>(
+        html`<cds-aichat-markdown .markdown=${markdown}></cds-aichat-markdown>`,
+      );
+      await el.updateComplete;
+      const root = el.shadowRoot;
+      if (!root) {
+        throw new Error("Expected shadow root to exist");
+      }
+      return root;
+    }
+
+    it("renders markdown tables inside details elements", async () => {
+      const root = await renderMarkdown(detailsWithTableMarkdown);
+      const details = root.querySelector("details");
+
+      expect(details).to.not.equal(null);
+      expect(details?.open).to.equal(true);
+      expect(details?.querySelector("h3")?.textContent).to.equal(
+        "Carbon elements",
+      );
+      const table = details?.querySelector("cds-aichat-table");
+      expect(table).to.not.equal(null);
+      if (!table) {
+        throw new Error("Expected cds-aichat-table inside details");
+      }
+
+      await table.updateComplete;
+      await waitUntil(
+        () => table.shadowRoot?.textContent?.includes("Diamond") ?? false,
+        "Expected carbon allotrope table to render inside details",
+        { timeout: 5000 },
+      );
+    });
+  });
   describe("custom attribute syntax", () => {
     async function renderMarkdown(markdown: string) {
       const el = await fixture<MarkdownElementInstance>(

--- a/packages/ai-chat-components/src/components/markdown/src/markdown-renderer.ts
+++ b/packages/ai-chat-components/src/components/markdown/src/markdown-renderer.ts
@@ -8,11 +8,17 @@
  */
 
 import DOMPurify from "dompurify";
-import { html, TemplateResult } from "lit";
+import { html, nothing, render, TemplateResult } from "lit";
 import { repeat } from "lit/directives/repeat.js";
 import { unsafeHTML } from "lit/directives/unsafe-html.js";
-import { nothing } from "lit";
-import { Directive, directive } from "lit/directive.js";
+import {
+  Directive,
+  ElementPart,
+  Part,
+  PartInfo,
+  PartType,
+  directive,
+} from "lit/directive.js";
 import { Token } from "markdown-it";
 import "@carbon/web-components/es/components/list/index.js";
 import "@carbon/web-components/es/components/checkbox/index.js";
@@ -27,7 +33,11 @@ import type {
 } from "../../table/src/table.js";
 import { extractTableData } from "./utils/table-helpers.js";
 import type { TableCellData } from "./utils/table-helpers.js";
-import { combineConsecutiveHtmlInline } from "./utils/html-helpers.js";
+import {
+  combineConsecutiveHtmlInline,
+  combineSplitHtmlBlocks,
+  HTML_CONTAINER_SLOT,
+} from "./utils/html-helpers.js";
 import type { TokenTree } from "./markdown-token-tree.js";
 
 // Generic attribute spread for Lit templates
@@ -50,6 +60,97 @@ class SpreadAttrs extends Directive {
   }
 }
 const spread = directive(SpreadAttrs);
+
+const sanitizeHtmlContent = (content: string) =>
+  DOMPurify.sanitize(content, {
+    ADD_ATTR: ["data-aichat-markdown"],
+    CUSTOM_ELEMENT_HANDLING: {
+      tagNameCheck: () => true, // Allow custom elements
+      attributeNameCheck: () => true,
+      allowCustomizedBuiltInElements: true,
+    },
+  });
+
+class HtmlContainer extends Directive {
+  private slotElement: HTMLElement | null = null;
+  private lastOpeningHtml = "";
+
+  constructor(partInfo: PartInfo) {
+    super(partInfo);
+    if (partInfo.type !== PartType.ELEMENT) {
+      throw new Error("HtmlContainer must be used on an element");
+    }
+  }
+
+  render(
+    _openingHtml: string,
+    _childTemplate: TemplateResult,
+    _sanitize: boolean,
+  ) {
+    return nothing;
+  }
+
+  update(
+    part: Part,
+    [openingHtml, childTemplate, sanitize]: [string, TemplateResult, boolean],
+  ) {
+    const host = (part as ElementPart).element as HTMLElement;
+
+    if (!this.slotElement || this.lastOpeningHtml !== openingHtml) {
+      this.lastOpeningHtml = openingHtml;
+      let content = `${openingHtml}${HTML_CONTAINER_SLOT}`;
+      if (sanitize && content) {
+        content = sanitizeHtmlContent(content);
+      }
+
+      const fragment = document.createRange().createContextualFragment(content);
+      host.replaceChildren(...Array.from(fragment.childNodes));
+      this.slotElement = host.querySelector("[data-aichat-markdown]");
+    }
+
+    if (this.slotElement) {
+      render(childTemplate, this.slotElement);
+    }
+
+    return nothing;
+  }
+}
+
+const htmlContainer = directive(HtmlContainer);
+
+function renderChildTokenTrees(
+  children: TokenTree[],
+  options: RenderTokenTreeOptions,
+  childContext?: RenderTokenTreeOptions["context"],
+): TemplateResult {
+  const normalizedChildren = combineConsecutiveHtmlInline(
+    combineSplitHtmlBlocks(children),
+  );
+
+  return html`${repeat(
+    normalizedChildren,
+    (child, index) => {
+      const stableKey = `${index}:${child.token.type}:${child.token.tag}`;
+
+      if (child.token.type?.includes("table")) {
+        return `table-${stableKey}`;
+      }
+
+      return `stable-${stableKey}`;
+    },
+    (child, index) => {
+      const result = renderTokenTree(child, {
+        ...options,
+        context: {
+          ...childContext,
+          parentChildren: normalizedChildren,
+          currentIndex: index,
+        },
+      });
+      return result ?? html``;
+    },
+  )}`;
+}
 
 /**
  * Configuration options for rendering TokenTrees into HTML.
@@ -140,16 +241,21 @@ export function renderTokenTree(
 
     // Apply HTML sanitization if requested
     if (sanitize && content) {
-      content = DOMPurify.sanitize(content, {
-        CUSTOM_ELEMENT_HANDLING: {
-          tagNameCheck: () => true, // Allow custom elements
-          attributeNameCheck: () => true,
-          allowCustomizedBuiltInElements: true,
-        },
-      });
+      content = sanitizeHtmlContent(content);
     }
 
     return html`${unsafeHTML(content)}`;
+  }
+
+  // Handle split HTML blocks that wrap markdown siblings (e.g. <details>…</details>).
+  if (token.type === "html_container") {
+    const openingHtml = token.content ?? "";
+    const innerContent = renderChildTokenTrees(children, options, context);
+
+    return html`<div
+      class="cds-aichat-markdown-html-container"
+      ${htmlContainer(openingHtml, innerContent, sanitize)}
+    ></div>`;
   }
 
   // Handle plain text content
@@ -234,35 +340,7 @@ export function renderTokenTree(
     // Optimization: single text child doesn't need repeat wrapper
     content = html`${children[0].token.content}`;
   } else {
-    const normalizedChildren = combineConsecutiveHtmlInline(children);
-
-    // Multiple or complex children: use repeat for stable keying
-    content = html`${repeat(
-      normalizedChildren,
-      (c, index) => {
-        // Generate stable key that doesn't depend on line positions
-        // This prevents unnecessary re-renders during streaming
-        const stableKey = `${index}:${c.token.type}:${c.token.tag}`;
-
-        if (c.token.type?.includes("table")) {
-          return `table-${stableKey}`;
-        }
-
-        return `stable-${stableKey}`;
-      },
-      (c, index) => {
-        const result = renderTokenTree(c, {
-          ...options,
-          context: {
-            ...childContext,
-            parentChildren: normalizedChildren,
-            currentIndex: index,
-          },
-        });
-        // Ensure we never return undefined, which Lit would render as the string "undefined"
-        return result ?? html``;
-      },
-    )}`;
+    content = renderChildTokenTrees(children, options, childContext);
   }
 
   // Handle tokens without HTML tags (just return content)

--- a/packages/ai-chat-components/src/components/markdown/src/markdown-renderer.ts
+++ b/packages/ai-chat-components/src/components/markdown/src/markdown-renderer.ts
@@ -127,9 +127,12 @@ function renderChildTokenTrees(
     combineSplitHtmlBlocks(children),
   );
 
+  // Multiple or complex children: use repeat for stable keying
   return html`${repeat(
     normalizedChildren,
     (child, index) => {
+      // Generate stable key that doesn't depend on line positions
+      // This prevents unnecessary re-renders during streaming
       const stableKey = `${index}:${child.token.type}:${child.token.tag}`;
 
       if (child.token.type?.includes("table")) {
@@ -147,6 +150,7 @@ function renderChildTokenTrees(
           currentIndex: index,
         },
       });
+      // Ensure we never return undefined, which Lit would render as the string "undefined"
       return result ?? html``;
     },
   )}`;

--- a/packages/ai-chat-components/src/components/markdown/src/markdown-token-tree.ts
+++ b/packages/ai-chat-components/src/components/markdown/src/markdown-token-tree.ts
@@ -1,5 +1,5 @@
 /*
- *  Copyright IBM Corp. 2025
+ *  Copyright IBM Corp. 2025, 2026
  *
  *  This source code is licensed under the Apache-2.0 license found in the
  *  LICENSE file in the root directory of this source tree.
@@ -57,6 +57,56 @@ const noHtmlMarkdown = new MarkdownIt("commonmark", {
   .use(markdownItHighlight)
   .use(markdownItTaskLists);
 
+function normalizeHtmlBlockBoundaries(markdown: string, allowHtml: boolean) {
+  if (!allowHtml) {
+    return markdown;
+  }
+
+  return markdown.replace(
+    /(^|\n)(\s*<\/\s*[A-Za-z][\w:-]*\s*>)(\r?\n)(?=\S)/g,
+    "$1$2$3$3",
+  );
+}
+
+function splitHtmlBlockTrailingMarkdown(
+  tokens: Token[],
+  allowHtml: boolean,
+): Token[] {
+  if (!allowHtml) {
+    return tokens;
+  }
+
+  return tokens.flatMap((token) => {
+    if (token.type !== "html_block") {
+      return [token];
+    }
+
+    const trailingMarkdownMatch = token.content.match(
+      /^(\s*<\/\s*[A-Za-z][\w:-]*\s*>)(\s*\n)([\s\S]*\S[\s\S]*)$/,
+    );
+
+    if (!trailingMarkdownMatch) {
+      return [token];
+    }
+
+    const [, closingHtml, leadingWhitespace, trailingMarkdown] =
+      trailingMarkdownMatch;
+    const htmlToken = {
+      ...token,
+      content: closingHtml,
+      map: token.map ? [token.map[0], token.map[0] + 1] : token.map,
+    } as Token;
+
+    return [
+      htmlToken,
+      ...markdownToMarkdownItTokens(
+        `${leadingWhitespace}${trailingMarkdown}`,
+        allowHtml,
+      ),
+    ];
+  });
+}
+
 /**
  * Parses markdown text into a flat array of markdown-it tokens.
  */
@@ -64,9 +114,14 @@ export function markdownToMarkdownItTokens(
   fullText: string,
   allowHtml = true,
 ): Token[] {
+  const normalizedText = normalizeHtmlBlockBoundaries(fullText, allowHtml);
+
   return allowHtml
-    ? htmlMarkdown.parse(fullText, {})
-    : noHtmlMarkdown.parse(fullText, {});
+    ? splitHtmlBlockTrailingMarkdown(
+        htmlMarkdown.parse(normalizedText, {}),
+        true,
+      )
+    : noHtmlMarkdown.parse(normalizedText, {});
 }
 
 /**

--- a/packages/ai-chat-components/src/components/markdown/src/markdown-token-tree.ts
+++ b/packages/ai-chat-components/src/components/markdown/src/markdown-token-tree.ts
@@ -57,6 +57,9 @@ const noHtmlMarkdown = new MarkdownIt("commonmark", {
   .use(markdownItHighlight)
   .use(markdownItTaskLists);
 
+// markdown-it treats a closing HTML tag and the next markdown line (ie. </div>\n##Heading) as one HTML
+// block when there is no blank line between them. Insert an extra newline so the
+// following markdown is parsed as markdown, not swallowed into the HTML token.
 function normalizeHtmlBlockBoundaries(markdown: string, allowHtml: boolean) {
   if (!allowHtml) {
     return markdown;
@@ -68,6 +71,9 @@ function normalizeHtmlBlockBoundaries(markdown: string, allowHtml: boolean) {
   );
 }
 
+// Fallback for html_block tokens that still bundle a closing tag with trailing
+// markdown on the next line. Split them so the closer stays HTML and the rest
+// is re-parsed as markdown.
 function splitHtmlBlockTrailingMarkdown(
   tokens: Token[],
   allowHtml: boolean,

--- a/packages/ai-chat-components/src/components/markdown/src/utils/html-helpers.ts
+++ b/packages/ai-chat-components/src/components/markdown/src/utils/html-helpers.ts
@@ -51,6 +51,10 @@ type HtmlBlockBoundary =
 /** Marker element appended to opening HTML so markdown children mount inside the block. */
 export const HTML_CONTAINER_SLOT = '<div data-aichat-markdown=""></div>';
 
+// Detects html_block openers (e.g. "<div>\n<summary>…") that markdown-it split from
+// their closing tag. Used by combineSplitHtmlBlocks to wrap later markdown siblings
+// back inside the HTML element. Returns null for closers, self-closing tags, or blocks
+// that already include a matching </tag>.
 function parseHtmlBlockOpening(
   content: string | undefined,
 ): HtmlBlockBoundary | null {

--- a/packages/ai-chat-components/src/components/markdown/src/utils/html-helpers.ts
+++ b/packages/ai-chat-components/src/components/markdown/src/utils/html-helpers.ts
@@ -44,6 +44,58 @@ type HtmlInlineTag =
   | { kind: "opening"; tagName: string; selfClosing: boolean }
   | { kind: "closing"; tagName: string };
 
+type HtmlBlockBoundary =
+  | { kind: "opening"; tagName: string }
+  | { kind: "closing"; tagName: string };
+
+/** Marker element appended to opening HTML so markdown children mount inside the block. */
+export const HTML_CONTAINER_SLOT = '<div data-aichat-markdown=""></div>';
+
+function parseHtmlBlockOpening(
+  content: string | undefined,
+): HtmlBlockBoundary | null {
+  const trimmed = (content ?? "").trim();
+
+  if (
+    !trimmed.startsWith("<") ||
+    trimmed.startsWith("</") ||
+    trimmed.startsWith("<!") ||
+    trimmed.startsWith("<?") ||
+    trimmed.startsWith("<%")
+  ) {
+    return null;
+  }
+
+  const openingMatch = trimmed.match(/^<\s*([A-Za-z][\w:-]*)\b/);
+  if (!openingMatch) {
+    return null;
+  }
+
+  const tagName = openingMatch[1].toLowerCase();
+  if (SELF_CLOSING_HTML_TAGS.has(tagName) || /\/>\s*$/.test(trimmed)) {
+    return null;
+  }
+
+  const closePattern = new RegExp(`</\\s*${tagName}\\s*>`, "i");
+  if (closePattern.test(trimmed)) {
+    return null;
+  }
+
+  return { kind: "opening", tagName };
+}
+
+function parseHtmlBlockClosing(
+  content: string | undefined,
+): HtmlBlockBoundary | null {
+  const trimmed = (content ?? "").trim();
+  const closingMatch = trimmed.match(/^<\/\s*([A-Za-z][\w:-]*)\s*>$/);
+  if (!closingMatch) {
+    return null;
+  }
+
+  return { kind: "closing", tagName: closingMatch[1].toLowerCase() };
+}
+
 // Minimal tag parser that ignores comments/entities (e.g., <!-- ... -->) and reports whether a tag opens, closes, or
 // self-closes a given element.
 function parseHtmlInlineTag(content: string | undefined): HtmlInlineTag | null {
@@ -193,6 +245,98 @@ export function combineConsecutiveHtmlInline(
     }
 
     combinedChildren.push(startNode);
+  }
+
+  return didCombine ? combinedChildren : children;
+}
+
+// Wraps markdown block tokens that sit between a split html_block opener and
+// closer so rendered content stays inside the HTML element (e.g. <details>).
+export function combineSplitHtmlBlocks(children: TokenTree[]): TokenTree[] {
+  if (children.length < 2) {
+    return children;
+  }
+
+  const combinedChildren: TokenTree[] = [];
+  let didCombine = false;
+
+  for (let index = 0; index < children.length; index++) {
+    const startNode = children[index];
+
+    if (startNode.token.type !== "html_block") {
+      combinedChildren.push(startNode);
+      continue;
+    }
+
+    const openingTag = parseHtmlBlockOpening(startNode.token.content);
+    if (!openingTag) {
+      combinedChildren.push(startNode);
+      continue;
+    }
+
+    const stack: string[] = [openingTag.tagName];
+    const innerChildren: TokenTree[] = [];
+    let endIndex = index;
+    let closingHtml = "";
+    let success = false;
+
+    for (let lookahead = index + 1; lookahead < children.length; lookahead++) {
+      const candidate = children[lookahead];
+
+      if (candidate.token.type === "html_block") {
+        const nestedClosing = parseHtmlBlockClosing(candidate.token.content);
+        if (nestedClosing) {
+          const expected = stack[stack.length - 1];
+          if (expected !== nestedClosing.tagName) {
+            break;
+          }
+
+          stack.pop();
+          endIndex = lookahead;
+
+          if (stack.length === 0) {
+            closingHtml = candidate.token.content ?? "";
+            success = true;
+            break;
+          }
+
+          innerChildren.push(candidate);
+          continue;
+        }
+
+        const nestedOpening = parseHtmlBlockOpening(candidate.token.content);
+        if (nestedOpening) {
+          stack.push(nestedOpening.tagName);
+        }
+
+        innerChildren.push(candidate);
+        continue;
+      }
+
+      innerChildren.push(candidate);
+    }
+
+    if (!success || endIndex <= index) {
+      combinedChildren.push(startNode);
+      continue;
+    }
+
+    combinedChildren.push({
+      key: [
+        startNode.key,
+        ...innerChildren.map((child) => child.key),
+        children[endIndex].key,
+      ].join("|"),
+      token: {
+        ...startNode.token,
+        type: "html_container",
+        tag: openingTag.tagName,
+        meta: { closingHtml },
+      },
+      children: innerChildren,
+    });
+    index = endIndex;
+    didCombine = true;
   }
 
   return didCombine ? combinedChildren : children;


### PR DESCRIPTION
Closes #1415

Currently passing in markdown within HTML tags will render the markdown as a sibling to the HTML tags

ie. 
```
<details open>

### Carbon elements
| Allotrope | Form | Notes |
|----------|------|-------|
| Diamond | Crystalline | Hardest natural material |
| Graphite | Layered | Used in pencils and lubricants |
| Graphene | Single layer | Excellent conductivity |

</details>
```

gets rendered as 
```
<details open=""></details>
<h3>Carbon elements</h3>
<div class="cds-aichat-table--square">
        <cds-aichat-table data-rounded=""></cds-aichat-table>
</div>
```

We add html-helpers to detect the pattern of the opening `html_block` like `<details>`, the normal markdown tokens in between, and then the matching closing `html_block` like `</details>`. Those then are combined into a `html_container` token where the children are the markdown tokens that belong inside the HTML tag.

On render, the markdown children are placed inside a `<div data-aichat-markdown>` to keep the markdown content inside the HTML tags.

*One thing to note* is we need to normalize the markdown so we need a new line placed as a boundary before and after the markdown to allow the parser to differentiate between the raw HTML and markdown. Hence why in the markdown example above we have new lines after and before the `<details>` tags.

#### Changelog

**Changed**

- Add `MARKDOWN_WITH_HTML` test case in the demo
- test case for markdown within HTML
- add logic in html-helpers to detect the html block openers, markdown, and closers - stores them in `html_container`
- in markdown-renderer.ts, we add logic to render the markdown children into the `data-aichat-markdown` div

#### Testing / Reviewing

Go to the demo deploy preview and go to the `text` response option. 
You should see a markdown table rendered in the response.
Using the inspector, see that the markdown table is rendered within the `<details>` HTML tags and you are able to show/hide the table by opening and closing the `details` element.

<img width="1526" height="858" alt="Screenshot 2026-05-22 at 12 25 59 PM" src="https://github.com/user-attachments/assets/8350bcb5-d1b2-4517-a87d-ad6890405b86" />
d 