### PR TITLE
fix: add truncated text edgecase for 0

### DIFF
--- a/packages/ai-chat-components/src/components/truncated-text/src/truncated-text.ts
+++ b/packages/ai-chat-components/src/components/truncated-text/src/truncated-text.ts
@@ -103,7 +103,7 @@ class CDSAIChatTruncatedText extends LitElement {
 
   private _syncTruncatedVars() {
     setVarsForSelector(this._truncatedSelector, {
-      "--line-clamp-value": String(this.lines),
+      "--line-clamp-value": this.lines === 0 ? "none" : String(this.lines),
       "--max-height-value": this._maxHeight || "none",
     });
   }


### PR DESCRIPTION
Closes #1560 

previously, to resolve #1558, i changed the default value `-webkit-line-clamp` in `truncated-text.scss` from `none` to `1` to alleviate a bug where it appeared that `dynamic-css-vars-sheet` wasn't setting the value passed from `this.lines` in the `truncated-text` component.

after further investigation, i'm still unable to explain why this is happening. any other value other than `1` when passed as a variable `-webkit-line-clamp: var(--line-clamp-value, 1);` causes it to not be defined. i checked in both chrome and firefox, both of which showed that `--line-clamp-value` was unset when `1` was passed in.

i asked bob to assist me in trying to figure out why this was happening, but it wasn't able to give me a reason. this edge case may just have to do with the internal `CSSStyleSheet` api

#### Changelog

**Changed**

- `packages/ai-chat-components/src/components/truncated-text/src/truncated-text.ts` allows users to pass `0` when they want to set line clamp to `none`

#### Testing / Reviewing

while running the demo app locally, try setting different values of `lines` in `packages/ai-chat-components/src/components/toolbar/src/toolbar.ts` in the `cds-aichat-truncated-text` component
