### PR TITLE
fix: structured data included in send

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,18 +1,3 @@
 # GitHub Copilot instructions
 
 The authoritative agent guidance for this repo lives in [AGENTS.md](../AGENTS.md) at the project root, plus a nested `AGENTS.md` in each package. Read those first — they are the single source of truth and are kept up to date.
-
-## TL;DR
-
-- Node ≥ 22, npm ≥ 10. On a fresh clone, run `npm install && npm run aiChat:build` once — workspace deps resolve through built artifacts (`dist/es/`, `es/`), not TS sources, so nothing works until both core packages are built.
-- Before editing a package, open that package's `AGENTS.md`:
-  - [packages/ai-chat/AGENTS.md](../packages/ai-chat/AGENTS.md)
-  - [packages/ai-chat-components/AGENTS.md](../packages/ai-chat-components/AGENTS.md)
-  - [demo/AGENTS.md](../demo/AGENTS.md)
-  - [examples/react/AGENTS.md](../examples/react/AGENTS.md) and [examples/web-components/AGENTS.md](../examples/web-components/AGENTS.md)
-- Commits follow conventional-commits (commitlint-enforced). Header ≤ 72 chars, lowercase imperative subject, no trailing period.
-- `npm run ci-check` runs lint/format/license/tests but **does not build**. For cross-cutting changes, also run `npm run build`. Per-package test/build commands are listed in the root AGENTS.md "Definition of done" table.
-- Don't edit generated output: `dist/`, `es/`, `es-custom/`, `packages/ai-chat-components/custom-elements.json`, `packages/ai-chat-components/react/` wrappers, `telemetry.yml` files. Regenerate them with the documented commands.
-- `packages/ai-chat/src/chat/components-legacy/` is closed to new components (bug fixes and refactoring transitions are fine). Author new UI in `components/` or lift reusable pieces to `@carbon/ai-chat-components`.
-
-For everything else — architecture, conventions, per-package gotchas, definition of done — see [AGENTS.md](../AGENTS.md).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,30 +1,18 @@
 This file provides guidance to agents when working with code in this repository.
 
-## TL;DR
+It is a **router**: find your package and your task below, then read the linked file. Detail lives in [references/](references/) and in each package's own `AGENTS.md` — this file points, it does not restate.
 
-- **First-time setup**: `npm install && npm run aiChat:build`. Workspace deps resolve through built artifacts (`dist/es/`, `es/`), not TS sources — nothing works until this completes; a changed package is invisible to its consumers until rebuilt.
-- **Before starting any build/watch yourself, ask the user whether `npm run aiChat:start` is already running.** Most developers keep it running; a parallel `npm run build` races the watcher.
+## Always-on rules
+
+A few things hold everywhere, regardless of what you touch:
+
+- **First-time setup**: `npm install && npm run aiChat:build`. Workspace deps resolve through built artifacts (`dist/es/`, `es/`), not TS sources — nothing works until this completes, and a changed package is invisible to its consumers until rebuilt.
+- **Ask before starting any build/watch yourself.** Most developers keep `npm run aiChat:start` running; a parallel `npm run build` races the watcher.
 - Node ≥ 22, npm ≥ 10.
