### PR TITLE
chore: dont let components fail silently on watch

### DIFF
--- a/packages/ai-chat-components/package.json
+++ b/packages/ai-chat-components/package.json
@@ -34,7 +34,7 @@
     "clean": "rimraf es es-custom dist storybook-static",
     "custom-elements": "cem analyze --config ./custom-elements-manifest.config.js",
     "postinstall": "ibmtelemetry --config=telemetry.yml",
-    "start": "concurrently \"npm run storybook\" \"npm run storybook:react\" \"node tasks/build.js --watch\"",
+    "start": "concurrently --names storybook,storybook-react,build --prefix-colors cyan,magenta,yellow --restart-tries Infinity --restart-after 2000 \"npm run storybook\" \"npm run storybook:react\" \"node tasks/build.js --watch\"",
     "storybook": "npm run custom-elements && storybook dev -p 6006",
     "storybook:build": "npm run custom-elements && storybook build",
     "storybook:react": "storybook dev -p 7007 -c .storybook-react",

--- a/packages/ai-chat-components/tasks/build.js
+++ b/packages/ai-chat-components/tasks/build.js
@@ -1,5 +1,5 @@
 /*
- *  Copyright IBM Corp. 2025
+ *  Copyright IBM Corp. 2025, 2026
  *
  *  This source code is licensed under the Apache-2.0 license found in the
  *  LICENSE file in the root directory of this source tree.
@@ -32,6 +32,44 @@ import typescript from "@rollup/plugin-typescript";
 const packageJson = JSON.parse(readFileSync("./package.json"));
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const watchMode = process.argv.includes("--watch");
+
+let currentWatcher;
+let postBuildInFlight = Promise.resolve();
+
+function showDeathBanner(kind, err) {
+  const RED = "\x1b[41;1;37m";
+  const RESET = "\x1b[0m";
+  const lines = [
+    "",
+    `${RED}================================================================${RESET}`,
+    `${RED}  [ai-chat-components] WATCH DIED (${kind})${" ".repeat(Math.max(0, 41 - kind.length))}${RESET}`,
+    `${RED}  es/ output is now STALE. concurrently will restart shortly.   ${RESET}`,
+    `${RED}================================================================${RESET}`,
+    err?.stack || String(err),
+    "",
+  ];
+  process.stderr.write(lines.join("\n") + "\n");
+}
+
+if (watchMode) {
+  process.on("unhandledRejection", (reason) => {
+    showDeathBanner("unhandledRejection", reason);
+    process.exit(1);
+  });
+  process.on("uncaughtException", (err) => {
+    showDeathBanner("uncaughtException", err);
+    process.exit(1);
+  });
+  process.on("SIGINT", () => {
+    currentWatcher?.close();
+    process.exit(0);
+  });
+  process.on("SIGTERM", () => {
+    showDeathBanner("SIGTERM", new Error("process killed externally"));
+    currentWatcher?.close();
+    process.exit(1);
+  });
+}
 
 async function build() {
   const esInputs = await globby([
@@ -68,7 +106,7 @@ async function build() {
     );
 
     if (watchMode) {
-      const watcher = watch({
+      currentWatcher = watch({
         ...cwcInputConfig,
         output: {
           dir: outputDirectory,
@@ -81,13 +119,23 @@ async function build() {
         },
       });
 
-      watcher.on("event", (event) => {
+      currentWatcher.on("event", (event) => {
         if (event.code === "START") {
           console.log("Building ai-chat-components...");
         } else if (event.code === "END") {
           console.log("Build complete");
+          postBuildInFlight = postBuildInFlight
+            .catch(() => {})
+            .then(() => postBuild())
+            .catch((err) => {
+              showDeathBanner("postBuild", err);
+              process.exit(1);
+            });
         } else if (event.code === "ERROR") {
           console.error("Build error:", event.error);
+        } else if (event.code === "FATAL") {
+          showDeathBanner("rollup FATAL", event.error);
+          process.exit(1);
         }
       });
     } else {
@@ -102,9 +150,10 @@ async function build() {
         exports: "named",
         sourcemap: true,
       });
+
+      await postBuild();
     }
   }
-  await postBuild();
 }
 
 const banner = `/**


### PR DESCRIPTION
The `node tasks/build.js --watch` child of `@carbon/ai-chat-components`'s `concurrently` group was dying silently mid-session — leaving Storybook subprocesses running, `es/` and `es-custom/` stale, and the dev experience broken without warning. This PR makes the death loud (a red `WATCH DIED` banner on stderr), auto-restartable (`concurrently --restart-tries Infinity --restart-after 2000`), and addresses the root cause by handling Rollup `FATAL` events plus process-level unhandled rejections/exceptions. It also runs `postBuild()` after every watch rebuild instead of only at startup, keeping `es-custom/` in sync with `es/` across watch cycles.

- [`packages/ai-chat-components/tasks/build.js`](packages/ai-chat-components/tasks/build.js) — adds `unhandledRejection` / `uncaughtException` / `SIGINT` / `SIGTERM` handlers, a `showDeathBanner` helper that writes a multi-line ANSI red block per line so it survives `concurrently`'s line prefixing, FATAL handling in the watcher event handler, and a `postBuildInFlight` promise chain that serializes the `es/ → es-custom/` copy across rebuilds. Reviewer should check that the one-shot (`node tasks/build.js`, no `--watch`) path still calls `postBuild()` exactly once after `cwcBundle.write`.

#### Changelog

**New**

- Red `WATCH DIED (<kind>)` stderr banner emitted by `node tasks/build.js --watch` when the watch dies (unhandled rejection, uncaught exception, Rollup FATAL event, external SIGTERM, or postBuild failure).
- `concurrently` flags on `@carbon/ai-chat-components`'s `start` script: `--names storybook,storybook-react,build`, `--prefix-colors cyan,magenta,yellow`, `--restart-tries Infinity`, `--restart-after 2000`. Auto-restarts the watch on death and labels each subprocess in the interleaved log.

**Changed**

- `postBuild()` in `tasks/build.js` now runs after every successful watch rebuild (via the Rollup `END` event), not only once at startup. Keeps `es-custom/` (the `cds → cds-custom` rewrite consumed by downstream packages) in sync with `es/` while the watch is running.
- Rollup watcher reference is now captured into module-scope `currentWatcher` so `SIGINT` (Ctrl-C) can close it cleanly before exiting.

**Removed**

- _(none)_

#### Testing / Reviewing

This change is not exercised through the demo site — it's a build-infrastructure fix. Verify manually:

1. **Identifiable prefixes.** `npm run aiChat:start`. Confirm each output line is prefixed `[build]`, `[storybook]`, or `[storybook-react]` in distinct colors.
2. **Watch rebuild + `es-custom/` freshness.** Edit any `.ts` file under `packages/ai-chat-components/src/`. Within ~3s confirm:
   - `[build]` logs `Building ai-chat-components...` then `Build complete` then `Copied SCSS token files to scss/`.
   - `packages/ai-chat-components/es/<corresponding>.js` mtime advances.
   - `packages/ai-chat-components/es-custom/<corresponding>.js` mtime advances (this is the bug fix for `es-custom/` staleness across watch cycles).
3. **Death + restart.** From another terminal: `pkill -TERM -f "tasks/build.js --watch"`. Confirm:
   - A red banner block titled `WATCH DIED (SIGTERM)` appears in the `aiChat:start` terminal, followed by the synthetic stack trace.
   - `concurrently` relaunches `[build]` within ~2s and you see a fresh `Building ai-chat-components...` then `Build complete`.
   - Editing a `src/` file after the restart still triggers a rebuild (per step 2).
   - Storybook (ports 6006, 7007) and the examples demo are unaffected — no Storybook flicker, no port reuse error.
4. **One-shot `build` path unchanged.** `npm run build --workspace=@carbon/ai-chat-components` (or `aiChat:build`) succeeds and `postBuild()` runs exactly once (a single `Copied SCSS token files to scss/` line).
5. **FATAL path (optional).** Temporarily introduce malformed SCSS in a file imported by a component. Confirm the banner labelled `WATCH DIED (rollup FATAL)` appears and `concurrently` restarts; revert the SCSS to return to a healthy state.
