### PR TITLE
feat(prompt-line): error state

### DIFF
--- a/demo/src/framework/demo-input-config-switcher.ts
+++ b/demo/src/framework/demo-input-config-switcher.ts
@@ -8,6 +8,7 @@
  */
 
 import "@carbon/web-components/es/components/dropdown/index.js";
+import "@carbon/web-components/es/components/checkbox/index.js";
 
 import { InputConfig, PublicConfig, ToolbarAction } from "@carbon/ai-chat";
 import Document16 from "@carbon/icons/es/document/16.js";
@@ -328,6 +329,31 @@ export class DemoInputConfigSwitcher extends LitElement {
     }
   }
 
+  private _handleErrorCheckbox(event: Event) {
+    const customEvent = event as CustomEvent;
+    const checked = customEvent.detail.checked as boolean;
+
+    this._updateInput((input) => {
+      const next: InputConfig = { ...(input ?? {}) };
+
+      if (checked) {
+        next.error = {
+          title: "Error: title goes here",
+          description: `Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod
+            tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
+            quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
+            consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse
+            cillum dolore eu fugiat nulla pariatur.`,
+          collapsible: true,
+        };
+      } else {
+        delete next.error;
+      }
+
+      return this._normalizeInput(next);
+    });
+  }
+
   render() {
     const input = this.config?.input;
 
@@ -454,6 +480,14 @@ export class DemoInputConfigSwitcher extends LitElement {
             >Disable expanded layout</cds-dropdown-item
           >
         </cds-dropdown>
+      </div>
+
+      <div class="input-section">
+        <cds-checkbox
+          ?checked="${this.config?.input?.error !== undefined}"
+          label-text="Show prompt line error"
+          @cds-checkbox-changed=${this._handleErrorCheckbox}
+        ></cds-checkbox>
       </div>
     `;
   }

--- a/packages/ai-chat-components/src/components/file-uploads/src/file-uploads.ts
+++ b/packages/ai-chat-components/src/components/file-uploads/src/file-uploads.ts
@@ -71,6 +71,8 @@ class FileUploadsElement extends LitElement {
               .iconDescription="${upload.status === "uploading"
                 ? this.uploadingFileLabel
                 : this.removeFileLabel}"
+              .errorSubject="${upload.errorMessage || ""}"
+              ?invalid="${upload.isError}"
               @cds-file-uploader-item-deleted="${() =>
                 this._handleFileRemove(upload.id)}"
             >

--- a/packages/ai-chat-components/src/components/file-uploads/src/file-uploads.ts
+++ b/packages/ai-chat-components/src/components/file-uploads/src/file-uploads.ts
@@ -71,8 +71,6 @@ class FileUploadsElement extends LitElement {
               .iconDescription="${upload.status === "uploading"
                 ? this.uploadingFileLabel
                 : this.removeFileLabel}"
-              .errorSubject="${upload.errorMessage || ""}"
-              ?invalid="${upload.isError}"
               @cds-file-uploader-item-deleted="${() =>
                 this._handleFileRemove(upload.id)}"
             >

--- a/packages/ai-chat-components/src/components/input/index.ts
+++ b/packages/ai-chat-components/src/components/input/index.ts
@@ -9,6 +9,7 @@
 
 import "./src/input-shell.js";
 import "./src/prompt-line.js";
+import "./src/error-message.js";
 import "./src/send-control.js";
 import "./src/stop-streaming-button.js";
 import "./src/autocomplete-controller.js";
@@ -22,6 +23,7 @@ export type {
   PromptLineController,
   PromptLineControllerInit,
 } from "./src/prompt-line-controller.js";
+export { default as ErrorMessage } from "./src/error-message.js";
 export { default as InputSendControlElement } from "./src/send-control.js";
 export { default as StopStreamingButton } from "./src/stop-streaming-button.js";
 export {

--- a/packages/ai-chat-components/src/components/input/src/error-message.scss
+++ b/packages/ai-chat-components/src/components/input/src/error-message.scss
@@ -1,0 +1,29 @@
+/*
+ *  Copyright IBM Corp. 2026
+ *
+ *  This source code is licensed under the Apache-2.0 license found in the
+ *  LICENSE file in the root directory of this source tree.
+ */
+
+@use "../../../globals/scss/vars" as *;
+@use "@carbon/styles/scss/theme";
+
+$block-class: #{$prefix}-error-message;
+
+.#{$block-class} {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.#{$block-class}__icon {
+  fill: theme.$support-error;
+}
+
+.#{$block-class}__text {
+  flex: 1;
+}
+
+.#{$block-class}__chevron svg {
+  fill: theme.$icon-primary;
+}

--- a/packages/ai-chat-components/src/components/input/src/error-message.scss
+++ b/packages/ai-chat-components/src/components/input/src/error-message.scss
@@ -6,24 +6,76 @@
  */
 
 @use "../../../globals/scss/vars" as *;
+@use "@carbon/layout";
 @use "@carbon/styles/scss/theme";
+@use "@carbon/styles/scss/type";
 
 $block-class: #{$prefix}-error-message;
 
 .#{$block-class} {
+  position: relative;
   display: flex;
-  align-items: center;
-  gap: 0.5rem;
+  align-items: flex-start;
+  gap: layout.$spacing-03;
+  inline-size: 100%;
+  min-height: layout.$spacing-08;
+
+  &::after {
+    z-index: -1;
+    position: absolute;
+    display: block;
+    background: theme.$border-subtle-00;
+    block-size: 1px;
+    content: "";
+    inline-size: calc(100% + #{layout.$spacing-05} + #{layout.$spacing-03});
+    inset-block-end: 0;
+    inset-inline-start: calc(-1 * #{layout.$spacing-05});
+  }
+}
+
+.#{$block-class}__icon-and-text {
+  display: flex;
+  flex: 1;
+  min-width: 0;
+  align-items: flex-start;
+  gap: layout.$spacing-05;
+  margin-block-start: layout.$spacing-04;
+}
+
+.#{$block-class}__icon-and-text--no-expand {
+  margin-inline-end: layout.$spacing-03;
 }
 
 .#{$block-class}__icon {
-  fill: theme.$support-error;
+  display: flex;
+  align-items: center;
+
+  svg {
+    fill: theme.$support-error;
+  }
 }
 
 .#{$block-class}__text {
+  @include type.type-style("helper-text-01");
+
   flex: 1;
+  color: theme.$support-error;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
 }
 
-.#{$block-class}__chevron svg {
-  fill: theme.$icon-primary;
+.#{$block-class}__text--expanded {
+  max-height: layout.$spacing-11;
+  overflow-y: auto;
+  white-space: normal;
+  text-overflow: clip;
+}
+
+.#{$block-class}__chevron {
+  margin-block: layout.$spacing-02;
+
+  svg {
+    fill: theme.$icon-primary;
+  }
 }

--- a/packages/ai-chat-components/src/components/input/src/error-message.scss
+++ b/packages/ai-chat-components/src/components/input/src/error-message.scss
@@ -18,11 +18,10 @@ $block-class: #{$prefix}-error-message;
   align-items: flex-start;
   gap: layout.$spacing-03;
   inline-size: 100%;
-  min-height: layout.$spacing-08;
 
   &::after {
-    z-index: -1;
     position: absolute;
+    z-index: -1;
     display: block;
     background: theme.$border-subtle-00;
     block-size: 1px;
@@ -33,20 +32,23 @@ $block-class: #{$prefix}-error-message;
   }
 }
 
-.#{$block-class}__icon-and-text {
+.#{$block-class}__warning-icon-and-text {
   display: flex;
   flex: 1;
-  min-width: 0;
   align-items: flex-start;
   gap: layout.$spacing-05;
   margin-block-start: layout.$spacing-04;
 }
 
-.#{$block-class}__icon-and-text--no-expand {
+.#{$block-class}__warning-icon-and-text--no-chevron {
   margin-inline-end: layout.$spacing-03;
 }
 
-.#{$block-class}__icon {
+:host([fullscreen]).#{$block-class}__warning-icon-and-text--no-chevron {
+  margin-inline-end: layout.$spacing-05;
+}
+
+.#{$block-class}__warning-icon {
   display: flex;
   align-items: center;
 
@@ -58,18 +60,20 @@ $block-class: #{$prefix}-error-message;
 .#{$block-class}__text {
   @include type.type-style("helper-text-01");
 
+  overflow: hidden;
   flex: 1;
   color: theme.$support-error;
-  overflow: hidden;
-  white-space: nowrap;
+  max-block-size: layout.$spacing-05;
+  padding-block-end: layout.$spacing-04;
   text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .#{$block-class}__text--expanded {
-  max-height: layout.$spacing-11;
+  max-block-size: layout.$spacing-11;
   overflow-y: auto;
-  white-space: normal;
   text-overflow: clip;
+  white-space: normal;
 }
 
 .#{$block-class}__chevron {
@@ -77,5 +81,6 @@ $block-class: #{$prefix}-error-message;
 
   svg {
     fill: theme.$icon-primary;
+    pointer-events: none;
   }
 }

--- a/packages/ai-chat-components/src/components/input/src/error-message.ts
+++ b/packages/ai-chat-components/src/components/input/src/error-message.ts
@@ -7,7 +7,14 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { css, html, LitElement, TemplateResult, unsafeCSS } from "lit";
+import {
+  css,
+  html,
+  LitElement,
+  PropertyValues,
+  TemplateResult,
+  unsafeCSS,
+} from "lit";
 import { property, state } from "lit/decorators.js";
 
 import "@carbon/web-components/es/components/icon-button/index.js";
@@ -35,16 +42,22 @@ class ErrorMessage extends LitElement {
   `;
 
   /**
-   * The error message text to display.
+   * The error title text to display.
    */
-  @property({ type: String, attribute: "message" })
-  message = "";
+  @property({ type: String, attribute: "title" })
+  title = "";
 
   /**
-   * Whether the error message is expandable.
+   * The error description text to display.
    */
-  @property({ type: Boolean, attribute: "expandable" })
-  expandable = false;
+  @property({ type: String, attribute: "description" })
+  description = "";
+
+  /**
+   * Whether the error message is collapsible.
+   */
+  @property({ type: Boolean, attribute: "collapsible" })
+  collapsible = false;
 
   /**
    * Whether the error message is in fullscreen layout.
@@ -56,7 +69,14 @@ class ErrorMessage extends LitElement {
    * Whether the error message is currently expanded.
    * @internal
    */
-  @state() private _isExpanded = false;
+  @state() private _isExpanded = true;
+
+  protected updated(changedProps: PropertyValues) {
+    super.updated(changedProps);
+    if (changedProps.has("collapsible")) {
+      this._isExpanded = !this.collapsible;
+    }
+  }
 
   /**
    * Toggles the expanded state to show more or less of the error message.
@@ -66,23 +86,26 @@ class ErrorMessage extends LitElement {
   }
 
   render() {
-    const warningIcon = html`<span class="${blockClass}__icon">
+    const warningIcon = html`<span class="${blockClass}__warning-icon">
       ${iconLoader(WarningFilled16)}
     </span>`;
 
+    const hasChevron = this.collapsible && this.description;
+
     let expandButton: TemplateResult | null = null;
-    if (this.expandable) {
+    if (hasChevron) {
       const icon = this._isExpanded ? ChevronUp16 : ChevronDown16;
-      const label = `${this._isExpanded ? "Condense" : "Expand"} error message`;
+      const label = `${this._isExpanded ? "Collapse" : "Expand"} error message`;
 
       expandButton = html`<cds-icon-button
         class="${blockClass}__chevron"
         kind="ghost"
         size="sm"
+        align="top-end"
         aria-label="${label}"
         @click="${this._handleClickExpanded}"
       >
-        ${iconLoader(icon, { slot: "icon" })}
+        ${iconLoader(icon, { slot: "icon", focusable: "true", tabindex: "-1" })}
         <span slot="tooltip-content">${label}</span>
       </cds-icon-button>`;
     }
@@ -90,8 +113,8 @@ class ErrorMessage extends LitElement {
     return html`
       <div class="${blockClass}">
         <div
-          class="${blockClass}__icon-and-text${!this.expandable
-            ? ` ${blockClass}__icon-and-text--no-expand`
+          class="${blockClass}__warning-icon-and-text${!hasChevron
+            ? ` ${blockClass}__warning-icon-and-text--no-chevron`
             : ""}"
         >
           ${this.fullscreen ? null : warningIcon}
@@ -100,7 +123,8 @@ class ErrorMessage extends LitElement {
               ? ` ${blockClass}__text--expanded`
               : ""}"
           >
-            ${this.message}
+            ${this.title}<br />
+            ${this._isExpanded ? this.description : ""}
           </div>
           ${this.fullscreen ? warningIcon : null}
         </div>

--- a/packages/ai-chat-components/src/components/input/src/error-message.ts
+++ b/packages/ai-chat-components/src/components/input/src/error-message.ts
@@ -1,0 +1,89 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { css, html, LitElement, TemplateResult, unsafeCSS } from "lit";
+import { property, state } from "lit/decorators.js";
+
+import { iconLoader } from "@carbon/web-components/es/globals/internal/icon-loader.js";
+import WarningFilled16 from "@carbon/icons/es/warning--filled/16.js";
+import ChevronDown16 from "@carbon/icons/es/chevron--down/16.js";
+import ChevronUp16 from "@carbon/icons/es/chevron--up/16.js";
+
+import { carbonElement } from "../../../globals/decorators/carbon-element.js";
+import prefix from "../../../globals/settings.js";
+
+import styles from "./error-message.scss?lit";
+
+const blockClass = `${prefix}-error-message`;
+
+/**
+ * Error message component for AI Chat input.
+ *
+ * @element cds-aichat-error-message
+ */
+@carbonElement(`${prefix}-error-message`)
+class ErrorMessage extends LitElement {
+  static styles = css`
+    ${unsafeCSS(styles)}
+  `;
+
+  /**
+   * The error message to display.
+   */
+  @property({ type: String, attribute: "message" })
+  message = "";
+
+  /**
+   * Whether the error message is expandable.
+   */
+  @property({ type: Boolean, attribute: "expandable" })
+  expandable = false;
+
+  /**
+   * Whether the error message is in fullscreen layout.
+   */
+  @property({ type: Boolean, attribute: "fullscreen" })
+  fullscreen = false;
+
+  /**
+   * Whether the error message is currently expanded
+   * @internal
+   */
+  @state() private isExpanded = false;
+
+  render() {
+    const warningIcon = html`<span class="${blockClass}__icon">
+      ${iconLoader(WarningFilled16)}
+    </span>`;
+
+    let chevronIcon: TemplateResult | null = null;
+    if (this.expandable) {
+      const icon = this.isExpanded ? ChevronUp16 : ChevronDown16;
+      chevronIcon = html`<span class="${blockClass}__chevron">
+        ${iconLoader(icon)}
+      </span>`;
+    }
+
+    return html`
+      <div class="${blockClass}">
+        ${!this.fullscreen && warningIcon}
+        <span class="${blockClass}__text">${this.message}</span>
+        ${this.fullscreen && warningIcon} ${chevronIcon}
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "cds-aichat-error-message": ErrorMessage;
+  }
+}
+
+export default ErrorMessage;

--- a/packages/ai-chat-components/src/components/input/src/error-message.ts
+++ b/packages/ai-chat-components/src/components/input/src/error-message.ts
@@ -10,6 +10,7 @@
 import { css, html, LitElement, TemplateResult, unsafeCSS } from "lit";
 import { property, state } from "lit/decorators.js";
 
+import "@carbon/web-components/es/components/icon-button/index.js";
 import { iconLoader } from "@carbon/web-components/es/globals/internal/icon-loader.js";
 import WarningFilled16 from "@carbon/icons/es/warning--filled/16.js";
 import ChevronDown16 from "@carbon/icons/es/chevron--down/16.js";
@@ -23,7 +24,7 @@ import styles from "./error-message.scss?lit";
 const blockClass = `${prefix}-error-message`;
 
 /**
- * Error message component for AI Chat input.
+ * Error message component for AI Chat prompt line.
  *
  * @element cds-aichat-error-message
  */
@@ -34,7 +35,7 @@ class ErrorMessage extends LitElement {
   `;
 
   /**
-   * The error message to display.
+   * The error message text to display.
    */
   @property({ type: String, attribute: "message" })
   message = "";
@@ -52,29 +53,58 @@ class ErrorMessage extends LitElement {
   fullscreen = false;
 
   /**
-   * Whether the error message is currently expanded
+   * Whether the error message is currently expanded.
    * @internal
    */
-  @state() private isExpanded = false;
+  @state() private _isExpanded = false;
+
+  /**
+   * Toggles the expanded state to show more or less of the error message.
+   */
+  private _handleClickExpanded() {
+    this._isExpanded = !this._isExpanded;
+  }
 
   render() {
     const warningIcon = html`<span class="${blockClass}__icon">
       ${iconLoader(WarningFilled16)}
     </span>`;
 
-    let chevronIcon: TemplateResult | null = null;
+    let expandButton: TemplateResult | null = null;
     if (this.expandable) {
-      const icon = this.isExpanded ? ChevronUp16 : ChevronDown16;
-      chevronIcon = html`<span class="${blockClass}__chevron">
-        ${iconLoader(icon)}
-      </span>`;
+      const icon = this._isExpanded ? ChevronUp16 : ChevronDown16;
+      const label = `${this._isExpanded ? "Condense" : "Expand"} error message`;
+
+      expandButton = html`<cds-icon-button
+        class="${blockClass}__chevron"
+        kind="ghost"
+        size="sm"
+        aria-label="${label}"
+        @click="${this._handleClickExpanded}"
+      >
+        ${iconLoader(icon, { slot: "icon" })}
+        <span slot="tooltip-content">${label}</span>
+      </cds-icon-button>`;
     }
 
     return html`
       <div class="${blockClass}">
-        ${!this.fullscreen && warningIcon}
-        <span class="${blockClass}__text">${this.message}</span>
-        ${this.fullscreen && warningIcon} ${chevronIcon}
+        <div
+          class="${blockClass}__icon-and-text${!this.expandable
+            ? ` ${blockClass}__icon-and-text--no-expand`
+            : ""}"
+        >
+          ${this.fullscreen ? null : warningIcon}
+          <div
+            class="${blockClass}__text${this._isExpanded
+              ? ` ${blockClass}__text--expanded`
+              : ""}"
+          >
+            ${this.message}
+          </div>
+          ${this.fullscreen ? warningIcon : null}
+        </div>
+        ${expandButton}
       </div>
     `;
   }

--- a/packages/ai-chat-components/src/components/input/src/input-shell.scss
+++ b/packages/ai-chat-components/src/components/input/src/input-shell.scss
@@ -69,6 +69,11 @@
   border-radius: layout.$spacing-03;
 }
 
+// Error state
+:host([has-error]) .#{$prefix}--input-container {
+  border: 1px solid theme.$support-error;
+}
+
 // Message actions visible — reduce start padding
 .#{$prefix}--input-container--has-message-actions {
   padding-inline-start: layout.$spacing-03;

--- a/packages/ai-chat-components/src/components/input/src/input-shell.scss
+++ b/packages/ai-chat-components/src/components/input/src/input-shell.scss
@@ -198,6 +198,7 @@
   flex: 0 1;
   align-self: flex-start;
   gap: layout.$spacing-03;
+  margin-block-start: layout.$spacing-04;
 }
 
 // -----------------------------------------------------------
@@ -276,8 +277,8 @@
   // end on its own.
   flex: 0 0 auto;
   order: 3;
-  margin-inline-start: auto;
   margin-block-start: layout.$spacing-04;
+  margin-inline-start: auto;
 }
 
 // With real actions the actions track (flex: 1 1 0) grows to fill the row and

--- a/packages/ai-chat-components/src/components/input/src/input-shell.scss
+++ b/packages/ai-chat-components/src/components/input/src/input-shell.scss
@@ -52,7 +52,7 @@
   min-block-size: 0;
   outline: button.$button-border-width solid transparent;
   outline-offset: -2px;
-  padding-block: layout.$spacing-04;
+  padding-block-end: layout.$spacing-04;
   padding-inline: layout.$spacing-05 layout.$spacing-03;
 }
 
