### PR TITLE
fix(feedback): pass selected category value via data-content attr

### DIFF
--- a/packages/ai-chat-components/src/components/feedback/__tests__/feedback.test.ts
+++ b/packages/ai-chat-components/src/components/feedback/__tests__/feedback.test.ts
@@ -46,4 +46,51 @@ describe("feedback", function () {
     );
     await expect(el).dom.to.equalSnapshot();
   });
+
+  it("should include selected categories in submit event", async () => {
+    const categories = ["Inaccurate", "Unhelpful", "Not relevant"];
+    let submittedCategories: string[] | undefined;
+
+    const el = await fixture<Feedback>(
+      html`<cds-aichat-feedback
+        is-open
+        show-text-area
+        .categories=${categories}
+        @feedback-submit=${(event: CustomEvent) => {
+          submittedCategories = event.detail.selectedCategories;
+        }}
+      ></cds-aichat-feedback>`,
+    );
+
+    // Find and click the first category tag
+    const firstTag = el.shadowRoot!.querySelector(
+      "cds-selectable-tag",
+    ) as HTMLElement;
+    expect(firstTag).to.exist;
+    expect(firstTag.getAttribute("data-content")).to.equal("Inaccurate");
+
+    firstTag.click();
+    await elementUpdated(el);
+
+    // Find and click the third category tag
+    const tags = el.shadowRoot!.querySelectorAll("cds-selectable-tag");
+    const thirdTag = tags[2] as HTMLElement;
+    expect(thirdTag).to.exist;
+    expect(thirdTag.getAttribute("data-content")).to.equal("Not relevant");
+
+    thirdTag.click();
+    await elementUpdated(el);
+
+    // Click submit button
+    const submitButton = el.shadowRoot!.querySelector("cds-button");
+    expect(submitButton).to.exist;
+    (submitButton as HTMLElement).click();
+    await elementUpdated(el);
+
+    // Verify the submitted categories
+    expect(submittedCategories).to.exist;
+    expect(submittedCategories).to.have.lengthOf(2);
+    expect(submittedCategories).to.include("Inaccurate");
+    expect(submittedCategories).to.include("Not relevant");
+  });
 });

--- a/packages/ai-chat-components/src/components/feedback/src/feedback.ts
+++ b/packages/ai-chat-components/src/components/feedback/src/feedback.ts
@@ -294,6 +294,7 @@ class CDSAIChatFeedback extends LitElement {
                           class="${prefix}--tag-list-button"
                           size="md"
                           text="${value}"
+                          data-content="${value}"
                           ?selected=${this._selectedCategories.has(value)}
                           ?disabled=${this.isReadonly}
                           @click=${this._handleCategoryClick}


### PR DESCRIPTION
Closes #1546

Regression where selected categories from the feedback component are not being returned. See video.

https://github.com/user-attachments/assets/09790e51-2c1b-4718-9b38-9915a845230d

The `_handleCategoryClick` method retrieves the category value via `button?.getAttribute("data-content")`, but this attribute is not set on the rendered tags, causing it to return `null` and preventing categories from being added to the selection.

Added `data-content="${value}"` attribute to each `<cds-selectable-tag>` element so the click handler can properly identify which category was selected.

#### Changelog

**New**

- Added test case to cover this issue

**Changed**

- Add `data-content="${value}"` to selectable-tag so the value can be retrieved

#### Testing / Reviewing

Go to WC and React storybook deploy previews
Go to Feedback story with categories
Select a few categories and hit submit
You should see the selected categories listed in the alert
