### PR TITLE
fix: remove experimental tag from workspace and history api

### DIFF
--- a/packages/ai-chat-components/src/components/workspace-shell/src/workspace-shell.ts
+++ b/packages/ai-chat-components/src/components/workspace-shell/src/workspace-shell.ts
@@ -33,10 +33,8 @@ class CDSAIChatWorkspaceShell extends LitElement {
   /**
    * Enable automatic header collapsible behavior based on available space.
    * When true, the header will automatically become collapsible when the
-   * body would have less space than the header. This prop is currently experimental
-   * and is subject to future changes.
+   * body would have less space than the header.
    *
-   * @experimental
    */
   @property({ type: Boolean, attribute: "auto-collapsible-header" })
   autoCollapsibleHeader = false;

--- a/packages/ai-chat/src/types/events/eventBusTypes.ts
+++ b/packages/ai-chat/src/types/events/eventBusTypes.ts
@@ -739,7 +739,6 @@ export interface BusEventHistoryPanelPreOpen extends BusEvent {
 
 /**
  * @category Events
- * @experimental
  */
 export interface BusEventWorkspacePreOpen extends BusEvent {
   type: BusEventType.WORKSPACE_PRE_OPEN;
@@ -768,7 +767,6 @@ export interface BusEventWorkspacePreOpen extends BusEvent {
 
 /**
  * @category Events
- * @experimental
  */
 export interface BusEventWorkspaceOpen extends BusEvent {
   type: BusEventType.WORKSPACE_OPEN;
@@ -797,7 +795,6 @@ export interface BusEventWorkspaceOpen extends BusEvent {
 
 /**
  * @category Events
- * @experimental
  */
 export interface BusEventWorkspacePreClose extends BusEvent {
   type: BusEventType.WORKSPACE_PRE_CLOSE;
@@ -826,7 +823,6 @@ export interface BusEventWorkspacePreClose extends BusEvent {
 
 /**
  * @category Events
- * @experimental
  */
 export interface BusEventWorkspaceClose extends BusEvent {
   type: BusEventType.WORKSPACE_CLOSE;

--- a/packages/ai-chat/src/types/instance/ChatInstance.ts
+++ b/packages/ai-chat/src/types/instance/ChatInstance.ts
@@ -137,7 +137,6 @@ export interface PublicCustomPanelsState {
   /**
    * State for the workspace custom panel.
    *
-   * @experimental
    */
   workspace: PublicWorkspaceCustomPanelState;
 
@@ -196,7 +195,6 @@ export type PublicChatState = Readonly<
     /**
      * State for the workspace panel.
      *
-     * @experimental
      */
     workspace: PublicWorkspaceCustomPanelState;
   }

--- a/packages/ai-chat/src/types/instance/apiTypes.ts
+++ b/packages/ai-chat/src/types/instance/apiTypes.ts
@@ -61,7 +61,6 @@ export enum PanelType {
    *
    * On small screens, the panel behaves like `DEFAULT`.
    *
-   * @experimental
    */
   WORKSPACE = "workspace",
 
@@ -71,7 +70,6 @@ export enum PanelType {
    * The history panel only appears in the chat panel when
    * config.history.isMobile is true.
    *
-   * @experimental
    */
   HISTORY = "history",
 }


### PR DESCRIPTION
Closes #1593 

remove experimental tag from workspace and history api, as well as any mention of experimental language in their jsdocs

#### Changelog

**Changed**

- `packages/ai-chat-components/src/components/workspace-shell/src/workspace-shell.ts`
- `packages/ai-chat/src/types/events/eventBusTypes.ts`
- `packages/ai-chat/src/types/instance/ChatInstance.ts`
- `packages/ai-chat/src/types/instance/apiTypes.ts`

#### Testing / Reviewing

start the docs app and review the changes
