### PR TITLE
fix: markdown streaming jitters

### DIFF
--- a/packages/ai-chat-components/src/components/markdown/__tests__/markdown.test.ts
+++ b/packages/ai-chat-components/src/components/markdown/__tests__/markdown.test.ts
@@ -1522,3 +1522,179 @@ HTTP: http://example.com
     });
   });
 });
+
+describe("cds-aichat-markdown thematic break (hr) rendering", () => {
+  const HR_DOC = `Intro paragraph.
+
+- one
+- two
+
+---
+
+## After break`;
+
+  // Successive snapshots simulating streaming: a paragraph, then the thematic
+  // break appears, then content after it. The break is always preceded by a
+  // (non-heading) paragraph, so its settled top gap is spacing-05 (1rem).
+  const HR_PREFIXES = [
+    "Para A.\n\nPara B.\n\n",
+    "Para A.\n\nPara B.\n\n---",
+    "Para A.\n\nPara B.\n\n---\n\n## After break",
+    "Para A.\n\nPara B.\n\n---\n\n## After break\n\nPara C.",
+  ];
+
+  const getStack = (el: MarkdownElementInstance) =>
+    el.shadowRoot?.querySelector(".cds-aichat-markdown-stack") ?? null;
+
+  it("renders `---` as a real <hr> directly in the markdown stack (not a plugin-fallback slot host)", async () => {
+    const el = await fixture<MarkdownElementInstance>(
+      html`<cds-aichat-markdown .markdown=${HR_DOC}></cds-aichat-markdown>`,
+    );
+    await el.updateComplete;
+
+    const stack = getStack(el);
+    expect(stack, "markdown stack should exist").to.not.equal(null);
+
+    const hr = stack?.querySelector("hr");
+    expect(hr, "a real <hr> should be rendered in the stack").to.not.equal(
+      null,
+    );
+
+    // The regression routed `hr` through the plugin-fallback path, which emits
+    // a <slot> placeholder and a light-DOM `<div slot=…>` host. Guard against
+    // that: no fallback slot/host should exist for the thematic break.
+    expect(
+      stack?.querySelector('slot[name^="cds-aichat-markdown-renderer-"]'),
+      "hr must not render via a fallback <slot>",
+    ).to.equal(null);
+    expect(
+      el.querySelector('[slot^="cds-aichat-markdown-renderer-pluginFallback"]'),
+      "hr must not create a light-DOM fallback host",
+    ).to.equal(null);
+  });
+
+  it("keeps the <hr> a stable stack child with steady top spacing across streaming ticks", async () => {
+    const el = await fixture<MarkdownElementInstance>(
+      html`<cds-aichat-markdown
+        .markdown=${HR_PREFIXES[0]}
+      ></cds-aichat-markdown>`,
+    );
+    await el.updateComplete;
+
+    for (const prefix of HR_PREFIXES) {
+      el.markdown = prefix;
+      await el.updateComplete;
+
+      const stack = getStack(el);
+      const hr = stack?.querySelector("hr") as HTMLElement | null;
+
+      // Whenever the parse yields a thematic break it must be a real <hr> in
+      // the stack — never a torn-down/re-added fallback host (the source of the
+      // "margin goes away and comes back" hop).
+      expect(
+        el.querySelector(
+          '[slot^="cds-aichat-markdown-renderer-pluginFallback"]',
+        ),
+        `no fallback host should exist for prefix: ${JSON.stringify(prefix)}`,
+      ).to.equal(null);
+
+      if (hr) {
+        // hr follows a (non-heading) list, so it gets the default inter-block
+        // gap (spacing-05 = 1rem = 16px) — and that value must not flip.
+        const marginTop = getComputedStyle(hr).marginBlockStart;
+        expect(
+          marginTop,
+          `hr top margin should be the settled 16px, got ${marginTop}`,
+        ).to.equal("16px");
+      }
+    }
+  });
+
+  it("preserves element identity for blocks above the streaming frontier (stable repeat key)", async () => {
+    const el = await fixture<MarkdownElementInstance>(
+      html`<cds-aichat-markdown
+        .markdown=${"Para A.\n\nPara B.\n\n---\n"}
+      ></cds-aichat-markdown>`,
+    );
+    await el.updateComplete;
+
+    const firstHr = getStack(el)?.querySelector("hr") ?? null;
+    expect(firstHr).to.not.equal(null);
+
+    // Append more content after the hr (as streaming would). The hr's start
+    // line is unchanged, so its repeat key is stable and Lit must reuse the
+    // same DOM node rather than remounting it.
+    el.markdown = "Para A.\n\nPara B.\n\n---\n\n## After break\n\nMore text.";
+    await el.updateComplete;
+
+    const secondHr = getStack(el)?.querySelector("hr") ?? null;
+    expect(secondHr).to.not.equal(null);
+    expect(secondHr, "hr element should be reused, not remounted").to.equal(
+      firstHr,
+    );
+  });
+
+  // Inline plugin (à la markdown-it-emoji): a `nesting=0` inline leaf rendered
+  // through the fallback path as a `<span slot=…>` host. Guards that the
+  // `.cds-aichat-markdown-stack > slot { display: block }` rule (added so block
+  // fallback hosts get stack spacing) does NOT affect inline plugin output:
+  // inline fallback slots live inside the paragraph, never as a direct child of
+  // the stack, so the child-combinator rule can't match them.
+  function inlineEmojiPlugin(md: any) {
+    md.inline.ruler.before(
+      "text",
+      "cds_test_emoji",
+      (state: any, silent: boolean) => {
+        if (!state.src.slice(state.pos).startsWith(":smile:")) {
+          return false;
+        }
+        if (!silent) {
+          const token = state.push("cds_test_emoji", "", 0);
+          token.content = "😀";
+        }
+        state.pos += ":smile:".length;
+        return true;
+      },
+    );
+    md.renderer.rules.cds_test_emoji = () =>
+      `<span class="cds-test-emoji">😀</span>`;
+  }
+
+  it("does not make inline plugin-fallback slots display:block", async () => {
+    const el = await fixture<MarkdownElementInstance>(
+      html`<cds-aichat-markdown
+        .markdownItPlugins=${[inlineEmojiPlugin]}
+        .markdown=${"Hi :smile: there"}
+      ></cds-aichat-markdown>`,
+    );
+    await el.updateComplete;
+
+    // The inline plugin output is hosted in a light-DOM <span slot=…> (inline),
+    // not a <div>.
+    const host = el.querySelector(
+      '[slot^="cds-aichat-markdown-renderer-pluginFallback"]',
+    );
+    expect(host, "inline fallback host should exist").to.not.equal(null);
+    expect(host?.tagName, "inline host should be a <span>").to.equal("SPAN");
+
+    // The slot placeholder sits inside the paragraph, never as a direct child
+    // of the markdown stack, so `> slot { display: block }` cannot match it.
+    const slot = el.shadowRoot?.querySelector(
+      'slot[name^="cds-aichat-markdown-renderer-pluginFallback"]',
+    ) as HTMLSlotElement | null;
+    expect(slot, "inline fallback slot should exist").to.not.equal(null);
+    expect(
+      slot?.parentElement?.tagName,
+      "inline fallback slot must be nested in the paragraph, not the stack",
+    ).to.equal("P");
+    expect(
+      getStack(el)?.contains(slot ?? null) &&
+        slot?.parentElement?.classList.contains("cds-aichat-markdown-stack"),
+      "inline slot must not be a direct child of the stack",
+    ).to.not.equal(true);
+    expect(
+      getComputedStyle(slot as Element).display,
+      "inline fallback slot should stay display:contents (inline flow), not block",
+    ).to.equal("contents");
+  });
+});

