### PR TITLE
fix: remove max body rule from commit lint

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
         72
       ],
       "body-max-line-length": [
-        2,
+        0,
         "always",
         90
       ],


### PR DESCRIPTION
Closes #1457 

removes `body-max-line-length` rule from the commit lint config

#### Changelog

**Changed**

- removes `body-max-line-length` rule from the commit lint config

#### Testing / Reviewing

verified updated config with `npx commitlint --print-config`
