### PR TITLE
fix: add max length to feedback

### DIFF
--- a/packages/ai-chat-components/src/components/feedback/__stories__/feedback-react.stories.jsx
+++ b/packages/ai-chat-components/src/components/feedback/__stories__/feedback-react.stories.jsx
@@ -85,6 +85,11 @@ export default {
       table: { category: "events" },
       description: "Fires when the panel is closed without submitting.",
     },
+    maxLength: {
+      control: "number",
+      description:
+        "The maximum number of characters allowed in the feedback text area.",
+    },
   },
 };
 
@@ -118,6 +123,7 @@ const renderFeedback = (args, options) => {
         onClose={() => {
           handleClose?.();
         }}
+        maxLength={args.maxLength}
       />
     </div>
   );
@@ -135,6 +141,7 @@ export const Default = {
     showBody: true,
     onSubmit: undefined,
     onClose: undefined,
+    maxLength: 1000,
   },
   render: (args) =>
     renderFeedback(args, {
@@ -162,6 +169,7 @@ export const WithCategories = {
     primaryLabel: "Submit",
     showTextArea: true,
     showBody: true,
+    maxLength: 1000,
   },
   render: (args) =>
     renderFeedback(args, {
@@ -196,6 +204,7 @@ export const WithDisclaimer = {
     primaryLabel: "Submit",
     showTextArea: true,
     showBody: true,
+    maxLength: 1000,
   },
   render: (args) =>
     renderFeedback(args, {
@@ -221,6 +230,7 @@ export const ReadOnly = {
     title: "Your feedback",
     showTextArea: true,
     showBody: false,
+    maxLength: 1000,
   },
   render: (args) =>
     renderFeedback(args, {

--- a/packages/ai-chat-components/src/components/feedback/__stories__/feedback.stories.js
+++ b/packages/ai-chat-components/src/components/feedback/__stories__/feedback.stories.js
@@ -79,6 +79,11 @@ export default {
       control: "boolean",
       description: "Show the body text (defaults to false)",
     },
+    maxLength: {
+      control: "number",
+      description:
+        "The maximum number of characters allowed in the feedback text area.",
+    },
   },
 };
 
@@ -92,6 +97,7 @@ export const Default = {
     primaryLabel: "Submit",
     showTextArea: true,
     showBody: true,
+    maxLength: 1000,
   },
   render: (args) => html`
     <div style="padding: 1rem; max-width: 24rem;">
@@ -114,6 +120,7 @@ export const Default = {
         @feedback-close=${() => {
           console.log("Feedback closed");
         }}
+        max-length=${args.maxLength}
       >
       </cds-aichat-feedback>
     </div>
@@ -131,6 +138,7 @@ export const WithCategories = {
     primaryLabel: "Submit",
     showTextArea: true,
     showBody: true,
+    maxLength: 1000,
   },
   render: (args) => html`
     <div style="padding: 1rem; max-width: 24rem;">
@@ -155,6 +163,7 @@ export const WithCategories = {
         @feedback-close=${() => {
           console.log("Feedback closed");
         }}
+        max-length=${args.maxLength}
       >
       </cds-aichat-feedback>
     </div>
@@ -175,6 +184,7 @@ export const WithDisclaimer = {
       "To better understand your feedback, a dedicated IBM team may review additional information (such as your prompt and the model output) to drive improvement of AI-powered features. Your content will not be used to train or enhance the AI model.",
     disclaimerCheckbox:
       "I agree to IBM collecting information related to my feedback.",
+    maxLength: 1000,
   },
   render: (args) => html`
     <div style="padding: 1rem; max-width: 24rem;">
@@ -200,6 +210,7 @@ export const WithDisclaimer = {
         @feedback-close=${() => {
           console.log("Feedback closed");
         }}
+        max-length=${args.maxLength}
       >
       </cds-aichat-feedback>
     </div>
@@ -213,6 +224,7 @@ export const ReadOnly = {
     title: "Your feedback",
     showTextArea: true,
     showBody: false,
+    maxLength: 1000,
   },
   render: (args) => html`
     <div style="padding: 1rem; max-width: 24rem;">
@@ -227,6 +239,7 @@ export const ReadOnly = {
           text: "The response was inaccurate and didn't address my question properly. It also included irrelevant information.",
           selectedCategories: ["Inaccurate", "Not relevant"],
         }}
+        max-length=${args.maxLength}
       >
       </cds-aichat-feedback>
     </div>

--- a/packages/ai-chat-components/src/components/feedback/__tests__/__snapshots__/feedback.test.snap.js
+++ b/packages/ai-chat-components/src/components/feedback/__tests__/__snapshots__/feedback.test.snap.js
@@ -1,0 +1,13 @@
+/* @web/test-runner snapshot v1 */
+export const snapshots = {};
+
+snapshots["feedback matches snapshot"] = 
+`<cds-aichat-feedback
+  body="What do you think of this response?"
+  text-area-placeholder="Provide additional feedback..."
+  title="Provide additional feedback"
+>
+</cds-aichat-feedback>
+`;
+/* end snapshot feedback matches snapshot */
+

--- a/packages/ai-chat-components/src/components/feedback/__tests__/feedback.test.ts
+++ b/packages/ai-chat-components/src/components/feedback/__tests__/feedback.test.ts
@@ -1,0 +1,49 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2025, 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { html, fixture, expect, elementUpdated } from "@open-wc/testing";
+import "@carbon/ai-chat-components/es/components/feedback/index.js";
+import Feedback from "@carbon/ai-chat-components/es/components/feedback/src/feedback.js";
+
+/**
+ * This repository uses the @web/test-runner library for testing
+ * Documentation on writing tests, plugins, and commands
+ * here: https://modern-web.dev/docs/test-runner/overview/
+ */
+
+describe("feedback", function () {
+  it("should render", async () => {
+    const el = await fixture<Feedback>(
+      html`<cds-aichat-feedback></cds-aichat-feedback>`,
+    );
+    expect(el).to.be.instanceOf(Feedback);
+    expect(el.shadowRoot).to.exist;
+  });
+
+  it("respects max-length attribute", async () => {
+    const el = await fixture<Feedback>(
+      html`<cds-aichat-feedback show-text-area></cds-aichat-feedback>`,
+    );
+
+    const textarea = el.shadowRoot!.querySelector("cds-textarea");
+    expect(textarea).to.exist;
+    expect(textarea?.getAttribute("max-count")).to.not.exist;
+
+    el.maxLength = 500;
+    await elementUpdated(el);
+    expect(textarea?.getAttribute("max-count")).to.equal("500");
+  });
+
+  it("matches snapshot", async () => {
+    const el = await fixture<Feedback>(
+      html`<cds-aichat-feedback></cds-aichat-feedback>`,
+    );
+    await expect(el).dom.to.equalSnapshot();
+  });
+});

--- a/packages/ai-chat-components/src/components/feedback/src/feedback.ts
+++ b/packages/ai-chat-components/src/components/feedback/src/feedback.ts
@@ -17,16 +17,13 @@ import "@carbon/web-components/es/components/textarea/index.js";
 
 import { iconLoader } from "@carbon/web-components/es/globals/internal/icon-loader.js";
 import Close16 from "@carbon/icons/es/close/16.js";
-import { html, LitElement, PropertyValues } from "lit";
+import { html, LitElement, nothing, PropertyValues } from "lit";
 import { property, state } from "lit/decorators.js";
 import { classMap } from "lit/directives/class-map.js";
 import { carbonElement } from "../../../globals/decorators/index.js";
 import prefix from "../../../globals/settings.js";
 import commonStyles from "../../../globals/scss/common.scss?lit";
 import styles from "./feedback.scss?lit";
-
-// The maximum number of characters the user is allowed to type into the text area.
-const MAX_TEXT_COUNT = 1000;
 
 /**
  * The component for displaying a panel requesting feedback from a user.
@@ -65,6 +62,12 @@ class CDSAIChatFeedback extends LitElement {
    */
   @property({ type: Object, attribute: false, reflect: true })
   initialValues?: FeedbackInitialValues;
+
+  /**
+   * The maximum number of characters allowed in the feedback text area.
+   */
+  @property({ type: Number, attribute: "max-length", reflect: true })
+  maxLength?: number;
 
   /**
    * The title to display in the popup. A default value will be used if no value is provided here.
@@ -310,7 +313,7 @@ class CDSAIChatFeedback extends LitElement {
                     ?disabled=${this.isReadonly}
                     placeholder="${this.placeholder}"
                     rows="3"
-                    max-count="${MAX_TEXT_COUNT}"
+                    max-count="${this.maxLength ?? nothing}"
                     @input=${this._handleTextInput}
                   ></cds-textarea>
                 </div>`

--- a/packages/ai-chat/src/chat/components-legacy/MessageTypeComponent.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/MessageTypeComponent.tsx
@@ -780,6 +780,7 @@ function MessageTypeComponent(props: MessageTypeComponentProps) {
     const {
       id: feedbackID,
       is_on,
+      max_length = 1000,
       show_positive_details = true,
       show_negative_details = true,
       show_text_area = true,
@@ -919,6 +920,7 @@ function MessageTypeComponent(props: MessageTypeComponentProps) {
           }`}
           isOpen={isOpen}
           isReadonly={isFeedbackSubmitted}
+          maxLength={max_length}
           onClose={() => onFeedbackClicked(isPositive)}
           onSubmit={(event: CustomEvent<FeedbackSubmitDetails>) =>
             onSubmit(isPositive, event.detail)

--- a/packages/ai-chat/src/types/messaging/Messages.ts
+++ b/packages/ai-chat/src/types/messaging/Messages.ts
@@ -793,6 +793,12 @@ export interface GenericItemMessageFeedbackOptions {
   id?: string;
 
   /**
+   * The maximum number of characters allowed in the feedback text area.
+   * defaults to 1000.
+   */
+  max_length?: number;
+
+  /**
    * Indicates if the user should be asked for additional detailed information when providing positive feedback. This
    * defaults to true.
    */


### PR DESCRIPTION
Closes #1371 

adds new prop to `GenericItemMessageFeedbackOptions` to support user defined maximum character length in the feedback component

#### Changelog

**New**

- `packages/ai-chat-components/src/components/feedback/__tests__/__snapshots__/feedback.test.snap.js`
- `packages/ai-chat-components/src/components/feedback/__tests__/feedback.test.ts` adds missing test file and basic testing

**Changed**

- `packages/ai-chat-components/src/components/feedback/__stories__/feedback-react.stories.jsx` updates stories with new `maxLength` prop
- `packages/ai-chat-components/src/components/feedback/__stories__/feedback.stories.js` updates stories with new `maxLength` prop
- `packages/ai-chat-components/src/components/feedback/src/feedback.ts` adds `max-length` prop
- `packages/ai-chat/src/chat/components-legacy/MessageTypeComponent.tsx` adds `max-length` prop
- `packages/ai-chat/src/types/messaging/Messages.ts` adds `max-length` definition

#### Testing / Reviewing

`npm run test` and tested in the demo app by updating `doText.ts` to include `max_length: 30,` in the `feedback` object
