### PR TITLE
feat: prompt line focus states

### DIFF
--- a/packages/ai-chat-components/src/components/input/src/error-message.scss
+++ b/packages/ai-chat-components/src/components/input/src/error-message.scss
@@ -15,6 +15,7 @@ $block-class: #{$prefix}-error-message;
 .#{$block-class} {
   position: relative;
   display: flex;
+  box-sizing: border-box;
   align-items: flex-start;
   gap: layout.$spacing-03;
   inline-size: 100%;
@@ -29,6 +30,20 @@ $block-class: #{$prefix}-error-message;
     inline-size: calc(100% + #{layout.$spacing-05} + #{layout.$spacing-03});
     inset-block-end: 0;
     inset-inline-start: calc(-1 * #{layout.$spacing-05});
+  }
+}
+
+// In expanded mode or when the prompt line has message actions, the
+// container's inline start padding is $spacing-03 (not $spacing-05), so
+// the error message padding and separator line must be adjusted to match.
+:host([actions-layout]) {
+  .#{$block-class} {
+    padding-inline-start: layout.$spacing-03;
+
+    &::after {
+      inline-size: calc(100% + #{layout.$spacing-03} + #{layout.$spacing-03});
+      inset-inline-start: calc(-1 * #{layout.$spacing-03});
+    }
   }
 }
 

--- a/packages/ai-chat-components/src/components/input/src/error-message.ts
+++ b/packages/ai-chat-components/src/components/input/src/error-message.ts
@@ -60,6 +60,12 @@ class ErrorMessage extends LitElement {
   collapsible = false;
 
   /**
+   * Whether the prompt line has alternate layout for expanded mode and/or message actions.
+   */
+  @property({ type: Boolean, reflect: true, attribute: "actions-layout" })
+  actionsLayout = false;
+
+  /**
    * Whether the error message is in fullscreen layout.
    */
   @property({ type: Boolean, attribute: "fullscreen" })

--- a/packages/ai-chat-components/src/components/input/src/input-shell.scss
+++ b/packages/ai-chat-components/src/components/input/src/input-shell.scss
@@ -103,7 +103,6 @@
   display: flex;
   flex: 1 0;
   align-items: center;
-  gap: layout.$spacing-03;
 }
 
 :host(:not([expanded])) ::slotted([slot="message-actions"]) {
@@ -233,11 +232,11 @@
 
 .#{$prefix}--input-container--expanded .#{$prefix}--input-text-and-actions {
   display: contents;
+  gap: layout.$spacing-03;
 }
 
 .#{$prefix}--input-container--expanded .#{$prefix}--input-text-area {
   flex-basis: 100%;
-  order: 1;
   border-radius: 4px;
   margin-block-end: 0;
   outline: button.$button-border-width solid transparent;
@@ -248,10 +247,6 @@
 .#{$prefix}--input-container--expanded
   .#{$prefix}--input-text-area:focus-within {
   outline-color: theme.$focus;
-}
-
-.#{$prefix}--input-container--expanded ::slotted([slot="message-actions"]) {
-  order: 2;
 }
 
 // The actions track takes the row's free space next to the send control (the
@@ -277,7 +272,6 @@
   // the row, so `margin-inline-start: auto` pushes the send control to the inline
   // end on its own.
   flex: 0 0 auto;
-  order: 3;
   margin-block: layout.$spacing-03;
   margin-inline-start: auto;
 }

--- a/packages/ai-chat-components/src/components/input/src/input-shell.scss
+++ b/packages/ai-chat-components/src/components/input/src/input-shell.scss
@@ -44,7 +44,6 @@
   flex-wrap: wrap;
   align-items: center;
   background-color: theme.$chat-prompt-background;
-  border-block-start: button.$button-outline-width solid theme.$border-subtle-01;
   border-end-end-radius: var(--cds-aichat-border-radius-end-end, 0);
   border-end-start-radius: var(--cds-aichat-border-radius-end-start, 0);
   color: theme.$text-primary;
@@ -53,6 +52,14 @@
   outline: button.$button-border-width solid transparent;
   outline-offset: -2px;
   padding-inline: layout.$spacing-05 layout.$spacing-03;
