### PR TITLE
feat: add consumer-owned session state persistence

### DIFF
--- a/packages/ai-chat/docs/CustomHistory.md
+++ b/packages/ai-chat/docs/CustomHistory.md
@@ -195,5 +195,6 @@ instance.on({
 - [chat-history-fullscreen example](https://github.com/carbon-design-system/carbon-ai-chat/tree/main/examples/web-components/chat-history-fullscreen) — a fullscreen web-component layout with a custom history panel.
 - [Slots](./WriteableElements.md) — render your own content into the history panel slot.
 - [Message format](./MessageFormat.md) — the request/response shapes history items wrap.
+- [Session state persistence](./StatePersistence.md) — own where the chat's session and UI state (views, disclaimer, human-agent connection) is stored, separately from conversation messages.
 - [Adding messages (legacy)](./AddMessageChunk.md) — getting live responses onscreen.
 - [Adding messages (experimental)](./UpsertMessage.md) — revising a message after it renders.

--- a/packages/ai-chat/docs/CustomServer.md
+++ b/packages/ai-chat/docs/CustomServer.md
@@ -6,6 +6,7 @@ children:
   - ./UpsertMessage.md
   - ./StructuredData.md
   - ./CustomHistory.md
+  - ./StatePersistence.md
 ---
 
 ## Overview
@@ -22,6 +23,7 @@ This page is the entry point. Depending on what you are building, continue to:
 - [Adding messages (experimental)](./UpsertMessage.md) — the preferred, experimental insert-or-update-by-ID flow.
 - [Structured data](./StructuredData.md) — send typed fields and uploaded files alongside the user's text.
 - [Conversation history](./CustomHistory.md) — loading and restoring previous conversations.
+- [Session state persistence](./StatePersistence.md) — own where the chat's session and UI state is stored.
 
 ## Connecting your server
 

--- a/packages/ai-chat/docs/StatePersistence.md
+++ b/packages/ai-chat/docs/StatePersistence.md
@@ -1,0 +1,55 @@
+---
+title: Session state persistence
+---
+
+## Overview
+
+Carbon AI Chat keeps a small amount of session state — which views are open, whether the disclaimer has been accepted, in-progress human-agent connection state, and similar UI flags — so a page reload restores where the user left off. By default this state lives in the browser's `sessionStorage`.
+
+Set {@link PublicConfig.persistedState} to take over that storage yourself: boot the chat from state you supply and receive every change to persist wherever you like (your own backend, `localStorage`, cross-device sync). This does not persist conversation messages — those load through [Conversation history](./CustomHistory.md) — only the session and UI state described by {@link PersistableState}.
+
+> **Note**: When you do not set {@link PublicConfig.persistedState}, the chat continues to use `sessionStorage` exactly as before. This is an opt-in override with no change to the default behavior.
+
+## What is persisted
+
+{@link PersistableState} is the value handed to and from your storage. Treat it as an opaque blob: store the whole thing and hand it back unchanged. It carries session and UI state such as disclaimer acceptance, home-screen state, and the human-agent connection subset needed to reconnect after a reload. It never contains conversation message text.
+
+## Providing your own storage
+
+Set {@link PersistedStateConfig.initialState} to boot from stored state, and {@link PersistedStateConfig.onStateChange} to receive changes to store.
+
+```ts
+import { PersistableState, PublicConfig } from "@carbon/ai-chat";
+
+// readFromMyStore / writeToMyStore are stand-ins for your own storage.
+const config: PublicConfig = {
+  persistedState: {
+    initialState: readFromMyStore(),
+    onStateChange: (state: PersistableState) => {
+      writeToMyStore(state);
+    },
+  },
+};
+```
+
+- {@link PersistedStateConfig.initialState} replaces the `sessionStorage` read at startup. It is synchronous — resolve any asynchronous load (for example from your backend) before you construct the chat and pass the resolved value. Omit it to start a fresh session.
+- {@link PersistedStateConfig.onStateChange} replaces the `sessionStorage` write. It is called with the complete {@link PersistableState} whenever that state changes — not on transient changes such as input text. Persist the value verbatim.
+
+Providing either field disables the internal `sessionStorage` entirely: the chat no longer reads, writes, or clears it.
+
+A restored session is treated as an existing session, so {@link PublicConfig.openChatByDefault} does not re-open the chat on reload.
+
+## Do not drop fields
+
+Round-trip the whole {@link PersistableState}. If you store only part of it, reload regresses:
+
+- Dropping `disclaimersAccepted` re-prompts the disclaimer on every reload and blocks messages until it is accepted again.
+- Dropping `humanAgentState` prevents an in-progress human-agent conversation from reconnecting.
+- Dropping `hasSentNonWelcomeMessage` re-sends the welcome message.
+
+Storing the value verbatim avoids all of these.
+
+## Related
+
+- [Conversation history](./CustomHistory.md) — persist and restore the conversation messages themselves, which are separate from session state.
+- [Server communication](./CustomServer.md) — connect the chat to your own backend.

--- a/packages/ai-chat/src/aiChatEntry.tsx
+++ b/packages/ai-chat/src/aiChatEntry.tsx
@@ -116,6 +116,11 @@ export { readCarbonChatSession } from "./globals/utils/readCarbonChatSession";
 export { PersistedHumanAgentState } from "./types/state/PersistedHumanAgentState";
 
 export {
+  PersistableState,
+  PersistedStateConfig,
+} from "./types/config/PersistedStateConfig";
+
+export {
   HomeScreenConfig,
   HomeScreenStarterButton,
   HomeScreenStarterButtons,

--- a/packages/ai-chat/src/chat/services/ChatActionsImpl.ts
+++ b/packages/ai-chat/src/chat/services/ChatActionsImpl.ts
@@ -2062,7 +2062,12 @@ class ChatActionsImpl {
 
     this.serviceManager.messageUpsertCoordinator.clearAll();
 
-    this.serviceManager.userSessionStorageService.clearSession();
+    // When the host owns persistence there is no sessionStorage to clear; the state reset dispatched
+    // below flows to its onStateChange callback like any other change.
+    const { persistedState } = store.getState().config.public;
+    if (!persistedState?.initialState && !persistedState?.onStateChange) {
+      this.serviceManager.userSessionStorageService.clearSession();
+    }
 
     this.serviceManager.store.dispatch(
       actions.setAppStateValue(

--- a/packages/ai-chat/src/chat/store/doCreateStore.ts
+++ b/packages/ai-chat/src/chat/store/doCreateStore.ts
@@ -45,6 +45,7 @@ import {
 } from "./reducerUtils";
 import { enLanguagePack } from "../../types/config/PublicConfig";
 import { LayoutConfig } from "../../types/config/PublicConfig";
+import { fromPersistableState } from "./persistenceUtils";
 
 /**
  * Deep merge helper that:
@@ -289,9 +290,17 @@ function doCreateStore(
 
   const initialState: AppState = createInitialState(config);
 
-  // Go pre-fill the launcher state from session storage if it exists.
-  const sessionStorageState =
-    serviceManager.userSessionStorageService?.loadSession();
+  // When the host owns persistence (config.persistedState), boot from its initialState instead of
+  // sessionStorage. Otherwise, pre-fill from session storage if a saved session exists.
+  const persistedStateConfig = config.public.persistedState;
+  const externallyPersisted = Boolean(
+    persistedStateConfig?.initialState || persistedStateConfig?.onStateChange,
+  );
+  const sessionStorageState = externallyPersisted
+    ? persistedStateConfig?.initialState
+      ? fromPersistableState(persistedStateConfig.initialState)
+      : null
+    : serviceManager.userSessionStorageService?.loadSession();
 
   if (sessionStorageState) {
     // Use the viewState from session storage as the targetViewState. Note, this overwrites the value that was set for

--- a/packages/ai-chat/src/chat/store/persistenceUtils.ts
+++ b/packages/ai-chat/src/chat/store/persistenceUtils.ts
@@ -1,0 +1,61 @@
+/*
+ *  Copyright IBM Corp. 2025, 2026
+ *
+ *  This source code is licensed under the Apache-2.0 license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ *  @license
+ */
+
+/**
+ * Translation between the internal {@link PersistedState} slice and the public
+ * {@link PersistableState} contract used by {@link PersistedStateConfig}. This is the single place
+ * where the two shapes are mapped, so the emit and restore paths cannot drift apart.
+ */
+
+import cloneDeep from "lodash-es/cloneDeep.js";
+
+import { PersistableState } from "../../types/config/PersistedStateConfig";
+import { PersistedState } from "../../types/state/AppState";
+import { VERSION } from "../utils/environmentVariables";
+import { DEFAULT_PERSISTED_TO_BROWSER } from "./reducerUtils";
+
+/**
+ * Converts a consumer-provided {@link PersistableState} into the internal {@link PersistedState} used
+ * to seed the store at boot. Fills the framework-internal bookkeeping the consumer does not manage:
+ * stamps the current `version`, marks the session as restored (`wasLoadedFromBrowser`) so
+ * `openChatByDefault` does not re-fire, and — mirroring the sessionStorage load path — never restores
+ * an expanded launcher.
+ */
+function fromPersistableState(input: PersistableState): PersistedState {
+  return {
+    ...cloneDeep(DEFAULT_PERSISTED_TO_BROWSER),
+    ...input,
+    version: VERSION,
+    wasLoadedFromBrowser: true,
+    launcherIsExpanded: false,
+  };
+}
+
+/**
+ * Converts the internal {@link PersistedState} slice into the public {@link PersistableState} handed
+ * to {@link PersistedStateConfig.onStateChange}, dropping the framework-internal bookkeeping
+ * (`version`, `wasLoadedFromBrowser`). Listing every field explicitly makes this a compile-time guard:
+ * if {@link PersistedState} gains a field, {@link PersistableState} includes it and this function
+ * fails to type-check until the field is handled here.
+ */
+function toPersistableState(persisted: PersistedState): PersistableState {
+  return {
+    viewState: persisted.viewState,
+    showUnreadIndicator: persisted.showUnreadIndicator,
+    launcherIsExpanded: persisted.launcherIsExpanded,
+    launcherShouldStartCallToActionCounterIfEnabled:
+      persisted.launcherShouldStartCallToActionCounterIfEnabled,
+    hasSentNonWelcomeMessage: persisted.hasSentNonWelcomeMessage,
+    disclaimersAccepted: persisted.disclaimersAccepted,
+    homeScreenState: persisted.homeScreenState,
+    humanAgentState: persisted.humanAgentState,
+  };
+}
+
+export { fromPersistableState, toPersistableState };

--- a/packages/ai-chat/src/chat/store/subscriptions.ts
+++ b/packages/ai-chat/src/chat/store/subscriptions.ts
@@ -16,24 +16,39 @@ import { BusEventType } from "../../types/events/eventBusTypes";
 import { PublicChatState } from "../../types/instance/ChatInstance";
 import isEqual from "lodash-es/isEqual.js";
 import { refreshLocalization } from "../utils/intlUtils";
+import { toPersistableState } from "./persistenceUtils";
 
 /**
- * Copies persistedToBrowserStorage to the session history.
+ * Persists `persistedToBrowserStorage` whenever it changes. By default this writes to the browser's
+ * sessionStorage. When the host owns persistence (`config.persistedState`), the change is reported to
+ * its `onStateChange` callback instead — the persisted-slice reference gate below is exactly "the
+ * persistable state changed", so the callback is not fired on transient changes such as input text.
  */
 function copyToSessionStorage(serviceManager: ServiceManager) {
   let previousPersistedToBrowserStorage =
     serviceManager.store.getState().persistedToBrowserStorage;
   return () => {
-    const { persistedToBrowserStorage } = serviceManager.store.getState();
+    const { persistedToBrowserStorage, config } =
+      serviceManager.store.getState();
     const persistChatSession =
       previousPersistedToBrowserStorage !== persistedToBrowserStorage;
 
     if (persistChatSession) {
       previousPersistedToBrowserStorage = persistedToBrowserStorage;
 
-      serviceManager.userSessionStorageService.persistSession(
-        persistedToBrowserStorage,
-      );
+      const persistedStateConfig = config.public.persistedState;
+      if (
+        persistedStateConfig?.initialState ||
+        persistedStateConfig?.onStateChange
+      ) {
+        persistedStateConfig.onStateChange?.(
+          toPersistableState(persistedToBrowserStorage),
+        );
+      } else {
+        serviceManager.userSessionStorageService.persistSession(
+          persistedToBrowserStorage,
+        );
+      }
     }
   };
 }

--- a/packages/ai-chat/src/serverEntry.ts
+++ b/packages/ai-chat/src/serverEntry.ts
@@ -110,6 +110,11 @@ export {
 export { PersistedHumanAgentState } from "./types/state/PersistedHumanAgentState";
 
 export {
+  PersistableState,
+  PersistedStateConfig,
+} from "./types/config/PersistedStateConfig";
+
+export {
   HomeScreenConfig,
   HomeScreenStarterButton,
   HomeScreenStarterButtons,

--- a/packages/ai-chat/src/types/config/PersistedStateConfig.ts
+++ b/packages/ai-chat/src/types/config/PersistedStateConfig.ts
@@ -1,0 +1,63 @@
+/*
+ *  Copyright IBM Corp. 2025, 2026
+ *
+ *  This source code is licensed under the Apache-2.0 license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ *  @license
+ */
+
+import { PersistedState } from "../state/AppState";
+
+/**
+ * The subset of session state that Carbon AI Chat can persist and restore, consumed by
+ * {@link PersistedStateConfig}. It is the full internal {@link PersistedState} minus the
+ * framework-internal bookkeeping (`version` and `wasLoadedFromBrowser`), so a value produced by
+ * {@link PersistedStateConfig.onStateChange} can be handed straight back to
+ * {@link PersistedStateConfig.initialState} to restore a session.
+ *
+ * @category Config
+ *
+ * @experimental
+ */
+export type PersistableState = Omit<
+  PersistedState,
+  "version" | "wasLoadedFromBrowser"
+>;
+
+/**
+ * Hands session-state persistence to the host page, set on {@link PublicConfig.persistedState}. By
+ * default Carbon AI Chat stores session state in the browser's `sessionStorage`; providing either
+ * field replaces that built-in storage — the chat no longer reads or writes `sessionStorage` and
+ * instead boots from {@link PersistedStateConfig.initialState} and reports every change to
+ * {@link PersistedStateConfig.onStateChange}. When neither field is set, the default `sessionStorage`
+ * behavior is unchanged.
+ *
+ * Round-trip the whole {@link PersistableState} value. Dropping fields such as `disclaimersAccepted`,
+ * `humanAgentState`, or `hasSentNonWelcomeMessage` regresses the experience on reload: the disclaimer
+ * re-prompts, an in-progress human-agent chat cannot reconnect, and the welcome message is re-sent.
+ *
+ * @category Config
+ * @experimental
+ */
+export interface PersistedStateConfig {
+  /**
+   * The session state to boot from, used in place of reading `sessionStorage`. Resolve any
+   * asynchronous load (for example from your own backend) before constructing the chat and pass the
+   * resolved value here. When omitted, the chat starts a fresh session but still reports changes to
+   * {@link PersistedStateConfig.onStateChange}.
+   *
+   * @experimental
+   */
+  initialState?: PersistableState;
+
+  /**
+   * Called whenever the persistable session state changes, so the host can store it wherever it likes
+   * (its own backend, `localStorage`, and so on). Replaces the internal `sessionStorage` write. The
+   * argument is the complete {@link PersistableState}; persist it verbatim so it can later seed
+   * {@link PersistedStateConfig.initialState}.
+   *
+   * @experimental
+   */
+  onStateChange?: (state: PersistableState) => void;
+}

--- a/packages/ai-chat/src/types/config/PublicConfig.ts
+++ b/packages/ai-chat/src/types/config/PublicConfig.ts
@@ -20,6 +20,7 @@ import type {
 } from "./ServiceDeskConfig";
 import { HistoryItem } from "../messaging/History";
 import { LauncherConfig } from "./LauncherConfig";
+import { PersistedStateConfig } from "./PersistedStateConfig";
 import { DeepPartial } from "../utilities/DeepPartial";
 import enLanguagePackData from "../../chat/languages/en.json";
 import type { ToolbarAction } from "@carbon/ai-chat-components/es/react/toolbar.js";
@@ -152,6 +153,14 @@ export interface PublicConfig {
    * The config object for chat history.
    */
   history?: HistoryConfig;
+
+  /**
+   * Hands session-state persistence to the host page. By default the chat persists session state to
+   * the browser's `sessionStorage`; set this to boot from your own
+   * {@link PersistedStateConfig.initialState} and receive changes via
+   * {@link PersistedStateConfig.onStateChange} instead. See {@link PersistedStateConfig}.
+   */
+  persistedState?: PersistedStateConfig;
 
   /**
    * The config object for changing Carbon AI Chat's layout.

--- a/packages/ai-chat/src/web-components/shared/flattenedPublicConfig.ts
+++ b/packages/ai-chat/src/web-components/shared/flattenedPublicConfig.ts
@@ -111,6 +111,8 @@ export const FLATTENED_PUBLIC_CONFIG_FIELDS = [
   },
   { name: "header", options: { type: Object } },
   { name: "history", options: { type: Object } },
+  // Carries the onStateChange callback, so it is property-only (no attribute).
+  { name: "persistedState", options: { attribute: false, type: Object } },
   { name: "layout", options: { type: Object } },
   { name: "messaging", options: { type: Object } },
   { name: "isReadonly", options: { type: Boolean, attribute: "is-readonly" } },

--- a/packages/ai-chat/tests/config/spec/configFanInCompleteness_spec.ts
+++ b/packages/ai-chat/tests/config/spec/configFanInCompleteness_spec.ts
@@ -70,6 +70,7 @@ const REACTIVE_BACKBONE_FIELDS = new Set<string>([
   "upload",
   "keyboardShortcuts",
   "markdown",
+  "persistedState",
 ]);
 
 const ALL_FIELDS = FLATTENED_PUBLIC_CONFIG_FIELDS.map((field) => field.name);

--- a/packages/ai-chat/tests/config/spec/persistedState_spec.ts
+++ b/packages/ai-chat/tests/config/spec/persistedState_spec.ts
@@ -1,0 +1,91 @@
+/*
+ *  Copyright IBM Corp. 2025, 2026
+ *
+ *  This source code is licensed under the Apache-2.0 license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ *  @license
+ */
+
+import actions from "../../../src/chat/store/actions";
+import { PersistableState } from "../../../src/types/config/PersistedStateConfig";
+import {
+  createBaseConfig,
+  renderChatAndGetInstanceWithStore,
+  setupBeforeEach,
+  setupAfterEach,
+} from "../../test_helpers";
+
+const HOSTNAME =
+  typeof window !== "undefined" ? window.location.hostname : "localhost";
+
+describe("PublicConfig.persistedState", () => {
+  beforeEach(setupBeforeEach);
+  afterEach(setupAfterEach);
+
+  describe("initialState", () => {
+    it("hydrates the store from initialState instead of sessionStorage", async () => {
+      const config = {
+        ...createBaseConfig(),
+        persistedState: {
+          initialState: {
+            hasSentNonWelcomeMessage: true,
+            disclaimersAccepted: { [HOSTNAME]: true },
+            homeScreenState: {
+              isHomeScreenOpen: true,
+              showBackToAssistant: false,
+            },
+          } as PersistableState,
+        },
+      };
+
+      const { store } = await renderChatAndGetInstanceWithStore(config);
+      const persisted = store.getState().persistedToBrowserStorage;
+
+      expect(persisted.hasSentNonWelcomeMessage).toBe(true);
+      expect(persisted.disclaimersAccepted[HOSTNAME]).toBe(true);
+      expect(persisted.homeScreenState.isHomeScreenOpen).toBe(true);
+      // A restored session must not re-fire openChatByDefault.
+      expect(persisted.wasLoadedFromBrowser).toBe(true);
+    });
+  });
+
+  describe("onStateChange", () => {
+    it("reports persisted-state changes with a version-free PersistableState", async () => {
+      const onStateChange = jest.fn();
+      const config = {
+        ...createBaseConfig(),
+        persistedState: { onStateChange },
+      };
+
+      const { store } = await renderChatAndGetInstanceWithStore(config);
+
+      onStateChange.mockClear();
+      store.dispatch(actions.acceptDisclaimer());
+
+      expect(onStateChange).toHaveBeenCalled();
+      const emitted: PersistableState =
+        onStateChange.mock.calls[onStateChange.mock.calls.length - 1][0];
+      expect(emitted.disclaimersAccepted[HOSTNAME]).toBe(true);
+      expect(emitted).not.toHaveProperty("version");
+      expect(emitted).not.toHaveProperty("wasLoadedFromBrowser");
+    });
+
+    it("does not fire for non-persisted state changes", async () => {
+      const onStateChange = jest.fn();
+      const config = {
+        ...createBaseConfig(),
+        persistedState: { onStateChange },
+      };
+
+      const { store } = await renderChatAndGetInstanceWithStore(config);
+
+      // No await between the clear and the assert, so no async boot task can
+      // interleave: this isolates the single synchronous dispatch below.
+      onStateChange.mockClear();
+      store.dispatch(actions.setAppStateValue("isBrowserPageVisible", false));
+
+      expect(onStateChange).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/ai-chat/tests/store/spec/persistenceUtils_spec.ts
+++ b/packages/ai-chat/tests/store/spec/persistenceUtils_spec.ts
@@ -1,0 +1,101 @@
+/*
+ *  Copyright IBM Corp. 2025, 2026
+ *
+ *  This source code is licensed under the Apache-2.0 license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ *  @license
+ */
+
+import {
+  fromPersistableState,
+  toPersistableState,
+} from "../../../src/chat/store/persistenceUtils";
+import { DEFAULT_PERSISTED_TO_BROWSER } from "../../../src/chat/store/reducerUtils";
+import { VERSION } from "../../../src/chat/utils/environmentVariables";
+import { PersistableState } from "../../../src/types/config/PersistedStateConfig";
+import { PersistedState } from "../../../src/types/state/AppState";
+
+describe("persistenceUtils", () => {
+  describe("toPersistableState", () => {
+    it("drops framework-internal bookkeeping (version, wasLoadedFromBrowser)", () => {
+      const persisted: PersistedState = {
+        ...DEFAULT_PERSISTED_TO_BROWSER,
+        version: "9.9.9",
+        wasLoadedFromBrowser: true,
+        hasSentNonWelcomeMessage: true,
+      };
+
+      const result = toPersistableState(persisted);
+
+      expect(result).not.toHaveProperty("version");
+      expect(result).not.toHaveProperty("wasLoadedFromBrowser");
+      expect(result.hasSentNonWelcomeMessage).toBe(true);
+    });
+
+    it("carries the reconnect-critical human agent subset", () => {
+      const persisted: PersistedState = {
+        ...DEFAULT_PERSISTED_TO_BROWSER,
+        humanAgentState: {
+          ...DEFAULT_PERSISTED_TO_BROWSER.humanAgentState,
+          isConnected: true,
+          isSuspended: true,
+        },
+      };
+
+      const result = toPersistableState(persisted);
+
+      expect(result.humanAgentState.isConnected).toBe(true);
+      expect(result.humanAgentState.isSuspended).toBe(true);
+    });
+  });
+
+  describe("fromPersistableState", () => {
+    it("stamps the current version and marks the session as restored", () => {
+      const result = fromPersistableState({} as PersistableState);
+
+      expect(result.version).toBe(VERSION);
+      expect(result.wasLoadedFromBrowser).toBe(true);
+    });
+
+    it("never restores an expanded launcher", () => {
+      const result = fromPersistableState({
+        ...toPersistableState(DEFAULT_PERSISTED_TO_BROWSER),
+        launcherIsExpanded: true,
+      });
+
+      expect(result.launcherIsExpanded).toBe(false);
+    });
+
+    it("fills defaults for omitted fields", () => {
+      const result = fromPersistableState({} as PersistableState);
+
+      expect(result.disclaimersAccepted).toEqual({});
+      expect(result.homeScreenState).toEqual(
+        DEFAULT_PERSISTED_TO_BROWSER.homeScreenState,
+      );
+    });
+  });
+
+  describe("round-trip", () => {
+    it("preserves the restorable, session-critical fields", () => {
+      const original: PersistedState = {
+        ...DEFAULT_PERSISTED_TO_BROWSER,
+        hasSentNonWelcomeMessage: true,
+        disclaimersAccepted: { "example.com": true },
+        homeScreenState: { isHomeScreenOpen: true, showBackToAssistant: true },
+        humanAgentState: {
+          ...DEFAULT_PERSISTED_TO_BROWSER.humanAgentState,
+          isConnected: true,
+        },
+      };
+
+      const restored = fromPersistableState(toPersistableState(original));
+
+      expect(restored.hasSentNonWelcomeMessage).toBe(true);
+      expect(restored.disclaimersAccepted).toEqual({ "example.com": true });
+      expect(restored.homeScreenState.isHomeScreenOpen).toBe(true);
+      expect(restored.humanAgentState.isConnected).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
Contributes to #1679

## Summary

Adds `PublicConfig.persistedState` — an opt-in callback interface letting hosts own where session-state (views, disclaimer acceptance, human-agent connection state) is persisted. By default, `sessionStorage` remains unchanged; providing `initialState` and/or `onStateChange` hands that storage to the host, mirroring the pattern established by `customLoadHistory`. Includes completeness guard fix: `persistedState` is classified in the config fan-in spec as a reactive-backbone field (boot-time read + fresh-read-per-fire, no extra per-field side-effect block).

**Files with particularly complex changes**:
- [`packages/ai-chat/src/chat/store/persistenceUtils.ts`](packages/ai-chat/src/chat/store/persistenceUtils.ts) — translation layer between internal `PersistedState` and public `PersistableState`; review the dual-direction mapping (`fromPersistableState` / `toPersistableState`) to confirm the frame-internal bookkeeping (`version`, `wasLoadedFromBrowser`) is handled correctly.
- [`packages/ai-chat/src/chat/store/subscriptions.ts`](packages/ai-chat/src/chat/store/subscriptions.ts) — `copyToSessionStorage` now branches on whether the host owns persistence; ensure the subscription gate (reference equality on `persistedToBrowserStorage`) still fires the callback at the right moments.

#### Changelog

**New**

- `PublicConfig.persistedState` + `PersistedStateConfig` interface: opt-in host-owned session-state persistence (boot from `initialState`, receive changes via `onStateChange`). When neither field is set, `sessionStorage` behavior is unchanged.
- `PersistableState` type: the public contract for session state passed to/from `onStateChange`. Opaque blob — store verbatim to avoid regressions (dropping fields like `disclaimersAccepted` or `humanAgentState` regresses the UX on reload).
- `persistenceUtils.ts`: `fromPersistableState` / `toPersistableState` helpers ensuring the public and internal state shapes cannot drift.
- Public documentation at `packages/ai-chat/docs/StatePersistence.md` (linked from `CustomHistory.md` and `CustomServer.md`).
- Unit tests: `persistedState_spec.ts` verifies host-owned persistence boot/restore flow; `persistenceUtils_spec.ts` verifies the translation layer.

**Changed**

- `doCreateStore.ts`: boot logic now checks `config.persistedState` first; if a host has opted in (either field set), uses `initialState` instead of `sessionStorage.loadSession()`, and skips the `sessionStorage` write entirely.
- `copyToSessionStorage` subscription: now routes persistence to `onStateChange` callback (if host owns it) instead of `userSessionStorageService.persistSession()`.
- `ChatActionsImpl.destroySession()`: skips `userSessionStorageService.clearSession()` when host owns persistence (the state reset dispatched below flows to `onStateChange` like any other change).
- `FLATTENED_PUBLIC_CONFIG_FIELDS`: added `persistedState` (property-only, no attribute, carries the callback).
- `configFanInCompleteness_spec.ts`: classified `persistedState` as a `REACTIVE_BACKBONE_FIELD` (boot-time read of `initialState` + fresh-read-per-fire of `onStateChange`; no extra per-field side-effect block needed).

#### Testing / Reviewing

This feature is not reachable from the demo site (requires a host to wire up the callback interface). Verify via unit tests:

```bash
cd packages/ai-chat
npx jest tests/config/spec/persistedState_spec.ts tests/store/spec/persistenceUtils_spec.ts
```

Focus areas:
- `persistedState_spec.ts` — verifies boot from `initialState`, observes state changes via `onStateChange`, confirms `sessionStorage` is never touched when host owns persistence.
- `persistenceUtils_spec.ts` — verifies the round-trip translation between `PersistedState` (internal) and `PersistableState` (public), confirms `version` and `wasLoadedFromBrowser` bookkeeping is added/dropped correctly.
- `configFanInCompleteness_spec.ts` — verifies `persistedState` is classified (failing test would indicate an unclassified field).

Also run the completeness spec:
```bash
npx jest tests/config/spec/configFanInCompleteness_spec.ts
```

All existing session-restore tests should remain green (behavior unchanged when `persistedState` is not set).