-- Each package has its own `AGENTS.md` with package-specific rules. Read the relevant one before your first edit:
-  - [packages/ai-chat/AGENTS.md](packages/ai-chat/AGENTS.md) — `@carbon/ai-chat` (the chat app). Topic siblings (load only what you need): [architecture.md](packages/ai-chat/references/architecture.md), [services.md](packages/ai-chat/references/services.md), [tests.md](packages/ai-chat/references/tests.md). Sub-areas: [src/chat/store/AGENTS.md](packages/ai-chat/src/chat/store/AGENTS.md), [src/types/AGENTS.md](packages/ai-chat/src/types/AGENTS.md), [docs/AGENTS.md](packages/ai-chat/docs/AGENTS.md) (with [docs/references/doc-style.md](packages/ai-chat/docs/references/doc-style.md)).
-  - [packages/ai-chat-components/AGENTS.md](packages/ai-chat-components/AGENTS.md) — `@carbon/ai-chat-components` (Lit components).
-  - [packages/typedoc-theme/AGENTS.md](packages/typedoc-theme/AGENTS.md) — `@carbon/typedoc-theme` (Carbon-themed TypeDoc theme for the docs site).
-  - [demo/AGENTS.md](demo/AGENTS.md) — full demo / integration-test harness.
-  - [examples/AGENTS.md](examples/AGENTS.md) — shared example rules (with [indexer-contract.md](examples/references/indexer-contract.md) for README format); flavor deltas in [examples/react/AGENTS.md](examples/react/AGENTS.md) / [examples/web-components/AGENTS.md](examples/web-components/AGENTS.md).
-- Do not read or edit generated output: `dist/`, `es/`, `es-custom/`, `storybook-static/`, `storybook-react-static/`, `node_modules/`, `packages/ai-chat-components/src/react/`, `packages/ai-chat-components/custom-elements.json`, `packages/ai-chat/dist/docs/`.
-- If you are not Bob, don't read `.bob/` (IBM Bob mode rules — not general guidance).
-- **Accessibility** is a repo-wide concern: every UI change in any package must hold WCAG 2.1 AA. Load [accessibility.md](references/accessibility.md) for the checklist, live-region patterns, and the centralized announcer utilities.
-- **Figma → code** (translating a design, calling the Carbon MCP server, or using the `carbon-builder` skill): load [figma.md](references/figma.md). The two primary packages are Web Components only — always pass `filters.component_type: "Web Components"` to Carbon MCP unless you are editing [demo/](demo/), [examples/react/](examples/react/), or a `-react.stories.jsx` / `-react.mdx` file.
-- **Web development tasks**: if your AI assistant supports browser automation or visual inspection tools (e.g., Bob's Advanced mode, Claude's Computer Use, browser MCP servers), use them for component development, styling work, and integration testing. Visual verification catches issues that code review alone misses.
-- **Sub-agents**: use sub-agents (when available) for specialized tasks like code reviews, plan reviews, complex analysis, or parallel work. Sub-agents provide fresh perspective without the main conversation's context bias and keep the primary thread focused.
-- **Before writing or changing any code**, follow [code-patterns.md](references/code-patterns.md) — the canonical home for code-authoring discipline (the laziness ladder & simplicity principles, prefix discipline, SCSS, RTL, component placement, comments). Process conventions (commits, branches, license headers, hooks) live in [conventions.md](references/conventions.md). These are the canonical homes — other docs link, not restate.
-- **Code reviews** (user-requested or self-review before marking a task done) follow the rubric in [code-review.md](references/code-review.md).
-- **Writing a plan** (when the user asks you to draft a multi-PR plan, design doc, or implementation plan before code is written) follow the rubric in [plan-authoring.md](references/plan-authoring.md). Plan files (`PLAN.md`, `PLAN-{N}-{title}.md`) live at the repo root and are git-ignored.
-- **Plan reviews** (when the user asks you to review PLAN.md, a design doc, or a multi-PR series before any code is written) follow the rubric in [plan-review.md](references/plan-review.md).
-- **Writing a PR description**: when asked to draft or write up a PR, follow [pr.md](references/pr.md).
-- **Writing a GitHub issue** (drafting or filing an issue or sub-issue): follow [issue-authoring.md](references/issue-authoring.md).
-- **Authoring or running an epic** (an umbrella issue tracking sub-issues): follow [epic-authoring.md](references/epic-authoring.md).
-- **Writing developer-facing copy** (README, JSDoc, Storybook MDX, `packages/ai-chat/docs/`): follow [tone.md](references/tone.md) for voice and word economy.
+- **Never read or edit generated output**: `dist/`, `es/`, `es-custom/`, `storybook-static/`, `storybook-react-static/`, `node_modules/`, `packages/ai-chat-components/src/react/`, `packages/ai-chat-components/custom-elements.json`, `packages/ai-chat/dist/docs/`, `telemetry.yml`. Regenerate via the documented commands (`npm run custom-elements`, `npm run telemetry:config`).
+- Every UI change holds **WCAG 2.1 AA** → [accessibility.md](references/accessibility.md) (checklist, live-region patterns, announcer utilities).
+- Use **sub-agents** (when available) for code/plan reviews, complex analysis, or parallel work — a fresh perspective without the main conversation's bias keeps the primary thread focused. Be aggressive with tasking additional sub-agents to review work or do discovery in parallel.
+- If you support **browser automation or visual inspection**, use it for component development, styling, and integration testing — visual verification catches issues code review alone misses.
 
 ## Repository layout
 
