### PR TITLE
docs: theme + content update

### DIFF
--- a/demo/tests/css-custom-properties.spec.ts
+++ b/demo/tests/css-custom-properties.spec.ts
@@ -1,0 +1,70 @@
+/*
+ *  Copyright IBM Corp. 2026
+ *
+ *  This source code is licensed under the Apache-2.0 license found in the
+ *  LICENSE file in the root directory of this source tree.
+ */
+
+import { PageObjectId } from "@carbon/ai-chat/server";
+import { test, expect } from "@playwright/test";
+
+import { destroyChatSession } from "./utils";
+
+// Import types for window.chatInstance without emitting runtime code
+import type {} from "../types/window";
+
+// Float layout renders the launcher button, whose painted background reads
+// `var(--cds-aichat-launcher-color-background, <default>)`. It is a good probe
+// for token inheritance because the value has to reach through two shadow
+// boundaries: the chat's render root and the launcher button's own shadow root.
+const FLOAT_SETTINGS = "/?settings=%7B%22layout%22%3A%22float%22%7D";
+
+// A distinctive color that is not any Carbon default, so a match is unambiguous.
+const OVERRIDE = "rgb(255, 0, 255)";
+
+test.afterEach(async ({ page }) => {
+  await destroyChatSession(page);
+});
+
+test("a host-page CSS custom property overrides a --cds-aichat-* token in the running chat", async ({
+  page,
+}) => {
+  await page.goto(FLOAT_SETTINGS);
+  await page.waitForLoadState("domcontentloaded");
+  await page.waitForFunction(() => Boolean(window.chatInstance), {
+    timeout: 10000,
+  });
+
+  const launcher = page.getByTestId(PageObjectId.LAUNCHER);
+  await expect(launcher).toBeVisible({ timeout: 15000 });
+
+  // Reads the painted background of the launcher button's inner `part`.
+  const readLauncherBackground = () =>
+    launcher.evaluate((host: Element) => {
+      const root = (host as HTMLElement).shadowRoot;
+      const button =
+        root?.querySelector('[part~="button"]') ??
+        root?.querySelector("button");
+      return button ? getComputedStyle(button).backgroundColor : null;
+    });
+
+  // Baseline: the launcher renders with the built-in default (Carbon
+  // button-primary), not our override color.
+  const before = await readLauncherBackground();
+  expect(before).not.toBeNull();
+  expect(before).not.toBe(OVERRIDE);
+
+  // A host page sets the token on the document root — the DOM equivalent of a
+  // page stylesheet rule `:root { --cds-aichat-launcher-color-background: ... }`.
+  // The chat no longer declares this token on its render container, so the value
+  // inherits through the shadow boundary instead of being shadowed by a default.
+  await page.evaluate((color) => {
+    document.documentElement.style.setProperty(
+      "--cds-aichat-launcher-color-background",
+      color,
+    );
+  }, OVERRIDE);
+
+  // The launcher button picks up the host value.
+  await expect.poll(readLauncherBackground, { timeout: 5000 }).toBe(OVERRIDE);
+});

