### PR TITLE
fix: processing failed with no loop value set

### DIFF
--- a/packages/ai-chat-components/src/components/processing/__stories__/processing-react.mdx
+++ b/packages/ai-chat-components/src/components/processing/__stories__/processing-react.mdx
@@ -1,12 +1,16 @@
-import { ArgTypes, Markdown, Meta } from '@storybook/addon-docs/blocks';
+import { ArgTypes, Markdown, Meta } from "@storybook/addon-docs/blocks";
 import * as ProcessingReactStories from "./processing-react.stories.jsx";
 
-<Meta of={ProcessingReactStories} parameters={{ previewTabs: { "storybook/docs/panel": { title: "Overview" } } }} />
+<Meta
+  of={ProcessingReactStories}
+  parameters={{
+    previewTabs: { "storybook/docs/panel": { title: "Overview" } },
+  }}
+/>
 
 # Processing
 
 [Source code](https://github.com/carbon-design-system/carbon-ai-chat/tree/main/packages/ai-chat-components/src/components/processing) &nbsp;|&nbsp; [Feedback](https://github.com/carbon-design-system/carbon-ai-chat/issues)
-
 
 ## Table of Contents
 
@@ -14,10 +18,9 @@ import * as ProcessingReactStories from "./processing-react.stories.jsx";
 - [Component API](#component-api)
 - [Feedback](#feedback)
 
-
 ## Overview
 
-Use `<Processing>` to show a compact AI loading indicator in React while work completes. Choose between the quick-load pulse or a looping linear animation depending on how long your task might take.
+Use `<Processing>` to show a compact AI loading indicator in React while work completes. By default the dots wait ~1s before animating in, so quick operations don't flash an indicator; pass `quickLoad` to skip that delay and show them immediately. Use `loop` for ongoing work, or let it play once when you don't need it to loop.
 
 ### Getting started
 
@@ -26,12 +29,12 @@ Here's a quick example to get you started.
 ```jsx
 import Processing from "@carbon/ai-chat-components/es/react/processing.js";
 
-function LoadingState() {
-  return <Processing quickLoad />;
-}
-
 function LinearProgress() {
   return <Processing loop />;
+}
+
+function InstantProgress() {
+  return <Processing loop quickLoad />;
 }
 ```
 
@@ -41,8 +44,8 @@ function LinearProgress() {
 
 #### Props
 
-- `quickLoad`: Enables the quick load animation.
-- `loop`: Enables the continuous linear animation.
+- `loop`: Enables the continuous linear animation. When omitted, the animation plays once.
+- `quickLoad`: Removes the ~1s entry delay so the dots appear immediately. Composes with `loop`.
 
 ## Feedback
 

--- a/packages/ai-chat-components/src/components/processing/__stories__/processing-react.stories.jsx
+++ b/packages/ai-chat-components/src/components/processing/__stories__/processing-react.stories.jsx
@@ -1,3 +1,12 @@
+/*
+ *  Copyright IBM Corp. 2025, 2026
+ *
+ *  This source code is licensed under the Apache-2.0 license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ *  @license
+ */
+
 /* eslint-disable */
 import React from "react";
 
@@ -19,6 +28,7 @@ const renderProcessing = (args) => (
 export const QuickLoad = {
   args: {
     quickLoad: true,
+    loop: true,
   },
   argTypes,
   render: renderProcessing,

--- a/packages/ai-chat-components/src/components/processing/__stories__/processing.stories.js
+++ b/packages/ai-chat-components/src/components/processing/__stories__/processing.stories.js
@@ -1,5 +1,5 @@
 /*
- *  Copyright IBM Corp. 2025
+ *  Copyright IBM Corp. 2025, 2026
  *
  *  This source code is licensed under the Apache-2.0 license found in the
  *  LICENSE file in the root directory of this source tree.
@@ -25,12 +25,13 @@ const argTypes = {
 export const QuickLoad = {
   args: {
     quickLoad: true,
+    loop: true,
     carbonTheme: "g10",
   },
   argTypes: argTypes,
   render: (args) =>
     html`<cds-aichat-processing
-      ?quickLoad=${args.quickLoad}
+      ?quick-load=${args.quickLoad}
       ?loop=${args.loop}
       carbonTheme=${args.carbonTheme}
     />`,
@@ -44,7 +45,7 @@ export const LinearLoop = {
   argTypes: argTypes,
   render: (args) =>
     html`<cds-aichat-processing
-      ?quickLoad=${args.quickLoad}
+      ?quick-load=${args.quickLoad}
       ?loop=${args.loop}
       carbonTheme=${args.carbonTheme}
     />`,
@@ -58,7 +59,7 @@ export const LinearNoLoop = {
   argTypes: argTypes,
   render: (args) => {
     return html` <cds-aichat-processing
-      ?quickLoad=${args.quickLoad}
+      ?quick-load=${args.quickLoad}
       ?loop=${args.loop}
       carbonTheme=${args.carbonTheme}
     />`;

--- a/packages/ai-chat-components/src/components/processing/__tests__/processing.test.ts
+++ b/packages/ai-chat-components/src/components/processing/__tests__/processing.test.ts
@@ -1,6 +1,6 @@
 // cspell:words CDSAIChatProcessing aichat
 /*
- *  Copyright IBM Corp. 2025
+ *  Copyright IBM Corp. 2025, 2026
  *
  *  This source code is licensed under the Apache-2.0 license found in the
  *  LICENSE file in the root directory of this source tree.
@@ -30,6 +30,18 @@ describe("aichat processing", function () {
     expect(el.shadowRoot?.querySelector(".dots")).to.exist;
   });
 
+  it("should fall back to linear--no-loop when loop is unset", async () => {
+    const el = await fixture<CDSAIChatProcessing>(
+      html`<cds-aichat-processing></cds-aichat-processing>`,
+    );
+
+    await el.updateComplete;
+
+    expect(el.shadowRoot?.querySelector(".linear--no-loop")).to.exist;
+    expect(el.shadowRoot?.querySelector(".linear:not(.linear--no-loop)")).to.not
+      .exist;
+  });
+
   it("should render with loop property", async () => {
     const el = await fixture<CDSAIChatProcessing>(
       html`<cds-aichat-processing loop></cds-aichat-processing>`,
@@ -40,13 +52,27 @@ describe("aichat processing", function () {
     expect(linearClass).to.exist;
   });
 
-  it("should render with quickLoad property", async () => {
+  it("should compose quickLoad with the non-looping variant by default", async () => {
     const el = await fixture<CDSAIChatProcessing>(
       html`<cds-aichat-processing quick-load></cds-aichat-processing>`,
     );
 
+    await el.updateComplete;
+
     expect(el.quickLoad).to.be.true;
-    const quickLoadClass = el.shadowRoot?.querySelector(".quick-load");
-    expect(quickLoadClass).to.exist;
+    const inner = el.shadowRoot?.querySelector(".quick-load");
+    expect(inner).to.exist;
+    expect(inner?.classList.contains("linear--no-loop")).to.be.true;
+  });
+
+  it("should compose quickLoad with the looping variant", async () => {
+    const el = await fixture<CDSAIChatProcessing>(
+      html`<cds-aichat-processing loop quick-load></cds-aichat-processing>`,
+    );
+
+    await el.updateComplete;
+
+    const inner = el.shadowRoot?.querySelector(".quick-load");
+    expect(inner?.classList.contains("linear")).to.be.true;
   });
 });

--- a/packages/ai-chat-components/src/components/processing/src/processing.scss
+++ b/packages/ai-chat-components/src/components/processing/src/processing.scss
@@ -1,5 +1,5 @@
 /*
- *  Copyright IBM Corp. 2025
+ *  Copyright IBM Corp. 2025, 2026
  *
  *  This source code is licensed under the Apache-2.0 license found in the
  *  LICENSE file in the root directory of this source tree.
@@ -156,6 +156,26 @@
   }
 }
 
+/*
+  QUICK LOAD: shift the whole sequence ~1s earlier so the dots appear
+  immediately instead of waiting out the entry delay. Only the animation-delay
+  is overridden, so this composes with both .linear and .linear--no-loop.
+*/
+
+.quick-load {
+  .dot--left {
+    animation-delay: 0ms, 0ms, 1000ms, 1000ms;
+  }
+
+  .dot--center {
+    animation-delay: 167ms, 167ms, 1167ms, 1167ms;
+  }
+
+  .dot--right {
+    animation-delay: 334ms, 334ms, 1334ms, 1334ms;
+  }
+}
+
 [dir="rtl"] .linear {
   .dot--left {
     animation-delay: 1334ms, 1334ms, 2334ms, 2334ms, 7334ms, 7334ms;
@@ -181,6 +201,20 @@
 
   .dot--right {
     animation-delay: 1000ms, 1000ms, 2000ms, 2000ms;
+  }
+}
+
+[dir="rtl"] .quick-load {
+  .dot--left {
+    animation-delay: 334ms, 334ms, 1334ms, 1334ms;
+  }
+
+  .dot--center {
+    animation-delay: 167ms, 167ms, 1167ms, 1167ms;
+  }
+
+  .dot--right {
+    animation-delay: 0ms, 0ms, 1000ms, 1000ms;
   }
 }
 

--- a/packages/ai-chat-components/src/components/processing/src/processing.ts
+++ b/packages/ai-chat-components/src/components/processing/src/processing.ts
@@ -1,5 +1,5 @@
 /*
- *  Copyright IBM Corp. 2025
+ *  Copyright IBM Corp. 2025, 2026
  *
  *  This source code is licensed under the Apache-2.0 license found in the
  *  LICENSE file in the root directory of this source tree.
@@ -27,15 +27,18 @@ class CDSAIChatProcessing extends LitElement {
   @property({ type: Boolean, attribute: "loop" })
   loop = false;
 
-  /** Enables the quick-load animation variant. */
+  /**
+   * Removes the ~1s entry delay so the dots appear immediately. Composes with
+   * both the looping and non-looping variants.
+   */
   @property({ type: Boolean, attribute: "quick-load" })
   quickLoad = false;
 
   render() {
     const classes = classMap({
-      [`quick-load`]: this.quickLoad === true,
-      [`linear`]: this.loop === true,
-      [`linear--no-loop`]: this.loop === false,
+      [`linear`]: this.loop,
+      [`linear--no-loop`]: !this.loop,
+      [`quick-load`]: this.quickLoad,
     });
 
     return html`<div class=${classes}>

--- a/packages/ai-chat/src/chat/components-legacy/MessagesTypingIndicator.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/MessagesTypingIndicator.tsx
@@ -1,5 +1,5 @@
 /*
- *  Copyright IBM Corp. 2025
+ *  Copyright IBM Corp. 2025, 2026
  *
  *  This source code is licensed under the Apache-2.0 license found in the
  *  LICENSE file in the root directory of this source tree.
@@ -48,6 +48,7 @@ function MessagesTypingIndicator({
                 <Processing
                   className="cds-aichat--processing-component"
                   loop
+                  quickLoad
                   carbonTheme={carbonTheme}
                   aria-label={processingLabel}
                 />{" "}


### PR DESCRIPTION
Fixes the `Processing` component's `quickLoad` variant, which was effectively dead: there was no CSS implementing `.quick-load`, and the Storybook bindings used `?quickLoad` (the property's attribute is `quick-load`), so the prop never took effect. This also clarifies the loop/no-loop class logic so the non-looping variant reliably renders when `loop` is omitted, and opts the chat typing indicator into `quickLoad` so the dots appear immediately instead of waiting out the ~1s entry delay.

- [`packages/ai-chat-components/src/components/processing/src/processing.scss`](packages/ai-chat-components/src/components/processing/src/processing.scss) — adds the new `.quick-load` keyframe-delay rules (and the RTL mirror); review the per-dot `animation-delay` timing values, which shift the whole sequence ~1s earlier while only overriding the delay so it composes with both `.linear` and `.linear--no-loop`.
- [`packages/ai-chat-components/src/components/processing/src/processing.ts`](packages/ai-chat-components/src/components/processing/src/processing.ts) — reworks the `classMap` so `loop`/`!loop` drive `linear`/`linear--no-loop` and `quick-load` is applied independently of the loop variant.

#### Changelog

**New**

- `.quick-load` animation rules (LTR + RTL) so `quickLoad` finally does something — it removes the ~1s entry delay and now composes with both the looping and non-looping variants.

**Changed**

- [`MessagesTypingIndicator`](packages/ai-chat/src/chat/components-legacy/MessagesTypingIndicator.tsx) now passes `quickLoad` alongside `loop`, so the chat typing indicator shows instantly.
- `classMap` in [`processing.ts`](packages/ai-chat-components/src/components/processing/src/processing.ts) reworked: `loop` drives `linear`/`linear--no-loop`, and `quick-load` is applied on its own rather than as a mutually exclusive variant.
- Storybook stories now bind `?quick-load` (was `?quickLoad`, which never set the attribute) and the `QuickLoad` stories set `loop` too, to demo composition; MDX docs reworded and the React stories file gained the standard license header.
- Tests updated to cover the no-loop fallback when `loop` is unset and `quickLoad` composing with both the looping and non-looping variants.

**Removed**

- None.

#### Testing / Reviewing

This is the chat typing indicator, so it's reachable in the demo, but the variants are easiest to review in Storybook plus the unit suite.

- **Storybook (Lit/React)** — Open the **Processing** stories. `QuickLoad` (now `loop` + `quickLoad`) should animate in immediately with no entry delay; `LinearLoop` and `LinearNoLoop` should be unchanged.
- **Demo** — with the watcher running (`npm run aiChat:start`), send a message in the demo chat; the typing indicator dots should appear instantly rather than after the ~1s delay.
