### PR TITLE
fix: lost max height of input in non-tiptap mode

### DIFF
--- a/packages/ai-chat-components/src/components/input/src/__tests__/prompt-line.test.ts
+++ b/packages/ai-chat-components/src/components/input/src/__tests__/prompt-line.test.ts
@@ -11,6 +11,7 @@ import { expect, fixture, html, oneEvent } from "@open-wc/testing";
 import { Extension } from "@tiptap/core";
 
 import "../prompt-line.js";
+import { PROMPT_LINE_MAX_BLOCK_SIZE } from "../prompt-line-constants.js";
 import type PromptLineElement from "../prompt-line.js";
 
 async function makePromptLine(
@@ -70,6 +71,14 @@ describe("<cds-aichat-prompt-line> (textarea mode)", function () {
     const el = await makePromptLine();
     expect(getTextarea(el)).to.not.equal(null);
     expect(el.getEditor()).to.equal(null);
+  });
+
+  it("caps the textarea height and scrolls past the cap", async () => {
+    const el = await makePromptLine();
+    const ta = getTextarea(el);
+    const style = getComputedStyle(ta);
+    expect(style.maxHeight).to.equal(PROMPT_LINE_MAX_BLOCK_SIZE);
+    expect(style.overflowY).to.equal("auto");
   });
 
   it("projects the editor host into light DOM with slot=editor", async () => {
@@ -182,6 +191,16 @@ describe("<cds-aichat-prompt-line> (rich upgrade)", function () {
     const host = el.querySelector('[slot="editor"]') as HTMLElement;
     expect(host.querySelector(".ProseMirror")).to.not.equal(null);
     expect(host.querySelector("textarea")).to.equal(null);
+  });
+
+  it("caps the rich content height at the same value as the textarea", async () => {
+    const el = await makePromptLine();
+    el.rich = true;
+    await waitForRich(el);
+    const pm = el.querySelector('[slot="editor"] .ProseMirror') as HTMLElement;
+    const style = getComputedStyle(pm);
+    expect(style.maxHeight).to.equal(PROMPT_LINE_MAX_BLOCK_SIZE);
+    expect(style.overflowY).to.equal("auto");
   });
 
   it("preserves the typed value across the upgrade", async () => {

--- a/packages/ai-chat-components/src/components/input/src/prompt-line-constants.ts
+++ b/packages/ai-chat-components/src/components/input/src/prompt-line-constants.ts
@@ -1,0 +1,18 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Max block size the prompt line grows to before it caps and shows a vertical
+ * scrollbar. Shared by both editing surfaces — the lite `<textarea>`
+ * ([./prompt-line-controller.ts]) and the rich Tiptap content node
+ * ([./tiptap/editor-styles.ts]) — so the two modes cap at the same height and
+ * the textarea→rich swap stays imperceptible. Keep them reading this one
+ * constant so they can't drift.
+ */
+export const PROMPT_LINE_MAX_BLOCK_SIZE = "157px";

--- a/packages/ai-chat-components/src/components/input/src/prompt-line-controller.ts
+++ b/packages/ai-chat-components/src/components/input/src/prompt-line-controller.ts
@@ -36,6 +36,7 @@ import {
   adoptOnRoot,
   setVarsForSelector,
 } from "../../shared/dynamic-css-var-sheet.js";
+import { PROMPT_LINE_MAX_BLOCK_SIZE } from "./prompt-line-constants.js";
 import { getRawText, textToDoc } from "./tiptap/json-utils.js";
 
 /** Updater shape accepted by `setContent` for reduce-style edits. */
@@ -130,9 +131,13 @@ function ensureTextareaStyleRules(): void {
   // Auto-grow wrapper: textarea and mirror occupy the same grid cell; the
   // (content-bearing) mirror dictates the height, the textarea stretches to
   // fill it. No per-keystroke inline `style.height` (CSP-safe auto-grow).
+  // Cap the box at the shared max and clip the (unbounded) mirror past it; the
+  // field below scrolls within that cap.
   setVarsForSelector(`.${TA_GROW_CLASS}`, {
     display: "grid",
     "inline-size": "100%",
+    "max-block-size": PROMPT_LINE_MAX_BLOCK_SIZE,
+    overflow: "hidden",
   });
   setVarsForSelector(`.${TA_GROW_CLASS} > *`, {
     "grid-area": "1 / 1 / 2 / 2",
@@ -158,9 +163,13 @@ function ensureTextareaStyleRules(): void {
     color: "var(--cds-text-primary, #161616)",
     outline: "none",
     resize: "none",
-    overflow: "hidden",
+    // The field is its own scroll container past the cap so the browser keeps
+    // the caret in view natively (an ancestor scroller would not track it).
+    "overflow-x": "hidden",
+    "overflow-y": "auto",
     "inline-size": "100%",
     "min-block-size": "0",
+    "max-block-size": PROMPT_LINE_MAX_BLOCK_SIZE,
   });
   setVarsForSelector(`.${TA_FIELD_CLASS}::placeholder`, {
     color: "var(--cds-text-secondary, #525252)",
@@ -184,8 +193,10 @@ const TYPING_TIMEOUT_MS = 5000;
 
 /**
  * `<textarea>`-backed controller. Tiptap-free; emits the same prompt events as
- * the rich editor. Auto-grows via a hidden mirror so the host's `max-height`
- * scroll cap (from input-shell) behaves the same as the contenteditable.
+ * the rich editor. Auto-grows via a hidden mirror, capped at
+ * `PROMPT_LINE_MAX_BLOCK_SIZE` with the field scrolling past it — the same cap
+ * the rich contenteditable applies (see ./tiptap/editor-styles.ts), so the
+ * textarea→rich swap is imperceptible.
  */
 export class TextareaController implements PromptLineController {
   private _wrap: HTMLDivElement | null = null;

--- a/packages/ai-chat-components/src/components/input/src/tiptap/editor-styles.ts
+++ b/packages/ai-chat-components/src/components/input/src/tiptap/editor-styles.ts
@@ -8,6 +8,7 @@
  */
 
 import { setVarsForSelector } from "../../../shared/dynamic-css-var-sheet.js";
+import { PROMPT_LINE_MAX_BLOCK_SIZE } from "../prompt-line-constants.js";
 
 const PM_CONTENT_CLASS = "cds-aichat--input-pm-content";
 const PM_PHONE_CLASS = "cds-aichat--input-pm-content--phone";
@@ -29,7 +30,7 @@ function ensurePmContentStyleRules(): void {
     "font-weight": "var(--cds-body-01-font-weight, 400)",
     "letter-spacing": "var(--cds-body-01-letter-spacing, 0.16px)",
     "line-height": "var(--cds-body-01-line-height, 1.42857)",
-    "max-height": "157px",
+    "max-block-size": PROMPT_LINE_MAX_BLOCK_SIZE,
     "overflow-y": "auto",
   });
   // Tiptap renders block content into real <p> tags inside the light-DOM


### PR DESCRIPTION
Restore the prompt line's max-height + scrollbar in lite (non-Tiptap) mode.

#1604 moved the 157px height cap off the shared editor slot and re-added it only to the rich Tiptap content node. The prompt line boots in textarea ("lite") mode and upgrades to rich on demand, so in its default state the field grew unbounded — no cap, no scrollbar.

- [`prompt-line-controller.ts`](packages/ai-chat-components/src/components/input/src/prompt-line-controller.ts) — field becomes its own scroll container (`overflow-y: auto` + `max-block-size`) so the browser tracks the caret natively; grow wrapper bounds the box and clips the oversized mirror.
- New [`prompt-line-constants.ts`](packages/ai-chat-components/src/components/input/src/prompt-line-constants.ts) — single source for the 157px cap, shared by both surfaces so they can't drift (the mismatch that caused this).

#### Changelog

**Changed**

- Lite-mode prompt line caps at 157px and shows a vertical scrollbar past it, matching rich mode.
- Rich PM content reads the shared height constant instead of a hardcoded literal.

#### Testing / Reviewing

- `npm run test:web-components --workspace=@carbon/ai-chat-components` — new `getComputedStyle` assertions cover the cap in both textarea and rich mode.
- Manual: open the input, type ~15 lines **before** triggering rich mode; field stops growing at 157px, scrolls, caret stays in view. Trigger rich mode and confirm the cap is identical.