+}
+
+:host(:not([disabled])) .#{$prefix}--input-container {
+  border-block-end: 1px solid theme.$border-strong;
+}
+
+.#{$prefix}--input-container:focus-within {
+  box-shadow: 0 4px 8px 0 theme.$ai-drop-shadow;
 }
 
 // Focus outline for non-expanded state — uses :focus-within so no JS class toggle needed.
@@ -66,7 +73,6 @@
 
 // Rounded container when at max width
 :host([rounded]) .#{$prefix}--input-container {
-  border: button.$button-outline-width solid theme.$border-subtle-00;
   border-radius: layout.$spacing-03;
 }
 
@@ -243,9 +249,14 @@
   outline-offset: -2px;
 }
 
-// Focus outline for expanded state — only on text area
+// Focus outline for expanded state — only on text area, and only when focus
+// arrived via keyboard navigation. `input-shell` listens for
+// `cds-aichat-prompt-focus` and reads `event.detail.keyboard`; the rich runtime
+// sets that flag when no pointer/touch event preceded the focus. The shell
+// toggles `--keyboard-focus` on the shadow-DOM text-area node, which this rule
+// targets directly.
 .#{$prefix}--input-container--expanded
-  .#{$prefix}--input-text-area:focus-within {
+  .#{$prefix}--input-text-area--keyboard-focus {
   outline-color: theme.$focus;
 }
 

--- a/packages/ai-chat-components/src/components/input/src/input-shell.scss
+++ b/packages/ai-chat-components/src/components/input/src/input-shell.scss
@@ -52,7 +52,6 @@
   min-block-size: 0;
   outline: button.$button-border-width solid transparent;
   outline-offset: -2px;
-  padding-block-end: layout.$spacing-04;
   padding-inline: layout.$spacing-05 layout.$spacing-03;
 }
 
@@ -103,11 +102,14 @@
   flex: 1 0;
   align-items: center;
   gap: layout.$spacing-03;
-  margin-block-start: layout.$spacing-04;
 }
 
-::slotted([slot="message-actions"]) {
+:host(:not([expanded])) ::slotted([slot="message-actions"]) {
   align-self: flex-start;
+  // !important required to override global CSS reset (common.scss) that sets
+  // margin: 0 on all divs including slotted elements
+  // stylelint-disable-next-line declaration-no-important
+  margin-block-start: layout.$spacing-04 !important;
 }
 
 // Lay the real action container's buttons out in a row with consistent
@@ -131,10 +133,15 @@
 // -----------------------------------------------------------
 .#{$prefix}--input-text-area {
   position: relative;
-  display: inline-block;
+  display: flex;
+  box-sizing: border-box;
   flex: 1 0;
+  align-items: center;
   inline-size: 100%;
-  min-block-size: 0;
+  margin-block: layout.$spacing-03;
+  min-block-size: layout.$spacing-08;
+  padding-block: layout.$spacing-03;
+  padding-inline: layout.$spacing-03;
 }
 
 // -----------------------------------------------------------
@@ -227,26 +234,9 @@
 }
 
 .#{$prefix}--input-container--expanded .#{$prefix}--input-text-area {
-  // Flex centering keeps a single line vertically centered within the
-  // restored min-height below (matching the non-expanded row alignment).
-  display: flex;
-  // Contain the `padding-inline` below within the full-width basis; otherwise
-  // (content-box, no shadow-DOM reset) it adds on top of `flex-basis: 100%` and
-  // the editor row overflows the container's inline-end edge.
-  box-sizing: border-box;
   flex-basis: 100%;
-  align-items: center;
   order: 1;
-  // Separate the editor from the actions/send row beneath it.
-  margin-block-end: layout.$spacing-03;
-  // On its own row the editor no longer shares the control row, so it loses
-  // the min-height the `sm` controls used to set; restore that floor.
-  min-block-size: layout.$spacing-07;
-  // The `sm` action and send buttons below center their 16px icon in a 32px
-  // box, insetting the SVG by `$spacing-03`. Inset the editor by the same
-  // amount so the text caret (start) and the editor's end line up with the
-  // button SVGs rather than the buttons' outer edges.
-  padding-inline: layout.$spacing-03;
+  margin-block-end: 0;
 }
 
 .#{$prefix}--input-container--expanded ::slotted([slot="message-actions"]) {
