### PR TITLE
fix(input): correct mismatch between input height and max height trigger

### DIFF
--- a/packages/ai-chat/src/chat/components-legacy/input/ContentEditableInput.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/input/ContentEditableInput.tsx
@@ -212,6 +212,13 @@ const ContentEditableInput = forwardRef<
     const lastNonCollapsedRangeRef = useRef<Range | null>(null);
 
     /**
+     * Counter to force re-render of the auto-resize effect when Enter is pressed.
+     * Some browsers don't fire onInput when only a <br> tag is inserted (Shift+Enter),
+     * so we need to manually trigger the height recalculation.
+     */
+    const [forceResizeCounter, setForceResizeCounter] = React.useState(0);
+
+    /**
      * Reads the current text from the DOM, enforces maxLength, and emits onChange.
      *
      * **Why read from DOM instead of tracking in state?**
@@ -272,6 +279,28 @@ const ContentEditableInput = forwardRef<
         lastNonCollapsedRangeRef.current = range.cloneRange();
       }
     }, []);
+
+    /**
+     * Handles keydown events to detect Enter key presses.
+     * When Enter is pressed (with or without Shift), we schedule a forced resize
+     * because some browsers don't fire onInput when only a <br> tag is inserted.
+     */
+    const handleKeyDown = useCallback(
+      (event: KeyboardEvent<HTMLDivElement>) => {
+        // Call the parent's onKeyDown handler first
+        onKeyDown?.(event);
+
+        // If Enter key is pressed (with or without Shift), force a resize check
+        // after the browser has had time to insert the <br> tag
+        if (event.key === "Enter" && !event.defaultPrevented) {
+          // Use setTimeout to ensure the DOM has been updated with the new line
+          setTimeout(() => {
+            setForceResizeCounter((prev) => prev + 1);
+          }, 0);
+        }
+      },
+      [onKeyDown],
+    );
 
     /**
      * Handles native paste events to enforce plain text only pasting.
@@ -428,10 +457,10 @@ const ContentEditableInput = forwardRef<
       const editor = editorRef.current;
       const sizerHeight = sizerRef.current.scrollHeight;
       applyDynamicStyles(editor, "editor-autoresize", {
-        "overflow-y": sizerHeight > MAX_AUTO_RESIZE_HEIGHT ? "auto" : "hidden",
+        "overflow-y": sizerHeight >= MAX_AUTO_RESIZE_HEIGHT ? "auto" : "hidden",
       });
       return () => clearDynamicStyles(editor, "editor-autoresize");
-    }, [autoSize, displayValue]);
+    }, [autoSize, displayValue, forceResizeCounter]);
 
     /**
      * Syncs external displayValue changes to the DOM without interfering with user input.
@@ -527,7 +556,7 @@ const ContentEditableInput = forwardRef<
           onBlur={onBlur}
           onFocus={onFocus}
           onInput={emitChangeFromDom}
-          onKeyDown={onKeyDown}
+          onKeyDown={handleKeyDown}
           role="textbox"
           tabIndex={disabled ? -1 : 0}
           spellCheck={true}

--- a/packages/ai-chat/src/chat/components-legacy/input/ContentEditableInput.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/input/ContentEditableInput.tsx
@@ -212,13 +212,6 @@ const ContentEditableInput = forwardRef<
     const lastNonCollapsedRangeRef = useRef<Range | null>(null);
 
     /**
-     * Counter to force re-render of the auto-resize effect when Enter is pressed.
-     * Some browsers don't fire onInput when only a <br> tag is inserted (Shift+Enter),
-     * so we need to manually trigger the height recalculation.
-     */
-    const [forceResizeCounter, setForceResizeCounter] = React.useState(0);
-
-    /**
      * Reads the current text from the DOM, enforces maxLength, and emits onChange.
      *
      * **Why read from DOM instead of tracking in state?**
@@ -279,28 +272,6 @@ const ContentEditableInput = forwardRef<
         lastNonCollapsedRangeRef.current = range.cloneRange();
       }
     }, []);
-
-    /**
-     * Handles keydown events to detect Enter key presses.
-     * When Enter is pressed (with or without Shift), we schedule a forced resize
-     * because some browsers don't fire onInput when only a <br> tag is inserted.
-     */
-    const handleKeyDown = useCallback(
-      (event: KeyboardEvent<HTMLDivElement>) => {
-        // Call the parent's onKeyDown handler first
-        onKeyDown?.(event);
-
-        // If Enter key is pressed (with or without Shift), force a resize check
-        // after the browser has had time to insert the <br> tag
-        if (event.key === "Enter" && !event.defaultPrevented) {
-          // Use setTimeout to ensure the DOM has been updated with the new line
-          setTimeout(() => {
-            setForceResizeCounter((prev) => prev + 1);
-          }, 0);
-        }
-      },
-      [onKeyDown],
-    );
 
     /**
      * Handles native paste events to enforce plain text only pasting.
@@ -460,7 +431,7 @@ const ContentEditableInput = forwardRef<
         "overflow-y": sizerHeight >= MAX_AUTO_RESIZE_HEIGHT ? "auto" : "hidden",
       });
       return () => clearDynamicStyles(editor, "editor-autoresize");
-    }, [autoSize, displayValue, forceResizeCounter]);
+    }, [autoSize, displayValue]);
 
     /**
      * Syncs external displayValue changes to the DOM without interfering with user input.
@@ -556,7 +527,7 @@ const ContentEditableInput = forwardRef<
           onBlur={onBlur}
           onFocus={onFocus}
           onInput={emitChangeFromDom}
-          onKeyDown={handleKeyDown}
+          onKeyDown={onKeyDown}
           role="textbox"
           tabIndex={disabled ? -1 : 0}
           spellCheck={true}

--- a/packages/ai-chat/src/chat/components-legacy/input/Input.scss
+++ b/packages/ai-chat/src/chat/components-legacy/input/Input.scss
@@ -208,7 +208,7 @@ label.cds-aichat--input-container__upload-button--disabled:hover {
 .cds-aichat--input-container
   .cds-aichat--text-area
   .cds-aichat--text-area-sizer {
-  max-block-size: 157px;
+  max-block-size: 180px;
 }
 
 .cds-aichat--input-container


### PR DESCRIPTION
Closes #1562

There is a mismatch with the max-height of the input inner text area (157px) and the `MAX_AUTO_RESIZE_HEIGHT` (180px) value that is referenced when the input determines when to have the scrollbar appear.

This causes an issue where at after a certain amount of lines entered in the input field, the line is partially hidden with no scrollbar appearing. See video.

This PR sets the max height of the text area to 180px, matching the `MAX_AUTO_RESIZE_HEIGHT` so that once the text area grows to that height, the scrollbar will kick in.

https://github.com/user-attachments/assets/e4f9451a-eee2-4983-9eaa-f9143679e9a5

#### Changelog

**Changed**

- set max height of text area to 180px
- have comparison set to >= in the case where the text area height is equal to the set trigger value (`MAX_AUTO_RESIZE_HEIGHT` )

#### Testing / Reviewing

Go to the demo deploy preview and enter lines into the input field one by one, you should see that the input field grows and the scrollbar appears once the input field hits max height. No text is obstructed.
