### PR TITLE
fix(scroll): wait for markdown to render before triggering scroll logic

### DIFF
--- a/packages/ai-chat/src/chat/components-legacy/MessagesComponent.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/MessagesComponent.tsx
@@ -511,19 +511,13 @@ class MessagesComponent extends PureComponent<MessagesProps, MessagesState> {
       return;
     }
 
-    const markdownElements = Array.from(
-      targetElem.querySelectorAll(`${prefix}-markdown`),
-    );
+    const markdownElement = targetElem.querySelector(`${prefix}-markdown`);
 
-    if (!markdownElements.length) {
+    if (!markdownElement) {
       return;
     }
 
-    await Promise.all(
-      markdownElements.map((element) =>
-        element.updateComplete?.catch((): undefined => undefined),
-      ),
-    );
+    await markdownElement.updateComplete?.catch((): undefined => undefined);
 
     await new Promise<void>((resolve): void => {
       requestAnimationFrame(() => resolve());

--- a/packages/ai-chat/src/chat/components-legacy/MessagesComponent.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/MessagesComponent.tsx
@@ -12,6 +12,7 @@ import throttle from "lodash-es/throttle.js";
 import React, { Fragment, PureComponent, ReactNode } from "react";
 import { useSelector } from "../hooks/useSelector";
 import DownToBottom16 from "@carbon/icons/es/down-to-bottom/16.js";
+import prefix from "@carbon/ai-chat-components/es/globals/settings.js";
 import { HumanAgentBannerContainer } from "./humanAgent/HumanAgentBannerContainer";
 import LatestWelcomeNodes from "./LatestWelcomeNodes";
 import { MessagesScrollHandle } from "./MessagesScrollHandle";
@@ -499,6 +500,37 @@ class MessagesComponent extends PureComponent<MessagesProps, MessagesState> {
   }
 
   /**
+   * Waits for nested markdown component to finish rendering before measuring
+   * the message for pinning and scrolling.
+   */
+  private async waitForMessageComponentLayout(
+    messageComponent: MessageClass,
+  ): Promise<void> {
+    const targetElem = messageComponent?.ref?.current;
+    if (!targetElem) {
+      return;
+    }
+
+    const markdownElements = Array.from(
+      targetElem.querySelectorAll(`${prefix}-markdown`),
+    );
+
+    if (!markdownElements.length) {
+      return;
+    }
+
+    await Promise.all(
+      markdownElements.map((element) =>
+        element.updateComplete?.catch((): undefined => undefined),
+      ),
+    );
+
+    await new Promise<void>((resolve): void => {
+      requestAnimationFrame(() => resolve());
+    });
+  }
+
+  /**
    * Recalculate the spacer height for the currently pinned message without touching scrollTop.
    * Used when content below the pin changes (resize, non-streaming response, streaming done).
    * Runs synchronously inside a requestAnimationFrame — must only be called from within one.
@@ -517,10 +549,10 @@ class MessagesComponent extends PureComponent<MessagesProps, MessagesState> {
     this.domSpacerHeight = result.deficit;
   }
 
-  private executeResolvedAutoScrollAction(
+  private async executeResolvedAutoScrollAction(
     options: AutoScrollOptions,
     scrollElement: HTMLElement,
-  ): void {
+  ): Promise<void> {
     const action = resolveAutoScrollAction({
       allMessagesByID: this.props.allMessagesByID,
       localMessageItems: this.props.localMessageItems,
@@ -559,6 +591,10 @@ class MessagesComponent extends PureComponent<MessagesProps, MessagesState> {
         scrollElement.scrollTop = 0;
         return;
       case "pin_message":
+        await this.waitForMessageComponentLayout(action.messageComponent);
+        if (!scrollElement.isConnected) {
+          return;
+        }
         this.executePinAndScroll(action.messageComponent, scrollElement);
         return;
       case "recalculate_spacer":
@@ -733,17 +769,19 @@ class MessagesComponent extends PureComponent<MessagesProps, MessagesState> {
     includePublicSpacerReconciliation = false,
   ) => {
     requestAnimationFrame(() => {
-      // Execute after DOM/layout settles for the current frame so measurements
-      // (scrollHeight, rects) match what the user can actually see.
-      const scrollElement = this.messagesContainerWithScrollingRef.current;
-      if (!scrollElement) {
-        return;
-      }
+      void (async () => {
+        // Execute after DOM/layout settles for the current frame so measurements
+        // (scrollHeight, rects) match what the user can actually see.
+        const scrollElement = this.messagesContainerWithScrollingRef.current;
+        if (!scrollElement) {
+          return;
+        }
 
-      this.executeResolvedAutoScrollAction(options, scrollElement);
-      if (includePublicSpacerReconciliation) {
-        this.reconcileSpacerAfterPublicDoAutoScroll(scrollElement);
-      }
+        await this.executeResolvedAutoScrollAction(options, scrollElement);
+        if (includePublicSpacerReconciliation) {
+          this.reconcileSpacerAfterPublicDoAutoScroll(scrollElement);
+        }
+      })();
     });
   };
 


### PR DESCRIPTION
Closes #1359

We have logic where when there is a tall request message (more than 1/4 of the chat height), it should scroll and only reveal the bottom 100px of that tall request message. There was a regression with this logic.

The request message height was being measured before it was rendered and so none of the messages were considered tall. The messages are rendered with `cds-aichat-markdown`, we have to wait for the markdown component to fully render before we trigger the measure and scroll logic.

WITH FIX:
https://github.com/user-attachments/assets/53a4015a-f8bf-4b49-9b21-a1665710e453



#### Changelog


**Changed**

- Add `waitForMessageComponentLayout()` taps into the markdown component, waits for the Lit `updateComplete` promise to resolve, and then waits one browser frame to apply layout so we are sure the message is rendered before we allow for the scroll logic to trigger

#### Testing / Reviewing

- Go to demo deploy preview and insert an extra long message in the input field, hit enter
- only the bottom 100px of the message should show
- enter a one line message and make sure it renders as it does currently with short messages (with extra spacing above the top of the request message)