@@ -277,7 +267,7 @@
   // end on its own.
   flex: 0 0 auto;
   order: 3;
-  margin-block-start: layout.$spacing-04;
+  margin-block: layout.$spacing-03;
   margin-inline-start: auto;
 }
 

--- a/packages/ai-chat-components/src/components/input/src/input-shell.scss
+++ b/packages/ai-chat-components/src/components/input/src/input-shell.scss
@@ -54,8 +54,23 @@
   padding-inline: layout.$spacing-05 layout.$spacing-03;
 }
 
-:host(:not([disabled])) .#{$prefix}--input-container {
+:host(:not([disabled])) .#{$prefix}--input-container--expanded {
   border-block-end: 1px solid theme.$border-strong;
+
+  &:focus-within {
+    box-shadow: 0 4px 8px 0 theme.$ai-drop-shadow;
+  }
+}
+
+// When prompt line is not in fullscreen layout (rounded), the enabled state border and
+// drop shadow appear above the shell instead of below.
+:host(:not([rounded]):not([disabled])) .#{$prefix}--input-container--expanded {
+  border-block-end: none;
+  border-block-start: 1px solid theme.$border-subtle;
+
+  &:focus-within {
+    box-shadow: 0 -4px 8px 0 theme.$ai-drop-shadow;
+  }
 }
 
 .#{$prefix}--input-container:focus-within {
@@ -243,7 +258,7 @@
 
 .#{$prefix}--input-container--expanded .#{$prefix}--input-text-area {
   flex-basis: 100%;
-  border-radius: 4px;
+  border-radius: layout.$spacing-02;
   margin-block-end: 0;
   outline: button.$button-border-width solid transparent;
   outline-offset: -2px;

--- a/packages/ai-chat-components/src/components/input/src/input-shell.scss
+++ b/packages/ai-chat-components/src/components/input/src/input-shell.scss
@@ -55,10 +55,12 @@
   padding-inline: layout.$spacing-05 layout.$spacing-03;
 }
 
-// Focus outline — uses :focus-within so no JS class toggle needed.
+// Focus outline for non-expanded state — uses :focus-within so no JS class toggle needed.
 // Kept adjacent to the base rule (ahead of higher-specificity :host variants)
 // so stylelint's no-descending-specificity rule is satisfied.
-.#{$prefix}--input-container:focus-within {
+.#{$prefix}--input-container:not(
+    .#{$prefix}--input-container--expanded
+  ):focus-within {
   outline-color: theme.$focus;
 }
 
@@ -236,7 +238,16 @@
 .#{$prefix}--input-container--expanded .#{$prefix}--input-text-area {
   flex-basis: 100%;
   order: 1;
+  border-radius: 4px;
   margin-block-end: 0;
+  outline: button.$button-border-width solid transparent;
+  outline-offset: -2px;
+}
+
+// Focus outline for expanded state — only on text area
+.#{$prefix}--input-container--expanded
+  .#{$prefix}--input-text-area:focus-within {
+  outline-color: theme.$focus;
 }
 
 .#{$prefix}--input-container--expanded ::slotted([slot="message-actions"]) {

--- a/packages/ai-chat-components/src/components/input/src/input-shell.ts
+++ b/packages/ai-chat-components/src/components/input/src/input-shell.ts
@@ -83,6 +83,21 @@ class InputShellElement extends LitElement {
       [`${prefix}--input-container--expanded`]: this.expanded,
     };
 
