### PR TITLE
fix: messages scroll behavior

### DIFF
--- a/packages/ai-chat/src/chat/components-legacy/MessagesComponent.scss
+++ b/packages/ai-chat/src/chat/components-legacy/MessagesComponent.scss
@@ -1,5 +1,5 @@
 /* 
- *  Copyright IBM Corp. 2025
+ *  Copyright IBM Corp. 2025, 2026
  *  
  *  This source code is licensed under the Apache-2.0 license found in the
  *  LICENSE file in the root directory of this source tree.
@@ -32,6 +32,7 @@
   flex: 1;
   block-size: 100%;
   inline-size: 100%;
+  overscroll-behavior: contain;
 }
 
 .cds-aichat--messages__wrapper:focus {


### PR DESCRIPTION
Closes #1376 

fixes scroll behavior in the messages widget

#### Changelog

**Changed**

- `packages/ai-chat/src/chat/components-legacy/MessagesComponent.scss` adds `overscroll-behavior: contain;`

#### Testing / Reviewing

`npm run test` and verified locally after following the same reproduction steps mentioned in the issue
