### PR TITLE
feat(prompt-line): attachment chips

### DIFF
--- a/packages/ai-chat-components/src/components/file-uploads/__tests__/file-upload-item.test.ts
+++ b/packages/ai-chat-components/src/components/file-uploads/__tests__/file-upload-item.test.ts
@@ -1,0 +1,87 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { expect, fixture, html, oneEvent } from "@open-wc/testing";
+import "@carbon/ai-chat-components/es/components/file-uploads/index.js";
+import type FileUploadItemElement from "@carbon/ai-chat-components/es/components/file-uploads/src/file-upload-item.js";
+import {
+  FileStatusValue,
+  type FileUpload,
+} from "@carbon/ai-chat-components/es/components/input/src/types.js";
+
+/**
+ * This repository uses the @web/test-runner library for testing
+ * Documentation on writing tests, plugins, and commands
+ * here: https://modern-web.dev/docs/test-runner/overview/
+ */
+
+function makeUpload(
+  id: string,
+  status: FileStatusValue,
+  opts: { isError?: boolean; errorMessage?: string; name?: string } = {},
+): FileUpload {
+  return {
+    id,
+    file: new File(["x"], opts.name ?? `${id}.txt`, { type: "text/plain" }),
+    status,
+    isError: opts.isError,
+    errorMessage: opts.errorMessage,
+  };
+}
+
+async function mount(upload: FileUpload): Promise<FileUploadItemElement> {
+  return fixture<FileUploadItemElement>(
+    html`<cds-aichat-file-upload-item
+      .upload="${upload}"
+    ></cds-aichat-file-upload-item>`,
+  );
+}
+
+describe("file-upload-item", () => {
+  it("renders a cds-file-uploader-item inside its shadow root", async () => {
+    const el = await mount(makeUpload("a", FileStatusValue.EDIT));
+    expect(el.renderRoot.querySelector("cds-file-uploader-item")).to.exist;
+  });
+
+  it("forwards cds-file-uploader-item-deleted as cds-aichat-file-remove with the correct fileId", async () => {
+    const el = await mount(makeUpload("a", FileStatusValue.EDIT));
+
+    const uploaderItem = el.renderRoot.querySelector("cds-file-uploader-item")!;
+    setTimeout(() =>
+      uploaderItem.dispatchEvent(
+        new CustomEvent("cds-file-uploader-item-deleted", {
+          bubbles: true,
+          composed: true,
+        }),
+      ),
+    );
+
+    const event = await oneEvent(el, "cds-aichat-file-remove");
+    expect(event.detail.fileId).to.equal("a");
+  });
+
+  it("does not fire cds-aichat-file-remove when upload is null", async () => {
+    const el = await fixture<FileUploadItemElement>(
+      html`<cds-aichat-file-upload-item></cds-aichat-file-upload-item>`,
+    );
+    // Nothing rendered; confirm no uploader item is present.
+    expect(el.renderRoot.querySelector("cds-file-uploader-item")).to.not.exist;
+  });
+
+  it("reflects isError state onto the inner cds-file-uploader-item", async () => {
+    const el = await mount(
+      makeUpload("a", FileStatusValue.EDIT, {
+        isError: true,
+        errorMessage: "Too large",
+      }),
+    );
+    const uploaderItem = el.renderRoot.querySelector("cds-file-uploader-item")!;
+    expect(uploaderItem.hasAttribute("invalid")).to.be.true;
+  });
+});

