### PR TITLE
fix(chat-history): add search attributes property for chat history

### DIFF
--- a/packages/ai-chat-components/src/components/chat-history/__stories__/chat-history-react.stories.jsx
+++ b/packages/ai-chat-components/src/components/chat-history/__stories__/chat-history-react.stories.jsx
@@ -73,6 +73,15 @@ export const Default = {
       description:
         "true if search should be turned off in chat history toolbar.",
     },
+    searchAttributes: {
+      control: "object",
+      description:
+        "Optional attributes to pass to the cds-search component. Allows customization of search behavior and appearance (e.g., label-text, placeholder, disabled, value, close-button-label-text).",
+    },
+    overflowMenuLabel: {
+      control: "text",
+      description: "Overflow menu tooltip label for history panel items.",
+    },
     showCloseAction: {
       control: "boolean",
       description: "renders close chat history action in header.",
@@ -85,6 +94,12 @@ export const Default = {
   args: {
     HeaderTitle: "Chats",
     searchOff: false,
+    searchAttributes: {
+      "label-text": "Search",
+      placeholder: "Search",
+      "close-button-label-text": "Clear search",
+    },
+    overflowMenuLabel: "Options",
     showCloseAction: true,
     showActions: false,
   },
@@ -359,6 +374,7 @@ export const Default = {
         />
         <HistoryToolbar
           searchOff={args.searchOff}
+          searchAttributes={args.searchAttributes}
           onSearchInput={handleSearchInput}
         />
         <HistoryContent
@@ -404,6 +420,7 @@ export const Default = {
                           name={item.name}
                           selected={item.selected}
                           rename={item.rename}
+                          overflowMenuLabel={args.overflowMenuLabel}
                           actions={pinnedHistoryItemActions}
                           onMenuAction={handleHistoryItemAction}
                           onSelected={handleSelectChat}
@@ -428,6 +445,7 @@ export const Default = {
                             name={chat.name}
                             selected={chat.selected}
                             rename={chat.rename}
+                            overflowMenuLabel={args.overflowMenuLabel}
                             actions={historyItemActions}
                             onMenuAction={handleHistoryItemAction}
                             onSelected={handleSelectChat}

--- a/packages/ai-chat-components/src/components/chat-history/__stories__/chat-history.stories.js
+++ b/packages/ai-chat-components/src/components/chat-history/__stories__/chat-history.stories.js
@@ -56,6 +56,8 @@ class ChatHistoryDemo extends LitElement {
     searchTotalCount: { type: Number },
     searchValue: { type: String },
     searchOff: { type: Boolean, attribute: "search-off" },
+    searchAttributes: { type: Object },
+    overflowMenuLabel: { type: String, attribute: "overflow-menu-label" },
     selectedId: { type: String },
     showCloseAction: { type: Boolean, attribute: "show-close-action" },
     showActions: { type: Boolean, attribute: "show-actions" },
@@ -76,6 +78,12 @@ class ChatHistoryDemo extends LitElement {
     super();
     this.headerTitle = "Chats";
     this.searchOff = false;
+    this.searchAttributes = {
+      "label-text": "Search",
+      placeholder: "Search chats",
+      "close-button-label-text": "Clear search",
+    };
+    this.overflowMenuLabel = "Options";
     this.showCloseAction = true;
     this.showActions = false;
     this.startPanel = false;
@@ -337,7 +345,10 @@ class ChatHistoryDemo extends LitElement {
           header-title="${this.headerTitle}"
           ?show-close-action=${this.showCloseAction}
         ></cds-aichat-history-header>
-        <cds-aichat-history-toolbar ?search-off=${this.searchOff}>
+        <cds-aichat-history-toolbar
+          ?search-off=${this.searchOff}
+          .searchAttributes=${this.searchAttributes}
+        >
         </cds-aichat-history-toolbar>
         <cds-aichat-history-content
           results-label="Results"
@@ -404,6 +415,8 @@ class ChatHistoryDemo extends LitElement {
                                   name="${item.name}"
                                   ?selected=${item.selected}
                                   ?rename=${item.rename}
+                                  overflow-menu-label="${this
+                                    .overflowMenuLabel}"
                                   .actions=${pinnedHistoryItemActions}
                                 ></cds-aichat-history-panel-item>
                               `,
@@ -426,6 +439,8 @@ class ChatHistoryDemo extends LitElement {
                                   id="${chat.id}"
                                   name="${chat.name}"
                                   ?selected=${chat.selected}
+                                  overflow-menu-label="${this
+                                    .overflowMenuLabel}"
                                   .actions=${historyItemActions}
                                 ></cds-aichat-history-panel-item>
                               `,
@@ -479,6 +494,15 @@ export const Default = {
       description:
         "true if search should be turned off in chat history toolbar.",
     },
+    searchAttributes: {
+      control: "object",
+      description:
+        "Optional attributes to pass to the cds-search component. Allows customization of search behavior and appearance (e.g., label-text, placeholder, disabled, value, close-button-label-text).",
+    },
+    overflowMenuLabel: {
+      control: "text",
+      description: "Overflow menu tooltip label for history panel items.",
+    },
     showCloseAction: {
       control: "boolean",
       description: "renders close chat history action in header.",
@@ -491,6 +515,12 @@ export const Default = {
   args: {
     HeaderTitle: "Chats",
     searchOff: false,
+    searchAttributes: {
+      "label-text": "Search",
+      placeholder: "Search",
+      "close-button-label-text": "Clear search",
+    },
+    overflowMenuLabel: "Options",
     showCloseAction: true,
     showActions: false,
   },
@@ -498,6 +528,8 @@ export const Default = {
     <cds-aichat-history-demo
       header-title="${args.HeaderTitle}"
       ?search-off=${args.searchOff}
+      .searchAttributes=${args.searchAttributes}
+      overflow-menu-label="${args.overflowMenuLabel}"
       ?show-close-action=${args.showCloseAction}
       ?show-actions=${args.showActions}
     ></cds-aichat-history-demo>

--- a/packages/ai-chat-components/src/components/chat-history/__stories__/chat-history.stories.js
+++ b/packages/ai-chat-components/src/components/chat-history/__stories__/chat-history.stories.js
@@ -78,7 +78,11 @@ class ChatHistoryDemo extends LitElement {
     super();
     this.headerTitle = "Chats";
     this.searchOff = false;
-    this.searchAttributes = {};
+    this.searchAttributes = {
+      "label-text": "Search",
+      placeholder: "Search",
+      "close-button-label-text": "Clear search",
+    };
     this.overflowMenuLabel = "Options";
     this.showCloseAction = true;
     this.showActions = false;
@@ -513,7 +517,7 @@ export const Default = {
     searchOff: false,
     searchAttributes: {
       "label-text": "Search",
-      placeholder: "Search chats",
+      placeholder: "Search",
       "close-button-label-text": "Clear search",
     },
     overflowMenuLabel: "Options",

--- a/packages/ai-chat-components/src/components/chat-history/__stories__/chat-history.stories.js
+++ b/packages/ai-chat-components/src/components/chat-history/__stories__/chat-history.stories.js
@@ -78,11 +78,7 @@ class ChatHistoryDemo extends LitElement {
     super();
     this.headerTitle = "Chats";
     this.searchOff = false;
-    this.searchAttributes = {
-      "label-text": "Search",
-      placeholder: "Search",
-      "close-button-label-text": "Clear search",
-    };
+    this.searchAttributes = {};
     this.overflowMenuLabel = "Options";
     this.showCloseAction = true;
     this.showActions = false;
@@ -517,7 +513,7 @@ export const Default = {
     searchOff: false,
     searchAttributes: {
       "label-text": "Search",
-      placeholder: "Search",
+      placeholder: "Search chats",
       "close-button-label-text": "Clear search",
     },
     overflowMenuLabel: "Options",
@@ -539,39 +535,36 @@ export const Default = {
 export const SearchResults = {
   render: () => {
     return html`
-    <cds-aichat-history-shell>
-      <cds-aichat-history-header
-        header-title="Chats"
-      ></cds-aichat-history-header>
-      <cds-aichat-history-toolbar></cds-aichat-history-toolbar>
-      <cds-aichat-history-content
-        results-label="Results"
-        results-count="4"
-      >
-        <cds-aichat-history-panel aria-label="Search results">
-        <cds-aichat-history-panel-items>
-          <cds-aichat-history-panel-menu expanded title="Search results">
-            ${iconLoader(Search16, {
-              slot: "title-icon",
-            })}
-            <cds-aichat-history-search-item date="Monday, 12:04 PM">
-              Here's the onboarding doc that includes all the information to
-              get started.
-            </cds-aichat-history-search-item>
-            <cds-aichat-history-search-item date="Monday, 12:04 PM">
-              Let's use this as the master invoice document.
-            </cds-aichat-history-search-item>
-            <cds-aichat-history-search-item date="Monday, 12:04 PM">
-              Noticed some discrepancies between these two files.
-            </cds-aichat-history-search-item>
-            <cds-aichat-history-search-item date="Monday, 12:04 PM">
-              Do we need a PO number on every documentation here?
-            </cds-aichat-history-search-item>
-          </cds-aichåat-history-panel-menu>
-        </cds-aichat-history-panel-items>
-        </cds-aichat-history-panel>
-      </cds-aichat-history-content>
-    </cds-aichat-history-shell>
+      <cds-aichat-history-shell>
+        <cds-aichat-history-header
+          header-title="Chats"
+        ></cds-aichat-history-header>
+        <cds-aichat-history-toolbar></cds-aichat-history-toolbar>
+        <cds-aichat-history-content results-label="Results" results-count="4">
+          <cds-aichat-history-panel aria-label="Search results">
+            <cds-aichat-history-panel-items>
+              <cds-aichat-history-panel-menu expanded title="Search results">
+                ${iconLoader(Search16, {
+                  slot: "title-icon",
+                })}
+                <cds-aichat-history-search-item date="Monday, 12:04 PM">
+                  Here's the onboarding doc that includes all the information to
+                  get started.
+                </cds-aichat-history-search-item>
+                <cds-aichat-history-search-item date="Monday, 12:04 PM">
+                  Let's use this as the master invoice document.
+                </cds-aichat-history-search-item>
+                <cds-aichat-history-search-item date="Monday, 12:04 PM">
+                  Noticed some discrepancies between these two files.
+                </cds-aichat-history-search-item>
+                <cds-aichat-history-search-item date="Monday, 12:04 PM">
+                  Do we need a PO number on every documentation here?
+                </cds-aichat-history-search-item>
+              </cds-aichat-history-panel-menu>
+            </cds-aichat-history-panel-items>
+          </cds-aichat-history-panel>
+        </cds-aichat-history-content>
+      </cds-aichat-history-shell>
     `;
   },
 };

--- a/packages/ai-chat-components/src/components/chat-history/__stories__/chat-history.stories.js
+++ b/packages/ai-chat-components/src/components/chat-history/__stories__/chat-history.stories.js
@@ -80,7 +80,7 @@ class ChatHistoryDemo extends LitElement {
     this.searchOff = false;
     this.searchAttributes = {
       "label-text": "Search",
-      placeholder: "Search chats",
+      placeholder: "Search",
       "close-button-label-text": "Clear search",
     };
     this.overflowMenuLabel = "Options";

--- a/packages/ai-chat-components/src/components/chat-history/src/history-panel-item.ts
+++ b/packages/ai-chat-components/src/components/chat-history/src/history-panel-item.ts
@@ -361,6 +361,7 @@ class CDSAIChatHistoryPanelItem extends HostListenerMixin(
       name,
       actions,
       rename,
+      overflowMenuLabel,
       _adjustMenuPosition: adjustMenuPosition,
       _handleMenuTriggerKeyDown: handleMenuTriggerKeyDown,
       _handleMenuItemClick: handleMenuItemClick,
@@ -385,7 +386,7 @@ class CDSAIChatHistoryPanelItem extends HostListenerMixin(
                   class: `${prefix}--overflow-menu__icon`,
                   slot: "icon",
                 })}
-                <span slot="tooltip-content">Options</span>
+                <span slot="tooltip-content">${overflowMenuLabel}</span>
                 <cds-overflow-menu-body flipped>
                   ${repeat(
                     actions,

--- a/packages/ai-chat-components/src/components/chat-history/src/history-toolbar.ts
+++ b/packages/ai-chat-components/src/components/chat-history/src/history-toolbar.ts
@@ -133,7 +133,7 @@ class CDSAIChatHistoryToolbar extends LitElement {
       ${!searchOff
         ? html`<cds-search
             close-button-label-text=${effectiveCloseButtonLabel}
-            ${spread(searchAttributes as any)}
+            ${searchAttributes ? spread(searchAttributes as any) : nothing}
           ></cds-search>`
         : nothing}
       <slot name="actions-end"></slot>

--- a/packages/ai-chat-components/src/components/chat-history/src/history-toolbar.ts
+++ b/packages/ai-chat-components/src/components/chat-history/src/history-toolbar.ts
@@ -9,6 +9,7 @@
 
 import { LitElement, html, nothing } from "lit";
 import { property } from "lit/decorators.js";
+import spread from "@carbon/web-components/es/globals/directives/spread.js";
 import prefix from "../../../globals/settings.js";
 import { carbonElement } from "../../../globals/decorators/carbon-element.js";
 
@@ -17,6 +18,22 @@ import "@carbon/web-components/es/components/icon-button/index.js";
 import AddComment16 from "@carbon/icons/es/add-comment/16.js";
 import { iconLoader } from "@carbon/web-components/es/globals/internal/icon-loader.js";
 import styles from "./chat-history.scss?lit";
+
+/**
+ * Attributes that can be passed to the cds-search component.
+ */
+export interface SearchAttributes {
+  /** Label text for the search icon */
+  "label-text"?: string;
+  /** Placeholder text for the search input */
+  placeholder?: string;
+  /** Whether the search input is disabled */
+  disabled?: boolean;
+  /** Value of the search input */
+  value?: string;
+  /** Label for the close button */
+  "close-button-label-text"?: string;
+}
 
 /**
  * Chat History Toolbar.
@@ -44,8 +61,48 @@ class CDSAIChatHistoryToolbar extends LitElement {
   @property({ type: Boolean, attribute: "search-off", reflect: true })
   searchOff;
 
+  /**
+   * @deprecated Use `searchAttributes['close-button-label-text']` instead.
+   * This property will be removed in a future major version.
+   */
   @property({ type: String, attribute: "close-button-label-text" })
   closeButtonLabelText = "Clear search";
+
+  /**
+   * Optional attributes to pass to the cds-search component.
+   * Allows customization of search behavior and appearance.
+   *
+   * Note: This is a JavaScript property only (not an HTML attribute).
+   * Use `.searchAttributes` to set it programmatically.
+   *
+   * Default values:
+   * - `close-button-label-text`: "Clear search" (can be overridden via deprecated `closeButtonLabelText` property)
+   *
+   * @example
+   * ```javascript
+   * // Via JavaScript property
+   * const toolbar = document.querySelector('cds-aichat-history-toolbar');
+   * toolbar.searchAttributes = {
+   *   'label-text': 'Search conversations',
+   *   placeholder: 'Type to search...',
+   *   disabled: false,
+   *   value: ''
+   * };
+   * ```
+   *
+   * @example
+   * ```html
+   * <!-- Via Lit template binding -->
+   * <cds-aichat-history-toolbar
+   *   .searchAttributes=${{
+   *     'label-text': 'Search conversations',
+   *     placeholder: 'Type to search...'
+   *   }}
+   * ></cds-aichat-history-toolbar>
+   * ```
+   */
+  @property({ type: Object, attribute: false })
+  searchAttributes?: SearchAttributes;
 
   /**
    * Handles new chat button click event
@@ -64,13 +121,19 @@ class CDSAIChatHistoryToolbar extends LitElement {
       closeButtonLabelText,
       newChatLabel,
       searchOff,
+      searchAttributes,
       _handleNewChatButtonClick: handleNewChatButtonClick,
     } = this;
+
+    // Use searchAttributes['close-button-label-text'] if provided, otherwise fall back to deprecated property
+    const effectiveCloseButtonLabel =
+      searchAttributes?.["close-button-label-text"] ?? closeButtonLabelText;
 
     return html` <slot name="actions-start"></slot>
       ${!searchOff
         ? html`<cds-search
-            close-button-label-text=${closeButtonLabelText}
+            close-button-label-text=${effectiveCloseButtonLabel}
+            ${spread(searchAttributes as any)}
           ></cds-search>`
         : nothing}
       <slot name="actions-end"></slot>


### PR DESCRIPTION
Closes #1447
Closes #1444

`cds-history-toolbar` imports the `cds-search` component from `@carbon/web-components`. Currently the search component is enclosed and there is no way to modify the it from `cds-history-toolbar`.

This PR adds a `searchAttributes` property to `cds-history-toolbar` which then passes the values to `cds-search` directly so that we can adjust values like the placeholder text or the disabled state.

```
export interface SearchAttributes {
  /** Label text for the search icon */
  "label-text"?: string;
  /** Placeholder text for the search input */
  placeholder?: string;
  /** Whether the search input is disabled */
  disabled?: boolean;
  /** Value of the search input */
  value?: string;
  /** Label for the close button */
  "close-button-label-text"?: string;
}
```

we can now pass in the above optional attributes directly to search.
```

this.searchAttributes: {
      "label-text": "Search",
      placeholder: "Search",
      "close-button-label-text": "Clear search",
    },
   ....
<cds-aichat-history-toolbar .searchAttributes=${this.searchAttributes}>
```

Also replaces the hardcoded overflow menu tooltip label that appears for every chat history item with the existing `overflowMenuLabel` attribute.

#### Changelog

**New**

- `searchAttributes` property to `cds-history-toolbar` to pass search specific attributes directly to the `cds-search` component
- added the `searchAttribute` to the storybook controls

**Changed**

- replace the hardcoded `Options` value for the overflow menu tooltip with existing `overflowMenuLabel` attribute.
- deprecated the existing `close-button-label-text` attribute in `cds-history-toolbar` in favor of using the `searchAttribute` property instead.

#### Testing / Reviewing
Check the storybooks and play around with the `searchAttribute` and `overflowMenuLabel` controls

**NOTE**: Make sure when editing the JSON control, you click out of the input field to see the changes reflect in the story.

<img width="1458" height="570" alt="Screenshot 2026-05-26 at 1 37 01 PM" src="https://github.com/user-attachments/assets/36e99946-3f06-4391-8808-025f5fe8148e" />