@@ -103,6 +103,7 @@
   flex: 1 0;
   align-items: center;
   gap: layout.$spacing-03;
+  margin-block-start: layout.$spacing-04;
 }
 
 ::slotted([slot="message-actions"]) {
@@ -120,7 +121,8 @@
   gap: layout.$spacing-03;
 }
 
-.#{$prefix}--input-container > *:not(:last-child) {
+.#{$prefix}--input-container
+  > *:not(:last-child):not(.#{$prefix}--field-messaging-container) {
   margin-inline-end: layout.$spacing-03;
 }
 
@@ -166,15 +168,12 @@
 }
 
 // -----------------------------------------------------------
-// Field messaging slot (inline error / status content beneath
-// the autocomplete row — char-count exceeded, etc.)
+// Field messaging row (used for error message)
 // -----------------------------------------------------------
-::slotted([slot="field-messaging"]) {
-  @include type.type-style("helper-text-01");
-
-  display: block;
-  color: theme.$support-error;
-  padding-block-start: layout.$spacing-03;
+.#{$prefix}--field-messaging-container {
+  flex-basis: 100%;
+  inline-size: 100%;
+  margin-inline: 0;
 }
 
 // -----------------------------------------------------------
@@ -278,6 +277,7 @@
   flex: 0 0 auto;
   order: 3;
   margin-inline-start: auto;