--- a/packages/ai-chat-components/src/components/file-uploads/__tests__/file-uploads.test.ts
+++ b/packages/ai-chat-components/src/components/file-uploads/__tests__/file-uploads.test.ts
@@ -159,17 +159,21 @@ describe("file-uploads", () => {
     await setUploads(el, [makeUpload("a", FileStatusValue.EDIT)]);
     clearRegions(el);
 
-    const item = el.renderRoot.querySelector("cds-file-uploader-item")!;
+    // file-uploads renders <cds-aichat-file-upload-item> elements, not
+    // <cds-file-uploader-item> directly. Simulate the remove event that
+    // file-upload-item fires after the user clicks the inner delete button.
+    const item = el.renderRoot.querySelector("cds-aichat-file-upload-item")!;
     setTimeout(() =>
       item.dispatchEvent(
-        new CustomEvent("cds-file-uploader-item-deleted", {
+        new CustomEvent("cds-aichat-file-remove", {
+          detail: { fileId: "testId" },
           bubbles: true,
           composed: true,
         }),
       ),
     );
     const event = await oneEvent(el, "cds-aichat-file-remove");
-    expect(event.detail.fileId).to.equal("a");
+    expect(event.detail.fileId).to.equal("testId");
 
     await aTimeout(ANNOUNCE_DELAY);
     expect(liveText(el)).to.contain("File removed.");

--- a/packages/ai-chat-components/src/components/file-uploads/index.ts
+++ b/packages/ai-chat-components/src/components/file-uploads/index.ts
@@ -8,5 +8,7 @@
  */
 
 import "./src/file-uploads.js";
+import "./src/file-upload-item.js";
 
 export { default as FileUploadsElement } from "./src/file-uploads.js";
+export { default as FileUploadItemElement } from "./src/file-upload-item.js";

--- a/packages/ai-chat-components/src/components/file-uploads/src/file-upload-item.scss
+++ b/packages/ai-chat-components/src/components/file-uploads/src/file-upload-item.scss
@@ -49,6 +49,8 @@ cds-file-uploader-item {
   background: #00000099;
   block-size: layout.$spacing-04;
   inline-size: layout.$spacing-05;
+  inset-block-end: layout.$spacing-01;
+  inset-inline-end: 0;
   inset-inline-start: layout.$spacing-02;
   pointer-events: none;
 

--- a/packages/ai-chat-components/src/components/file-uploads/src/file-upload-item.scss
+++ b/packages/ai-chat-components/src/components/file-uploads/src/file-upload-item.scss
@@ -1,0 +1,74 @@
+/*
+ *  Copyright IBM Corp. 2026
+ *
+ *  This source code is licensed under the Apache-2.0 license found in the
+ *  LICENSE file in the root directory of this source tree.
+ */
+
+@use "../../../globals/scss/vars" as *;
+@use "@carbon/layout";
+@use "@carbon/styles/scss/type";
+
+$block-class: #{$prefix}-file-upload-item;
+
+:host {
+  display: block;
+  margin-inline-end: layout.$spacing-03;
+}
+
+cds-file-uploader-item {
+  @include type.type-style("body-compact-01");
+
+  border-radius: layout.$spacing-03;
+}
+
+.#{$block-class}__preview-wrapper {
+  position: relative;
+  display: inline-block;
+  overflow: hidden;
+  border-radius: 6px;
+  block-size: 36px;
+  inline-size: 36px;
+  margin-inline-end: layout.$spacing-05;
+  vertical-align: middle;
+}
+
+.#{$block-class}__video-preview-wrapper {
+  padding: 0;
+  border: 0;
+  background: none;
+  cursor: pointer;
+}
+
+.#{$block-class}__play-badge {
+  position: absolute;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 6px;
+  background: #00000099;
+  block-size: layout.$spacing-04;
+  inline-size: layout.$spacing-05;
+  inset-inline-start: layout.$spacing-02;
+  pointer-events: none;
+
+  svg {
+    block-size: layout.$spacing-03;
+    fill: #ffffff;
+    inline-size: layout.$spacing-03;
+  }
+}
+
+.#{$block-class}__preview {
+  display: block;
+  block-size: 100%;
+  inline-size: 100%;
+  object-fit: cover;
+}
+
+.#{$block-class}__icon {
+  display: inline-flex;
+  align-items: center;
+  margin-inline-end: layout.$spacing-03;
+  vertical-align: middle;
+}

