### PR TITLE
fix(markdown): remove default disabled state for checkbox

### DIFF
--- a/packages/ai-chat-components/src/components/markdown/src/markdown-renderer.ts
+++ b/packages/ai-chat-components/src/components/markdown/src/markdown-renderer.ts
@@ -457,7 +457,7 @@ function renderWithStaticTag(
       const { checked, disabled, ...otherAttrs } = attrs;
       const isChecked = checked === "true";
       const isDisabled =
-        disabled === undefined ? true : disabled === "" || disabled === "true";
+        disabled === undefined ? false : disabled === "" || disabled === "true";
 
       return html`<cds-checkbox
         ?checked=${isChecked}

--- a/packages/ai-chat-components/src/components/markdown/src/plugins/markdown-it-task-lists.ts
+++ b/packages/ai-chat-components/src/components/markdown/src/plugins/markdown-it-task-lists.ts
@@ -1,5 +1,5 @@
 /*
- *  Copyright IBM Corp. 2025
+ *  Copyright IBM Corp. 2025, 2026
  *
  *  This source code is licensed under the Apache-2.0 license found in the
  *  LICENSE file in the root directory of this source tree.
@@ -73,10 +73,7 @@ function markdownItTaskLists(md: MarkdownIt) {
         1,
       );
       checkboxOpenToken.content = "";
-      checkboxOpenToken.attrs = [
-        ["checked", checked ? "true" : "false"],
-        ["disabled", "true"],
-      ];
+      checkboxOpenToken.attrs = [["checked", checked ? "true" : "false"]];
 
       const checkboxCloseToken: Token = new state.Token(
         "task_checkbox_close",


### PR DESCRIPTION
Closes #1557

The markdown checkboxes are coming through as disabled by default. 

```
## Task Lists

- [x] Completed task
- [ ] Incomplete task
- [x] Another completed task
- [ ] Another incomplete task
```
produces 

<img height="300" alt="Screenshot 2026-06-08 at 12 48 33 PM" src="https://github.com/user-attachments/assets/790fe316-f040-4d77-bbac-cf5568ddc748" />

This PR removes the hardcorded disabled state from the checkboxes that are rendered by the markdown component.

#### Changelog

**Removed**

- Remove disabled attribute from being applied by default

#### Testing / Reviewing

Go to storybook deploy preview and go to "Markdown - with Checkboxes" story. See that the checkboxes are not disabled except for the ones that are labeled as disabled
