### PR TITLE
chore(demo): memoize history element for demo

### DIFF
--- a/demo/src/react/DemoApp.tsx
+++ b/demo/src/react/DemoApp.tsx
@@ -144,6 +144,18 @@ function DemoApp({ config, settings, onChatInstanceReady }: AppProps) {
    */
   const historyIsMobile =
     instance?.getState().customPanels.history.isMobile ?? false;
+
+  // Memoize history panel separately to prevent rerenders when stateText changes
+  const historyPanelElement = useMemo(
+    () => (
+      <HistoryWriteableElementExample
+        instance={instance as ChatInstance}
+        isMobile={historyIsMobile}
+      />
+    ),
+    [instance, historyIsMobile],
+  );
+
   const allWriteableElements = useMemo(
     () => ({
       headerBottomElement: (
@@ -215,15 +227,9 @@ function DemoApp({ config, settings, onChatInstanceReady }: AppProps) {
           parentStateText={stateText}
         />
       ),
-      historyPanelElement: (
-        <HistoryWriteableElementExample
-          instance={instance as ChatInstance}
-          parentStateText={stateText}
-          isMobile={historyIsMobile}
-        />
-      ),
+      historyPanelElement,
     }),
-    [instance, historyIsMobile, stateText],
+    [instance, historyPanelElement, stateText],
   );
 
   /**

--- a/demo/src/react/HistoryWriteableElementExample.tsx
+++ b/demo/src/react/HistoryWriteableElementExample.tsx
@@ -37,7 +37,6 @@ import { ChatInstance, PanelType } from "@carbon/ai-chat";
 
 interface HistoryExampleProps {
   instance: ChatInstance;
-  parentStateText: string;
   isMobile: boolean;
 }
 
@@ -82,7 +81,6 @@ const loadChat = async (event: CustomEvent, instance: ChatInstance) => {
 
 function HistoryWriteableElementExample({
   instance,
-  parentStateText: _parentStateText,
   isMobile,
 }: HistoryExampleProps) {
   const historyShellRef = useRef<HTMLElement | null>(null);


### PR DESCRIPTION
Closes #1480

The chat history panel menu keeps re-rendering in React demo - see video

https://github.com/user-attachments/assets/c1f58b1d-ddab-4315-9125-5dec5a23abf4

The `historyPanelElement` was part of `allWriteableElements` in the React demo app, which recreated every time `stateText` changed (every 2 seconds). This caused `renderWriteableElements` to also recreate, triggering a rerender of the history panel and resetting its state.

This PR memoizes the `historyPanelElement` so it only depends on and rerenders on change of `historyIsMobile` and `instance`. 

#### Changelog

**Changed**

- memoize `historyPanelElement`

**Removed**

- Removes `parentStateText` references in the `demo/src/react/HistoryWriteableElementExample.tsx` file as it's not needed

#### Testing / Reviewing

Go to demo deploy preview
Enable chat history via chat configurations section
Toggle menu section (ie. Today) in chat history
See that it remains closed and doesn't rerender expanded
