### PR TITLE
fix: table rounded corners bug

### DIFF
--- a/packages/ai-chat-components/src/components/table/src/table.scss
+++ b/packages/ai-chat-components/src/components/table/src/table.scss
@@ -1,5 +1,5 @@
 /*
- *  Copyright IBM Corp. 2025
+ *  Copyright IBM Corp. 2025, 2026
  *
  *  This source code is licensed under the Apache-2.0 license found in the
  *  LICENSE file in the root directory of this source tree.
@@ -19,9 +19,9 @@
 // Apply rounded corners to the container when data-rounded is set
 :host([data-rounded]),
 :host([data-rounded=""]) {
-  .cds-ai-chat-table-container {
-    @include rounded-self;
-  }
+  overflow: hidden;
+
+  @include rounded-self;
 }
 
 // Carbon link styles for links in table cells


### PR DESCRIPTION
Closes #1519 

the table component wasn't properly rounding corners when it should have been. it wasn't just enough to add `overflow: hidden` because the mixin wasn't working in the lit version. looks like the selector just needed to be updated. i went initially with just putting it on the host element, but the container will still work if refactored outside of the host selector like this;

```
:host { ... }
.cds-ai-chat-table-container {
  overflow: hidden;
  @include rounded-self;
}
```

#### Changelog

**Changed**

- `packages/ai-chat-components/src/components/table/src/table.scss` fixed css to properly round table corners

#### Testing / Reviewing

run the storybook and review the corners in the table story
