### PR TITLE
feat: custom panel header config

### DIFF
--- a/demo/src/framework/demo-chat-instance-switcher.ts
+++ b/demo/src/framework/demo-chat-instance-switcher.ts
@@ -129,6 +129,7 @@ export class DemoChatInstanceSwitcher extends LitElement {
   @state() accessor _aiEnabled: boolean = false;
   @state() accessor _showFrame: boolean = false;
   @state() accessor _fullWidth: boolean = false;
+  @state() accessor _showChatHeader: boolean = false;
 
   private readonly _panelExamples: PanelControlExample[] = [
     {
@@ -326,6 +327,9 @@ export class DemoChatInstanceSwitcher extends LitElement {
       if (this._fullWidth) {
         options.fullWidth = true;
       }
+      if (this._showChatHeader) {
+        options.showChatHeader = true;
+      }
 
       // Generate dynamic panel content
       const panelBody = this._generatePanelBody(options);
@@ -370,6 +374,11 @@ export class DemoChatInstanceSwitcher extends LitElement {
     if (options.fullWidth) {
       optionsList.push(
         `<li><code>fullWidth</code>: <strong>true</strong></li>`,
+      );
+    }
+    if (options.showChatHeader) {
+      optionsList.push(
+        `<li><code>showChatHeader</code>: <strong>true</strong></li>`,
       );
     }
 
@@ -607,6 +616,15 @@ export class DemoChatInstanceSwitcher extends LitElement {
                   this._fullWidth = e.target.checked;
                 }}
                 label-text="Full width layout"
+              >
+              </cds-checkbox>
+
+              <cds-checkbox
+                ?checked=${this._showChatHeader}
+                @cds-checkbox-changed=${(e: any) => {
+                  this._showChatHeader = e.target.checked;
+                }}
+                label-text="Show chat header"
               >
               </cds-checkbox>
             </div>

--- a/demo/src/framework/demo-chat-instance-switcher.ts
+++ b/demo/src/framework/demo-chat-instance-switcher.ts
@@ -125,11 +125,13 @@ export class DemoChatInstanceSwitcher extends LitElement {
   // Panel configuration state
   @state() accessor _hideBackButton: boolean = false;
   @state() accessor _backButtonType: "minimize" | "close" = "minimize";
+  @state() accessor _backButtonPosition: "start" | "end" = "end";
   @state() accessor _disableAnimation: boolean = false;
   @state() accessor _aiEnabled: boolean = false;
   @state() accessor _showFrame: boolean = false;
   @state() accessor _fullWidth: boolean = false;
   @state() accessor _showChatHeader: boolean = false;
+  @state() accessor _openFromSide: boolean = false;
 
   private readonly _panelExamples: PanelControlExample[] = [
     {
@@ -310,6 +312,7 @@ export class DemoChatInstanceSwitcher extends LitElement {
       const options: any = {
         title: "Custom Panel Configuration",
         backButtonType: this._backButtonType,
+        backButtonPosition: this._backButtonPosition,
       };
 
       if (this._hideBackButton) {
@@ -329,6 +332,9 @@ export class DemoChatInstanceSwitcher extends LitElement {
       }
       if (this._showChatHeader) {
         options.showChatHeader = true;
+      }
+      if (this._openFromSide) {
+        options.openFromSide = true;
       }
 
       // Generate dynamic panel content
@@ -356,6 +362,11 @@ export class DemoChatInstanceSwitcher extends LitElement {
         `<li><code>backButtonType</code>: <strong>"${options.backButtonType}"</strong></li>`,
       );
     }
+    if (options.backButtonPosition) {
+      optionsList.push(
+        `<li><code>backButtonPosition</code>: <strong>"${options.backButtonPosition}"</strong></li>`,
+      );
+    }
     if (options.disableAnimation) {
       optionsList.push(
         `<li><code>disableAnimation</code>: <strong>true</strong></li>`,
@@ -379,6 +390,11 @@ export class DemoChatInstanceSwitcher extends LitElement {
     if (options.showChatHeader) {
       optionsList.push(
         `<li><code>showChatHeader</code>: <strong>true</strong></li>`,
+      );
+    }
+    if (options.openFromSide) {
+      optionsList.push(
+        `<li><code>openFromSide</code>: <strong>true</strong></li>`,
       );
     }
 
@@ -625,6 +641,25 @@ export class DemoChatInstanceSwitcher extends LitElement {
                   this._showChatHeader = e.target.checked;
                 }}
                 label-text="Show chat header"
+              >
+              </cds-checkbox>
+
+              <cds-checkbox
+                ?checked=${this._openFromSide}
+                @cds-checkbox-changed=${(e: any) => {
+                  this._openFromSide = e.target.checked;
+                }}
+                label-text="Open from side"
+              >
+              </cds-checkbox>
+
+              <cds-checkbox
+                ?checked=${this._backButtonPosition === "start"}
+                ?disabled=${this._hideBackButton}
+                @cds-checkbox-changed=${(e: any) => {
+                  this._backButtonPosition = e.target.checked ? "start" : "end";
+                }}
+                label-text="Position back button at start"
               >
               </cds-checkbox>
             </div>

--- a/packages/ai-chat/src/chat/AppShellPanels.tsx
+++ b/packages/ai-chat/src/chat/AppShellPanels.tsx
@@ -303,7 +303,7 @@ export const AppShellPanels = React.memo(function AppShellPanels({
                 >
                   <div className="cds-aichat--panel-header-content">
                     <PanelHeader
-                      title={`**${panelTitle}**`}
+                      title={panelTitle}
                       labelBackButton={languagePack.general_returnToAssistant}
                       backButtonType={
                         "backButtonType" in customPanelState.options
@@ -323,7 +323,6 @@ export const AppShellPanels = React.memo(function AppShellPanels({
                           customPanelState.options.hideBackButton
                         )
                       }
-                      backButtonPosition="start"
                     />
                   </div>
                 </div>

--- a/packages/ai-chat/src/chat/AppShellPanels.tsx
+++ b/packages/ai-chat/src/chat/AppShellPanels.tsx
@@ -229,12 +229,24 @@ export const AppShellPanels = React.memo(function AppShellPanels({
         animationOnOpen={
           customPanelState.options.disableAnimation
             ? "none"
-            : "slide-in-from-bottom"
+            : "openFromSide" in customPanelState.options &&
+                customPanelState.options.openFromSide
+              ? "slide-in-from-start"
+              : "slide-in-from-bottom"
         }
         animationOnClose={
           customPanelState.options.disableAnimation
             ? "none"
-            : "slide-out-to-bottom"
+            : "openFromSide" in customPanelState.options &&
+                customPanelState.options.openFromSide
+              ? "slide-out-to-start"
+              : "slide-out-to-bottom"
+        }
+        openFromSide={
+          "openFromSide" in customPanelState.options &&
+          customPanelState.options.openFromSide
+            ? true
+            : false
         }
         onOpenStart={() => {
           serviceManager.eventBus.fire(
@@ -309,6 +321,15 @@ export const AppShellPanels = React.memo(function AppShellPanels({
                         "backButtonType" in customPanelState.options
                           ? customPanelState.options.backButtonType
                           : undefined
+                      }
+                      backButtonPosition={
+                        "backButtonPosition" in customPanelState.options
+                          ? customPanelState.options.backButtonPosition
+                          : undefined
+                      }
+                      openFromSide={
+                        "openFromSide" in customPanelState.options &&
+                        customPanelState.options.openFromSide
                       }
                       onClickBack={() => {
                         serviceManager.store.dispatch(

--- a/packages/ai-chat/src/chat/AppShellPanels.tsx
+++ b/packages/ai-chat/src/chat/AppShellPanels.tsx
@@ -219,7 +219,13 @@ export const AppShellPanels = React.memo(function AppShellPanels({
             ? true
             : false
         }
-        showChatHeader={!isLegacyCustomPanel}
+        showChatHeader={
+          !isLegacyCustomPanel &&
+          "showChatHeader" in customPanelState.options &&
+          customPanelState.options.showChatHeader
+            ? true
+            : false
+        }
         animationOnOpen={
           customPanelState.options.disableAnimation
             ? "none"

--- a/packages/ai-chat/src/chat/AppShellPanels.tsx
+++ b/packages/ai-chat/src/chat/AppShellPanels.tsx
@@ -303,7 +303,7 @@ export const AppShellPanels = React.memo(function AppShellPanels({
                 >
                   <div className="cds-aichat--panel-header-content">
                     <PanelHeader
-                      title={panelTitle}
+                      title={`**${panelTitle}**`}
                       labelBackButton={languagePack.general_returnToAssistant}
                       backButtonType={
                         "backButtonType" in customPanelState.options
@@ -323,6 +323,7 @@ export const AppShellPanels = React.memo(function AppShellPanels({
                           customPanelState.options.hideBackButton
                         )
                       }
+                      backButtonPosition="start"
                     />
                   </div>
                 </div>

--- a/packages/ai-chat/src/chat/components/carbon/IconButton.tsx
+++ b/packages/ai-chat/src/chat/components/carbon/IconButton.tsx
@@ -1,0 +1,21 @@
+/*
+ *  Copyright IBM Corp. 2026
+ *
+ *  This source code is licensed under the Apache-2.0 license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ *  @license
+ */
+
+import { createComponent } from "@lit/react";
+import React from "react";
+// Export the actual class for the component that will *directly* be wrapped with React.
+import CarbonIconButtonElement from "@carbon/web-components/es/components/icon-button/icon-button.js";
+
+const IconButton = createComponent({
+  tagName: "cds-icon-button",
+  elementClass: CarbonIconButtonElement,
+  react: React,
+});
+
+export default IconButton;

--- a/packages/ai-chat/src/chat/components/panels/PanelHeader.tsx
+++ b/packages/ai-chat/src/chat/components/panels/PanelHeader.tsx
@@ -10,6 +10,7 @@
 import React, { useMemo } from "react";
 
 import ChevronDown16 from "@carbon/icons/es/chevron--down/16.js";
+import ChevronLeft16 from "@carbon/icons/es/chevron--left/16.js";
 import CloseLarge16 from "@carbon/icons/es/close--large/16.js";
 import Toolbar from "@carbon/ai-chat-components/es/react/toolbar.js";
 import IconButton from "../carbon/IconButton";
@@ -19,10 +20,12 @@ import { isDirectionRTL } from "../../utils/domUtils";
 import { carbonIconToReact } from "../../utils/carbonIcon";
 
 const ChevronDown = carbonIconToReact(ChevronDown16);
+const ChevronLeft = carbonIconToReact(ChevronLeft16);
 const CloseLarge = carbonIconToReact(CloseLarge16);
 
 interface PanelHeaderProps {
   title?: string;
+  openFromSide?: boolean;
   showBackButton?: boolean;
   labelBackButton?: string;
   backButtonType?: "minimize" | "close";
@@ -36,29 +39,49 @@ interface PanelHeaderProps {
  */
 function PanelHeader({
   title,
+  openFromSide,
   showBackButton = true,
   labelBackButton,
   backButtonType = "minimize",
   backButtonPosition = "end",
   onClickBack,
 }: PanelHeaderProps) {
+  const { backButtonIcon, BackButtonIcon } = useMemo(() => {
+    const icons = {
+      close: { iconDescriptor: CloseLarge16, IconComponent: CloseLarge },
+      side: { iconDescriptor: ChevronLeft16, IconComponent: ChevronLeft },
+      down: { iconDescriptor: ChevronDown16, IconComponent: ChevronDown },
+    };
+
+    const iconKey =
+      backButtonType === "close" ? "close" : openFromSide ? "side" : "down";
+    const selected = icons[iconKey];
+
+    return {
+      backButtonIcon: selected.iconDescriptor,
+      BackButtonIcon: selected.IconComponent,
+    };
+  }, [backButtonType, openFromSide]);
+
   const toolbarActions = useMemo(() => {
-    return showBackButton && backButtonPosition !== "start"
-      ? [
-          {
-            text: labelBackButton ?? "",
-            icon: backButtonType === "close" ? CloseLarge16 : ChevronDown16,
-            size: "md",
-            onClick: () => onClickBack?.(),
-          },
-        ]
-      : [];
+    if (!showBackButton || backButtonPosition === "start") {
+      return [];
+    }
+
+    return [
+      {
+        text: labelBackButton ?? "",
+        icon: backButtonIcon,
+        size: "md",
+        onClick: () => onClickBack?.(),
+      },
+    ];
   }, [
-    backButtonType,
     labelBackButton,
     onClickBack,
     showBackButton,
     backButtonPosition,
+    backButtonIcon,
   ]);
 
   const tooltipAlign = isDirectionRTL() ? "bottom-end" : "bottom-start";
@@ -78,11 +101,7 @@ function PanelHeader({
               leaveDelayMs={0}
               onClick={() => onClickBack?.()}
             >
-              {backButtonType === "close" ? (
-                <CloseLarge slot="icon" />
-              ) : (
-                <ChevronDown slot="icon" />
-              )}
+              <BackButtonIcon slot="icon" />
               {labelBackButton && (
                 <span slot="tooltip-content">{labelBackButton}</span>
               )}

--- a/packages/ai-chat/src/chat/components/panels/PanelHeader.tsx
+++ b/packages/ai-chat/src/chat/components/panels/PanelHeader.tsx
@@ -1,5 +1,5 @@
 /*
- *  Copyright IBM Corp. 2025
+ *  Copyright IBM Corp. 2025, 2026
  *
  *  This source code is licensed under the Apache-2.0 license found in the
  *  LICENSE file in the root directory of this source tree.
@@ -9,15 +9,24 @@
 
 import React, { useMemo } from "react";
 
-import ChevronDown20 from "@carbon/icons/es/chevron--down/20.js";
-import CloseLarge20 from "@carbon/icons/es/close--large/20.js";
+import ChevronDown16 from "@carbon/icons/es/chevron--down/16.js";
+import CloseLarge16 from "@carbon/icons/es/close--large/16.js";
 import Toolbar from "@carbon/ai-chat-components/es/react/toolbar.js";
+import IconButton from "../carbon/IconButton";
+import { BUTTON_KIND } from "@carbon/web-components/es/components/button/defs.js";
+import { MarkdownWithDefaults } from "../util/MarkdownWithDefaults";
+import { isDirectionRTL } from "../../utils/domUtils";
+import { carbonIconToReact } from "../../utils/carbonIcon";
+
+const ChevronDown = carbonIconToReact(ChevronDown16);
+const CloseLarge = carbonIconToReact(CloseLarge16);
 
 interface PanelHeaderProps {
   title?: string;
   showBackButton?: boolean;
   labelBackButton?: string;
   backButtonType?: "minimize" | "close";
+  backButtonPosition?: "start" | "end";
   onClickBack?: () => void;
 }
 
@@ -30,25 +39,56 @@ function PanelHeader({
   showBackButton = true,
   labelBackButton,
   backButtonType = "minimize",
+  backButtonPosition = "end",
   onClickBack,
 }: PanelHeaderProps) {
   const toolbarActions = useMemo(() => {
-    return showBackButton
+    return showBackButton && backButtonPosition !== "start"
       ? [
           {
             text: labelBackButton ?? "",
-            icon: backButtonType === "close" ? CloseLarge20 : ChevronDown20,
+            icon: backButtonType === "close" ? CloseLarge16 : ChevronDown16,
             size: "md",
             onClick: () => onClickBack?.(),
           },
         ]
       : [];
-  }, [backButtonType, labelBackButton, onClickBack, showBackButton]);
+  }, [
+    backButtonType,
+    labelBackButton,
+    onClickBack,
+    showBackButton,
+    backButtonPosition,
+  ]);
+
+  const tooltipAlign = isDirectionRTL() ? "bottom-end" : "bottom-start";
 
   return (
     <div data-floating-menu-container>
       <Toolbar actions={toolbarActions}>
-        <div slot="title">{title}</div>
+        <div slot="title">{title && <MarkdownWithDefaults text={title} />}</div>
+        {showBackButton && backButtonPosition === "start" && (
+          <div slot="navigation">
+            <IconButton
+              data-rounded="top-left"
+              size="md"
+              kind={BUTTON_KIND.GHOST}
+              align={tooltipAlign}
+              enterDelayMs={0}
+              leaveDelayMs={0}
+              onClick={() => onClickBack?.()}
+            >
+              {backButtonType === "close" ? (
+                <CloseLarge slot="icon" />
+              ) : (
+                <ChevronDown slot="icon" />
+              )}
+              {labelBackButton && (
+                <span slot="tooltip-content">{labelBackButton}</span>
+              )}
+            </IconButton>
+          </div>
+        )}
       </Toolbar>
     </div>
   );

--- a/packages/ai-chat/src/chat/store/reducerUtils.ts
+++ b/packages/ai-chat/src/chat/store/reducerUtils.ts
@@ -86,6 +86,7 @@ const DEFAULT_CUSTOM_PANEL_CONFIG_OPTIONS: DefaultCustomPanelConfigOptions = {
   fullWidth: false,
   backButtonType: "minimize",
   showChatHeader: false,
+  openFromSide: false,
 };
 deepFreeze(DEFAULT_CUSTOM_PANEL_CONFIG_OPTIONS);
 

--- a/packages/ai-chat/src/chat/store/reducerUtils.ts
+++ b/packages/ai-chat/src/chat/store/reducerUtils.ts
@@ -85,6 +85,7 @@ const DEFAULT_CUSTOM_PANEL_CONFIG_OPTIONS: DefaultCustomPanelConfigOptions = {
   disableAnimation: false,
   fullWidth: false,
   backButtonType: "minimize",
+  showChatHeader: false,
 };
 deepFreeze(DEFAULT_CUSTOM_PANEL_CONFIG_OPTIONS);
 

--- a/packages/ai-chat/src/types/instance/apiTypes.ts
+++ b/packages/ai-chat/src/types/instance/apiTypes.ts
@@ -236,6 +236,13 @@ export interface DefaultCustomPanelConfigOptions {
   backButtonType?: "minimize" | "close";
 
   /**
+   * Controls the position of the back button in the panel header.
+   * Use "start" to position it at the beginning in the navigation slot,
+   * or "end" to position it at the end in the toolbar actions.
+   */
+  backButtonPosition?: "start" | "end";
+
+  /**
    * Shows the AI gradient background on your panel. Can be used with in concert with showFrame.
    */
   aiEnabled?: boolean;
@@ -255,6 +262,12 @@ export interface DefaultCustomPanelConfigOptions {
    * Make the main chat header visible while the panel is open.
    */
   showChatHeader?: boolean;
+
+  /**
+   * When true, the panel will slide in/out from the side instead of from the bottom.
+   * By default, panels animate from the bottom.
+   */
+  openFromSide?: boolean;
 }
 /**
  * Options supported by the workspace custom panel implementation.

--- a/packages/ai-chat/src/types/instance/apiTypes.ts
+++ b/packages/ai-chat/src/types/instance/apiTypes.ts
@@ -1,5 +1,5 @@
 /*
- *  Copyright IBM Corp. 2025
+ *  Copyright IBM Corp. 2025, 2026
  *
  *  This source code is licensed under the Apache-2.0 license found in the
  *  LICENSE file in the root directory of this source tree.
@@ -250,6 +250,11 @@ export interface DefaultCustomPanelConfigOptions {
    * width slot, set fullWidth to true.
    */
   fullWidth?: boolean;
+
+  /**
+   * Make the main chat header visible while the panel is open.
+   */
+  showChatHeader?: boolean;
 }
 /**
  * Options supported by the workspace custom panel implementation.

--- a/packages/ai-chat/tests/instance/spec/customPanels_spec.ts
+++ b/packages/ai-chat/tests/instance/spec/customPanels_spec.ts
@@ -1,5 +1,5 @@
 /*
- *  Copyright IBM Corp. 2025
+ *  Copyright IBM Corp. 2025, 2026
  *
  *  This source code is licensed under the Apache-2.0 license found in the
  *  LICENSE file in the root directory of this source tree.
@@ -183,6 +183,28 @@ describe("ChatInstance.customPanels", () => {
       expect(options.disableAnimation).toBe(true);
       expect(options.hidePanelHeader).toBe(false);
       expect(options.hideBackButton).toBe(false);
+    });
+
+    it("should open panel with openFromSide option", async () => {
+      const config = createBaseConfig();
+      const { instance, store } =
+        await renderChatAndGetInstanceWithStore(config);
+      const panel = instance.customPanels.getPanel();
+
+      const defaultPanelOptions: DefaultCustomPanelConfigOptions = {
+        title: "Side Panel",
+        openFromSide: true,
+      };
+
+      panel.open(defaultPanelOptions);
+
+      const state = store.getState();
+      expect(state.customPanelState.isOpen).toBe(true);
+      expect(state.customPanelState.options.title).toBe("Side Panel");
+      expect(
+        (state.customPanelState.options as DefaultCustomPanelConfigOptions)
+          .openFromSide,
+      ).toBe(true);
     });
 
     it("should honor deprecated hideCloseButton option as override", async () => {


### PR DESCRIPTION
Closes #1191 

Updates custom panel config to allow users to match existing Chat history panel pattern, filling the entire area of the Chat shell and opening/closing from the side. Also provides options to match panel header appearance in older AI Chat versions.

#### Changelog

**New**

- Adds Panel props `showChatHeader`, `openFromSide`, and `backButtonPosition` in `DefaultCustomPanelConfigOptions`. Showcases new options in demo app.
- Adds `backButtonPosition` to `PanelHeader` to set close button position at the start of toolbar using the "navigation" slot. Setting this to true matches panel header appearance in older AI chat versions.
- Panel header updates direction of back button chevron based on value of `openFromSide`
- `PanelHeader` title supports markdown. Users can match previous bold styling with markdown.
- `packages/ai-chat/src/chat/components/carbon/IconButton.tsx` creates React wrapper of `cds-icon-button` for use in packages/ai-chat
- Test for `openFromSide` option

#### Testing / Reviewing

- Go to demo app
- In the Chat config Panel controls, test the following controls work as expected (all chat layout modes for React & WC):
  - "Show chat header"
  - "Open from side"
  - "Position back button at start"