+    // In expanded mode, render text-area before message-actions to match visual order
+
+    const textAreaContent = html`
+      <div class="${prefix}--input-text-area">
+        <slot name="editor"></slot>
+      </div>
+    `;
+
+    const messageActionsContent = html`
+      <slot
+        name="message-actions"
+        @slotchange=${this._handleMessageActionsSlotChange}
+      ></slot>
+    `;
+
     return html`
       <div class="${prefix}--input-shell">
         <div class=${classMap(containerClasses)}>
@@ -94,13 +109,8 @@ class InputShellElement extends LitElement {
             <slot name="field-messaging"></slot>
           </div>
           <div class="${prefix}--input-text-and-actions">
-            <slot
-              name="message-actions"
-              @slotchange=${this._handleMessageActionsSlotChange}
-            ></slot>
-            <div class="${prefix}--input-text-area">
-              <slot name="editor"></slot>
-            </div>
+            ${this.expanded ? textAreaContent : messageActionsContent}
+            ${this.expanded ? messageActionsContent : textAreaContent}
           </div>
           <div class="${prefix}--input-send-control-container">
             <slot name="send-control"></slot>

--- a/packages/ai-chat-components/src/components/input/src/input-shell.ts
+++ b/packages/ai-chat-components/src/components/input/src/input-shell.ts
@@ -58,8 +58,39 @@ class InputShellElement extends LitElement {
   @property({ type: Boolean, reflect: true, attribute: "has-error" })
   hasError = false;
 
+  /** Whether the input shell is disabled. */
+  @property({ type: Boolean, reflect: true })
+  disabled = false;
+
   @state()
   private _hasMessageActions = false;
+
+  @state()
+  private _editorKeyboardFocus = false;
+
+  override connectedCallback(): void {
+    super.connectedCallback();
+    this.addEventListener(
+      "cds-aichat-prompt-focus",
+      this._handlePromptFocus as EventListener,
+    );
+    this.addEventListener(
+      "cds-aichat-prompt-blur",
+      this._handlePromptBlur as EventListener,
+    );
+  }
+
+  override disconnectedCallback(): void {
+    super.disconnectedCallback();
+    this.removeEventListener(
+      "cds-aichat-prompt-focus",
+      this._handlePromptFocus as EventListener,
+    );
+    this.removeEventListener(
+      "cds-aichat-prompt-blur",
+      this._handlePromptBlur as EventListener,
+    );
+  }
 
   override willUpdate(changedProperties: PropertyValues): void {
     super.willUpdate(changedProperties);
@@ -83,10 +114,15 @@ class InputShellElement extends LitElement {
       [`${prefix}--input-container--expanded`]: this.expanded,
     };
 
+    const textAreaClasses = {
+      [`${prefix}--input-text-area`]: true,
+      [`${prefix}--input-text-area--keyboard-focus`]: this._editorKeyboardFocus,
+    };
+
     // In expanded mode, render text-area before message-actions to match visual order
 
     const textAreaContent = html`
-      <div class="${prefix}--input-text-area">
+      <div class=${classMap(textAreaClasses)}>
         <slot name="editor"></slot>
       </div>
     `;
@@ -119,6 +155,18 @@ class InputShellElement extends LitElement {
       </div>
     `;
   }