--- a/packages/ai-chat-components/src/components/file-uploads/src/file-upload-item.ts
+++ b/packages/ai-chat-components/src/components/file-uploads/src/file-upload-item.ts
@@ -64,7 +64,7 @@ class FileUploadItemElement extends LitElement {
   /** The File instance the current object URL was created for. */
   private _objectURLFile: File | null = null;
 
-  private _getOrCreateObjectURL(): string {
+  private _getOrCreateObjectURL(): string | null {
     if (this.upload && this._objectURLFile !== this.upload.file) {
       if (this._objectURL) {
         URL.revokeObjectURL(this._objectURL);
@@ -72,7 +72,7 @@ class FileUploadItemElement extends LitElement {
       this._objectURL = URL.createObjectURL(this.upload.file);
       this._objectURLFile = this.upload.file;
     }
-    return this._objectURL!;
+    return this._objectURL;
   }
 
   private _hasMediaPreview(): boolean {
@@ -119,10 +119,15 @@ class FileUploadItemElement extends LitElement {
 
     // Image preview
     if (type.startsWith("image/")) {
+      const url = this._getOrCreateObjectURL();
+      if (!url) {
+        return;
+      }
+
       return html`<span class="${prefix}-file-upload-item__preview-wrapper"
         ><img
           class="${prefix}-file-upload-item__preview"
-          src="${this._getOrCreateObjectURL()}"
+          src="${url}"
           width="36"
           height="36"
           alt=""
@@ -136,7 +141,7 @@ class FileUploadItemElement extends LitElement {
       const openVideo = () => {
         const newWindow = window.open("", "_blank", "width=800,height=600");
 
-        if (!newWindow) {
+        if (!url || !newWindow) {
           return;
         }
 

--- a/packages/ai-chat-components/src/components/file-uploads/src/file-upload-item.ts
+++ b/packages/ai-chat-components/src/components/file-uploads/src/file-upload-item.ts
@@ -1,0 +1,277 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { css, html, LitElement, nothing, unsafeCSS } from "lit";
+import { property } from "lit/decorators.js";
+
+import { carbonElement } from "../../../globals/decorators/carbon-element.js";
+import prefix from "../../../globals/settings.js";
+
+import "@carbon/web-components/es/components/file-uploader/index.js";
+
+import { iconLoader } from "@carbon/web-components/es/globals/internal/icon-loader.js";
+import DocumentPDF20 from "@carbon/icons/es/PDF/20.js";
+import DocumentTXT20 from "@carbon/icons/es/TXT/20.js";
+import DocumentXLS20 from "@carbon/icons/es/XLS/20.js";
+import DocumentZIP20 from "@carbon/icons/es/ZIP/20.js";
+import DocumentPPT20 from "@carbon/icons/es/PPT/20.js";
+import DocumentCSV20 from "@carbon/icons/es/CSV/20.js";
+import DocumentDOC20 from "@carbon/icons/es/DOC/20.js";
+import DocumentHTML20 from "@carbon/icons/es/HTML/20.js";
+import DocumentJSON20 from "@carbon/icons/es/JSON/20.js";
+import PlayFilledAlt16 from "@carbon/icons/es/play--filled--alt/16.js";
+
+import type {
+  FileUpload,
+  FileRemoveEventDetail,
+} from "../../input/src/types.js";
+
+import styles from "./file-upload-item.scss?lit";
+
+/**
+ * Renders a single file upload chip with an optional media preview or file-type icon.
+ *
+ * @element cds-aichat-file-upload-item
+ * @fires {CustomEvent<FileRemoveEventDetail>} cds-aichat-file-remove - Fired when the remove button is clicked
+ */
+@carbonElement(`${prefix}-file-upload-item`)
+class FileUploadItemElement extends LitElement {
+  static styles = css`
+    ${unsafeCSS(styles)}
+  `;
+
+  /** The file upload data to render. */
+  @property({ type: Object, attribute: false })
+  upload: FileUpload | null = null;
+
+  /** Label for the remove file button. */
+  @property({ type: String, attribute: "remove-file-label" })
+  removeFileLabel = "Remove file";
+
+  /** Label for the uploading status. */
+  @property({ type: String, attribute: "uploading-file-label" })
+  uploadingFileLabel = "Uploading";
+
+  /** Object URL created for image/video previews. Revoked on disconnect or when the file changes. */
+  private _objectURL: string | null = null;
+
+  /** The File instance the current object URL was created for. */
+  private _objectURLFile: File | null = null;
+
+  private _getOrCreateObjectURL(): string {
+    if (this.upload && this._objectURLFile !== this.upload.file) {
+      if (this._objectURL) {
+        URL.revokeObjectURL(this._objectURL);
+      }
+      this._objectURL = URL.createObjectURL(this.upload.file);
+      this._objectURLFile = this.upload.file;
+    }
+    return this._objectURL!;
+  }
+
+  private _hasMediaPreview(): boolean {
+    if (!this.upload) {
+      return false;
+    }
+    const { type } = this.upload.file;
+    return type.startsWith("image/") || type.startsWith("video/");
+  }
+
+  firstUpdated() {
+    if (!this._hasMediaPreview()) {
+      return;
+    }
+    const uploaderItem = this.shadowRoot?.querySelector(
+      "cds-file-uploader-item",
+    );
+    const innerRoot = uploaderItem?.shadowRoot;
+    if (!innerRoot) {
+      return;
+    }
+    // apply style that reduces margin when there is a media preview being rendered in the chip
+    const style = document.createElement("style");
+    style.textContent =
+      ".cds--file-filename { margin-inline-start: 2px !important; }";
+    innerRoot.appendChild(style);
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    if (this._objectURL) {
+      URL.revokeObjectURL(this._objectURL);
+      this._objectURL = null;
+      this._objectURLFile = null;
+    }
+  }
+
+  private _renderPreview() {
+    if (!this.upload) {
+      return nothing;
+    }
+
+    const { type, name } = this.upload.file;
+
+    // Image preview
+    if (type.startsWith("image/")) {
+      return html`<span class="${prefix}-file-upload-item__preview-wrapper"
+        ><img
+          class="${prefix}-file-upload-item__preview"
+          src="${this._getOrCreateObjectURL()}"
+          width="36"
+          height="36"
+          alt=""
+          aria-hidden="true"
+      /></span>`;
+    }
+
+    // Video preview
+    if (type.startsWith("video/")) {
+      const url = this._getOrCreateObjectURL();
+      const openVideo = () => {
+        const newWindow = window.open("", "_blank", "width=800,height=600");
+        if (!newWindow) {
+          return;
+        }
+        const style = newWindow.document.createElement("style");
+        style.textContent =
+          "* { margin: 0; padding: 0; background: #000 } video { display: block; width: 100%; height: 100vh; object-fit: contain }";
+        const video = newWindow.document.createElement("video");
+        video.src = url;
+        video.controls = true;
+        video.autoplay = true;
+        newWindow.document.title = this.upload!.file.name;
+        newWindow.document.head.appendChild(style);
+        newWindow.document.body.appendChild(video);
+      };
+      return html`<button
+        class="${prefix}-file-upload-item__preview-wrapper ${prefix}-file-upload-item__video-preview-wrapper"
+        type="button"
+        aria-label="Play video"
+        @click="${openVideo}"
+      >
+        <video
+          class="${prefix}-file-upload-item__preview"
+          src="${url}"
+          width="36"
+          height="36"
+          preload="metadata"
+          muted
+          playsinline
+          tabindex="-1"
+          aria-hidden="true"
+          @loadedmetadata="${(e: Event) => {
+            (e.target as HTMLVideoElement).currentTime = 0.1;
+          }}"
+        ></video
+        ><span class="${prefix}-file-upload-item__play-badge" aria-hidden="true"
+          >${iconLoader(PlayFilledAlt16)}</span
+        >
+      </button>`;
+    }
+
+    // File type icon (for supported icons)
+    const extension = name.split(".").pop()?.toLowerCase() ?? "";
+    const mime = type.toLowerCase();
+
+    type IconEntry = [boolean, typeof DocumentPDF20];
+    const iconMap: IconEntry[] = [
+      [mime === "application/pdf" || extension === "pdf", DocumentPDF20],
+      [mime === "text/plain" || extension === "txt", DocumentTXT20],
+      [
+        mime === "application/vnd.ms-excel" ||
+          mime ===
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" ||
+          extension === "xls" ||
+          extension === "xlsx",
+        DocumentXLS20,
+      ],
+      [
+        mime === "application/zip" ||
+          mime === "application/x-zip-compressed" ||
+          extension === "zip",
+        DocumentZIP20,
+      ],
+      [
+        mime === "application/vnd.ms-powerpoint" ||
+          mime ===
+            "application/vnd.openxmlformats-officedocument.presentationml.presentation" ||
+          extension === "ppt" ||
+          extension === "pptx",
+        DocumentPPT20,
+      ],
+      [mime === "text/csv" || extension === "csv", DocumentCSV20],
+      [
+        mime === "application/msword" ||
+          mime ===
+            "application/vnd.openxmlformats-officedocument.wordprocessingml.document" ||
+          extension === "doc" ||
+          extension === "docx",
+        DocumentDOC20,
+      ],
+      [
+        mime === "text/html" || extension === "html" || extension === "htm",
+        DocumentHTML20,
+      ],
+      [mime === "application/json" || extension === "json", DocumentJSON20],
+    ];
+
+    const match = iconMap.find((entry) => entry[0] === true);
+    if (match) {
+      return html`<span
+        class="${prefix}-file-upload-item__icon"
+        aria-hidden="true"
+        >${iconLoader(match[1])}</span
+      >`;
+    }
+
+    return nothing;
+  }
+
+  private _handleRemove() {
+    if (!this.upload) {
+      return;
+    }
+    this.dispatchEvent(
+      new CustomEvent<FileRemoveEventDetail>("cds-aichat-file-remove", {
+        detail: { fileId: this.upload.id },
+        bubbles: true,
+        composed: true,
+      }),
+    );
+  }
+
+  render() {
+    if (!this.upload) {
+      return nothing;
+    }
+
+    return html`
+      <cds-file-uploader-item
+        size="md"
+        .state="${this.upload.status}"
+        .iconDescription="${this.upload.status === "uploading"
+          ? this.uploadingFileLabel
+          : this.removeFileLabel}"
+        .errorSubject="${this.upload.errorMessage || ""}"
+        ?invalid="${this.upload.isError}"
+        @cds-file-uploader-item-deleted="${this._handleRemove}"
+      >
+        ${this._renderPreview()} ${this.upload.file.name}
+      </cds-file-uploader-item>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "cds-aichat-file-upload-item": FileUploadItemElement;
+  }
+}
+
+export default FileUploadItemElement;

--- a/packages/ai-chat-components/src/components/file-uploads/src/file-upload-item.ts
+++ b/packages/ai-chat-components/src/components/file-uploads/src/file-upload-item.ts
@@ -11,6 +11,7 @@ import { css, html, LitElement, nothing, unsafeCSS } from "lit";
 import { property } from "lit/decorators.js";
 
 import { carbonElement } from "../../../globals/decorators/carbon-element.js";
+import { isBrowser } from "../../../globals/utils/browser-utils.js";
 import prefix from "../../../globals/settings.js";
 
 import "@carbon/web-components/es/components/file-uploader/index.js";
@@ -121,7 +122,7 @@ class FileUploadItemElement extends LitElement {
     if (type.startsWith("image/")) {
       const url = this._getOrCreateObjectURL();
       if (!url) {
-        return;
+        return nothing;
       }
 
       return html`<span class="${prefix}-file-upload-item__preview-wrapper"
@@ -138,10 +139,16 @@ class FileUploadItemElement extends LitElement {
     // Video preview
     if (type.startsWith("video/")) {
       const url = this._getOrCreateObjectURL();
-      const openVideo = () => {
-        const newWindow = window.open("", "_blank", "width=800,height=600");
+      if (!url) {
+        return nothing;
+      }
 
-        if (!url || !newWindow) {
+      const openVideo = () => {
+        const newWindow = isBrowser()
+          ? window.open("", "_blank", "width=800,height=600")
+          : null;
+
+        if (!newWindow) {
           return;
         }
 
@@ -152,7 +159,7 @@ class FileUploadItemElement extends LitElement {
         video.src = url;
         video.controls = true;
         video.autoplay = true;
-        newWindow.document.title = this.upload!.file.name;
+        newWindow.document.title = name;
         newWindow.document.head.appendChild(style);
         newWindow.document.body.appendChild(video);
       };

--- a/packages/ai-chat-components/src/components/file-uploads/src/file-upload-item.ts
+++ b/packages/ai-chat-components/src/components/file-uploads/src/file-upload-item.ts
@@ -135,9 +135,11 @@ class FileUploadItemElement extends LitElement {
       const url = this._getOrCreateObjectURL();
       const openVideo = () => {
         const newWindow = window.open("", "_blank", "width=800,height=600");
+
         if (!newWindow) {
           return;
         }
+
         const style = newWindow.document.createElement("style");
         style.textContent =
           "* { margin: 0; padding: 0; background: #000 } video { display: block; width: 100%; height: 100vh; object-fit: contain }";
@@ -149,6 +151,7 @@ class FileUploadItemElement extends LitElement {
         newWindow.document.head.appendChild(style);
         newWindow.document.body.appendChild(video);
       };
+
       return html`<button
         class="${prefix}-file-upload-item__preview-wrapper ${prefix}-file-upload-item__video-preview-wrapper"
         type="button"
@@ -237,6 +240,7 @@ class FileUploadItemElement extends LitElement {
     if (!this.upload) {
       return;
     }
+
     this.dispatchEvent(
       new CustomEvent<FileRemoveEventDetail>("cds-aichat-file-remove", {
         detail: { fileId: this.upload.id },

--- a/packages/ai-chat-components/src/components/file-uploads/src/file-uploads.scss
+++ b/packages/ai-chat-components/src/components/file-uploads/src/file-uploads.scss
@@ -32,10 +32,7 @@
   overflow-x: auto;
   overflow-y: hidden;
 
-  cds-file-uploader-item {
+  cds-aichat-file-upload-item {
     flex-shrink: 0;
-    border-radius: layout.$spacing-03;
-    margin-block-end: layout.$spacing-03;
-    margin-inline-end: layout.$spacing-03;
   }
 }

--- a/packages/ai-chat-components/src/components/file-uploads/src/file-uploads.scss
+++ b/packages/ai-chat-components/src/components/file-uploads/src/file-uploads.scss
@@ -28,10 +28,13 @@
 
 .cds-aichat--file-uploads-container {
   display: flex;
-  flex-wrap: wrap;
-  inline-size: 100%;
+  flex-wrap: nowrap;
+  overflow-x: auto;
+  overflow-y: hidden;
 
   cds-file-uploader-item {
+    flex-shrink: 0;
+    border-radius: layout.$spacing-03;
     margin-block-end: layout.$spacing-03;
     margin-inline-end: layout.$spacing-03;
   }

--- a/packages/ai-chat-components/src/components/file-uploads/src/file-uploads.ts
+++ b/packages/ai-chat-components/src/components/file-uploads/src/file-uploads.ts
@@ -20,7 +20,10 @@ import { property } from "lit/decorators.js";
 import { AriaAnnouncerManager } from "../../../globals/utils/aria-announcer-manager.js";
 import { carbonElement } from "../../../globals/decorators/carbon-element.js";
 import prefix from "../../../globals/settings.js";
-import type { FileUpload } from "../../input/src/types.js";
+import type {
+  FileUpload,
+  FileRemoveEventDetail,
+} from "../../input/src/types.js";
 
 import "./file-upload-item.js";
 import styles from "./file-uploads.scss?lit";
@@ -195,17 +198,12 @@ class FileUploadsElement extends LitElement {
     this._snapshots = this._snapshotOf(this.uploads);
   }
 
-  private _handleFileRemove(fileId: string) {
+  private _handleFileRemove(_e: CustomEvent<FileRemoveEventDetail>) {
     // Announce here rather than in the diff so we only speak on a user-initiated
     // removal, not when uploads clear on send.
     this._announcer.announce(this.fileRemovedLabel);
-    this.dispatchEvent(
-      new CustomEvent<FileRemoveEventDetail>("cds-aichat-file-remove", {
-        detail: { fileId },
-        bubbles: true,
-        composed: true,
-      }),
-    );
+    // Event was dispatched composed+bubbling from file-upload-item — it will
+    // continue to bubble to the consumer. No need to re-dispatch.
   }
 
   render() {
@@ -217,19 +215,12 @@ class FileUploadsElement extends LitElement {
             <div class="${prefix}--file-uploads-container">
               ${this.uploads.map(
                 (upload) => html`
-                  <cds-file-uploader-item
-                    size="sm"
-                    .state="${upload.status}"
-                    .iconDescription="${upload.status === "uploading"
-                      ? this.uploadingFileLabel
-                      : this.removeFileLabel}"
-                    .errorSubject="${upload.errorMessage || ""}"
-                    ?invalid="${upload.isError}"
-                    @cds-file-uploader-item-deleted="${() =>
-                      this._handleFileRemove(upload.id)}"
-                  >
-                    ${upload.file.name}
-                  </cds-file-uploader-item>
+                  <cds-aichat-file-upload-item
+                    .upload="${upload}"
+                    remove-file-label="${this.removeFileLabel}"
+                    uploading-file-label="${this.uploadingFileLabel}"
+                    @cds-aichat-file-remove="${this._handleFileRemove}"
+                  ></cds-aichat-file-upload-item>
                 `,
               )}
             </div>

--- a/packages/ai-chat-components/src/components/file-uploads/src/file-uploads.ts
+++ b/packages/ai-chat-components/src/components/file-uploads/src/file-uploads.ts
@@ -20,14 +20,9 @@ import { property } from "lit/decorators.js";
 import { AriaAnnouncerManager } from "../../../globals/utils/aria-announcer-manager.js";
 import { carbonElement } from "../../../globals/decorators/carbon-element.js";
 import prefix from "../../../globals/settings.js";
+import type { FileUpload } from "../../input/src/types.js";
 
-import "@carbon/web-components/es/components/file-uploader/index.js";
-
-import type {
-  FileUpload,
-  FileRemoveEventDetail,
-} from "../../input/src/types.js";
-
+import "./file-upload-item.js";
 import styles from "./file-uploads.scss?lit";
 
 /** Minimal per-file state captured between renders to diff status transitions. */

--- a/packages/ai-chat-components/src/components/input/src/input-shell.scss
+++ b/packages/ai-chat-components/src/components/input/src/input-shell.scss
@@ -66,11 +66,15 @@
 // drop shadow appear above the shell instead of below.
 :host(:not([rounded]):not([disabled])) .#{$prefix}--input-container--expanded {
   border-block-end: none;
-  border-block-start: 1px solid theme.$border-subtle;
 
   &:focus-within {
     box-shadow: 0 -4px 8px 0 theme.$ai-drop-shadow;
   }
+}
+
+:host(:not([rounded]):not([disabled]):not([has-error]):not([has-file-uploads]))
+  .#{$prefix}--input-container--expanded {
+  border-block-start: 1px solid theme.$border-subtle;
 }
 
 .#{$prefix}--input-container:focus-within {
@@ -94,6 +98,13 @@
 // Error state
 :host([has-error]) .#{$prefix}--input-container {
   border: 1px solid theme.$support-error;
+}
+
+// Non-rounded shell with file uploads — round the top corners to visually
+// contain the upload chips.
+:host(:not([rounded])[has-file-uploads]) .#{$prefix}--input-container {
+  border-start-end-radius: layout.$spacing-03;
+  border-start-start-radius: layout.$spacing-03;
 }
 
 // Message actions visible — reduce start padding

--- a/packages/ai-chat-components/src/components/input/src/input-shell.scss
+++ b/packages/ai-chat-components/src/components/input/src/input-shell.scss
@@ -109,8 +109,20 @@
 // the row break.
 // -----------------------------------------------------------
 .#{$prefix}--input-uploads-and-autocomplete {
+  position: relative;
+  box-sizing: border-box;
   flex-basis: 100%;
-  inline-size: 100%;
+}
+
+.#{$prefix}--input-uploads-and-autocomplete--has-uploads::after {
+  position: absolute;
+  display: block;
+  background: theme.$border-subtle-00;
+  block-size: 1px;
+  content: "";
+  inline-size: calc(100% + #{layout.$spacing-05} + #{layout.$spacing-03});
+  inset-block-end: 0;
+  inset-inline-start: calc(-1 * #{layout.$spacing-03});
 }
 
 // -----------------------------------------------------------
@@ -218,6 +230,7 @@
   flex-wrap: wrap;
   inline-size: 100%;
   margin-block-start: layout.$spacing-03;
+  margin-inline-start: layout.$spacing-03;
   max-block-size: 200px;
   overflow-x: hidden;
   overflow-y: auto;

--- a/packages/ai-chat-components/src/components/input/src/input-shell.scss
+++ b/packages/ai-chat-components/src/components/input/src/input-shell.scss
@@ -127,6 +127,7 @@
 
 .#{$prefix}--input-uploads-and-autocomplete--has-uploads::after {
   position: absolute;
+  z-index: -1;
   display: block;
   background: theme.$border-subtle-00;
   block-size: 1px;

--- a/packages/ai-chat-components/src/components/input/src/input-shell.ts
+++ b/packages/ai-chat-components/src/components/input/src/input-shell.ts
@@ -71,6 +71,9 @@ class InputShellElement extends LitElement {
   @state()
   private _editorKeyboardFocus = false;
 
+  /** Watches the slotted file-uploads element for `has-uploads` attribute changes. */
+  private _fileUploadsObserver: MutationObserver | null = null;
+
   override connectedCallback(): void {
     super.connectedCallback();
     this.addEventListener(
@@ -93,6 +96,7 @@ class InputShellElement extends LitElement {
       "cds-aichat-prompt-blur",
       this._handlePromptBlur as EventListener,
     );
+    this._fileUploadsObserver?.disconnect();
   }
 
   override willUpdate(changedProperties: PropertyValues): void {
@@ -189,6 +193,25 @@ class InputShellElement extends LitElement {
   };
 
   private _handleFileUploadsSlotChange = (): void => {
+    // Reconnect the MutationObserver to whatever element is now slotted so we
+    // re-render when its `has-uploads` attribute changes (which doesn't fire a
+    // slotchange event).
+    this._fileUploadsObserver?.disconnect();
+    const slot = this.renderRoot?.querySelector(
+      `slot[name="file-uploads"]`,
+    ) as HTMLSlotElement | null;
+    const el = slot?.assignedElements()[0];
+    if (el) {
+      if (!this._fileUploadsObserver) {
+        this._fileUploadsObserver = new MutationObserver(() =>
+          this.requestUpdate(),
+        );
+      }
+      this._fileUploadsObserver.observe(el, {
+        attributes: true,
+        attributeFilter: ["has-uploads"],
+      });
+    }
     this.requestUpdate();
   };
 
@@ -214,7 +237,11 @@ class InputShellElement extends LitElement {
     const slot = this.renderRoot?.querySelector(
       `slot[name="file-uploads"]`,
     ) as HTMLSlotElement | null;
-    this._hasFileUploads = slot ? slot.assignedElements().length > 0 : false;
+
+    this._hasFileUploads = slot
+      ? slot.assignedElements().some((el) => el.hasAttribute("has-uploads"))
+      : false;
+
     this.toggleAttribute("has-file-uploads", this._hasFileUploads);
   }
 }

--- a/packages/ai-chat-components/src/components/input/src/input-shell.ts
+++ b/packages/ai-chat-components/src/components/input/src/input-shell.ts
@@ -215,6 +215,7 @@ class InputShellElement extends LitElement {
       `slot[name="file-uploads"]`,
     ) as HTMLSlotElement | null;
     this._hasFileUploads = slot ? slot.assignedElements().length > 0 : false;
+    this.toggleAttribute("has-file-uploads", this._hasFileUploads);
   }
 }
 

--- a/packages/ai-chat-components/src/components/input/src/input-shell.ts
+++ b/packages/ai-chat-components/src/components/input/src/input-shell.ts
@@ -66,6 +66,9 @@ class InputShellElement extends LitElement {
   private _hasMessageActions = false;
 
   @state()
+  private _hasFileUploads = false;
+
+  @state()
   private _editorKeyboardFocus = false;
 
   override connectedCallback(): void {
@@ -104,6 +107,7 @@ class InputShellElement extends LitElement {
     // Deriving here (rather than snapshotting in the handler) re-reads the
     // settled assignment each render, so the occupancy can't latch.
     this._updateHasMessageActions();
+    this._updateHasFileUploads();
   }
 
   override render() {
@@ -112,6 +116,12 @@ class InputShellElement extends LitElement {
       [`${prefix}--input-container--has-message-actions`]:
         this._hasMessageActions,
       [`${prefix}--input-container--expanded`]: this.expanded,
+    };
+
+    const uploadsRowClasses = {
+      [`${prefix}--input-uploads-and-autocomplete`]: true,
+      [`${prefix}--input-uploads-and-autocomplete--has-uploads`]:
+        this._hasFileUploads,
     };
 
     const textAreaClasses = {
@@ -137,8 +147,11 @@ class InputShellElement extends LitElement {
     return html`
       <div class="${prefix}--input-shell">
         <div class=${classMap(containerClasses)}>
-          <div class="${prefix}--input-uploads-and-autocomplete">
-            <slot name="file-uploads"></slot>
+          <div class=${classMap(uploadsRowClasses)}>
+            <slot
+              name="file-uploads"
+              @slotchange=${this._handleFileUploadsSlotChange}
+            ></slot>
             <slot name="autocomplete-content"></slot>
           </div>
           <div class="${prefix}--field-messaging-container">
@@ -175,6 +188,10 @@ class InputShellElement extends LitElement {
     this.requestUpdate();
   };
 
+  private _handleFileUploadsSlotChange = (): void => {
+    this.requestUpdate();
+  };
+
   /**
    * Derives `_hasMessageActions` from the `message-actions` slot's current
    * occupancy. Consumers may project a writeable passthrough
@@ -191,6 +208,13 @@ class InputShellElement extends LitElement {
           .assignedElements()
           .some((element) => !element.hasAttribute("data-prompt-line-slot"))
       : false;
+  }
+
+  private _updateHasFileUploads(): void {
+    const slot = this.renderRoot?.querySelector(
+      `slot[name="file-uploads"]`,
+    ) as HTMLSlotElement | null;
+    this._hasFileUploads = slot ? slot.assignedElements().length > 0 : false;
   }
 }
 

--- a/packages/ai-chat-components/src/globals/utils/browser-utils.ts
+++ b/packages/ai-chat-components/src/globals/utils/browser-utils.ts
@@ -31,4 +31,11 @@ const IS_PHONE = IS_MOBILE && (screenWidth < 500 || screenHeight < 500);
 // Assume the phone is in portrait mode if the width is small.
 const IS_PHONE_IN_PORTRAIT_MODE = IS_PHONE && screenWidth < 500;
 
-export { IS_IOS, IS_ANDROID, IS_MOBILE, IS_PHONE, IS_PHONE_IN_PORTRAIT_MODE };
+export {
+  isBrowser,
+  IS_IOS,
+  IS_ANDROID,
+  IS_MOBILE,
+  IS_PHONE,
+  IS_PHONE_IN_PORTRAIT_MODE,
+};


### PR DESCRIPTION
Closes #1353 

Updates attachment chips to visually match the designs and support an image/video preview or file-type icon. Note: this PR doesn't match the status icon (error, loading, success) within the designs since the component from `@carbon/web-components` provides its own error and loading states.

#### Changelog

**New**

- Separates file upload item into a new component `cds-aichat-file-upload-item`.
- File upload item supports rendering an image preview, video preview (button that opens video in new tab), or file type icon within the attachment chip. Uses [URL.createObjectURL()](https://developer.mozilla.org/en-US/docs/Web/API/URL/createObjectURL_static) on the uploaded file to get the URL for the preview image used in the `<image>` or `<video>` element. 
- file uploads row scrolls horizontally when needed to view all attachments.
- `file-upload-item.scss` and `file-uploads.scss` contain new styles for attachment chips and the container component.
- `_fileUploadsObserver` in the Input Shell watches the slotted file uploads element for changes in its has-uploads attribute. `_hasFileUploads` tracks whether there are file uploads to apply appropriate styles to the Input shell.
- Tests for `cds-aichat-file-upload-item`.
- Exports `isBrowser()` from `packages/ai-chat-components/src/globals/utils/browser-utils.ts` for use within ai-chat-components package.


#### Testing / Reviewing

- Open the demo deploy preview
- Chat Config -> Input -> enable file uploads
- Test uploading various file types:
  - videos (.mov, .mp4): verify the video preview opens in a new tab
  - images (.jpg, .png)
  - file types for which we provide icons (.doc, .xls, .ppt, .zip): verify the icon renders properly
  - file types for which we don't provide icons (.js, .jsx, .ts): default chip should look correct
- Verify the file uploads row renders properly in the prompt line according to the designs
- Test in fullscreen, sidebar, and float layouts