### PR TITLE
fix: isAtMaxWidth is true when messagesMaxWidth equals hostWidth

### DIFF
--- a/packages/ai-chat-components/src/components/chat-shell/src/resize-observer-manager.ts
+++ b/packages/ai-chat-components/src/components/chat-shell/src/resize-observer-manager.ts
@@ -98,8 +98,8 @@ export class ResizeObserverManager {
     const messagesMaxWidth = this.getMessagesMaxWidth();
 
     const updateAtMaxWidth = (hostWidth: number) => {
-      // When host is less than max-width, input-and-messages is "at max width" (filling container)
-      const isAtMaxWidth = hostWidth < messagesMaxWidth;
+      // When host is less than or equal to max-width, input-and-messages is "at max width" (filling container)
+      const isAtMaxWidth = hostWidth <= messagesMaxWidth;
       onWidthChange({ isAtMaxWidth, currentWidth: hostWidth });
     };
 


### PR DESCRIPTION
Closes #1151

`ResizeObserverManager.observeInputAndMessagesWidth` currently sets `isAtMaxWidth` to true only when the width of the input/messages is strictly greater than the host width. When the input/messages are equal to the host width, `isAtMaxWidth` should still be true so that the appropriate styling is applied.

#### Testing / Reviewing

- Checkout branch locally and go to `demo/src/react/DemoApp.tsx`
- Update the float example (lines 369-377) to:
```
const customLayout = {
  customProperties: {
    height: "800px",
    width: "800px",
  }
}

return settings.layout === "float" ? (
  <ChatContainer
      {...config}
      layout={customLayout}
      onBeforeRender={onBeforeRender}
      renderUserDefinedResponse={renderUserDefinedResponse}
      renderCustomMessageFooter={renderCustomMessageFooter}
      renderWriteableElements={renderWriteableElements}
      serviceDeskFactory={serviceDeskFactory}
    />
```
- In the React demo app float layout, verify the extra spacing below the input doesn't appear (div with class `"input-after messages-max-width"` does not have `margin-block-end: 32px`) and the input has appropriate rounded corners.