### PR TITLE
fix: remove usemaxheight from carousel

### DIFF
--- a/packages/ai-chat-components/src/components/carousel/src/carousel.ts
+++ b/packages/ai-chat-components/src/components/carousel/src/carousel.ts
@@ -88,7 +88,6 @@ class CDSAICarousel extends LitElement {
           this._currentIndex = endData.currentIndex;
           this._dispatchChange(endData);
         },
-        useMaxHeight: true,
       };
       this.carousel = initCarousel(this.container[0], config);
       this._lastIndex = Object.keys(this.carousel.allViews).length - 1;


### PR DESCRIPTION
Closes #1520 

removes `useMaxHeight` from carousel implementation to try to alleviate issue with scrollbar

#### Changelog

**Changed**

- `packages/ai-chat-components/src/components/carousel/src/carousel.ts` removed `useMaxHeight` from the carousel config

#### Testing / Reviewing

review the storybook and demo