--- a/packages/ai-chat-components/src/components/code-snippet/__stories__/code-snippet-react.stories.jsx
+++ b/packages/ai-chat-components/src/components/code-snippet/__stories__/code-snippet-react.stories.jsx
@@ -1,3 +1,12 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 /* eslint-disable */
 import React, {
   useCallback,
@@ -20,6 +29,8 @@ const renderSnippet = (args, code) => {
     editable,
     disabled,
     hideCopyButton,
+    hideLineNumbers,
+    hideFold,
     maxCollapsedNumberOfRows,
     maxExpandedNumberOfRows,
     minCollapsedNumberOfRows,
@@ -38,6 +49,8 @@ const renderSnippet = (args, code) => {
     editable,
     disabled,
     hideCopyButton,
+    hideLineNumbers,
+    hideFold,
   };
 
   if (typeof maxCollapsedNumberOfRows !== "undefined") {
@@ -91,6 +104,8 @@ const StreamingDemo = (args) => {
     editable,
     disabled,
     hideCopyButton,
+    hideLineNumbers,
+    hideFold,
     language,
     defaultLanguage,
     maxCollapsedNumberOfRows,
@@ -139,6 +154,8 @@ const StreamingDemo = (args) => {
     editable,
     disabled,
     hideCopyButton,
+    hideLineNumbers,
+    hideFold,
   };
 
   if (typeof language !== "undefined") {
@@ -231,6 +248,8 @@ export const Default = {
     editable: false,
     disabled: false,
     hideCopyButton: false,
+    hideLineNumbers: false,
+    hideFold: false,
     maxCollapsedNumberOfRows: 15,
     showMoreText: "Show more",
     showLessText: "Show less",

--- a/packages/ai-chat-components/src/components/code-snippet/__stories__/code-snippet.stories.js
+++ b/packages/ai-chat-components/src/components/code-snippet/__stories__/code-snippet.stories.js
@@ -1,5 +1,5 @@
 /*
- *  Copyright IBM Corp. 2025
+ *  Copyright IBM Corp. 2025, 2026
  *
  *  This source code is licensed under the Apache-2.0 license found in the
  *  LICENSE file in the root directory of this source tree.
@@ -28,6 +28,8 @@ const renderSnippet = (args, code) => {
       ?disabled=${args.disabled}
       ?hide-copy-button=${args.hideCopyButton}
       ?hide-header=${args.hideHeader}
+      ?hide-line-numbers=${args.hideLineNumbers}
+      ?hide-fold=${args.hideFold}
       max-collapsed-number-of-rows=${ifDefined(args.maxCollapsedNumberOfRows)}
       max-expanded-number-of-rows=${ifDefined(args.maxExpandedNumberOfRows)}
       min-collapsed-number-of-rows=${ifDefined(args.minCollapsedNumberOfRows)}
@@ -78,6 +80,8 @@ export const Default = {
     editable: false,
     disabled: false,
     hideCopyButton: false,
+    hideLineNumbers: false,
+    hideFold: false,
     maxCollapsedNumberOfRows: 15,
     showMoreText: "Show more",
     showLessText: "Show less",
@@ -343,6 +347,8 @@ export const FullHeightMode = {
     editable: true,
     disabled: false,
     hideCopyButton: false,
+    hideLineNumbers: false,
+    hideFold: false,
     maxCollapsedNumberOfRows: 0,
     maxExpandedNumberOfRows: 0,
   },
@@ -356,6 +362,8 @@ export const FullHeightMode = {
         ?highlight=${args.highlight}
         ?disabled=${args.disabled}
         ?hide-copy-button=${args.hideCopyButton}
+        ?hide-line-numbers=${args.hideLineNumbers}
+        ?hide-fold=${args.hideFold}
         max-collapsed-number-of-rows=${args.maxCollapsedNumberOfRows}
         max-expanded-number-of-rows=${args.maxExpandedNumberOfRows}
       >

--- a/packages/ai-chat-components/src/components/code-snippet/src/code-snippet.scss
+++ b/packages/ai-chat-components/src/components/code-snippet/src/code-snippet.scss
@@ -41,7 +41,14 @@
 .#{$prefix}--snippet {
   display: block;
   padding: 0;
-  background: theme.$background;
+  // Use the chat-shell surface token rather than $background. $background tracks
+  // the page canvas (e.g. gray #f4f4f4 in g10), so the snippet rendered gray
+  // when placed outside a card / on a non-white layer. $chat-shell-background is
+  // a single, layer-independent surface (white in white/g10, #262626 in
+  // g90/g100), so the snippet stays consistent and matches the card it usually
+  // lives in. (Longer term neither card nor snippet should key off this token
+  // for their surface — tracked separately.)
+  background: theme.$chat-shell-background;
   font-family: inherit;
   max-inline-size: 100%;
 
@@ -82,6 +89,13 @@
   .#{$prefix}--snippet {
     background-color: theme.$layer;
     color: theme.$text-disabled;
+  }
+
+  // Keep the gutter the same color as the disabled surface. The enabled gutter
+  // uses chat-shell-background (see codemirror/theme.ts); override it here so the
+  // disabled snippet reads as one flat $layer surface.
+  .cm-gutters {
+    background-color: theme.$layer;
   }
 
   .#{$prefix}--snippet-container {

--- a/packages/ai-chat-components/src/components/code-snippet/src/code-snippet.ts
+++ b/packages/ai-chat-components/src/components/code-snippet/src/code-snippet.ts
@@ -130,11 +130,22 @@ class CDSAIChatCodeSnippet extends FocusMixin(LitElement) {
   @property({ type: Boolean, reflect: true, attribute: "hide-header" })
   hideHeader = false;
 
+  /** Hide the line-number gutter in the editor. */
+  @property({ type: Boolean, reflect: true, attribute: "hide-line-numbers" })
+  hideLineNumbers = false;
+
+  /**
+   * Hide the fold gutter, removing the ability to collapse and expand code
+   * blocks (the fold keyboard shortcuts are dropped along with the gutter).
+   */
+  @property({ type: Boolean, reflect: true, attribute: "hide-fold" })
+  hideFold = false;
+
   /**
    * Maximum rows to show when collapsed.
    * Set to 0 along with maxExpandedNumberOfRows to enable fill-container mode.
    */
-  @property({ attribute: "max-collapsed-number-of-rows" })
+  @property({ type: Number, attribute: "max-collapsed-number-of-rows" })
   maxCollapsedNumberOfRows = 15;
 
   /**
@@ -142,15 +153,15 @@ class CDSAIChatCodeSnippet extends FocusMixin(LitElement) {
    * Set to 0 along with maxCollapsedNumberOfRows to enable fill-container mode,
    * where the component fills its container's height with a scrollbar.
    */
-  @property({ attribute: "max-expanded-number-of-rows" })
+  @property({ type: Number, attribute: "max-expanded-number-of-rows" })
   maxExpandedNumberOfRows = 0;
 
   /** Minimum rows to show when collapsed. */
-  @property({ attribute: "min-collapsed-number-of-rows" })
+  @property({ type: Number, attribute: "min-collapsed-number-of-rows" })
   minCollapsedNumberOfRows = 3;
 
   /** Minimum rows to show when expanded. */
-  @property({ attribute: "min-expanded-number-of-rows" })
+  @property({ type: Number, attribute: "min-expanded-number-of-rows" })
   minExpandedNumberOfRows = 16;
 
   /** Label for the “show less” control. */
@@ -518,7 +529,11 @@ class CDSAIChatCodeSnippet extends FocusMixin(LitElement) {
     const readOnlyCompartment = this.readOnlyCompartment;
     const contentAttributesCompartment = this.contentAttributesCompartment;
 
-    const needsRecreate = !this.editorView || changedProperties.has("editable");
+    const needsRecreate =
+      !this.editorView ||
+      changedProperties.has("editable") ||
+      changedProperties.has("hideLineNumbers") ||
+      changedProperties.has("hideFold");
 
     if (needsRecreate) {
       // Prevent creating multiple editors simultaneously
@@ -643,6 +658,8 @@ class CDSAIChatCodeSnippet extends FocusMixin(LitElement) {
         setupOptions: {
           foldCollapseLabel: this.foldCollapseLabel,
           foldExpandLabel: this.foldExpandLabel,
+          hideLineNumbers: this.hideLineNumbers,
+          hideFold: this.hideFold,
         },
       });
     } finally {

--- a/packages/ai-chat-components/src/components/code-snippet/src/codemirror/base-setup.ts
+++ b/packages/ai-chat-components/src/components/code-snippet/src/codemirror/base-setup.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright IBM Corp. 2025
+ * Copyright IBM Corp. 2025, 2026
  *
  * This source code is licensed under the Apache-2.0 license found in the
  * LICENSE file in the root directory of this source tree.
@@ -30,6 +30,8 @@ export interface BaseCodeMirrorSetupOptions {
   foldCollapseLabel?: string;
   foldExpandLabel?: string;
   enableDiffDecorator?: boolean;
+  hideLineNumbers?: boolean;
+  hideFold?: boolean;
 }
 
 /**
@@ -37,6 +39,10 @@ export interface BaseCodeMirrorSetupOptions {
  *  - keep the layout oriented (gutters, folding)
  *  - preserve indentation and basic syntax cues
  *  - avoid heavier behaviors like search, autocomplete, multi-caret history
+ *
+ * `hideLineNumbers` drops the line-number gutter and `hideFold` drops the
+ * folding affordances (gutter, marker key handler, and fold keymap) so callers
+ * can render a leaner surface for short, static snippets.
  */
 export function baseCodeMirrorSetup(
   options: BaseCodeMirrorSetupOptions = {},
@@ -45,20 +51,26 @@ export function baseCodeMirrorSetup(
     foldCollapseLabel = "Collapse code block",
     foldExpandLabel = "Expand code block",
     enableDiffDecorator = false,
+    hideLineNumbers = false,
+    hideFold = false,
   } = options;
 
   return [
     // Line number column for navigation and copy context
-    lineNumbers(),
-    // Event handler for keyboard accessibility on fold markers
-    carbonFoldMarkerKeyHandler(),
-    // Folding gutter affordances with Carbon chevron icon
-    foldGutter({
-      markerDOM: createCarbonFoldMarker({
-        collapseLabel: foldCollapseLabel,
-        expandLabel: foldExpandLabel,
-      }),
-    }),
+    ...(hideLineNumbers ? [] : [lineNumbers()]),
+    // Folding affordances: keyboard handler + Carbon chevron gutter. Dropped
+    // together when folding is hidden so no open/close control survives.
+    ...(hideFold
+      ? []
+      : [
+          carbonFoldMarkerKeyHandler(),
+          foldGutter({
+            markerDOM: createCarbonFoldMarker({
+              collapseLabel: foldCollapseLabel,
+              expandLabel: foldExpandLabel,
+            }),
+          }),
+        ]),
     // Selection rendering that respects multiple carets
     drawSelection(),
     // Maintain indentation on new lines
@@ -73,7 +85,7 @@ export function baseCodeMirrorSetup(
     keymap.of([
       ...closeBracketsKeymap,
       ...defaultKeymap,
-      ...foldKeymap,
+      ...(hideFold ? [] : foldKeymap),
       ...lintKeymap,
     ]),
     // Conditionally add diff line decorator for diff language

--- a/packages/ai-chat-components/src/components/code-snippet/src/codemirror/theme.ts
+++ b/packages/ai-chat-components/src/components/code-snippet/src/codemirror/theme.ts
@@ -1,5 +1,5 @@
 /*
- *  Copyright IBM Corp. 2025
+ *  Copyright IBM Corp. 2025, 2026
  *
  *  This source code is licensed under the Apache-2.0 license found in the
  *  LICENSE file in the root directory of this source tree.
@@ -84,9 +84,11 @@ export function createCarbonTheme() {
       borderLeftColor: "var(--cds-text-primary, #161616)",
     },
 
-    // Gutters
+    // Gutters. Match the snippet surface (chat-shell-background) so the gutter
+    // and code area read as one surface. The disabled state overrides both to
+    // $layer in code-snippet.scss (:host([disabled])), keeping them matched.
     ".cm-gutters": {
-      backgroundColor: "var(--cds-background, #ffffff)",
+      backgroundColor: "var(--cds-chat-shell-background, #ffffff)",
       color: "var(--cds-text-helper, #6f6f6f)",
       border: "none",
     },
@@ -107,7 +109,7 @@ export function createCarbonTheme() {
 
     ".cm-scroller": {
       maxBlockSize: "var(--cds-snippet-max-height, 16rem)",
-      minBlockSize: "var(--cds-snippet-min-height, 3rem)",
+      minBlockSize: "var(--cds-snippet-min-height, auto)",
     },
 
     // Fold gutter / caret icons

--- a/packages/ai-chat/docs/AGENTS_DOC_STYLE.md
+++ b/packages/ai-chat/docs/AGENTS_DOC_STYLE.md
@@ -89,8 +89,6 @@ function App() {
 }
 ```
 
-A **single** shell command goes in inline single backticks, not a fenced block — `` `npm install @carbon/ai-chat` ``, not a ` ```bash ` block. Reserve fenced blocks for multi-line scripts or command sequences. See the install sections of [React.md](./React.md) and [WebComponent.md](./WebComponent.md) for the pattern.
-
 All examples must be tested. Follow the validation checklist in [AGENTS.md](AGENTS.md) → _Code examples in docs_.
 
 ## Admonitions

--- a/packages/ai-chat/docs/AddMessageChunk.md
+++ b/packages/ai-chat/docs/AddMessageChunk.md
@@ -6,9 +6,9 @@ title: Adding messages (legacy)
 
 Stream a response onto the screen as your assistant produces it with {@link ChatInstanceMessaging.addMessageChunk}. The examples below call `instance.messaging`, so you need a {@link ChatInstance} first — get one from the `onBeforeRender` prop. It uses three types of chunks ({@link StreamChunk}) to progressively build and finalize a message response:
 
-1. **Partial item chunks** — incremental updates to an individual item.
-2. **Complete item chunks** — finalize one item while others keep streaming.
-3. **Final response chunks** — the authoritative final state for the whole message.
+- **Partial item chunks** — incremental updates to an individual item.
+- **Complete item chunks** — finalize one item while others keep streaming.
+- **Final response chunks** — the authoritative final state for the whole message.
 
 For one-shot, non-streaming inserts use {@link ChatInstanceMessaging.addMessage} instead; your assistant can return responses in either format and switch between them. To accumulate state in your app and apply it with one call per update, see [Adding messages (experimental)](./UpsertMessage.md). It also covers regenerate and optimistic updates.
 
@@ -125,10 +125,7 @@ await instance.messaging.addMessageChunk({
 
 ## Typical streaming flow
 
-1. Generate a unique `response_id` for the message
-2. Loop through your streaming source, sending partial item chunks for each update
-3. (Optional) Send complete item chunks when individual items are finalized
-4. Send a final response chunk with the complete message
+Generate a unique `response_id` for the message, then loop through your streaming source, sending a partial item chunk for each update. Optionally send complete item chunks as individual items are finalized. Finish with a final response chunk carrying the complete message.
 
 The Carbon AI Chat appends partial text updates at draw time (for {@link TextItem} and {@link ConversationalSearchItem}), renders streaming text, and transitions to the final state when the final response chunk arrives.
 

--- a/packages/ai-chat/docs/Angular.md
+++ b/packages/ai-chat/docs/Angular.md
@@ -12,11 +12,15 @@ Angular renders the Carbon AI Chat web components directly, so the [web componen
 
 Install using `npm`:
 
-`npm install @carbon/ai-chat`
+```
+npm install @carbon/ai-chat
+```
 
 Or using `yarn`:
 
-`yarn add @carbon/ai-chat`
+```
+yarn add @carbon/ai-chat
+```
 
 > **Note**: Install the required `peerDependencies`. See the [peer dependency changes](https://github.com/carbon-design-system/carbon-ai-chat/blob/main/docs/peer-dependency-changes.md) for a history of additions, removals, and version updates across releases.
 

--- a/packages/ai-chat/docs/CustomMessageFooter.md
+++ b/packages/ai-chat/docs/CustomMessageFooter.md
@@ -8,7 +8,7 @@ Render your own content beneath an assistant message — copy and share actions,
 
 ## How it works
 
-A message renders a custom footer when your backend includes `custom_footer_slot` on it. When the chat receives such a message, it fires a {@link BusEventType.CUSTOM_FOOTER_SLOT} event carrying an `additional_data` object, which you populate on the backend with whatever the footer needs to render (for example, a flag to allow copy or a share URL).
+A message renders a custom footer when your backend includes `custom_footer_slot` on it. Populate its `additional_data` object on the backend with whatever the footer needs to render (for example, a flag to allow copy or a share URL).
 
 Give each message's `custom_footer_slot` a unique `slot_name`. The slot name identifies a single footer instance, so reusing the same value across messages collapses them onto one slot and only the first message's footer renders. Derive it from the message ID or a counter — for example, `copy_footer_${id}`.
 
@@ -17,16 +17,14 @@ Your renderer receives the accumulated {@link RenderCustomMessageFooterState} fo
 - The {@link GenericItem} message item the footer attaches to, for reading message content.
 - The full {@link MessageResponse} the item belongs to.
 - The {@link ChatInstance}, for calling instance methods from the footer.
-- The `additionalData` object your backend attached to the event.
+- The `additionalData` object your backend attached to the message.
 
 ## Rendering a footer
 
-Each framework exposes a managed renderer that subscribes to the event, tracks each slot, and manages element lifecycle for you:
+Each framework exposes a managed renderer that tracks each slot and manages element lifecycle for you:
 
 - **React** — pass the {@link ChatContainerProps.renderCustomMessageFooter} render prop. See [React](./React.md#custom-message-footer).
 - **Web component** — set the {@link CdsAiChatContainerAttributes.renderCustomMessageFooter} callback property. See [Web component](./WebComponent.md#custom-message-footer).
-
-For fine-grained control, you can instead subscribe to {@link BusEventType.CUSTOM_FOOTER_SLOT} directly and manage slots yourself — see the legacy approach on each framework page.
 
 ## Related
 

--- a/packages/ai-chat/docs/Customization.md
+++ b/packages/ai-chat/docs/Customization.md
@@ -20,7 +20,7 @@ Customize the chat UI at three levels, from quickest to deepest:
 - **Restyle** — inherit or inject a Carbon theme and override the chat's CSS custom-property tokens for color, sizing, and placement.
 - **Inject your own content** — render your own markup into slots, overlay panels, message responses, and footers.
 
-The inject-your-own-content areas render through your framework, so they need the {@link ChatInstance} and the APIs differ between [React](./React.md) and the [web component](./WebComponent.md).
+The inject-your-own-content areas render through your framework using the {@link ChatInstance}, so their APIs differ between [React](./React.md) and the [web component](./WebComponent.md). Be sure to refer to the documentation for your framework for implementation differences.
 
 Pick the area you want to customize:
 

--- a/packages/ai-chat/docs/Homescreen.md
+++ b/packages/ai-chat/docs/Homescreen.md
@@ -31,7 +31,7 @@ To hide the default greeting and starters and supply your own markup instead, se
 
 ## Returning to the home screen
 
-By default users can reopen the home screen after sending a message. Set {@link HomeScreenConfig.disableReturn} to `true` to keep them in the conversation once it starts.
+By default users can navigate back to the home screen after sending a message. Set {@link HomeScreenConfig.disableReturn} to `true` to keep them in the conversation once it starts.
 
 ## Related
 

--- a/packages/ai-chat/docs/Layout.md
+++ b/packages/ai-chat/docs/Layout.md
@@ -27,13 +27,13 @@ Size and place the chat by overriding its `--cds-aichat-*` custom properties in 
 
 These shared tokens apply to both the floating and custom-element layouts:
 
-| Token                              | Default | Description                                    |
-| ---------------------------------- | ------- | ---------------------------------------------- |
-| `--cds-aichat-messages-max-width`  | `672px` | Maximum width for message content area         |
-| `--cds-aichat-messages-min-width`  | `320px` | Minimum width for message content area         |
-| `--cds-aichat-workspace-min-width` | `480px` | Minimum width for workspace panel              |
-| `--cds-aichat-history-width`       | `320px` | Width of the history / conversation list panel |
-| `--cds-aichat-card-max-width`      | `424px` | Maximum width for card components              |
+| Token                              | Default | Description                                                   |
+| ---------------------------------- | ------- | ------------------------------------------------------------- |
+| `--cds-aichat-messages-max-width`  | `672px` | Maximum width for message content area, including prompt line |
+| `--cds-aichat-messages-min-width`  | `320px` | Minimum width for message content area, including prompt line |
+| `--cds-aichat-workspace-min-width` | `480px` | Minimum width for workspace panel                             |
+| `--cds-aichat-history-width`       | `320px` | Width of the history / conversation list panel                |
+| `--cds-aichat-card-max-width`      | `424px` | Maximum width for card components                             |
 
 You can also set these tokens from config through {@link LayoutConfig.customProperties} (keys come from {@link LayoutCustomProperties}) if you'd rather keep them out of a stylesheet.
 

--- a/packages/ai-chat/docs/Overview.md
+++ b/packages/ai-chat/docs/Overview.md
@@ -22,13 +22,13 @@ See the [React](./React.md), [web component](./WebComponent.md) and [Angular](./
 
 Each component accepts {@link PublicConfig}'s options as props that control how the chat looks and behaves before your users see it. Set where the chat renders along with its size, frame, and corners ({@link LayoutConfig}); which surfaces appear — the {@link LauncherConfig launcher} (IBM's or your own), {@link HeaderConfig header}, {@link HomeScreenConfig home screen}, and {@link InputConfig input}; how the chat reaches your server ({@link PublicConfigMessaging}); and its theme, language, and assistant identity. See {@link PublicConfig} for every option.
 
-### Instance methods
+## Instance methods
 
 You get the {@link ChatInstance} from the {@link ChatContainerProps.onBeforeRender} callback, which the chat calls with the instance before it renders. Each instance provides imperative runtime methods your website can call any time after the instance is available. These methods aren't attributes or props — they affect internal or shared chat state.
 
 Use the instance to add, update, and remove messages ({@link ChatInstanceMessaging}); open, close, or switch the chat view ({@link ChatInstance.changeView}); read or seed the input field ({@link ChatInstanceInput}); subscribe to events ({@link EventHandlers.on}); hand off to a human agent ({@link ChatInstanceServiceDeskActions}); and render your own content into the chat's slots ({@link WriteableElements}). See {@link ChatInstance} for the full API.
 
-### Events
+## Events
 
 The Carbon AI Chat fires {@link BusEvent events} throughout its life cycle. Subscribe with {@link EventHandlers.on} to react to messages received ({@link BusEventType.RECEIVE}), the chat opening or closing ({@link BusEventType.VIEW_CHANGE}), user feedback ({@link BusEventType.FEEDBACK}), and human-agent handoff. Many events also fire in a `pre:` form the chat awaits before it acts ({@link BusEventType.PRE_SEND}), so a handler can inspect, change, or cancel what happens next. See {@link BusEvent} for every event.
 

--- a/packages/ai-chat/docs/React.md
+++ b/packages/ai-chat/docs/React.md
@@ -20,11 +20,15 @@ For more information, see [the examples page](https://github.com/carbon-design-s
 
 Install with npm:
 
-`npm install @carbon/ai-chat`
+```
+npm install @carbon/ai-chat
+```
 
 Or with yarn:
 
-`yarn add @carbon/ai-chat`
+```
+yarn add @carbon/ai-chat
+```
 
 > **Note**: Install the required `peerDependencies`. See the [peer dependency changes](https://github.com/carbon-design-system/carbon-ai-chat/blob/main/docs/peer-dependency-changes.md) for a history of additions, removals, and version updates across releases.
 

--- a/packages/ai-chat/docs/StructuredData.md
+++ b/packages/ai-chat/docs/StructuredData.md
@@ -8,8 +8,8 @@ Sometimes a user's message needs to carry more than text — a form selection, a
 
 It is request-side only: it travels on {@link MessageInput.structured_data} in the {@link MessageRequest} your {@link PublicConfigMessaging.customSendMessage} function receives, and is never part of a {@link MessageResponse}. Two sources populate it, and they merge into one payload:
 
-1. **The host sets it** — push fields into the pending input with {@link ChatInstanceInput.updateStructuredData}.
-2. **File uploads contribute it** — when {@link PublicConfig.upload} is enabled, each file's {@link UploadConfig.onFileUpload} handler returns a fragment that is merged in.
+- **The host sets it** — push fields into the pending input with {@link ChatInstanceInput.updateStructuredData}.
+- **File uploads contribute it** — when {@link PublicConfig.upload} is enabled, each file's {@link UploadConfig.onFileUpload} handler returns a fragment that is merged in.
 
 > This API is experimental. Its shape may still change.
 

--- a/packages/ai-chat/docs/Theming.md
+++ b/packages/ai-chat/docs/Theming.md
@@ -36,16 +36,18 @@ See [React](./React.md) and [web components](./WebComponent.md) for how config r
 
 ## Override specific colors
 
-The chat exposes two layers of CSS custom properties you can override from your own stylesheet:
+The chat exposes two layers of CSS custom properties:
 
 - `--cds-aichat-*` tokens style the chat's own shell and launcher.
 - The underlying Carbon `--cds-*` tokens style the Carbon components rendered inside the chat — buttons, links, inputs, and surfaces.
 
-Custom properties inherit through the chat's shadow boundary, so setting them on a host element flows into the chat:
+### Override with your own CSS
+
+The simplest way to recolor (or resize) the chat is to set these custom properties on a host element. They inherit through the chat's shadow boundary, so the chat picks them up:
 
 ```css
 .my-host {
-  /* Chat shell token */
+  /* Chat shell tokens */
   --cds-aichat-launcher-color-background: #1a1a2e;
   /* Carbon component tokens */
   --cds-link-primary: #1a1a2e;
@@ -53,7 +55,29 @@ Custom properties inherit through the chat's shadow boundary, so setting them on
 }
 ```
 
-The chat picks up your `--cds-*` overrides whenever it inherits its theme from the page — the default, or when your site uses Carbon. If you force a theme with `injectCarbonTheme`, the chat supplies its own Carbon tokens, so recolor the shell with the `--cds-aichat-*` tokens instead (or override `--cds-*` in inherit mode).
+The `--cds-aichat-*` shell tokens are overridable this way in every theme mode. The Carbon `--cds-*` tokens are overridable this way whenever the chat inherits its theme — the default, or when your site uses Carbon.
+
+### Override under a forced theme
+
+If you force a theme with {@link PublicConfig.injectCarbonTheme}, the chat supplies its own Carbon `--cds-*` tokens, so page-level `--cds-*` overrides no longer reach the Carbon components. Set them through {@link LayoutConfig.customProperties} instead — the chat injects these inside its own DOM, so they win over the forced theme. A bare key sets a `--cds-aichat-*` shell token; a key prefixed with `$` sets a Carbon `--cds-*` token (`$`-prefixed values must be hexadecimal colors):
+
+```tsx
+import { ChatContainer, CarbonTheme } from "@carbon/ai-chat";
+import type { PublicConfig } from "@carbon/ai-chat";
+
+const config: PublicConfig = {
+  injectCarbonTheme: CarbonTheme.G100,
+  layout: {
+    customProperties: {
+      // Chat shell token -> --cds-aichat-launcher-color-background
+      "launcher-color-background": "#1a1a2e",
+      // Carbon component tokens -> --cds-button-primary / --cds-link-primary
+      "$button-primary": "#1a1a2e",
+      "$link-primary": "#1a1a2e",
+    },
+  },
+};
+```
 
 [Layout](./Layout.md) documents the `--cds-aichat-*` sizing and placement tokens and how to set them through {@link LayoutConfig.customProperties}; [Launcher](./Launcher.md) documents the launcher and unread-indicator tokens.
 

--- a/packages/ai-chat/docs/WebComponent.md
+++ b/packages/ai-chat/docs/WebComponent.md
@@ -18,11 +18,15 @@ You receive the {@link ChatInstance} from {@link CdsAiChatContainerAttributes.on
 
 Install by using `npm`:
 
-`npm install @carbon/ai-chat`
+```
+npm install @carbon/ai-chat
+```
 
 Or using `yarn`:
 
-`yarn add @carbon/ai-chat`
+```
+yarn add @carbon/ai-chat
+```
 
 > **Note**: Install the required `peerDependencies`. See the [peer dependency changes](https://github.com/carbon-design-system/carbon-ai-chat/blob/main/docs/peer-dependency-changes.md) for a history of additions, removals, and version updates across releases.
 

--- a/packages/ai-chat/src/chat/AppShellStyles.scss
+++ b/packages/ai-chat/src/chat/AppShellStyles.scss
@@ -1,5 +1,5 @@
 /*
- *  Copyright IBM Corp. 2025
+ *  Copyright IBM Corp. 2025, 2026
  *
  *  This source code is licensed under the Apache-2.0 license found in the
  *  LICENSE file in the root directory of this source tree.
@@ -29,7 +29,6 @@ Chat custom css properties
 */
 
 @use "@carbon/colors";
-@use "@carbon/styles/scss/components/button/tokens";
 
 // Import shared tokens from @carbon/ai-chat-components
 // These are the public configurable tokens that are shared across both packages
@@ -41,60 +40,21 @@ Chat custom css properties
   color: theme.$text-primary;
   inline-size: 100%;
 
-  /* **************************************************************************************************************** */
-
-  /* Shared tokens from @carbon/ai-chat-components */
-  /* These are imported and will be available as CSS custom properties */
-  /* See @carbon/ai-chat-components/scss/_custom-properties.scss for the full list */
-
-  /* **************************************************************************************************************** */
-
-  /* Container-specific properties (ChatContainer floating widget) */
-
-  /* Application sizing and positioning */
-  --cds-aichat-max-height: 640px;
-
-  /* WCAG 2.1 states that the widget must be usable at 320x256 (or the equivalent from zoom happening) https://www.w3.org/WAI/WCAG21/Understanding/reflow.html
-  We make sure the min-height at least 150px (to show at least the header/footer and one line of text) and is the lower of 256px minus the spacing from the bottom of the view port or 100vh - the bottom position. */
-  --cds-aichat-min-height: max(
-    150px,
-    calc(min(256px, 100vh) - var(--cds-aichat-bottom-position))
-  );
-
-  /* Container positioning */
-  --cds-aichat-bottom-position: #{layout.$spacing-09};
-  --cds-aichat-right-position: #{layout.$spacing-07};
-  --cds-aichat-top-position: auto;
-  --cds-aichat-left-position: auto;
-
-  /* Container sizing */
-  /* The smaller of 380px or the available width of the screen. This is to account for zoom levels pushing us to 320px. */
-  --cds-aichat-width: min(380px, var(--cds-aichat-max-width));
-  --cds-aichat-height: calc(100vh - (2 * #{layout.$spacing-07}));
-
-  /* Container z-index */
-  --cds-aichat-z-index: 99999;
-
-  /* **************************************************************************************************************** */
-
-  /* Launcher properties (ChatContainer-specific) */
-  /* These properties control the floating launcher button appearance and behavior */
-
-  /* Launcher sizing and positioning */
-  --cds-aichat-launcher-default-size: 56px;
-  --cds-aichat-launcher-position-bottom: #{layout.$spacing-09};
-  --cds-aichat-launcher-position-right: #{layout.$spacing-07};
-  --cds-aichat-launcher-extended-width: 280px;
-
-  /* Launcher colors */
-  --cds-aichat-launcher-color-background: #{tokens.$button-primary};
-  --cds-aichat-launcher-color-avatar: #{theme.$text-on-color};
-  --cds-aichat-launcher-color-focus-border: #{theme.$text-on-color};
-  --cds-aichat-launcher-mobile-color-text: #{theme.$text-on-color};
-
-  /* Unread indicator colors */
-  --cds-aichat-unread-indicator-color-background: #{theme.$support-error};
-  --cds-aichat-unread-indicator-color-text: #{theme.$text-on-color};
+  /*
+   * The chat's themeable --cds-aichat-* tokens (sizing, positioning, launcher,
+   * and unread-indicator colors) are intentionally NOT declared on this wrapper.
+   * Each consumer reads them with a built-in default through the
+   * `get-var(name, default)` helper, e.g. `var(--cds-aichat-width, 380px)`.
+   *
+   * Keeping the defaults in the consumer fallback — instead of declaring them
+   * here — lets a host page (or `layout.customProperties`) override any token by
+   * setting the matching --cds-aichat-* property. A value declared on this
+   * wrapper would shadow the inherited host value and silently win.
+   *
+   * Contextual overrides are the deliberate exception: the phone and
+   * rounded-corner blocks below still declare tokens so those modes win over a
+   * host value.
+   */
 }
 
 .cds-aichat--container--render .cds-aichat--widget--rounded {

--- a/packages/ai-chat/src/chat/utils/styleUtils.ts
+++ b/packages/ai-chat/src/chat/utils/styleUtils.ts
@@ -1,5 +1,5 @@
 /*
- *  Copyright IBM Corp. 2025
+ *  Copyright IBM Corp. 2025, 2026
  *
  *  This source code is licensed under the Apache-2.0 license found in the
  *  LICENSE file in the root directory of this source tree.
@@ -211,7 +211,7 @@ function mergeCSSVariables(
     // Variables starting with "$" are carbon theme tokens and should all be colors
     if (key.startsWith("$") && !value.match(HEXADECIMAL_REGEX)) {
       console.warn(
-        `${WA_CONSOLE_PREFIX} You tried to call "updateCSSVariables" with an invalid value for "${key}": "${publicVars[key]}". You must use hexadecimal values for colors.`,
+        `${WA_CONSOLE_PREFIX} Invalid value for "layout.customProperties" key "${key}": "${publicVars[key]}". Carbon theme tokens (keys starting with "$") must use hexadecimal color values.`,
       );
       // Delete color values that are not in hexadecimal format to ensure we can use them in methods in ./colors.
       delete result[key];

--- a/packages/ai-chat/src/globals/scss/_chat-float-layout.scss
+++ b/packages/ai-chat/src/globals/scss/_chat-float-layout.scss
@@ -34,7 +34,22 @@
 
 // Application layout variables (only used in this file)
 $max-height: get-var("max-height", 640px);
-$min-height: get-var("min-height", 150px);
+// WCAG 2.1 reflow (320x256): keep the widget at least 150px tall, otherwise the
+// lower of 256px-from-top or the space above the bottom offset. This default
+// lives here (not on the container) so a host override of --cds-aichat-min-height
+// can still win; see AppShellStyles.scss.
+$min-height: get-var(
+  "min-height",
+  max(
+    150px,
+    calc(
+      min(256px, 100vh) - var(
+          --cds-aichat-bottom-position,
+          #{layout.$spacing-09}
+        )
+    )
+  )
+);
 $width: get-var("width", 380px);
 $height: get-var("height", calc(100vh - (2 * #{layout.$spacing-07})));
 

--- a/packages/ai-chat/src/types/config/PublicConfig.ts
+++ b/packages/ai-chat/src/types/config/PublicConfig.ts
@@ -587,16 +587,32 @@ export interface LayoutConfig {
   corners?: CornersType | PerCornerConfig;
 
   /**
-   * CSS variable overrides for the chat UI. This is a convienience method, you may also set these properties via CSS.
+   * CSS custom property overrides for the chat UI. This is a convenience method; you may also set
+   * these properties via CSS. Unlike page-level CSS, these overrides are injected inside the chat
+   * and win even when a theme is forced with {@link PublicConfig.injectCarbonTheme}.
    *
-   * Keys correspond to values from `LayoutCustomProperties` (e.g. `LayoutCustomProperties.height`),
-   * which map to the underlying `--cds-aichat-…` custom properties.
-   * Values are raw CSS values such as `"420px"`, `"9999"`, etc.
+   * Two token layers are supported, distinguished by the key:
+   *
+   * - **Chat shell tokens** — a value from `LayoutCustomProperties` (e.g. `"width"` or
+   *   `"launcher-color-background"`) maps to the matching `--cds-aichat-…` custom property.
+   * - **Carbon theme tokens** — any Carbon token name prefixed with `$` (e.g. `"$button-primary"`)
+   *   maps to the matching `--cds-…` custom property (`--cds-button-primary`). Use this to recolor
+   *   the Carbon components rendered inside the chat. `$`-prefixed values must be hexadecimal colors.
+   *
+   * Values are raw CSS values such as `"420px"`, `"9999"`, or `"#1a1a2e"`.
    *
    * Example:
-   * { height: "560px", width: "420px" }
+   * ```ts
+   * {
+   *   width: "420px",
+   *   "launcher-color-background": "#1a1a2e",
+   *   "$button-primary": "#1a1a2e",
+   * }
+   * ```
    */
-  customProperties?: Partial<Record<LayoutCustomProperties, string>>;
+  customProperties?: Partial<
+    Record<LayoutCustomProperties | `$${string}`, string>
+  >;
 }
 
 /**

--- a/packages/ai-chat/tests/utils/spec/styleUtils_spec.ts
+++ b/packages/ai-chat/tests/utils/spec/styleUtils_spec.ts
@@ -1,0 +1,94 @@
+/*
+ *  Copyright IBM Corp. 2025, 2026
+ *
+ *  This source code is licensed under the Apache-2.0 license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ *  @license
+ */
+
+import {
+  convertCSSVariablesToString,
+  mergeCSSVariables,
+} from "../../../src/chat/utils/styleUtils";
+import { CarbonTheme } from "../../../src/types/config/PublicConfig";
+
+describe("styleUtils", () => {
+  describe("convertCSSVariablesToString", () => {
+    it("maps bare keys to --cds-aichat-* shell tokens", () => {
+      const css = convertCSSVariablesToString({
+        "launcher-color-background": "#1a1a2e",
+      });
+      expect(css).toContain("--cds-aichat-launcher-color-background:#1a1a2e;");
+    });
+
+    it("maps $-prefixed keys to Carbon --cds-* tokens", () => {
+      const css = convertCSSVariablesToString({
+        "$button-primary": "#1a1a2e",
+        "$link-primary": "#abcdef",
+      });
+      expect(css).toContain("--cds-button-primary:#1a1a2e;");
+      expect(css).toContain("--cds-link-primary:#abcdef;");
+      // The "$" should be stripped, not emitted as part of the property name.
+      expect(css).not.toContain("--cds-$");
+    });
+
+    it("targets the theme classes so overrides win under injectCarbonTheme", () => {
+      const css = convertCSSVariablesToString({ "$button-primary": "#1a1a2e" });
+      // Doubled render class (specificity 0,2,0) beats Carbon's single theme class,
+      // and each forced theme class is covered explicitly.
+      expect(css).toContain(
+        ".cds-aichat--container--render.cds-aichat--container--render",
+      );
+      expect(css).toContain(".cds-aichat--container--render.cds--g100");
+      expect(css).toContain(":host");
+    });
+
+    it("returns an empty string for empty or nullish input", () => {
+      expect(convertCSSVariablesToString({})).toBe("");
+      expect(
+        convertCSSVariablesToString(
+          undefined as unknown as Record<string, string>,
+        ),
+      ).toBe("");
+    });
+  });
+
+  describe("mergeCSSVariables", () => {
+    const noWhiteLabel = {} as never;
+
+    it("keeps $-prefixed Carbon tokens with hexadecimal values", () => {
+      const result = mergeCSSVariables(
+        { "$button-primary": "#1a1a2e" },
+        noWhiteLabel,
+        CarbonTheme.G100,
+        true,
+      );
+      expect(result["$button-primary"]).toBe("#1a1a2e");
+    });
+
+    it("drops $-prefixed tokens whose value is not hexadecimal", () => {
+      const warn = jest.spyOn(console, "warn").mockImplementation(() => {});
+      const result = mergeCSSVariables(
+        { "$button-primary": "rebeccapurple" },
+        noWhiteLabel,
+        CarbonTheme.G100,
+        true,
+      );
+      expect(result["$button-primary"]).toBeUndefined();
+      expect(warn).toHaveBeenCalledTimes(1);
+      warn.mockRestore();
+    });
+
+    it("preserves bare shell tokens with non-color values", () => {
+      const result = mergeCSSVariables(
+        { width: "420px", "launcher-color-background": "#1a1a2e" },
+        noWhiteLabel,
+        CarbonTheme.G100,
+        true,
+      );
+      expect(result.width).toBe("420px");
+      expect(result["launcher-color-background"]).toBe("#1a1a2e");
+    });
+  });
+});

--- a/packages/typedoc-theme/carbonThemePlugin.js
+++ b/packages/typedoc-theme/carbonThemePlugin.js
@@ -16,13 +16,15 @@ import { promises as fs, cpSync } from "fs";
 const require = createRequire(import.meta.url);
 
 const CARBON_ASSETS = [
-  "carbonSearch.js",
-  "carbonSearchModal.js",
+  /*"carbonSearch.js",
+  "carbonSearchModal.js",*/
   "redirectToOverview.js",
   "carbonTheme.css",
   "cookiePreferences.js",
   "versionDropdown.js",
   "experimentalToPreview.js",
+  "sideNavFocus.js",
+  "signatureCards.js",
 ];
 
 export function load(app) {

--- a/packages/typedoc-theme/theme/assets/carbonTheme.css
+++ b/packages/typedoc-theme/theme/assets/carbonTheme.css
@@ -52,11 +52,20 @@ cds-aichat-code-snippet:not(:defined) {
   font-family: var(--cds-code-01-font-family, monospace);
 }
 
-/* Breathing room above each fenced code block, applied in both the
- * pre-hydration and hydrated states so the spacing doesn't shift on load. */
-cds-aichat-code-snippet {
-  display: block;
+/* Breathing room above each fenced code block. The `.cds--tile` class (from
+ * @carbon/styles) already sets display:block; we only add the top margin. We
+ * use the class rather than the <cds-tile> web component because that
+ * component's updated() lifecycle rewrites the first <a> inside the tile with
+ * extra <br>s, which mangles the link-heavy signature blocks. */
+.cds--tile {
   margin-top: 1rem;
+}
+
+/* Signature tiles (see theme/assets/signatureCards.js) hold a single-line
+ * TypeDoc signature, so drop the tile's default min-block-size (4rem) and let
+ * it hug the content. Scoped so fenced-code tiles keep theirs. */
+.carbon-main-content .carbon-signature-tile {
+  min-block-size: 0;
 }
 
 /* Hide main content until key UI shell components are ready */
@@ -123,8 +132,10 @@ h6 {
 }
 
 p {
-  font-size: var(--cds-body-01, 1rem);
-  line-height: 1.5;
+  font-size: var(--cds-body-02-font-size, 1rem);
+  font-weight: var(--cds-body-02-font-weight, 400);
+  letter-spacing: var(--cds-body-02-letter-spacing, 0);
+  line-height: var(--cds-body-02-line-height, 1.5);
   color: var(--cds-text-primary, #161616);
   margin: var(--cds-spacing-04, 0.75rem) 0 0 0;
 }
@@ -158,6 +169,23 @@ a:hover {
   display: flex;
 }
 
+.tsd-signature {
+  font-family: var(--cds-code-01-font-family, 'IBM Plex Mono', monospace);
+  font-size: var(--cds-code-01-font-size, 0.875rem);
+  font-weight: var(--cds-code-01-font-weight, 400);
+  letter-spacing: var(--cds-code-01-letter-spacing, 0.16px);
+  line-height: var(--cds-code-01-line-height, 1.5);
+}
+
+/* TypeDoc lays out long signatures across multiple lines with <br/> + non-
+ * breaking-space indentation. The generic .tsd-anchor-link flex rule above
+ * would make the signature a flex row — where <br/> is inert — collapsing the
+ * whole signature onto one line. Keep signature blocks block-level so the line
+ * breaks render. (The permalink icon still flows inline at the end.) */
+.tsd-signature.tsd-anchor-link {
+  display: block;
+}
+
 a:visited {
   color: var(--cds-link-visited, #8a3ffc);
 }
@@ -168,38 +196,34 @@ a:focus {
 }
 
 .carbon-main-content {
-  padding: var(--cds-spacing-09, 4rem) var(--cds-spacing-09, 4rem)
-    var(--cds-spacing-09, 4rem)
-    calc(
-      var(--cds-shell-side-nav-width, 16rem) + var(--cds-spacing-09, 4rem)
-    );
+  /* Offset for the fixed UI Shell side nav. Horizontal gutters, max-width, and
+     centering come from the nested Carbon css-grid (.carbon-hero /
+     .carbon-page-shell), so we add no inline padding here — that would
+     double-pad the grid. Mirrors the Carbon design site's offset-container +
+     nested-grid pattern. */
+  margin-inline-start: var(--cds-shell-side-nav-width, 16rem);
+  padding-block: var(--cds-spacing-09, 4rem);
+  padding-inline: 0;
+  /* Fill the viewport so the gray (cds--g10) zone reaches the bottom on short
+     pages. main-content starts at the top (behind the fixed header), so the
+     full viewport height applies; box-sizing is border-box, so this adds no
+     scrollbar. dvh keeps it correct under mobile browser chrome. */
+  min-height: 100vh;
+  min-height: 100dvh;
 }
 
-/* Apply Carbon pre styles to TypeDoc signatures */
-pre, .tsd-signature {
-  background-color: var(--cds-layer-01, #f4f4f4);
-  border: 1px solid var(--cds-border-subtle-01, #e0e0e0);
-  border-radius: var(--cds-border-radius, 0);
-  color: var(--cds-text-primary, #161616);
-  font-family: var(--cds-code-01-font-family, 'IBM Plex Mono', 'Menlo', 'DejaVu Sans Mono', 'Bitstream Vera Sans Mono', Courier, monospace);
-  font-size: var(--cds-code-01-font-size, 0.75rem);
-  font-weight: var(--cds-code-01-font-weight, 400);
-  letter-spacing: var(--cds-code-01-letter-spacing, 0.32px);
-  line-height: var(--cds-code-01-line-height, 1.25);
-  overflow-x: auto;
-  padding: var(--cds-spacing-03, 0.5rem);
-  white-space: pre;
-
-  button {
-    display: none;
-  }
+/* Hero region scaffold: present in the DOM but hidden until a future task
+   populates it (title / summary / links / decorative image). See
+   theme/layouts/default.js (.carbon-hero). */
+.carbon-hero {
+  display: none;
 }
 
 pre, code {
   background-color: var(--cds-layer-01, #f4f4f4);
 }
 
-pre, div.tsd-signature, .tsd-member-group, .tsd-comment {
+pre, .tsd-member-group, .tsd-comment {
   margin: var(--cds-spacing-05, 1rem) 0;
 }
 
@@ -210,24 +234,24 @@ cds-breadcrumb {
 /* Carbon styling for core TypeDoc elements */
 .tsd-summary {
   color: var(--cds-text-secondary, #525252);
-  font-size: var(--cds-body-compact-01-font-size, 0.875rem);
-  line-height: var(--cds-body-compact-01-line-height, 1.29);
+  font-size: var(--cds-body-02-font-size, 1rem);
+  font-weight: var(--cds-body-02-font-weight, 400);
+  letter-spacing: var(--cds-body-02-letter-spacing, 0);
+  line-height: var(--cds-body-02-line-height, 1.5);
   margin: var(--cds-spacing-03, 0.5rem) 0;
 }
 
 .tsd-type-declaration {
-  margin: var(--cds-spacing-03, 0.5rem) 0;
-  padding: var(--cds-spacing-03, 0.5rem);
-  background-color: var(--cds-layer-01);
+  /* The wrapping .cds--tile (see theme/assets/signatureCards.js) now provides
+     the container surface, so keep this block plain inside the tile. */
+  margin: 0;
 }
 
 /* Carbon Accordion-style for TypeDoc details/summary elements */
 details.tsd-accordion {
-  border-block-start: 1px solid var(--cds-border-subtle, #e0e0e0);
   display: block;
   overflow: visible;
-  transition: border-color 0.11s cubic-bezier(0.2, 0, 0.38, 0.9);
-  margin: 0;
+  margin: 1rem 0 0 0;
 }
 
 details.tsd-accordion:last-child {
@@ -341,10 +365,10 @@ details.tsd-accordion > .tsd-accordion-details {
 /* Content inside accordions */
 details.tsd-accordion .tsd-accordion-details > p,
 details.tsd-accordion section > p {
-  font-size: var(--cds-body-01-font-size, 0.875rem);
-  font-weight: var(--cds-body-01-font-weight, 400);
-  letter-spacing: var(--cds-body-01-letter-spacing, 0.16px);
-  line-height: var(--cds-body-01-line-height, 1.42857);
+  font-size: var(--cds-body-02-font-size, 1rem);
+  font-weight: var(--cds-body-02-font-weight, 400);
+  letter-spacing: var(--cds-body-02-letter-spacing, 0);
+  line-height: var(--cds-body-02-line-height, 1.5);
 }
 
 /* Carbon Tag styling for TypeDoc tags */
@@ -464,17 +488,12 @@ code.tsd-tag-since {
   color: var(--cds-tag-color-blue, #161616);
 }
 
-/* Example tags - green variant for examples */
-.tsd-tag-example,
-code.tsd-tag-example {
-  background-color: var(--cds-tag-background-green, #a7f0ba);
-  color: var(--cds-tag-color-green, #161616);
-}
-
 .tsd-description {
   color: var(--cds-text-primary, #161616);
-  font-size: var(--cds-body-01-font-size, 0.875rem);
-  line-height: var(--cds-body-01-line-height, 1.43);
+  font-size: var(--cds-body-02-font-size, 1rem);
+  font-weight: var(--cds-body-02-font-weight, 400);
+  letter-spacing: var(--cds-body-02-letter-spacing, 0);
+  line-height: var(--cds-body-02-line-height, 1.5);
   margin: var(--cds-spacing-05, 1rem) 0;
 }
 
@@ -509,8 +528,10 @@ code.tsd-tag-example {
 
 .tsd-comment {
   color: var(--cds-text-primary, #161616);
-  font-size: var(--cds-body-01-font-size, 0.875rem);
-  line-height: var(--cds-body-01-line-height, 1.43);
+  font-size: var(--cds-body-02-font-size, 1rem);
+  font-weight: var(--cds-body-02-font-weight, 400);
+  letter-spacing: var(--cds-body-02-letter-spacing, 0);
+  line-height: var(--cds-body-02-line-height, 1.5);
 }
 
 .tsd-comment-tag {
@@ -620,78 +641,12 @@ code.tsd-tag-example {
   margin-block-start: var(--cds-spacing-03, 0.5rem);
 }
 
-/* Carbon-style list styling scoped to main content */
-.carbon-main-content ul,
-.carbon-main-content ol {
-  color: var(--cds-text-primary, #161616);
-  font-size: var(--cds-body-01-font-size, 0.875rem);
-  font-weight: var(--cds-body-01-font-weight, 400);
-  line-height: var(--cds-body-01-line-height, 1.43);
-  margin: var(--cds-spacing-05, 1rem) 0;
-  padding-left: var(--cds-spacing-06, 1.5rem);
-}
-
-.carbon-main-content ul {
-  list-style-type: none;
-}
-
-.carbon-main-content ul li {
-  position: relative;
-  margin: var(--cds-spacing-03, 0.5rem) 0;
-  padding-left: var(--cds-spacing-04, 0.75rem);
-}
-
-.carbon-main-content ul li::before {
-  content: "•";
-  color: var(--cds-text-secondary, #525252);
-  font-size: 1rem;
-  font-weight: 600;
-  position: absolute;
-  left: 0;
-  top: 0;
-}
-
-.carbon-main-content ol {
-  list-style-type: decimal;
-  counter-reset: list-counter;
-}
-
-.carbon-main-content ol li {
-  margin: var(--cds-spacing-03, 0.5rem) 0;
-  padding-left: var(--cds-spacing-02, 0.25rem);
-  counter-increment: list-counter;
-}
-
-.carbon-main-content ol li::marker {
-  color: var(--cds-text-secondary, #525252);
-  font-weight: 600;
-}
-
-/* Nested list styles */
-.carbon-main-content ul ul,
-.carbon-main-content ol ol,
-.carbon-main-content ul ol,
-.carbon-main-content ol ul {
-  margin: var(--cds-spacing-02, 0.25rem) 0;
-  padding-left: var(--cds-spacing-05, 1rem);
-}
-
-.carbon-main-content ul ul li::before {
-  content: "◦";
-  font-size: 0.875rem;
-}
-
-.carbon-main-content ul ul ul li::before {
-  content: "▪";
-  font-size: 0.75rem;
-}
-
 /* Accessible code highlighting colors based on highlight.js a11y-light theme */
 /* Force override of TypeDoc's default highlight colors with higher specificity */
 :root,
 html,
 body,
-.cds-theme-zone-white {
+.cds--white {
   /* Override TypeDoc's highlight colors with a11y-light theme colors for accessibility */
   --light-hl-0: #7928a1 !important;  /* Keywords/selectors (purple) - from hljs-keyword */
   --light-hl-1: #545454 !important;  /* Default text - from hljs base color */
@@ -786,16 +741,11 @@ body,
 .hl-18, pre .hl-18, code .hl-18 { color: #d91e18 !important; } /* Warnings - red */
 .hl-19, pre .hl-19, code .hl-19 { color: #696969 !important; } /* Secondary text - light gray */
 
-/* Ensure code backgrounds use Carbon layer color */
-pre, code, .tsd-signature {
-  background: var(--code-background) !important;
-}
-
 /* Override TypeDoc signature and kind colors with accessible alternatives */
 :root,
 html,
 body,
-.cds-theme-zone-white {
+.cds--white {
   /* TypeDoc signature colors - using a11y-light theme colors */
   --light-color-text-aside: #696969 !important;           /* Comments color from a11y-light */
   --color-text-aside: #696969 !important;
@@ -906,6 +856,7 @@ cds-side-nav cds-side-nav-items {
 
 @media screen and (max-width: 1055px) {
   .carbon-main-content {
-    padding: var(--cds-spacing-09, 4rem);
+    /* Side nav overlays at this width, so drop the offset. */
+    margin-inline-start: 0;
   }
 }

--- a/packages/typedoc-theme/theme/assets/sideNavFocus.js
+++ b/packages/typedoc-theme/theme/assets/sideNavFocus.js
@@ -1,0 +1,65 @@
+/*
+ *  Copyright IBM Corp. 2026
+ *
+ *  This source code is licensed under the Apache-2.0 license found in the
+ *  LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Stops the Carbon UI Shell side nav from stealing focus when a navigation item
+ * is clicked on wide screens.
+ *
+ * `cds-side-nav` runs in `collapse-mode="responsive"`. In that mode it expands
+ * itself on `focusin` and then moves focus to the first navigation item. On
+ * wide screens (at or above the 66rem side-nav breakpoint) the side nav is
+ * already shown as a persistent sidebar, so that expand-and-focus is pure side
+ * effect: clicking a link focuses it, the side nav expands, and focus jumps to
+ * the first item ("Overview") mid-click. That scrolls the page to the top and
+ * races the link's own navigation, so the first click appears to only scroll up
+ * without changing pages and a second click is needed to navigate -- by then
+ * the side nav is already expanded, so no focus move happens.
+ *
+ * Below the breakpoint the side nav is an off-canvas drawer and moving focus
+ * into it when it opens is the desired behavior, so the focus handling is only
+ * suppressed while the side nav is the persistent desktop sidebar.
+ */
+(function () {
+  "use strict";
+
+  // Carbon's side-nav responsive breakpoint. Above it the nav is a persistent
+  // sidebar; below it the nav is an off-canvas drawer toggled by the header
+  // menu button.
+  const persistentSideNav = window.matchMedia("(min-width: 66rem)");
+
+  // The navigable items. Focus is only intercepted when it originates from one
+  // of these, so the version dropdown (also a child of the side nav) keeps its
+  // own focus handling.
+  const NAV_ITEM_TAGS = new Set([
+    "CDS-SIDE-NAV-LINK",
+    "CDS-SIDE-NAV-MENU",
+    "CDS-SIDE-NAV-MENU-ITEM",
+  ]);
+
+  function isPersistentNavItemFocus(event) {
+    if (!persistentSideNav.matches) {
+      return false;
+    }
+    const path = event.composedPath();
+    return (
+      path.some((node) => node.nodeName === "CDS-SIDE-NAV") &&
+      path.some((node) => NAV_ITEM_TAGS.has(node.nodeName))
+    );
+  }
+
+  // Capture phase: run before `cds-side-nav`'s own focusin/focusout listeners
+  // and stop the event from reaching them, so it never flips `expanded` and
+  // moves focus to the first item.
+  function suppressSideNavFocus(event) {
+    if (isPersistentNavItemFocus(event)) {
+      event.stopPropagation();
+    }
+  }
+
+  document.addEventListener("focusin", suppressSideNavFocus, true);
+  document.addEventListener("focusout", suppressSideNavFocus, true);
+})();

--- a/packages/typedoc-theme/theme/assets/signatureCards.js
+++ b/packages/typedoc-theme/theme/assets/signatureCards.js
@@ -1,0 +1,70 @@
+/*
+ *  Copyright IBM Corp. 2025, 2026
+ *
+ *  This source code is licensed under the Apache-2.0 license found in the
+ *  LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Wrap each TypeDoc code block in a Carbon tile surface, so signatures and type
+ * declarations are presented like the fenced code blocks produced by
+ * markdownItCarbon.js. The target element is moved inside a `<div class="cds--tile">`.
+ *
+ * We use the `.cds--tile` CSS class from @carbon/styles (already loaded by the
+ * theme) rather than the `<cds-tile>` web component on purpose: the published
+ * `/tag/latest/` web component runs an `updated()` lifecycle that grabs the
+ * first `<a>` in the tile and prepends two `<br>`s to it on every render, which
+ * mangles the link-heavy signature markup. The plain CSS class gives the
+ * identical surface with no JavaScript touching the slotted content.
+ *
+ * Targets:
+ *   - div.tsd-signature      — the prominent member / preview signature boxes.
+ *   - .tsd-type-declaration  — the "Type Declaration" blocks.
+ *
+ * `li.tsd-signature` (nested type-detail lists) is intentionally excluded so we
+ * don't move an <li> out of its <ul> and break list semantics. Elements already
+ * inside a tile are skipped so a type declaration nested in another doesn't
+ * produce nested tiles.
+ */
+(function () {
+  const SELECTOR =
+    ".carbon-main-content div.tsd-signature, .carbon-main-content .tsd-type-declaration";
+
+  function wrapInTiles() {
+    // querySelectorAll returns document order, so outer elements wrap before
+    // inner ones and the closest() guard skips anything already tiled.
+    document.querySelectorAll(SELECTOR).forEach((el) => {
+      // Guard against re-wrapping if this ever runs more than once.
+      if (el.dataset.carbonTile !== undefined) {
+        return;
+      }
+      // Skip elements already inside a tile (e.g. a type declaration nested in
+      // one we just wrapped) so we don't create nested tiles.
+      if (el.closest(".cds--tile")) {
+        return;
+      }
+      el.dataset.carbonTile = "";
+
+      const tile = document.createElement("div");
+      // No theme class on the tile: it inherits the surrounding `.cds--g10`
+      // layer context (see .carbon-main-content in the layout), so `.cds--tile`
+      // paints g10's layer-01 (white). Forcing `cds--white` here would re-base
+      // it to the white theme, whose layer-01 is gray.
+      //
+      // `carbon-signature-tile` lets carbonTheme.css drop the tile's default
+      // min-block-size so it hugs the block. Fenced-code tiles keep their
+      // default sizing.
+      tile.className = "cds--tile carbon-signature-tile";
+
+      // Insert the tile where the element is, then move the element into it.
+      el.parentNode.insertBefore(tile, el);
+      tile.appendChild(el);
+    });
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", wrapInTiles);
+  } else {
+    wrapInTiles();
+  }
+})();

--- a/packages/typedoc-theme/theme/layouts/default.js
+++ b/packages/typedoc-theme/theme/layouts/default.js
@@ -296,14 +296,14 @@ export const defaultLayout = (context, template, props) => {
           true,
         ),
       }),
-      JSX.createElement("script", {
+      /*JSX.createElement("script", {
         defer: true,
         src: context.relativeURL("assets/carbonSearchModal.js", true),
       }),
       JSX.createElement("script", {
         defer: true,
         src: context.relativeURL("assets/carbonSearch.js", true),
-      }),
+      }),*/
       JSX.createElement("script", {
         defer: true,
         src: context.relativeURL("assets/redirectToOverview.js", true),
@@ -320,15 +320,19 @@ export const defaultLayout = (context, template, props) => {
         defer: true,
         src: context.relativeURL("assets/versionDropdown.js", true),
       }),
+      JSX.createElement("script", {
+        defer: true,
+        src: context.relativeURL("assets/sideNavFocus.js", true),
+      }),
+      JSX.createElement("script", {
+        defer: true,
+        src: context.relativeURL("assets/signatureCards.js", true),
+      }),
       context.hook("head.end", context),
     ),
     JSX.createElement(
       "body",
-      // `cds-theme-zone-white` (CDN web-components themes.css) defines core
-      // tokens like --cds-text-primary but NOT the --cds-syntax-* tokens the
-      // code-snippet highlighter reads. `cds--white` (vendored @carbon/styles)
-      // supplies those, so both classes are needed for syntax highlighting.
-      { class: "cds-theme-zone-white cds--white" },
+      { class: "cds--white" },
       context.hook("body.begin", context),
       // Carbon UI Shell header
       JSX.createElement(
@@ -349,7 +353,7 @@ export const defaultLayout = (context, template, props) => {
         JSX.createElement(
           "div",
           { class: "cds--header__global" },
-          JSX.createElement(
+          /*JSX.createElement(
             "cds-header-global-action",
             {
               "aria-label": "Search",
@@ -371,7 +375,7 @@ export const defaultLayout = (context, template, props) => {
                 d: "M29 27.5859l-7.5521-7.5521a11.0177 11.0177 0 1 0-1.4141 1.4141L27.5859 29ZM4 13a9 9 0 1 1 9 9A9.01 9.01 0 0 1 4 13Z",
               }),
             ),
-          ),
+          ),*/
         ),
       ),
       JSX.createElement(
@@ -392,12 +396,50 @@ export const defaultLayout = (context, template, props) => {
       // Main content container for Carbon UI Shell
       JSX.createElement(
         "div",
-        { class: "carbon-main-content" },
+        { class: "carbon-main-content cds--g10" },
         context.hook("content.begin", context),
-        renderPageTitle(context, props),
-        template(props),
-        context.hook("content.end", context),
-        context.footer(),
+        // Hero region (Carbon "page-header" analog). Scaffolded now but hidden
+        // via CSS (.carbon-hero { display: none }); a future task will populate
+        // it (title / summary / links / decorative image) and reveal it. Mirrors
+        // the Carbon design site grid: content col-span-8 + aside col-start-13
+        // col-span-4, collapsing to full width below xlg.
+        JSX.createElement(
+          "div",
+          { class: "carbon-hero cds--css-grid cds--css-grid--start" },
+          JSX.createElement("div", {
+            class:
+              "carbon-hero__content cds--css-grid-column cds--sm:col-span-4 cds--md:col-span-8 cds--lg:col-span-12 cds--xlg:col-span-8",
+          }),
+          JSX.createElement("div", {
+            class:
+              "carbon-hero__aside cds--css-grid-column cds--sm:col-span-4 cds--md:col-span-8 cds--lg:col-span-16 cds--xlg:col-start-13 cds--xlg:col-span-4",
+          }),
+        ),
+        // Page shell grid: the body content column plus a reserved (empty)
+        // in-page navigation column. The 12+4 split engages at xlg; below xlg the
+        // nav column collapses (col-span-0 -> display:none) and the content goes
+        // full width (col-span-16), matching the Carbon design site.
+        JSX.createElement(
+          "div",
+          { class: "carbon-page-shell cds--css-grid cds--css-grid--start" },
+          JSX.createElement(
+            "div",
+            {
+              class:
+                "carbon-content-column cds--css-grid-column cds--sm:col-span-4 cds--md:col-span-8 cds--lg:col-span-16 cds--xlg:col-span-12",
+            },
+            renderPageTitle(context, props),
+            template(props),
+            context.hook("content.end", context),
+            context.footer(),
+          ),
+          // Reserved in-page navigation column. Intentionally empty for now; a
+          // future task fills it (e.g. context.pageNavigation(props) sticky TOC).
+          JSX.createElement("div", {
+            class:
+              "carbon-nav-column cds--css-grid-column cds--sm:col-span-0 cds--md:col-span-0 cds--lg:col-span-0 cds--xlg:col-span-4",
+          }),
+        ),
       ),
       // Carbon modal used to host TypeDoc search UI
       JSX.createElement(

--- a/packages/typedoc-theme/theme/markdownItCarbon.js
+++ b/packages/typedoc-theme/theme/markdownItCarbon.js
@@ -62,19 +62,31 @@ export function applyCarbonRules(parser) {
   // Both max-row attributes are 0 to put the snippet in fill-container mode: it
   // renders every line in full and never shows the "Show more"/"Show less"
   // button, which suits static docs where collapsing code adds no value.
+  // `hide-line-numbers` drops the line-number gutter and `hide-fold` drops the
+  // fold gutter (no collapse/expand control) for cleaner inline prose snippets.
   rules.fence = (tokens, idx) => {
     const token = tokens[idx];
     const lang = (token.info || "").trim().split(/\s+/)[0] || "";
     const code = escapeText(token.content.replace(/\n$/, ""));
-    return `<cds-aichat-code-snippet language="${lang}" highlight max-collapsed-number-of-rows="0" max-expanded-number-of-rows="0">${code}</cds-aichat-code-snippet>`;
+    return `<div class="cds--tile"><cds-aichat-code-snippet hide-header hide-line-numbers hide-fold language="${lang}" highlight max-collapsed-number-of-rows="0" max-expanded-number-of-rows="0">${code}</cds-aichat-code-snippet></div>`;
   };
 
   // Lists. cds-unordered-list auto-detects nesting at runtime via
   // closest(cds-list-item); cds-ordered-list does not, but nested ordered lists
   // are rare in the docs. Add explicit `nested` handling later if needed.
-  rules.bullet_list_open = () => "<cds-unordered-list>";
+  // The `isExpressive` flag renders list items at Carbon body-02 (16px) to match
+  // the surrounding prose; the components otherwise default to body-01 (14px) on
+  // their shadow-DOM wrapper, which page CSS can't override for slotted items.
+  // We set both attribute spellings on purpose: the boolean property has no
+  // explicit `attribute:` in the CDN's current `/tag/latest/` build, so Lit
+  // observes the lowercased `isexpressive`, while newer builds pin it to
+  // `is-expressive`. Emitting both keeps lists at body-02 across either, which
+  // matters because the floating CDN tag can roll forward without notice.
+  rules.bullet_list_open = () =>
+    "<cds-unordered-list isexpressive is-expressive>";
   rules.bullet_list_close = () => "</cds-unordered-list>";
-  rules.ordered_list_open = () => "<cds-ordered-list>";
+  rules.ordered_list_open = () =>
+    "<cds-ordered-list isexpressive is-expressive>";
   rules.ordered_list_close = () => "</cds-ordered-list>";
   rules.list_item_open = () => "<cds-list-item>";
   rules.list_item_close = () => "</cds-list-item>";


### PR DESCRIPTION
Makes host-page CSS custom properties actually reach the running chat, adds `hide-line-numbers` / `hide-fold` to the code-snippet component, and reworks the TypeDoc docs-site theme (signature cards, side-nav focus fix, grid layout, body-02 typography). Despite the `docs:` subject, this also changes public component/config behavior, so it is worth reviewing as a code change.

Files with particularly complex changes:

- [packages/ai-chat/src/chat/AppShellStyles.scss](packages/ai-chat/src/chat/AppShellStyles.scss) and [packages/ai-chat/src/globals/scss/_chat-float-layout.scss](packages/ai-chat/src/globals/scss/_chat-float-layout.scss) — the `--cds-aichat-*` defaults are removed from the chat wrapper and moved into each consumer's `get-var(name, default)` fallback. The subtle invariant: a value declared on the wrapper would *shadow* an inherited host value and silently win, so the defaults must live in the fallback instead. Review the new `min-height` fallback expression (now an inline `max(150px, calc(min(256px, 100vh) - var(...)))`) carefully.
- [packages/ai-chat-components/src/components/code-snippet/src/codemirror/base-setup.ts](packages/ai-chat-components/src/components/code-snippet/src/codemirror/base-setup.ts) — `hideLineNumbers` / `hideFold` conditionally drop CodeMirror extensions; `hideFold` must drop the gutter, the marker key handler, *and* the fold keymap together so no collapse control survives.
- [packages/typedoc-theme/theme/assets/signatureCards.js](packages/typedoc-theme/theme/assets/signatureCards.js) and [packages/typedoc-theme/theme/assets/sideNavFocus.js](packages/typedoc-theme/theme/assets/sideNavFocus.js) — new client scripts that mutate the rendered DOM: one wraps signature blocks in `.cds--tile` surfaces (deliberately the CSS class, not the `<cds-tile>` web component, which mangles link-heavy markup), the other suppresses the persistent side nav's focus-stealing on wide screens via a capture-phase `focusin`/`focusout` handler.
- [packages/typedoc-theme/theme/assets/carbonTheme.css](packages/typedoc-theme/theme/assets/carbonTheme.css) — large reshuffle: `.carbon-main-content` switches from inline padding to a side-nav margin offset + nested CSS grid, typography moves to body-02, and a block of bespoke list styling is removed in favor of expressive Carbon lists.

#### Major changes

**New**

- `hide-line-numbers` and `hide-fold` boolean attributes on `cds-aichat-code-snippet` to render a leaner editor without the line-number gutter or fold affordances (also surfaced as Storybook knobs and React-wrapper props).
- `layout.customProperties` now accepts `$`-prefixed Carbon token keys (e.g. `"$button-primary"`) that map to the matching `--cds-*` custom property, letting hosts recolor the Carbon components rendered inside the chat — including under a forced `injectCarbonTheme`. `$`-prefixed values must be hexadecimal colors.

**Changed**

- The chat no longer declares its `--cds-aichat-*` sizing/positioning/launcher/unread tokens on the render wrapper. Each consumer reads them through `get-var(name, default)`, so a host-page rule (or `layout.customProperties`) on `--cds-aichat-*` now inherits through the shadow boundary and wins instead of being shadowed by a wrapper default. Contextual phone/rounded-corner overrides are the deliberate exception and still declare tokens.
- TypeDoc docs-site theme reworked: signatures and type declarations are wrapped in Carbon tile surfaces; `.carbon-main-content` now offsets the fixed side nav via margin + a nested CSS grid (with a hidden hero scaffold and a reserved in-page-nav column) instead of inline padding; prose typography moves to Carbon body-02; fenced code blocks render in a tile with `hide-header`/`hide-line-numbers`/`hide-fold`; and Markdown lists render as expressive `cds-unordered-list` / `cds-ordered-list`.

**Removed**

- The TypeDoc theme's built-in search (header search action, `carbonSearch.js`, `carbonSearchModal.js`) is disabled (commented out, not deleted).

#### Minor changes

**New**

- [demo/tests/css-custom-properties.spec.ts](demo/tests/css-custom-properties.spec.ts) — Playwright test asserting a host-page `--cds-aichat-launcher-color-background` override reaches the launcher button through two shadow boundaries in float layout.
- [packages/ai-chat/tests/utils/spec/styleUtils_spec.ts](packages/ai-chat/tests/utils/spec/styleUtils_spec.ts) — Jest coverage for `convertCSSVariablesToString` / `mergeCSSVariables`, including `$`-prefixed token mapping, theme-class targeting, and the hexadecimal-only validation.

**Changed**

- Code-snippet surface tokens: the snippet and its gutter now key off `$chat-shell-background` (layer-independent) instead of `$background` (page canvas), so the snippet stays consistent off-card and on non-white layers; the disabled gutter is pinned to `$layer`; the scroller `min-block-size` default changes from `3rem` to `auto`.
- The `max/min-(collapsed|expanded)-number-of-rows` properties are now declared with `type: Number`, so attribute values coerce to numbers instead of strings.
- The invalid-`customProperties` console warning now names the `layout.customProperties` key and explains that `$`-prefixed Carbon tokens require hexadecimal color values.
- Documentation content/style fixes across [Theming.md](packages/ai-chat/docs/Theming.md) (split into "Override with your own CSS" / "Override under a forced theme" with a `customProperties` example), [Layout.md](packages/ai-chat/docs/Layout.md), [PublicConfig.ts](packages/ai-chat/src/types/config/PublicConfig.ts) JSDoc, and minor edits to Overview/React/Angular/WebComponent/Customization/Homescreen/StructuredData/AddMessageChunk/CustomMessageFooter.

**Removed**

- Dropped the bespoke `.carbon-main-content` list styling, the `.tsd-tag-example` green tag variant, and the now-unused `cds-theme-zone-white` body class from the TypeDoc theme (replaced by `cds--white` / `cds--g10`).
- Removed the AGENTS_DOC_STYLE.md rule mandating inline backticks for single shell commands.

#### Testing / Reviewing

Most of this is reachable from the demo site — run the chat with the float layout and confirm host-page overrides flow through.

Demo (host-override behavior):

1. Start the watcher and demo per [demo/AGENTS.md](demo/AGENTS.md): `npm run aiChat:start` in one terminal, then `npm start` from `demo/`.
2. Load the float layout: append `?settings=%7B%22layout%22%3A%22float%22%7D` (i.e. `settings={"layout":"float"}`).
3. In devtools, run `document.documentElement.style.setProperty("--cds-aichat-launcher-color-background", "rgb(255,0,255)")` and confirm the launcher button repaints magenta — it should, because the chat no longer declares that token on its wrapper.

Unit / component tests:

- `@carbon/ai-chat`: run the Jest suite covering [styleUtils_spec.ts](packages/ai-chat/tests/utils/spec/styleUtils_spec.ts) for the `$`-prefixed-token mapping and hex validation.
- `@carbon/ai-chat-components`: open the code-snippet Storybook stories and toggle the new **hideLineNumbers** / **hideFold** knobs; verify the gutter disappears and that folding (gutter, chevrons, and fold keyboard shortcuts) is fully gone when `hideFold` is on. Check the disabled state still reads as one flat `$layer` surface.

Docs-site theme (TypeDoc):

- Build the docs site and visually check: signatures/type declarations render as tiles, long multi-line signatures keep their line breaks, prose is body-02, fenced code blocks are headerless with no line numbers or fold control, and lists render expressive.
