### PR TITLE
fix(chat-history): only set actions menu to visible for expanded history menus

### DIFF
--- a/packages/ai-chat-components/src/components/chat-history/src/chat-history.scss
+++ b/packages/ai-chat-components/src/components/chat-history/src/chat-history.scss
@@ -279,7 +279,9 @@
   visibility: hidden;
 }
 
-:host(#{$prefix}-history-panel-item[selected]) #{$cds-prefix}-overflow-menu {
+:host(#{$prefix}-history-panel-menu[expanded])
+  :host(#{$prefix}-history-panel-item[selected])
+  #{$cds-prefix}-overflow-menu {
   visibility: visible;
 }
 

--- a/packages/ai-chat-components/src/components/chat-history/src/chat-history.scss
+++ b/packages/ai-chat-components/src/components/chat-history/src/chat-history.scss
@@ -279,8 +279,7 @@
   visibility: hidden;
 }
 
-:host(#{$prefix}-history-panel-menu[expanded])
-  :host(#{$prefix}-history-panel-item[selected])
+:host(#{$prefix}-history-panel-item[selected][parent-menu-expanded])
   #{$cds-prefix}-overflow-menu {
   visibility: visible;
 }

--- a/packages/ai-chat-components/src/components/chat-history/src/history-panel-item.ts
+++ b/packages/ai-chat-components/src/components/chat-history/src/history-panel-item.ts
@@ -350,9 +350,6 @@ class CDSAIChatHistoryPanelItem extends HostListenerMixin(
     if (parentMenu) {
       this._parentMenu = parentMenu as HTMLElement;
 
-      // Set initial value from the parent menu's expanded property
-      this.parentMenuExpanded = (parentMenu as any).expanded !== false;
-
       // Listen for toggle events from the parent menu
       this._parentMenuToggleListener = ((event: CustomEvent) => {
         this.parentMenuExpanded = event.detail.expanded;
@@ -379,6 +376,15 @@ class CDSAIChatHistoryPanelItem extends HostListenerMixin(
         "cds-side-nav-menu-toggled",
         this._parentMenuToggleListener,
       );
+    }
+  }
+
+  firstUpdated() {
+    if (this._parentMenu) {
+      const expandedValue = (this._parentMenu as any).expanded;
+      if (expandedValue !== undefined) {
+        this.parentMenuExpanded = expandedValue;
+      }
     }
   }
 

--- a/packages/ai-chat-components/src/components/chat-history/src/history-panel-item.ts
+++ b/packages/ai-chat-components/src/components/chat-history/src/history-panel-item.ts
@@ -92,6 +92,13 @@ class CDSAIChatHistoryPanelItem extends HostListenerMixin(
   @property({ type: Boolean, reflect: true, attribute: "show-actions" })
   showActions = false;
 
+  /**
+   * `true` if the parent menu is expanded.
+   * This is automatically set based on the parent history-panel-menu's expanded attribute.
+   */
+  @property({ type: Boolean, reflect: true, attribute: "parent-menu-expanded" })
+  parentMenuExpanded = true;
+
   @query(`${prefix}-history-panel-item-input`) input!: HTMLElement;
 
   @query("cds-overflow-menu") overflowMenu!: HTMLElement;
@@ -120,6 +127,16 @@ class CDSAIChatHistoryPanelItem extends HostListenerMixin(
    * MutationObserver to watch for changes to parent panel's always-show-actions attribute
    */
   private _parentObserver?: MutationObserver;
+
+  /**
+   * Event listener for parent menu toggle events
+   */
+  private _parentMenuToggleListener?: EventListener;
+
+  /**
+   * Reference to parent menu element
+   */
+  private _parentMenu?: HTMLElement;
 
   /**
    *
@@ -327,6 +344,25 @@ class CDSAIChatHistoryPanelItem extends HostListenerMixin(
         attributeFilter: ["show-actions"],
       });
     }
+
+    // Track parent menu's expanded state
+    const parentMenu = this.closest(`${prefix}-history-panel-menu`);
+    if (parentMenu) {
+      this._parentMenu = parentMenu as HTMLElement;
+
+      // Set initial value from the parent menu's expanded property
+      this.parentMenuExpanded = (parentMenu as any).expanded !== false;
+
+      // Listen for toggle events from the parent menu
+      this._parentMenuToggleListener = ((event: CustomEvent) => {
+        this.parentMenuExpanded = event.detail.expanded;
+      }) as EventListener;
+
+      parentMenu.addEventListener(
+        "cds-side-nav-menu-toggled",
+        this._parentMenuToggleListener,
+      );
+    }
   }
 
   disconnectedCallback() {
@@ -336,6 +372,14 @@ class CDSAIChatHistoryPanelItem extends HostListenerMixin(
 
     super.disconnectedCallback();
     this._parentObserver?.disconnect();
+
+    // Remove event listener from parent menu
+    if (this._parentMenu && this._parentMenuToggleListener) {
+      this._parentMenu.removeEventListener(
+        "cds-side-nav-menu-toggled",
+        this._parentMenuToggleListener,
+      );
+    }
   }
 
   updated(changedProperties: Map<string, any>) {


### PR DESCRIPTION
Closes #1360

The actions menu for the selected history-panel-item was set to visible even when the parent menu was closed, causing the actions menu to get focus when user tabbed from the close menu. See video.

https://github.com/user-attachments/assets/65aaabdb-e939-4060-910f-d9dae410b884

#### Changelog

**Changed**

- only make the overflow menu visible for selected chat item if the parent menu is expanded
- add event listener for parent menu toggle and set the `parentMenuExpanded` attribute accordingly

#### Testing / Reviewing

Go to demo or or storybook deploy previews
Enable/ go to chat history story
Toggle close the menu with the selected chat history item and tab, the focus should go to the next menu title instead of the hidden overflow menu