### PR TITLE
chore: improve test suite memory allocation

### DIFF
--- a/packages/ai-chat/jest.config.cjs
+++ b/packages/ai-chat/jest.config.cjs
@@ -53,4 +53,9 @@ module.exports = {
   testTimeout: 10000,
   modulePathIgnorePatterns: ["<rootDir>/dist/"],
   extensionsToTreatAsEsm: [".ts", ".tsx"],
+  // Recycle a worker once it exceeds this between tests, before accumulated
+  // jsdom/Lit/timer state can crash it (SIGSEGV). Cap concurrent workers so
+  // peak combined memory stays bounded on both CI runners and local machines.
+  workerIdleMemoryLimit: "512MB",
+  maxWorkers: "50%",
 };

--- a/packages/ai-chat/tests/test_helpers.ts
+++ b/packages/ai-chat/tests/test_helpers.ts
@@ -1,5 +1,5 @@
 /*
- *  Copyright IBM Corp. 2025
+ *  Copyright IBM Corp. 2025, 2026
  *
  *  This source code is licensed under the Apache-2.0 license found in the
  *  LICENSE file in the root directory of this source tree.
@@ -8,7 +8,7 @@
  */
 
 import React from "react";
-import { render, waitFor } from "@testing-library/react";
+import { cleanup, render, waitFor } from "@testing-library/react";
 import { ChatContainer } from "../src/react/ChatContainer";
 import { PublicConfig } from "../src/types/config/PublicConfig";
 import { ChatContainerProps } from "../src/types/component/ChatContainer";
@@ -143,8 +143,11 @@ export const setupBeforeEach = () => {
 
 /**
  * Standard afterEach cleanup for tests.
- * Clears the document body to ensure clean DOM between tests.
+ * Unmounts rendered React trees (running effect/component cleanup) before
+ * clearing the DOM, so jsdom/Lit/timer state does not accumulate across the
+ * many specs sharing a Jest worker.
  */
 export const setupAfterEach = () => {
+  cleanup();
   document.body.innerHTML = "";
 };


### PR DESCRIPTION
our test suite is big and was crashing workers. now forcing less workers if memory usage gets too high.