+
+  private _handlePromptFocus = (event: CustomEvent): void => {
+    // Both the textarea controller and the rich runtime pass `{ keyboard: true }`
+    // in the event detail when focus arrived via keyboard navigation (no preceding
+    // pointer/touch event).
+    this._editorKeyboardFocus =
+      (event.detail as { keyboard?: boolean })?.keyboard === true;
+  };
+
+  private _handlePromptBlur = (): void => {
+    this._editorKeyboardFocus = false;
+  };
 
   private _handleMessageActionsSlotChange = (): void => {
     // Request an update so `willUpdate()` re-derives occupancy from the settled

--- a/packages/ai-chat-components/src/components/input/src/prompt-line-controller.ts
+++ b/packages/ai-chat-components/src/components/input/src/prompt-line-controller.ts
@@ -326,6 +326,7 @@ export class TextareaController implements PromptLineController {
   }
 
   focus(): void {
+    this._focusFromMouse = true;
     this._textarea?.focus();
   }
 

--- a/packages/ai-chat-components/src/components/input/src/prompt-line-controller.ts
+++ b/packages/ai-chat-components/src/components/input/src/prompt-line-controller.ts
@@ -202,6 +202,8 @@ export class TextareaController implements PromptLineController {
   private _wrap: HTMLDivElement | null = null;
   private _textarea: HTMLTextAreaElement | null = null;
   private _mirror: HTMLDivElement | null = null;
+  private _host: HTMLElement | null = null;
+  private _focusFromMouse = false;
 
   private _isTyping = false;
   private _typingTimer: ReturnType<typeof setTimeout> | null = null;
@@ -244,11 +246,18 @@ export class TextareaController implements PromptLineController {
     this._wrap = wrap;
     this._textarea = textarea;
     this._mirror = mirror;
+    this._host = host;
 
     textarea.addEventListener("input", this._onInput);
     textarea.addEventListener("keydown", this._onKeydown);
     textarea.addEventListener("focus", this._onFocus);
     textarea.addEventListener("blur", this._onBlur);
+
+    // Pointer/touch before focus marks the next focus as mouse-driven so we
+    // suppress the keyboard-focus outline.
+    host.addEventListener("pointerdown", this._setMouseFlag);
+    host.addEventListener("mousedown", this._setMouseFlag);
+    host.addEventListener("touchstart", this._setMouseFlag);
 
     this._syncMirror();
   }
@@ -261,6 +270,12 @@ export class TextareaController implements PromptLineController {
       ta.removeEventListener("keydown", this._onKeydown);
       ta.removeEventListener("focus", this._onFocus);
       ta.removeEventListener("blur", this._onBlur);
+    }
+    const host = this._host;
+    if (host) {
+      host.removeEventListener("pointerdown", this._setMouseFlag);
+      host.removeEventListener("mousedown", this._setMouseFlag);
+      host.removeEventListener("touchstart", this._setMouseFlag);
     }
     this._wrap?.remove();
     this._wrap = null;
@@ -442,8 +457,14 @@ export class TextareaController implements PromptLineController {
     }
   };
 
+  private _setMouseFlag = (): void => {
+    this._focusFromMouse = true;
+  };
+
   private _onFocus = (): void => {
-    this._dispatch("cds-aichat-prompt-focus");
+    const wasMouseFocus = this._focusFromMouse;
+    this._focusFromMouse = false;
+    this._dispatch("cds-aichat-prompt-focus", { keyboard: !wasMouseFocus });
   };
 
   private _onBlur = (): void => {

--- a/packages/ai-chat-components/src/components/input/src/prompt-line-controller.ts
+++ b/packages/ai-chat-components/src/components/input/src/prompt-line-controller.ts
@@ -221,6 +221,7 @@ export class TextareaController implements PromptLineController {
     textarea.classList.toggle(TA_PHONE_CLASS, IS_PHONE);
     textarea.setAttribute("rows", "1");
     textarea.setAttribute("spellcheck", "true");
+    textarea.setAttribute("tabindex", "0");
     textarea.placeholder = init.placeholder;
     textarea.value = init.value;
     textarea.readOnly = init.disabled;

--- a/packages/ai-chat-components/src/components/input/src/prompt-line-rich-runtime.ts
+++ b/packages/ai-chat-components/src/components/input/src/prompt-line-rich-runtime.ts
@@ -287,7 +287,7 @@ class RichController implements PromptLineController {
       if (!wasMouseFocus) {
         editor.view.dom.classList.add(PM_KEYBOARD_FOCUS_CLASS);
       }
-      this._dispatch("cds-aichat-prompt-focus");
+      this._dispatch("cds-aichat-prompt-focus", { keyboard: !wasMouseFocus });
     });
     editor.on("blur", () => {
       editor.view.dom.classList.remove(PM_KEYBOARD_FOCUS_CLASS);

--- a/packages/ai-chat-components/src/components/input/src/prompt-line-rich-runtime.ts
+++ b/packages/ai-chat-components/src/components/input/src/prompt-line-rich-runtime.ts
@@ -86,6 +86,7 @@ class RichController implements PromptLineController {
     host.setAttribute("role", "textbox");
     host.setAttribute("aria-multiline", "true");
     host.setAttribute("spellcheck", "true");
+    host.setAttribute("tabindex", "0");
     if (init.ariaLabel) {
       host.setAttribute("aria-label", init.ariaLabel);
     }

--- a/packages/ai-chat/src/chat/components/input/Input.tsx
+++ b/packages/ai-chat/src/chat/components/input/Input.tsx
@@ -532,7 +532,12 @@ function Input(props: InputProps, ref: Ref<InputFunctions>) {
   const hasError = hasErrorProp || overMaxLength;
 
   return (
-    <InputShell rounded={rounded} expanded={expanded} hasError={hasError}>
+    <InputShell
+      rounded={rounded}
+      expanded={expanded}
+      hasError={hasError}
+      disabled={disableInput}
+    >
       <PromptLine
         slot="editor"
         ref={promptLineRef}

--- a/packages/ai-chat/src/chat/components/input/Input.tsx
+++ b/packages/ai-chat/src/chat/components/input/Input.tsx
@@ -471,6 +471,9 @@ function Input(props: InputProps, ref: Ref<InputFunctions>) {
    * Renders the error message component if an error is provided.
    */
   const renderErrorMessage = () => {
+    // Whether the prompt line has alternate layout for expanded mode and/or message actions
+    const actionsLayout = expanded || showUploadButton || effectiveActions;
+
     if (overMaxLength) {
       const errorText = intl.formatMessage(
         { id: "input_maxCharCountExceeded" },
@@ -483,6 +486,7 @@ function Input(props: InputProps, ref: Ref<InputFunctions>) {
           >
             <ErrorMessage
               fullscreen={chatWidthBreakpoint === ChatWidthBreakpoint.WIDE}
+              actionsLayout={actionsLayout}
               title="Error: Max character count exceeded"
               description={errorText}
               collapsible={true}
@@ -505,6 +509,7 @@ function Input(props: InputProps, ref: Ref<InputFunctions>) {
         <AnnounceOnMountComponent announceOnce={announcement}>
           <ErrorMessage
             fullscreen={chatWidthBreakpoint === ChatWidthBreakpoint.WIDE}
+            actionsLayout={actionsLayout}
             title={error.title}
             description={error?.description}
             collapsible={error?.collapsible}

--- a/packages/ai-chat/src/chat/utils/carbonIcon.ts
+++ b/packages/ai-chat/src/chat/utils/carbonIcon.ts
@@ -1,5 +1,5 @@
 /*
- *  Copyright IBM Corp. 2025
+ *  Copyright IBM Corp. 2025, 2026
  *
  *  This source code is licensed under the Apache-2.0 license found in the
  *  LICENSE file in the root directory of this source tree.
@@ -75,6 +75,7 @@ export function carbonIconToReact(
         width: icon.attrs.width || 16,
         height: icon.attrs.height || 16,
         fill: icon.attrs.fill || "currentColor",
+        tabIndex: -1,
         ...transformedProps,
       },
       icon.content.map((child, i) =>


### PR DESCRIPTION
Closes #1354

Updates focus states in the prompt line. This includes visual styling for when the prompt line is enabled, active (has focus-within), and has the text area focused via keyboard navigation.

#### Changelog

**New**
- `disabled` prop in Input Shell used for applying styles for the disabled state.
- Input Shell listens for `cds-aichat-prompt-focus` and `cds-aichat-prompt-blur` events to track when elements receive focus specifically via keyboard navigation. This is used to apply the blue border around the text area/editor. 
- `prompt-line-controller.ts` listens for `pointerdown`, `mousedown`, and `touchstart` to detect when a focus event is triggered via keyboard (matches implementation in `prompt-line-rich-runtime.ts` so behavior is the same whether or not in tiptap mode). It dispatches a `cds-aichat-prompt-focus` event with a detail indicating whether it was received via keyboard.
- `actionsLayout` prop in `<ErrorMessage>` is used to adjust error message spacing when the prompt line is either expanded, has the file upload button, or has other message action buttons. This fixes a visual bug in the error message with certain prompt line configurations.

**Changed**

- Updates `input-shell.scss` to apply a focus ring around the text area when it receives focus via keyboard nav. This only applies in the expanded prompt line.
- Fixes margin/padding issues in the prompt line. Simplifies `cds-aichat--input-text-area` styles for better consistency between expanded and non-expanded layouts.
- Ensure the text area focus state occurs in the correct Tab order. The render order of the text area and message actions in input shell is conditional based on the expanded state so we rely on DOM placement rather than the css `order` property for focus nav.
- Fixed issue in utility `carbonIconToReact()` that allowed svg within the iconButton to become focusable

#### Testing / Reviewing

- Go to demo deploy preview
- Using the Input config dropdowns enable expanded layout and add dummy message actions
- Verify the focus states match the designs
- Test in fullscreen, sidebar, and float
- Disable expanded layout and ensure no regressions to default input