### PR TITLE
fix: btn click

### DIFF
--- a/packages/ai-chat-components/src/components/toolbar/__stories__/toolbar-react.stories.jsx
+++ b/packages/ai-chat-components/src/components/toolbar/__stories__/toolbar-react.stories.jsx
@@ -140,7 +140,7 @@ export default {
         ),
         "custom 1": (
           <div slot="fixed-actions">
-            <Button onclick={action("onClick")} size="md">
+            <Button onClick={action("onClick")} size="md">
               test
             </Button>
           </div>

--- a/packages/ai-chat/src/chat/components-legacy/responseTypes/buttonItem/BaseButtonItemComponent.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/responseTypes/buttonItem/BaseButtonItemComponent.tsx
@@ -135,7 +135,7 @@ function BaseButtonItemComponent({
     kind: isStandard
       ? (buttonKind as BUTTON_KIND)
       : (buttonKind as CHAT_BUTTON_KIND),
-    onclick,
+    onClick,
     rel: url ? "noopener noreferrer" : undefined,
     size: isStandard ? (size as BUTTON_SIZE) : (size as CHAT_BUTTON_SIZE),
     target: linkTarget,


### PR DESCRIPTION
Closes #1458 

fixes issue with improper click props

#### Changelog

**Changed**

- `packages/ai-chat-components/src/components/toolbar/__stories__/toolbar-react.stories.jsx` updates `onclick` to `onClick`
- `packages/ai-chat/src/chat/components-legacy/responseTypes/buttonItem/BaseButtonItemComponent.tsx` updates `onclick` to `onClick`

#### Testing / Reviewing

`npm run test` and manual testing in storybook