--- a/packages/ai-chat-components/src/components/markdown/src/markdown-renderer.ts
+++ b/packages/ai-chat-components/src/components/markdown/src/markdown-renderer.ts
@@ -97,9 +97,14 @@ function renderChildTokenTrees(
   return html`${repeat(
     normalizedChildren,
     (child, index) => {
-      // Generate stable key that doesn't depend on line positions
-      // This prevents unnecessary re-renders during streaming
-      const stableKey = `${index}:${child.token.type}:${child.token.tag}`;
+      // Key by start line + type + tag rather than array index so blocks keep
+      // a stable identity when earlier siblings transiently merge/split during
+      // streaming re-parses (which would otherwise re-key and remount later
+      // blocks — e.g. remounting a code snippet and reloading its editor). We
+      // use `token.map?.[0]` (start line, like `slotNameFor`) rather than the
+      // node's `key`/`generateKey`, whose embedded end line advances every tick.
+      const startLine = child.token.map?.[0] ?? index;
+      const stableKey = `${startLine}:${child.token.type}:${child.token.tag}`;
 
       if (child.token.type?.includes("table")) {
         return `table-${stableKey}`;
@@ -383,6 +388,9 @@ function renderWithStaticTag(
 
     case "pre":
       return html`<pre ${spread(attrs)}>${content}</pre>`;
+
+    case "hr":
+      return html`<hr ${spread(attrs)} />`;
 
     // Headings
     case "h1":

--- a/packages/ai-chat-components/src/components/markdown/src/markdown.scss
+++ b/packages/ai-chat-components/src/components/markdown/src/markdown.scss
@@ -62,6 +62,14 @@
     display: block;
     max-inline-size: 100%;
 
+    // Plugin-fallback output is projected through named `<slot>` placeholders.
+    // A bare `<slot>` is `display: contents` and carries no box, so the spacing
+    // rules below wouldn't reach it. Make it a block box so slot-hosted blocks
+    // get the same (and same-flickering-free) spacing as native children.
+    > slot {
+      display: block;
+    }
+
     > *:not(:first-child) {
       margin-block-start: layout.$spacing-05;
     }
@@ -136,6 +144,13 @@
     border: solid 1px theme.$chat-bubble-border;
     background-color: theme.$layer-02;
     white-space: pre-wrap;
+  }
+
+  hr {
+    border: 0;
+    margin: 0;
+    background-color: theme.$border-subtle-01;
+    block-size: 1px;
   }
 
   img {

--- a/packages/ai-chat-components/src/components/markdown/src/markdown.ts
+++ b/packages/ai-chat-components/src/components/markdown/src/markdown.ts
@@ -763,12 +763,6 @@ class CDSAIChatMarkdown extends LitElement {
           const tag = descriptor.isInline ? "span" : "div";
           host = document.createElement(tag);
           host.setAttribute("slot", descriptor.slotName);
-          // Shadow-DOM `.cds-aichat-markdown-stack > *:not(:first-child)`
-          // doesn't reach slot-projected content; apply the same spacing
-          // inline (block hosts only — inline spans flow with text).
-          if (!descriptor.isInline) {
-            host.style.marginBlockStart = "1rem";
-          }
           this.slotHosts.set(descriptor.slotName, host);
           this.appendChild(host);
         }
@@ -816,10 +810,6 @@ class CDSAIChatMarkdown extends LitElement {
       if (!host) {
         host = document.createElement("div");
         host.setAttribute("slot", descriptor.slotName);
-        // Match the spacing applied to direct children of
-        // `.cds-aichat-markdown-stack`; shadow CSS doesn't reach
-        // slot-projected light-DOM hosts, so we apply it inline.
-        host.style.marginBlockStart = "1rem";
         this.slotHosts.set(descriptor.slotName, host);
         this.appendChild(host);
       }

--- a/packages/ai-chat-components/src/components/markdown/src/utils/plugin-fallback.ts
+++ b/packages/ai-chat-components/src/components/markdown/src/utils/plugin-fallback.ts
@@ -40,6 +40,8 @@ const NATIVELY_HANDLED_TOKEN_TYPES = new Set<string>([
   "html_inline",
   "html_container",
   "inline",
+  "hr",
+  "thematic_break",
 ]);
 
 // HTML tags whose paired open/close (or self-contained leaf) is rendered by
@@ -49,6 +51,7 @@ const NATIVELY_HANDLED_TAGS = new Set<string>([
   "p",
   "blockquote",
   "pre",
+  "hr",
   "h1",
   "h2",
   "h3",


### PR DESCRIPTION
Closes #1573

Fixes a streaming-markdown regression where a thematic break (`---`/`<hr>`) — and the block following it — visibly "hops up and down" as content streams in, losing and regaining its top margin on nearly every tick. This was introduced by #1470 (plugin extensibility): `thematic_break` has no explicit case in the hand-written renderer, so it began routing through the new plugin-fallback path, which projects the `<hr>` into a light-DOM `<div slot=…>` host carrying a hard-coded inline `margin-block-start: 1rem`. During streaming the `---` token blinks in and out across re-parses (no blank line precedes it in the demo), so that host is torn down and re-added repeatedly, and the hard-coded margin also ignored `:first-child`/heading-adjacency. The fix renders `hr` natively again so it stays a stable child of the markdown stack governed by the existing (stable) stack spacing CSS, and replaces the hard-coded host margin with CSS that also keeps genuine plugin-fallback blocks spacing-correct.

Files with non-obvious changes:
- [packages/ai-chat-components/src/components/markdown/src/markdown-renderer.ts](packages/ai-chat-components/src/components/markdown/src/markdown-renderer.ts) — adds the native `hr` case, and changes the top-level `repeat()` key from array-index to start-line + type + tag so blocks above the streaming frontier aren't remounted when earlier siblings transiently merge/split.
- [packages/ai-chat-components/src/components/markdown/src/markdown.ts](packages/ai-chat-components/src/components/markdown/src/markdown.ts) — removes the hard-coded inline `margin-block-start: 1rem` from both slot-host creation sites; spacing now comes from CSS.
- [packages/ai-chat-components/src/components/markdown/src/markdown.scss](packages/ai-chat-components/src/components/markdown/src/markdown.scss) — adds `> slot { display: block }` so block fallback hosts pick up the stack's existing spacing rules (a bare `<slot>` is `display: contents` and carries no box); inline fallback slots live inside the paragraph and are unaffected by the child-combinator selector.

#### Changelog

**New**

- Thematic breaks (`---`) now render a real, styled `<hr>` element directly in the markdown stack.
- Regression tests for hr rendering: native `<hr>` (not a fallback slot/host), steady top spacing across streaming ticks, stable element identity above the streaming frontier, and confirmation that inline plugin-fallback slots are not affected by the new slot rule.

**Changed**

- `thematic_break`/`hr` is now natively handled by the renderer instead of routing through the markdown-it plugin-fallback path.
- Top-level block keying for Lit's `repeat()` is now start-line based (position-independent) rather than array-index based, preventing avoidable remounts (e.g. a code snippet reloading its editor) during streaming.
- Block plugin-fallback host spacing is now owned by stack CSS, so a fallback block that is first or follows a heading gets the correct (non-flickering) top margin.

**Removed**

- The hard-coded inline `margin-block-start: 1rem` previously applied to every block slot-host.