+  margin-block-start: layout.$spacing-04;
 }
 
 // With real actions the actions track (flex: 1 1 0) grows to fill the row and

--- a/packages/ai-chat-components/src/components/input/src/input-shell.scss
+++ b/packages/ai-chat-components/src/components/input/src/input-shell.scss
@@ -170,10 +170,11 @@
 // the autocomplete row — char-count exceeded, etc.)
 // -----------------------------------------------------------
 ::slotted([slot="field-messaging"]) {
+  @include type.type-style("helper-text-01");
+
   display: block;
   color: theme.$support-error;
   padding-block-start: layout.$spacing-03;
-  @include type.type-style("label-01");
 }
 
 // -----------------------------------------------------------

--- a/packages/ai-chat-components/src/components/input/src/input-shell.ts
+++ b/packages/ai-chat-components/src/components/input/src/input-shell.ts
@@ -89,6 +89,8 @@ class InputShellElement extends LitElement {
           <div class="${prefix}--input-uploads-and-autocomplete">
             <slot name="file-uploads"></slot>
             <slot name="autocomplete-content"></slot>
+          </div>
+          <div class="${prefix}--field-messaging-container">
             <slot name="field-messaging"></slot>
           </div>
           <div class="${prefix}--input-text-and-actions">

--- a/packages/ai-chat-components/src/components/input/src/input-shell.ts
+++ b/packages/ai-chat-components/src/components/input/src/input-shell.ts
@@ -56,7 +56,7 @@ class InputShellElement extends LitElement {
   
   /** Whether the prompt line is in an error state */
   @property({ type: Boolean, reflect: true, attribute: "has-error" })
-  hasError = true;
+  hasError = false;
 
   @state()
   private _hasMessageActions = false;

--- a/packages/ai-chat-components/src/components/input/src/input-shell.ts
+++ b/packages/ai-chat-components/src/components/input/src/input-shell.ts
@@ -55,7 +55,7 @@ class InputShellElement extends LitElement {
   expanded = false;
   
   /** Whether the prompt line is in an error state */
-  @property({ type: Boolean, reflect: true, attribute: "has-error"  })
+  @property({ type: Boolean, reflect: true, attribute: "has-error" })
   hasError = true;
 
   @state()

--- a/packages/ai-chat-components/src/components/input/src/input-shell.ts
+++ b/packages/ai-chat-components/src/components/input/src/input-shell.ts
@@ -53,6 +53,10 @@ class InputShellElement extends LitElement {
    */
   @property({ type: Boolean, reflect: true })
   expanded = false;
+  
+  /** Whether the prompt line is in an error state */
+  @property({ type: Boolean, reflect: true, attribute: "has-error"  })
+  hasError = true;
 
   @state()
   private _hasMessageActions = false;

--- a/packages/ai-chat-components/src/components/input/src/input-shell.ts
+++ b/packages/ai-chat-components/src/components/input/src/input-shell.ts
@@ -53,7 +53,7 @@ class InputShellElement extends LitElement {
    */
   @property({ type: Boolean, reflect: true })
   expanded = false;
-  
+
   /** Whether the prompt line is in an error state */
   @property({ type: Boolean, reflect: true, attribute: "has-error" })
   hasError = false;

--- a/packages/ai-chat-components/src/react/error-message.ts
+++ b/packages/ai-chat-components/src/react/error-message.ts
@@ -1,0 +1,23 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { createComponent } from "@lit/react";
+import React from "react";
+import ErrorMessage from "../components/input/src/error-message.js";
+import { withWebComponentBridge } from "./utils/withWebComponentBridge.js";
+
+const CDSAIChatErrorMessage = withWebComponentBridge(
+  createComponent({
+    tagName: "cds-aichat-error-message",
+    elementClass: ErrorMessage,
+    react: React,
+  }),
+);
+
+export default CDSAIChatErrorMessage;

--- a/packages/ai-chat/src/chat/AppShell.tsx
+++ b/packages/ai-chat/src/chat/AppShell.tsx
@@ -402,8 +402,6 @@ function AppShell({
           u.status === "uploading"
             ? FileStatusValue.UPLOADING
             : FileStatusValue.EDIT,
-        isError: u.status === "error",
-        errorMessage: u.errorMessage,
       })),
     [inputState.pendingUploads],
   );
@@ -414,6 +412,28 @@ function AppShell({
     isAssistantUploadEnabled &&
     uploadConfig?.maxFiles !== undefined &&
     inputState.pendingUploads.length >= uploadConfig.maxFiles;
+
+  // Derive InputConfig.error
+  const inputError = useMemo(() => {
+    // check file and pending uploads first
+    const fileWithError = inputState.files.find((f) => f.isError);
+    const pendingUploadWithError = inputState.pendingUploads.find(
+      (u) => u.status === "error",
+    );
+
+    const uploadError = fileWithError || pendingUploadWithError;
+    if (uploadError) {
+      return {
+        title: "File upload error",
+        description:
+          "errorMessage" in uploadError ? uploadError.errorMessage : undefined,
+        collapsible: false,
+      };
+    }
+
+    // Fall back to config-provided error if no file upload errors
+    return publicConfig.input?.error;
+  }, [inputState.files, inputState.pendingUploads, publicConfig.input?.error]);
 
   // Panel callbacks
   const {
@@ -919,6 +939,7 @@ function AppShell({
                     (!IS_PHONE_IN_PORTRAIT_MODE ||
                       !!publicConfig.disableCustomElementMobileEnhancements)
                   }
+                  error={inputError}
                 />
               </div>
 

--- a/packages/ai-chat/src/chat/AppShell.tsx
+++ b/packages/ai-chat/src/chat/AppShell.tsx
@@ -402,6 +402,8 @@ function AppShell({
           u.status === "uploading"
             ? FileStatusValue.UPLOADING
             : FileStatusValue.EDIT,
+        isError: u.status === "error",
+        errorMessage: u.errorMessage,
       })),
     [inputState.pendingUploads],
   );

--- a/packages/ai-chat/src/chat/components/input/Input.tsx
+++ b/packages/ai-chat/src/chat/components/input/Input.tsx
@@ -8,6 +8,7 @@
  */
 
 import React, { forwardRef, Ref, useMemo, useRef, useState } from "react";
+import { AnnounceOnMountComponent } from "../util/AnnounceOnMountComponent";
 import InputShell from "@carbon/ai-chat-components/es/react/input-shell.js";
 import InputSendControl from "@carbon/ai-chat-components/es/react/input-send-control.js";
 import FileUploads from "@carbon/ai-chat-components/es/react/file-uploads.js";
@@ -144,6 +145,24 @@ interface InputProps {
    * Whether the input container should have rounded corners (at wider breakpoints).
    */
   rounded?: boolean;
+
+  /**
+   * Error configuration for displaying an error message in the input field.
+   */
+  error?: {
+    /**
+     * The error title to display.
+     */
+    title: string;
+    /**
+     * The error description to display.
+     */
+    description?: string;
+    /**
+     * Whether the error message container should be collapsible.
+     */
+    collapsible?: boolean;
+  };
 }
 
 /**
@@ -218,12 +237,14 @@ function Input(props: InputProps, ref: Ref<InputFunctions>) {
     maxInputChars = 10000,
     trackInputState = false,
     rounded,
+    error,
   } = props;
 
   const serviceManager = useServiceManager();
   const languagePack = useLanguagePack();
   const intl = useIntl();
   const store = serviceManager.store;
+  const hasErrorProp = error !== undefined;
 
   // Get chat width breakpoint and height to determine autocomplete settings
   const chatWidthBreakpoint = useSelector(
@@ -289,6 +310,7 @@ function Input(props: InputProps, ref: Ref<InputFunctions>) {
     disableSend,
     isSendDisabledFromConfig,
     onSendInput,
+    hasErrorProp,
   });
 
   const hasValidInput = useMemo(
@@ -445,6 +467,53 @@ function Input(props: InputProps, ref: Ref<InputFunctions>) {
     expanded,
   ]);
 
+  /**
+   * Renders the error message component if an error is provided.
+   */
+  const renderErrorMessage = () => {
+    if (overMaxLength) {
+      const errorText = intl.formatMessage(
+        { id: "input_maxCharCountExceeded" },
+        { max: maxInputChars, current: rawInputValue.length },
+      );
+      return (
+        <div slot="field-messaging">
+          <AnnounceOnMountComponent
+            announceOnce={`Error: Max character count exceeded. ${errorText}`}
+          >
+            <ErrorMessage
+              fullscreen={chatWidthBreakpoint === ChatWidthBreakpoint.WIDE}
+              title="Error: Max character count exceeded"
+              description={errorText}
+              collapsible={true}
+            />
+          </AnnounceOnMountComponent>
+        </div>
+      );
+    }
+
+    if (!hasErrorProp) {
+      return null;
+    }
+
+    const announcement = error.description
+      ? `${error.title}. ${error.description}`
+      : error.title;
+
+    return (
+      <div slot="field-messaging">
+        <AnnounceOnMountComponent announceOnce={announcement}>
+          <ErrorMessage
+            fullscreen={chatWidthBreakpoint === ChatWidthBreakpoint.WIDE}
+            title={error.title}
+            description={error?.description}
+            collapsible={error?.collapsible}
+          />
+        </AnnounceOnMountComponent>
+      </div>
+    );
+  };
+
   if (!isInputVisible) {
     return null;
   }
@@ -454,15 +523,11 @@ function Input(props: InputProps, ref: Ref<InputFunctions>) {
     placeholder ||
     (disableInput ? undefined : languagePack.input_placeholder) ||
     "";
-  const charCountMessage = overMaxLength
-    ? intl.formatMessage(
-        { id: "input_maxCharCountExceeded" },
-        { max: maxInputChars, current: rawInputValue.length },
-      )
-    : null;
+
+  const hasError = hasErrorProp || overMaxLength;
 
   return (
-    <InputShell rounded={rounded} expanded={expanded}>
+    <InputShell rounded={rounded} expanded={expanded} hasError={hasError}>
       <PromptLine
         slot="editor"
         ref={promptLineRef}
@@ -489,15 +554,7 @@ function Input(props: InputProps, ref: Ref<InputFunctions>) {
 
       {autocompleteContent}
 
-      {charCountMessage && (
-        <div slot="field-messaging" role="status" aria-live="polite">
-          <ErrorMessage
-            fullscreen
-            expandable
-            message={charCountMessage}
-          ></ErrorMessage>
-        </div>
-      )}
+      {renderErrorMessage()}
 
       {(showUploadButton || effectiveActions) && (
         <div slot="message-actions">

--- a/packages/ai-chat/src/chat/components/input/Input.tsx
+++ b/packages/ai-chat/src/chat/components/input/Input.tsx
@@ -491,7 +491,11 @@ function Input(props: InputProps, ref: Ref<InputFunctions>) {
 
       {charCountMessage && (
         <div slot="field-messaging" role="status" aria-live="polite">
-          <ErrorMessage fullscreen expandable message={charCountMessage}></ErrorMessage>
+          <ErrorMessage
+            fullscreen
+            expandable
+            message={charCountMessage}
+          ></ErrorMessage>
         </div>
       )}
 

--- a/packages/ai-chat/src/chat/components/input/Input.tsx
+++ b/packages/ai-chat/src/chat/components/input/Input.tsx
@@ -12,6 +12,7 @@ import InputShell from "@carbon/ai-chat-components/es/react/input-shell.js";
 import InputSendControl from "@carbon/ai-chat-components/es/react/input-send-control.js";
 import FileUploads from "@carbon/ai-chat-components/es/react/file-uploads.js";
 import PromptLine from "@carbon/ai-chat-components/es/react/prompt-line.js";
+import ErrorMessage from "@carbon/ai-chat-components/es/react/error-message.js";
 import type { FileUpload } from "@carbon/ai-chat-components/es/components/input/src/types.js";
 import { FileStatusValue } from "@carbon/ai-chat-components/es/components/input/src/types.js";
 import type { PromptLineElement } from "@carbon/ai-chat-components/es/components/input/index.js";
@@ -490,7 +491,7 @@ function Input(props: InputProps, ref: Ref<InputFunctions>) {
 
       {charCountMessage && (
         <div slot="field-messaging" role="status" aria-live="polite">
-          {charCountMessage}
+          <ErrorMessage fullscreen expandable message={charCountMessage}></ErrorMessage>
         </div>
       )}
 

--- a/packages/ai-chat/src/chat/components/input/useInputValueSync.ts
+++ b/packages/ai-chat/src/chat/components/input/useInputValueSync.ts
@@ -115,7 +115,8 @@ function useInputValueSync({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [store, trackInputState]);
 
-  const overMaxLength = rawInputValue.length > maxInputChars;
+  // const overMaxLength = rawInputValue.length > maxInputChars;
+  const overMaxLength = rawInputValue.length > 10; // TODO: remove. only for testing purposes 
 
   const effectiveDisableSend =
     disableSend || isSendDisabledFromConfig || overMaxLength;

--- a/packages/ai-chat/src/chat/components/input/useInputValueSync.ts
+++ b/packages/ai-chat/src/chat/components/input/useInputValueSync.ts
@@ -51,6 +51,11 @@ interface UseInputValueSyncArgs {
    * when the user sends a message.
    */
   onSendInput: (text: string, displayContent?: JSONContent) => void;
+
+  /**
+   * Whether an error has been passed to the Input.
+   */
+  hasErrorProp: boolean;
 }
 
 /**
@@ -67,6 +72,7 @@ function useInputValueSync({
   disableSend,
   isSendDisabledFromConfig,
   onSendInput,
+  hasErrorProp,
 }: UseInputValueSyncArgs) {
   const store = serviceManager.store;
 
@@ -115,11 +121,10 @@ function useInputValueSync({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [store, trackInputState]);
 
-  // const overMaxLength = rawInputValue.length > maxInputChars;
-  const overMaxLength = rawInputValue.length > 10; // TODO: remove. only for testing purposes
+  const overMaxLength = rawInputValue.length > maxInputChars;
 
   const effectiveDisableSend =
-    disableSend || isSendDisabledFromConfig || overMaxLength;
+    disableSend || isSendDisabledFromConfig || hasErrorProp;
 
   /**
    * Handle input value changes from the prompt-line. Dispatches to Redux if

--- a/packages/ai-chat/src/chat/components/input/useInputValueSync.ts
+++ b/packages/ai-chat/src/chat/components/input/useInputValueSync.ts
@@ -124,7 +124,7 @@ function useInputValueSync({
   const overMaxLength = rawInputValue.length > maxInputChars;
 
   const effectiveDisableSend =
-    disableSend || isSendDisabledFromConfig || hasErrorProp;
+    disableSend || isSendDisabledFromConfig || overMaxLength || hasErrorProp;
 
   /**
    * Handle input value changes from the prompt-line. Dispatches to Redux if

--- a/packages/ai-chat/src/chat/components/input/useInputValueSync.ts
+++ b/packages/ai-chat/src/chat/components/input/useInputValueSync.ts
@@ -116,7 +116,7 @@ function useInputValueSync({
   }, [store, trackInputState]);
 
   // const overMaxLength = rawInputValue.length > maxInputChars;
-  const overMaxLength = rawInputValue.length > 10; // TODO: remove. only for testing purposes 
+  const overMaxLength = rawInputValue.length > 10; // TODO: remove. only for testing purposes
 
   const effectiveDisableSend =
     disableSend || isSendDisabledFromConfig || overMaxLength;

--- a/packages/ai-chat/src/types/config/InputConfig.ts
+++ b/packages/ai-chat/src/types/config/InputConfig.ts
@@ -189,11 +189,12 @@ export interface InputConfig {
    * @experimental
    */
   expanded?: boolean;
-  menuOptions?: InputMenuOption[];
 
   /**
    * Error configuration for displaying an error message in the input field.
    * When provided, an error message will be displayed in the prompt line.
+   *
+   * @experimental
    */
   error?: {
     /**

--- a/packages/ai-chat/src/types/config/InputConfig.ts
+++ b/packages/ai-chat/src/types/config/InputConfig.ts
@@ -189,4 +189,24 @@ export interface InputConfig {
    * @experimental
    */
   expanded?: boolean;
+  menuOptions?: InputMenuOption[];
+
+  /**
+   * Error configuration for displaying an error message in the input field.
+   * When provided, an error message will be displayed in the prompt line.
+   */
+  error?: {
+    /**
+     * The error title to display.
+     */
+    title: string;
+    /**
+     * The error description to display.
+     */
+    description?: string;
+    /**
+     * Whether the error message container should be collapsible.
+     */
+    collapsible?: boolean;
+  };
 }


### PR DESCRIPTION
Closes #1355 

Adds error message component that matches the prompt line error state design [specs](https://www.figma.com/design/HynmDtJaDMh0IkGdvgWTZP/Carbon-AI---AI-Chat-Dev-Handoff---Phase-2?node-id=897-55129&t=BZMrftes0aE8DJ36-0). Updates AppShell and Input to use the new component to render errors, including file upload errors, over max length, and any error passed to Input via `InputConfig.error`.

#### Changelog

**New**

- `CDSAIChatErrorMessage` component used to render all prompt line errors in the "field-messaging" slot.
- Input renders all errors using `<AnnounceOnMountComponent>` so a screenreader will always announce the value of `announceOnce` the first time the error component is mounted.
- Demo config control to show example prompt line error state.
-  InputShell `hasError` prop used to apply styles when in an error state.
- `InputConfig.error` config option for passing errors to the Input.
- Adds logic to `AppShell.tsx` to detect errors (such as file uploads) and pass them to the Input using `InputConfig.error`.


**Changed**

- Modified styles in `packages/ai-chat-components/src/components/input/src/input-shell.scss`. Removed padding at the top of the shell as this spacing is easier to control from within the stacked slots.
- `overMaxLength` error detected in `packages/ai-chat/src/chat/components/input/Input.tsx` renders using new error message component.
 
#### Testing / Reviewing

- Go to demo site
- Toggle the Input config checkbox "Show prompt line error"
- Test the error message in all layouts (Fullscreen, sidebar, float) for React & WC and verify it matches the designs
- Make sure error state goes away when option is unchecked
- Verify the "max char count" error works with the new component by pasting >10,000 chars to input
- Optional: run locally and test `CDSAIChatErrorMessage` with `collapsible` turned off