@@ -37,90 +25,41 @@ Lerna + npm-workspaces monorepo.
 - `examples/react/*` and `examples/web-components/*` — webpack dev-server examples; default port 3000 (override with `PORT=`).
 - `docs/` — developer handbook, peer-dep history. Not the consumer-facing site (that lives in `packages/ai-chat/docs/`).
 
-## Common commands
+## Which package am I editing?
 
-Run from repo root unless noted. **Ask first** if the user has `npm run aiChat:start` running; don't kick off a parallel build/watch.
+Read that package's `AGENTS.md` before your first edit. Each one routes onward to its own topic references (architecture, services, tests, types…) with "read when" triggers — so this table stops at the package boundary.
 
-| Task                                                               | Command                                   |
-| ------------------------------------------------------------------ | ----------------------------------------- |
-| Fresh install + first-time build                                   | `npm install && npm run aiChat:build`     |
-| Dev watch (builds + watches both packages + demo, TypeDoc on 5001) | `npm run aiChat:start`                    |
-| Storybook (Lit)                                                    | `npm run aiChat:start:storybook`          |
-| Storybook (React wrappers)                                         | `npm run aiChat:start:storybook:react`    |
-| Build everything                                                   | `npm run build`                           |
-| Build only the ai-chat stack (components + ai-chat + demo)         | `npm run aiChat:build`                    |
-| Lint (eslint on `packages/`)                                       | `npm run lint`                            |
-| Stylelint                                                          | `npm run lint:styles`                     |
-| License header check                                               | `npm run lint:license`                    |
-| Prettier check / write                                             | `npm run format` / `npm run format:write` |
-| All tests                                                          | `npm run test`                            |
-| Lint + format + license + test gate (no build)                     | `npm run ci-check`                        |
-| Clean everything                                                   | `npm run clean`                           |
+| Editing…                       | Read                                                                                                                                        |
+| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `packages/ai-chat/`            | [packages/ai-chat/AGENTS.md](packages/ai-chat/AGENTS.md)                                                                                    |
+| `packages/ai-chat-components/` | [packages/ai-chat-components/AGENTS.md](packages/ai-chat-components/AGENTS.md)                                                              |
+| `packages/typedoc-theme/`      | [packages/typedoc-theme/AGENTS.md](packages/typedoc-theme/AGENTS.md)                                                                        |
+| `demo/`                        | [demo/AGENTS.md](demo/AGENTS.md)                                                                                                            |
+| `examples/**`                  | [examples/AGENTS.md](examples/AGENTS.md) (+ [react](examples/react/AGENTS.md) / [web-components](examples/web-components/AGENTS.md) deltas) |
 
-### Running a single example
+## What am I doing?
 
-Build the packages first, then from the root:
+| Task                                                | Read                                                        |
+| --------------------------------------------------- | ----------------------------------------------------------- |
+| Writing or changing any code                        | [code-patterns.md](references/code-patterns.md)             |
+| Commits, branches, PR titles, license headers       | [conventions.md](references/conventions.md)                 |
+| Building, testing, or running a single example/test | [commands.md](references/commands.md)                       |
+| Knowing which gate to run before shipping           | [definition-of-done.md](references/definition-of-done.md)   |
+| Reviewing a diff (or self-review before done)       | [code-review.md](references/code-review.md)                 |
+| Writing a multi-PR plan, design doc, or approach    | [plan-authoring.md](references/plan-authoring.md)           |
+| Reviewing a plan before any code is written         | [plan-review.md](references/plan-review.md)                 |
+| Writing a PR description                            | [pr.md](references/pr.md)                                   |
+| Filing a GitHub issue or sub-issue                  | [issue-authoring.md](references/issue-authoring.md)         |
+| Authoring or running an epic (umbrella issue)       | [epic-authoring.md](references/epic-authoring.md)           |
+| Writing developer-facing copy (README/JSDoc/MDX)    | [tone.md](references/tone.md)                               |
+| Translating a Figma design / calling Carbon MCP     | [figma.md](references/figma.md)                             |
+| Editing an `AGENTS.md` or `references/` file itself | [authoring-agents-md.md](references/authoring-agents-md.md) |
 
