### PR TITLE
docs: minor updates to UI customization docs

### DIFF
--- a/packages/ai-chat/docs/Header.md
+++ b/packages/ai-chat/docs/Header.md
@@ -4,7 +4,7 @@ title: Header
 
 ## Overview
 
-The header is the bar across the top of the chat. It is on by default; configure it through {@link PublicConfig.header} with a {@link HeaderConfig}. Set {@link HeaderConfig.isOn} to `false` to drop it entirely — useful for a fullscreen or embedded chat that reuses your application's own header.
+The header is the bar across the top of the chat. It is displayed by default and can be configured through {@link PublicConfig.header} with a {@link HeaderConfig}. To remove the header entirely, set {@link HeaderConfig.isOn} to `false`. This is useful for a fullscreen or embedded chat that reuses your application's own header.
 
 ```ts
 import type { PublicConfig } from "@carbon/ai-chat";
@@ -19,7 +19,7 @@ const config: PublicConfig = {
 
 ## Title and name
 
-Set {@link HeaderConfig.title} for the header title and {@link HeaderConfig.name} for the name shown after it.
+Set {@link HeaderConfig.title} for the header title and {@link HeaderConfig.name} for the **bolded** name shown directly after it.
 
 ## Built-in buttons
 

--- a/packages/ai-chat/docs/WriteableElements.md
+++ b/packages/ai-chat/docs/WriteableElements.md
@@ -4,13 +4,13 @@ title: Slots
 
 ## Overview
 
-Render your own content into slots around the chat — a custom footer, header, or panel content.
+You may render custom content inside of various slots throughout the chat, such as the chat footer, above the prompt line, and panel content.
 
 ## Writing to a slot
 
-Write your own content into slots around the chat. You write to them as portals from your application with frameworks such as React, Angular, Vue, or a web component. {@link WriteableElementName} lists the available slots.
+Write to slots as portals from your application with frameworks such as [React](./React.md), [Angular](./Angular.md), Vue, or [web components](./WebComponent.md). See {@link WriteableElementName} for a list of available slots.
 
-These examples use the {@link ChatInstance} (`instance`); see [React](./React.md) or [web components](./WebComponent.md) for how to get it.
+Access slots via {@link ChatInstance.writeableElements}.
 
 ### Align rounded corners
 


### PR DESCRIPTION
Minor updates to `Header` and `Slots` pages in the "UI customization" docs section.