### PR TITLE
fix: move scroll behavior from prompt line wrapper to pm content

### DIFF
--- a/packages/ai-chat-components/src/components/input/src/input-shell.scss
+++ b/packages/ai-chat-components/src/components/input/src/input-shell.scss
@@ -132,11 +132,10 @@
 ::slotted([slot="editor"]) {
   position: relative;
   z-index: 2;
+  overflow: visible;
   flex: 1 0;
   inline-size: 100%;
-  max-block-size: 157px;
   min-block-size: 0;
-  overflow-y: auto;
 }
 
 // -----------------------------------------------------------

--- a/packages/ai-chat-components/src/components/input/src/tiptap/editor-styles.ts
+++ b/packages/ai-chat-components/src/components/input/src/tiptap/editor-styles.ts
@@ -29,6 +29,8 @@ function ensurePmContentStyleRules(): void {
     "font-weight": "var(--cds-body-01-font-weight, 400)",
     "letter-spacing": "var(--cds-body-01-letter-spacing, 0.16px)",
     "line-height": "var(--cds-body-01-line-height, 1.42857)",
+    "max-height": "157px",
+    "overflow-y": "auto",
   });
   // Tiptap renders block content into real <p> tags inside the light-DOM
   // contenteditable. Neutralize the user-agent / host paragraph margin so


### PR DESCRIPTION
Moves scroll behavior styles from prompt-line wrapper to ProseMirror content so tooltips can escape

#### Changelog

**Changed**

-  Moved the following scroll behavior styles from "editor" slot to inner ProseMirror content
```
max-block-size: 157px;
overflow-y: auto;
```
- Set `overflow: visible` on editor slot so tooltips escape


#### Testing / Reviewing

1. `npm run start --workspace=@carbon/ai-chat-examples-web-components-input-mentions-and-commands-custom-render`
2. Add a mention tag to the prompt line (e.g. "`@Jane Smith`")
3. Verify that tooltip on tag is not at all obscured by a parent element