-```bash
-npm run start --workspace=@carbon/ai-chat-examples-react-basic-float
-PORT=3001 npm run start --workspace=@carbon/ai-chat-examples-react-basic-custom-element-fullscreen
-```
-
-When `aiChat:start` is running in another terminal, example webpack servers hot-reload on package rebuilds.
-
-### Running a single test
-
-- `@carbon/ai-chat` uses Jest. From `packages/ai-chat/`:
-  ```bash
-  npx jest path/to/file_spec.ts
-  npx jest -t "test name pattern"
-  ```
-- `@carbon/ai-chat-components` has two suites:
-  - Web components via `@web/test-runner`: `npm run test:web-components --workspace=@carbon/ai-chat-components` (pass a glob to narrow).
-  - React wrappers via Jest: `npm run test:react --workspace=@carbon/ai-chat-components`.
-  - Regenerate WTR snapshots: `npm run test:updateSnapshot --workspace=@carbon/ai-chat-components`.
-
-## Definition of done
-
-`npm run ci-check` does **not** run `build`, and workspace deps resolve through built artifacts (`es/`, `dist/es/`) rather than TS sources. **Always run `build` BEFORE `ci-check`** — running them the other way around (or running `ci-check` on its own after edits) makes tests resolve consumer imports against a stale `es/`, which surfaces as confusing "no exported member 'X'" errors even though the source clearly exports X. Pick the minimum gate for the area you edited:
-
-**Before running any `build` row below, ask the user whether `npm run aiChat:start` is already running** — a parallel build races the watcher (canonical rule: [Common commands](#common-commands), and TL;DR above). This applies to the `build` gates here, not to `ci-check`/`test`/`lint`, which write no artifacts.
-
-| Area edited                       | Minimum gate before shipping                                                                                                                                             |
-| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Cross-cutting / multiple packages | `npm run build && npm run ci-check`                                                                                                                                      |
-| `packages/ai-chat/`               | `npm run build --workspace=@carbon/ai-chat` + `npm run test --workspace=@carbon/ai-chat`                                                                                 |
-| `packages/ai-chat-components/`    | `npm run build --workspace=@carbon/ai-chat-components` + `npm run test --workspace=@carbon/ai-chat-components` (runs web-components + react suites)                      |
-| `demo/`                           | `npm run build --workspace=@carbon/ai-chat-examples-demo` + `npm run test --workspace=@carbon/ai-chat-examples-demo` (Playwright)                                        |
-| `examples/**`                     | `npm run build --workspace=<example>` + visual smoke via `npm run start --workspace=<example>` (load in browser, open chat, send one message, confirm no console errors) |
-| SCSS only                         | `npm run lint:styles && npm run format`                                                                                                                                  |
-
-Always run `npm run lint` + `npm run lint:license` before opening a PR if you touched more than one file — husky's pre-commit only runs prettier/eslint/stylelint on staged files and does not check license headers.
-
-Before declaring a task done, self-review the diff against [code-review.md](references/code-review.md). Prefer a sub-agent for independence and to keep the main conversation lean. Act on **Blocker** findings before handing back; surface **Important** findings to the user.
-
-## Gotchas
-
-- `packages/ai-chat/src/chat/components-legacy/` is closed to **new** components — author new UI in `components/`, or lift reusable pieces to `@carbon/ai-chat-components`. Bug fixes and refactoring transitions out are welcome.
-- `packages/ai-chat-components/src/react/` and `custom-elements.json` are generated by `npm run custom-elements`. Don't hand-edit.
-- `telemetry.yml` files are generated — regenerate with `npm run telemetry:config`.
-- Each example's README must follow the Indexer contract — see [examples/AGENTS.md](examples/AGENTS.md).
+Plan files (`PLAN.md`, `PLAN-{N}-{title}.md`) live at the repo root and are git-ignored.
 
 ## Conventions
 
-Repo-wide rules live in two canonical guides. Package-level `AGENTS.md` files should link to these, not restate them.
+Repo-wide rules live in two canonical guides. Package-level `AGENTS.md` files link here, they do not restate.
 
 - **Code-authoring discipline** — read before writing or changing any code: the laziness ladder & simplicity principles, plus prefix discipline, SCSS/BEM, RTL logical properties, component placement, comments → [code-patterns.md](references/code-patterns.md).
-- **Process conventions** (commits, branches & PR titles, license headers, commit hooks) → [conventions.md](references/conventions.md).
-
-## Authoring AGENTS.md files
-
-Rules for keeping these guidance files lean — agents (especially smaller-context ones) load them top-down, so total tokens matter.
-
-- **Per-file budget**: ~200 lines max. Beyond that, split topic detail into kebab-case files under a `references/` subfolder (`references/<topic>.md`) and link to them from the parent `AGENTS.md` with a short "read when…" hint. Bare `AGENTS.md` stays the directory's entry point; only the topic detail moves into `references/`.
-- **One topic per file**: if a leaf file has two unrelated H2 sections, the second one is its own file.
-- **Front-load a TL;DR or pointer index**: agents scan from the top; bury nothing important.
-- **Prefer tables and bullets over prose**: same information density, fewer tokens, easier to scan.
-- **Cross-reference, don't restate**: when a rule is repo-wide (prefix discipline, license headers, `aiChat:start` watcher, conventional commits), link to its canonical home — [code-patterns.md](references/code-patterns.md) or [conventions.md](references/conventions.md) — instead of inlining.
-- **Trim human-onboarding prose**: drop "we chose this because…" framing unless the _why_ changes how an agent applies the rule.
-- **Each leaf file ends with a "Related guidance" section** so an agent landing cold can navigate to neighbors without re-reading the parent.
+- **Process conventions** — commits, branches & PR titles, license headers, commit hooks → [conventions.md](references/conventions.md).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+Read [AGENTS.md](AGENTS.md) — the single source of truth for this repo, shared by every agent. It is a router: it points you to the right package `AGENTS.md` and `references/` doc for whatever you're doing. Start there for build commands, conventions, architecture, and the per-area definition of done. Read the relevant package's own `AGENTS.md` before your first edit there.
 
-You should never list yourself as a contributor on a commit.
+The only Claude-specific rule lives here:
 
-All repo conventions, build commands, and architecture notes live in [AGENTS.md](AGENTS.md) — read it before editing or reviewing any file.
+- Never list yourself as a contributor or co-author on a commit or PR (no `Co-Authored-By: Claude` trailers) — author them as the user only.

--- a/examples/AGENTS.md
+++ b/examples/AGENTS.md
@@ -4,6 +4,17 @@ Guidance that applies to both [react/](react/) and [web-components/](web-compone
 
 > **Prerequisite**: packages must be built first. See root [AGENTS.md](../AGENTS.md) — examples resolve deps through `dist/es/`.
 
+## Running an example
+
+Build the packages first, then from the repo root start any single example by its workspace name (override the default port 3000 with `PORT=`):
+
+```bash
+npm run start --workspace=@carbon/ai-chat-examples-react-basic-float
+PORT=3001 npm run start --workspace=@carbon/ai-chat-examples-react-basic-custom-element-fullscreen
+```
+
+When `npm run aiChat:start` is running in another terminal, example webpack servers hot-reload on package rebuilds.
+
 ## Adding a new example
 
 1. **Pick a base and copy it.** Each flavor lists its canonical scaffolds in its own `AGENTS.md`. Both include webpack config, `tsconfig.json`, HTML entry, and `package.json`. Rename the folder to `<slug>` and update the workspace name to the flavor's naming pattern.

--- a/packages/ai-chat-components/src/components/input/src/__tests__/prompt-line.test.ts
+++ b/packages/ai-chat-components/src/components/input/src/__tests__/prompt-line.test.ts
@@ -13,6 +13,8 @@ import { Extension } from "@tiptap/core";
 import "../prompt-line.js";
 import { PROMPT_LINE_MAX_BLOCK_SIZE } from "../prompt-line-constants.js";
 import type PromptLineElement from "../prompt-line.js";
+import { carbonMention } from "../tiptap/carbon-mention.js";
+import type { SuggestionItem } from "../tiptap/types.js";
 
 async function makePromptLine(
   attrs: Partial<{
@@ -267,6 +269,38 @@ describe("<cds-aichat-prompt-line> (rich upgrade)", function () {
     await el.updateComplete;
     await Promise.resolve();
     expect(el.getEditor()).to.not.equal(null);
+  });
+
+  // Regression: clearContent() is the post-send wipe. It must be a host-origin
+  // (programmatic) edit so the carbon-mention/command removal plugin stays
+  // silent — otherwise sending strips the just-captured mention/command fields
+  // from the host's structured_data sidecar before the message is built. See
+  // issue #1619.
+  it("does NOT fire a mention onRemove when clearContent() wipes the doc", async () => {
+    const removed: SuggestionItem[] = [];
+    const el = await makePromptLine();
+    el.extensions = [
+      carbonMention({
+        trigger: "@",
+        items: [{ id: "u1", label: "Alice" }],
+        onRemove: (item) => removed.push(item),
+      }),
+    ];
+    el.rich = true;
+    await waitForRich(el);
+
+    // Insert a mention chip programmatically (does not fire onSelect/onRemove).
+    el.getEditor()!.commands.insertContent({
+      type: "mention",
+      attrs: { id: "u1", label: "Alice", value: "u1", data: null },
+    });
+    await Promise.resolve();
+
+    el.clearContent();
+    await Promise.resolve();
+
+    expect(removed).to.have.lengthOf(0);
+    expect(el.getEditor()!.getText()).to.equal("");
   });
 });
 

--- a/packages/ai-chat-components/src/components/input/src/prompt-line-rich-runtime.ts
+++ b/packages/ai-chat-components/src/components/input/src/prompt-line-rich-runtime.ts
@@ -153,7 +153,23 @@ class RichController implements PromptLineController {
   }
 
   clearContent(): void {
-    this._editor?.commands.clearContent(true);
+    const editor = this._editor;
+    if (!editor) {
+      return;
+    }
+    // Tag the clear as host-origin so the carbon-mention/command removal plugin
+    // treats the post-send wipe as programmatic (not a user edit) and skips
+    // firing `onRemove`. Otherwise a send would strip the just-captured
+    // mention/command fields from the host's structured_data sidecar before
+    // `doSend` merges them. Mirrors `_dispatchSetContent`.
+    editor
+      .chain()
+      .command(({ tr }) => {
+        setHostOriginMeta(tr);
+        return true;
+      })
+      .clearContent(true)
+      .run();
   }
 
   getEditor(): Editor | null {

--- a/packages/ai-chat/AGENTS.md
+++ b/packages/ai-chat/AGENTS.md
@@ -65,7 +65,7 @@ npx jest -t "pattern"
 
 ## Definition of done
 
-See root [AGENTS.md](../../AGENTS.md#definition-of-done) for the gate. Additionally: if you changed anything under `src/types/`, `aiChatEntry.tsx`, or `serverEntry.ts`, verify a consumer (`demo/` or an example) still builds against the new artifacts.
+See [definition-of-done.md](../../references/definition-of-done.md) for the gate. Additionally: if you changed anything under `src/types/`, `aiChatEntry.tsx`, or `serverEntry.ts`, verify a consumer (`demo/` or an example) still builds against the new artifacts.
 
 ## Authoring rules
 

--- a/references/authoring-agents-md.md
+++ b/references/authoring-agents-md.md
@@ -1,0 +1,17 @@
+# authoring-agents-md.md — writing & maintaining AGENTS.md files
+
+Load this when creating or editing an `AGENTS.md` file or a `references/` topic doc. These files are loaded top-down by agents (especially smaller-context ones), so total tokens matter — keep them lean.
+
+- **Per-file budget**: ~200 lines max. Beyond that, split topic detail into kebab-case files under a `references/` subfolder (`references/<topic>.md`) and link to them from the parent `AGENTS.md` with a short "read when…" hint. The bare `AGENTS.md` stays the directory's entry point; only the topic detail moves into `references/`.
+- **One topic per file**: if a leaf file has two unrelated H2 sections, the second one is its own file.
+- **Front-load a TL;DR or pointer index**: agents scan from the top; bury nothing important.
+- **Prefer tables and bullets over prose**: same information density, fewer tokens, easier to scan.
+- **Cross-reference, don't restate**: when a rule is repo-wide (prefix discipline, license headers, the `aiChat:start` watcher, conventional commits), link to its canonical home — [code-patterns.md](code-patterns.md) or [conventions.md](conventions.md) — instead of inlining it.
+- **Every reference link carries a "read when…" trigger, and lives in the router that owns the file's scope.** Top-level `references/` are triggered from the root [AGENTS.md](../AGENTS.md) task router; a package's own `references/` (e.g. `architecture.md`, `services.md`, `tests.md`) are triggered from that package's `AGENTS.md`. Never dump a bare list of links — the reader can't tell when to open which.
+- **Trim human-onboarding prose**: drop "we chose this because…" framing unless the _why_ changes how an agent applies the rule.
+- **Each leaf file ends with a "Related guidance" section** so an agent landing cold can navigate to neighbors without re-reading the parent.
+
+## Related guidance
+
+- [Root AGENTS.md](../AGENTS.md) — the router these rules produce
+- [tone.md](tone.md) — voice & word economy for developer-facing copy

--- a/references/commands.md
+++ b/references/commands.md
@@ -1,0 +1,39 @@
+# commands.md — build, test & run commands
+
+Load this when you need to build, watch, lint, format, test, or run an example/Storybook. Run from the repo root unless noted.
+
+> **Ask first** if the user has `npm run aiChat:start` running — don't kick off a parallel build/watch; it races the watcher.
+
+## Common commands
+
+| Task                                                               | Command                                   |
+| ------------------------------------------------------------------ | ----------------------------------------- |
+| Fresh install + first-time build                                   | `npm install && npm run aiChat:build`     |
+| Dev watch (builds + watches both packages + demo, TypeDoc on 5001) | `npm run aiChat:start`                    |
+| Storybook (Lit)                                                    | `npm run aiChat:start:storybook`          |
+| Storybook (React wrappers)                                         | `npm run aiChat:start:storybook:react`    |
+| Build everything                                                   | `npm run build`                           |
+| Build only the ai-chat stack (components + ai-chat + demo)         | `npm run aiChat:build`                    |
+| Lint (eslint on `packages/`)                                       | `npm run lint`                            |
+| Stylelint                                                          | `npm run lint:styles`                     |
+| License header check                                               | `npm run lint:license`                    |
+| Prettier check / write                                             | `npm run format` / `npm run format:write` |
+| All tests                                                          | `npm run test`                            |
+| Lint + format + license + test gate (no build)                     | `npm run ci-check`                        |
+| Clean everything                                                   | `npm run clean`                           |
+
+Which gate to run before shipping a change → [definition-of-done.md](definition-of-done.md).
+
+## Running a single example or test
+
+Each lives with the thing it tests — no recipes are restated here:
+
+- **One example** → [examples/AGENTS.md](../examples/AGENTS.md) ("Running an example").
+- **One `@carbon/ai-chat` test** (Jest) → [packages/ai-chat/references/tests.md](../packages/ai-chat/references/tests.md).
+- **One `@carbon/ai-chat-components` test** (two runners — `@web/test-runner` + Jest) → [packages/ai-chat-components/AGENTS.md](../packages/ai-chat-components/AGENTS.md).
+
+## Related guidance
+
+- [Root AGENTS.md](../AGENTS.md) — repo router
+- [definition-of-done.md](definition-of-done.md) — which gate to run before shipping
+- [conventions.md](conventions.md) — commits, branches, license headers, hooks

--- a/references/definition-of-done.md
+++ b/references/definition-of-done.md
@@ -1,0 +1,29 @@
+# definition-of-done.md — gates before shipping
+
+Load this to pick the minimum verification gate for what you changed, before marking a task done or opening a PR.
+
+`npm run ci-check` does **not** run `build`, and workspace deps resolve through built artifacts (`es/`, `dist/es/`) rather than TS sources. **Always run `build` BEFORE `ci-check`** — running them the other way around (or running `ci-check` on its own after edits) makes tests resolve consumer imports against a stale `es/`, which surfaces as confusing "no exported member 'X'" errors even though the source clearly exports X.
+
+> **Before running any `build` row below, ask the user whether `npm run aiChat:start` is already running** — a parallel build races the watcher (see [commands.md](commands.md) and the Always-on rules in the root [AGENTS.md](../AGENTS.md)). This applies to the `build` gates here, not to `ci-check`/`test`/`lint`, which write no artifacts.
+
+## Minimum gate by area edited
+
+| Area edited                       | Minimum gate before shipping                                                                                                                                             |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Cross-cutting / multiple packages | `npm run build && npm run ci-check`                                                                                                                                      |
+| `packages/ai-chat/`               | `npm run build --workspace=@carbon/ai-chat` + `npm run test --workspace=@carbon/ai-chat`                                                                                 |
+| `packages/ai-chat-components/`    | `npm run build --workspace=@carbon/ai-chat-components` + `npm run test --workspace=@carbon/ai-chat-components` (runs web-components + react suites)                      |
+| `demo/`                           | `npm run build --workspace=@carbon/ai-chat-examples-demo` + `npm run test --workspace=@carbon/ai-chat-examples-demo` (Playwright)                                        |
+| `examples/**`                     | `npm run build --workspace=<example>` + visual smoke via `npm run start --workspace=<example>` (load in browser, open chat, send one message, confirm no console errors) |
+| SCSS only                         | `npm run lint:styles && npm run format`                                                                                                                                  |
+
+Always run `npm run lint` + `npm run lint:license` before opening a PR if you touched more than one file — husky's pre-commit only runs prettier/eslint/stylelint on staged files and does not check license headers.
+
+Before declaring a task done, self-review the diff against [code-review.md](code-review.md). Prefer a sub-agent for independence and to keep the main conversation lean. Act on **Blocker** findings before handing back; surface **Important** findings to the user.
+
+## Related guidance
+
+- [Root AGENTS.md](../AGENTS.md) — repo router
+- [commands.md](commands.md) — the commands referenced above
+- [code-review.md](code-review.md) — review rubric
+- [conventions.md](conventions.md) — commits, branches, license headers, hooks

--- a/references/figma.md
+++ b/references/figma.md
@@ -46,7 +46,7 @@ Read-only access to design frames. Use to pull frame metadata, component names, 
 2. Call Carbon MCP `code_search` with `filters.component_type` set per the table.
 3. Author in the matching package following its existing patterns: [packages/ai-chat/AGENTS.md](../packages/ai-chat/AGENTS.md) or [packages/ai-chat-components/AGENTS.md](../packages/ai-chat-components/AGENTS.md).
 4. Apply accessibility from [accessibility.md](accessibility.md) — Figma frames rarely encode live-region or focus-order requirements.
-5. Verify per the per-area gate in [root AGENTS.md Definition of done](../AGENTS.md#definition-of-done).
+5. Verify per the per-area gate in [definition-of-done.md](definition-of-done.md).
 
 ## Code Connect
 

--- a/references/plan-authoring.md
+++ b/references/plan-authoring.md
@@ -50,7 +50,7 @@ The execution detail for one step. Written so an agent loading cold can implemen
 - **Scope** — one paragraph: what this step does and what it explicitly does not. Resist the urge to repeat `PLAN.md` context here.
 - **Files touched** — concrete paths the executor will create / edit / delete. Vague plans produce drift; specific paths force you to verify the codebase as you draft.
 - **Implementation steps** — ordered list. Each step short enough that a reasonable executor can complete it without further design questions. Cite file paths and line numbers for any claim about existing code.
-- **Validation** — how to know the step is correct: which tests to add, which existing tests must still pass, which manual checks (browser smoke, type-check, build) are required. Refer to the relevant gate in [AGENTS.md](../AGENTS.md#definition-of-done).
+- **Validation** — how to know the step is correct: which tests to add, which existing tests must still pass, which manual checks (browser smoke, type-check, build) are required. Refer to the relevant gate in [definition-of-done.md](definition-of-done.md).
 - **Risk / open questions** — anything you're not sure about. Better to flag uncertainty than bury it.
 
 ## Style


### PR DESCRIPTION
Closes #1619 

Fixes mention/command `structured_data` getting stripped on send. The post-send `clearContent()` wasn't tagged host-origin, so the carbon-mention/command removal plugin read the wipe as a user deletion and fired `onRemove` per chip — clearing the just-captured fields from the host's `structured_data` sidecar before the message was built.

- [`packages/ai-chat-components/src/components/input/src/prompt-line-rich-runtime.ts`](packages/ai-chat-components/src/components/input/src/prompt-line-rich-runtime.ts) — `clearContent()` now chains a host-origin meta tag before `clearContent(true)`, mirroring `_dispatchSetContent`. Verify against the removal plugin's origin gate in [`tiptap/carbon-mention.ts`](packages/ai-chat-components/src/components/input/src/tiptap/carbon-mention.ts).

#### Changelog

**Changed**

- `<cds-aichat-prompt-line>` rich mode no longer fires mention/command `onRemove` on the post-send clear, so `structured_data` retains its captured fields through send.
- Made the root AGENTS.md more strictly a router so the agents don't take on any additional context they don't need.

#### Testing / Reviewing

- From `packages/ai-chat-components`: `npm run test:web-components -- src/components/input/src/__tests__/prompt-line.test.ts`
- New regression test `does NOT fire a mention onRemove when clearContent() wipes the doc` — fails without the runtime change.