### PR TITLE
chore: update type exports

### DIFF
--- a/packages/ai-chat/src/aiChatEntry.tsx
+++ b/packages/ai-chat/src/aiChatEntry.tsx
@@ -278,6 +278,8 @@ export {
   HumanAgentMessageType,
   ChainOfThoughtStep,
   ChainOfThoughtStepStatus,
+  CHAT_BUTTON_KIND,
+  CHAT_BUTTON_SIZE,
   ReasoningSteps,
   ReasoningStep,
   ReasoningStepOpenState,

--- a/packages/ai-chat/src/serverEntry.ts
+++ b/packages/ai-chat/src/serverEntry.ts
@@ -263,6 +263,8 @@ export {
   HumanAgentMessageType,
   ChainOfThoughtStep,
   ChainOfThoughtStepStatus,
+  CHAT_BUTTON_KIND,
+  CHAT_BUTTON_SIZE,
   ReasoningSteps,
   ReasoningStep,
   ReasoningStepOpenState,

--- a/packages/ai-chat/src/types/component/ChatContainer.ts
+++ b/packages/ai-chat/src/types/component/ChatContainer.ts
@@ -150,7 +150,7 @@ type WCRenderCustomMessageFooter = (
  * `display_content` — typically a consumer-registered custom node such as a
  * task card, file pill, or mention with rich rendering.
  *
- * @category Composition
+ * @category React
  * @experimental
  */
 interface RenderUserDefinedInputNodeState {
@@ -166,7 +166,7 @@ interface RenderUserDefinedInputNodeState {
  * library manages the slot lifecycle — register a renderer that returns the
  * React node for nodes you care about and `null` for everything else.
  *
- * @category Composition
+ * @category React
  * @experimental
  */
 type RenderUserDefinedInputNode = (
@@ -180,7 +180,7 @@ type RenderUserDefinedInputNode = (
  * `HTMLElement` (or `null`). The library moves / removes the element as
  * messages mount and unmount.
  *
- * @category Composition
+ * @category Web component
  * @experimental
  */
 type WCRenderUserDefinedInputNode = (

--- a/packages/ai-chat/src/types/messaging/Messages.ts
+++ b/packages/ai-chat/src/types/messaging/Messages.ts
@@ -21,10 +21,10 @@ import {
   BUTTON_SIZE,
 } from "@carbon/web-components/es/components/button/defs.js";
 import {
-  CHAT_BUTTON_KIND,
-  CHAT_BUTTON_SIZE,
+  CHAT_BUTTON_KIND as _CHAT_BUTTON_KIND,
+  CHAT_BUTTON_SIZE as _CHAT_BUTTON_SIZE,
 } from "@carbon/ai-chat-components/es/react/chat-button.js";
-import { ChainOfThoughtStepStatus } from "@carbon/ai-chat-components/es/components/chain-of-thought/defs.js";
+import { ChainOfThoughtStepStatus as _ChainOfThoughtStepStatus } from "@carbon/ai-chat-components/es/components/chain-of-thought/defs.js";
 import { WorkspaceCustomPanelConfigOptions } from "../instance/apiTypes";
 import type { JSONContent } from "@tiptap/core";
 
@@ -698,11 +698,14 @@ export interface ItemStreamingMetadata {
 }
 
 /**
- * Status of the chain of thought step.
+ * The processing status of a single chain-of-thought step, surfaced on
+ * {@link ChainOfThoughtStep.status}. An icon reflecting this status is rendered
+ * in the chain-of-thought view; when omitted, the UI assumes success.
  *
  * @category Messaging
  */
-export { ChainOfThoughtStepStatus };
+export const ChainOfThoughtStepStatus = _ChainOfThoughtStepStatus;
+export type ChainOfThoughtStepStatus = _ChainOfThoughtStepStatus;
 
 /**
  * A chain of thought step is meant to show tool calls and other steps made by your agent
@@ -1753,6 +1756,25 @@ enum ButtonItemKind {
    */
   LINK = "link",
 }
+
+/**
+ * The Carbon AI-chat button style applied to {@link ButtonItem.kind}. Selects
+ * the visual treatment (primary, secondary, tertiary, ...) for buttons rendered
+ * by the chat.
+ *
+ * @category Messaging
+ */
+export const CHAT_BUTTON_KIND = _CHAT_BUTTON_KIND;
+export type CHAT_BUTTON_KIND = _CHAT_BUTTON_KIND;
+
+/**
+ * The Carbon AI-chat button size applied to {@link ButtonItem.size}. Selects the
+ * height and padding scale for buttons rendered by the chat.
+ *
+ * @category Messaging
+ */
+export const CHAT_BUTTON_SIZE = _CHAT_BUTTON_SIZE;
+export type CHAT_BUTTON_SIZE = _CHAT_BUTTON_SIZE;
 
 /**
  * This message item represents a button that can perform various actions such as sending messages, opening URLs, or showing panels.


### PR DESCRIPTION
Closes #1468

Applies the local re-declaration pattern (see [`src/types/AGENTS.md`](packages/ai-chat/src/types/AGENTS.md)) to the last two cross-package public types that were still leaking past it: `ChainOfThoughtStepStatus` and `CHAT_BUTTON_KIND` / `CHAT_BUTTON_SIZE`. A transparent `export { X } from "@carbon/ai-chat-components"` (or a direct upstream import used in a public type) makes TypeDoc resolve through to the upstream declaration and read _its_ JSDoc — so our local `@category Messaging` block is ignored and the symbol lands in the docs `*` ("Other types") catchall. Re-declaring each as a local `const` + `type` alias with consumer-linking JSDoc keeps TypeDoc, the Elasticsearch index, and the MCP server pointed at the docs we own.

It also removes an orphan `@category Composition` value (never registered in `categoryOrder`, so its three types were silently falling into the docs `*` catchall) by reassigning those types to the existing category that matches their renderer surface.

- [`packages/ai-chat/src/types/messaging/Messages.ts`](packages/ai-chat/src/types/messaging/Messages.ts) — the substantive change. Upstream imports are aliased to `_`-prefixed names; the old transparent `export { ChainOfThoughtStepStatus }` becomes a local `const`+`type` re-declaration; `CHAT_BUTTON_KIND` / `CHAT_BUTTON_SIZE` get the same treatment next to `ButtonItem`. The subtlety worth reviewing: because the re-declarations live in this same file, the in-file property-type references (`ChainOfThoughtStep.status`, `ButtonItem.kind`, `ButtonItem.size`) now resolve to the local aliases with no other type-file edits — confirm none of them still bind to the upstream import.
- [`packages/ai-chat/src/types/component/ChatContainer.ts`](packages/ai-chat/src/types/component/ChatContainer.ts) — three `@category Composition` tags reassigned: `RenderUserDefinedInputNode` and the shared `RenderUserDefinedInputNodeState` → `React`; `WCRenderUserDefinedInputNode` → `Web component`. This follows the file's existing precedent (`RenderUserDefinedResponse` → React, `WCRenderUserDefinedResponse` → Web component, and the shared `RenderUserDefinedState` already in React). `@experimental` is preserved on all three.

#### Changelog

**New**

- `CHAT_BUTTON_KIND` and `CHAT_BUTTON_SIZE` are now exported from `@carbon/ai-chat` (via `aiChatEntry.tsx` and `serverEntry.ts`), so consumers referencing `ButtonItem.kind` / `ButtonItem.size` get resolvable, documented enums.

**Changed**

- `ChainOfThoughtStepStatus` is now a local re-declaration instead of a transparent re-export, so its `@category Messaging` JSDoc (and `{@link ChainOfThoughtStep.status}` back-link) renders on the docs site instead of being ignored.
- `CHAT_BUTTON_KIND` / `CHAT_BUTTON_SIZE` are surfaced through local re-declarations with consumer-linking JSDoc rather than imported straight from `@carbon/ai-chat-components`.
- `RenderUserDefinedInputNode`, `RenderUserDefinedInputNodeState`, and `WCRenderUserDefinedInputNode` move out of the unregistered `Composition` category (previously the `*`/"Other types" catchall) into `React` / `React` / `Web component` respectively, matching the other render-callback types in the same file.

**Removed**

- _(none)_

#### Testing / Reviewing

No code changes, just run the docs site and check that nothing expoded