### PR TITLE
refactor: renames and relocates StreamingRichText

### DIFF
--- a/packages/ai-chat/src/chat/components-legacy/MessageTypeComponent.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/MessageTypeComponent.tsx
@@ -48,7 +48,7 @@ import { GridItemComponent } from "./responseTypes/grid/GridItemComponent";
 import { IFrameMessage } from "./responseTypes/iframe/IFrameMessage";
 import { Image } from "./responseTypes/image/Image";
 import { OptionComponent } from "./responseTypes/options/OptionComponent";
-import { StreamingRichText } from "./responseTypes/util/StreamingRichText";
+import { MarkdownWithErrorHandling } from "../components/util/MarkdownWithErrorHandling";
 import { VideoComponent } from "./responseTypes/video/VideoComponent";
 import { useSelector } from "../hooks/useSelector";
 import { shallowEqual } from "../store/appStore";
@@ -403,7 +403,7 @@ function MessageTypeComponent(props: MessageTypeComponentProps) {
     originalMessage?: MessageResponse,
   ) {
     return (
-      <StreamingRichText
+      <MarkdownWithErrorHandling
         text={localMessageItem.item.text}
         streamingState={localMessageItem.ui_state.streamingState}
         isStreamingError={

--- a/packages/ai-chat/src/chat/components/util/MarkdownWithErrorHandling.tsx
+++ b/packages/ai-chat/src/chat/components/util/MarkdownWithErrorHandling.tsx
@@ -9,15 +9,15 @@
 
 import React from "react";
 
-import { useSelector } from "../../../hooks/useSelector";
-import { shallowEqual } from "../../../store/appStore";
-import { AppState } from "../../../../types/state/AppState";
-import { LocalMessageItemStreamingState } from "../../../../types/messaging/LocalMessageItem";
-import InlineError from "../../../components/util/InlineError";
-import { MarkdownWithDefaults } from "../../../components/util/MarkdownWithDefaults";
-import { TextItem } from "../../../../types/messaging/Messages";
+import { useSelector } from "../../hooks/useSelector";
+import { shallowEqual } from "../../store/appStore";
+import { AppState } from "../../../types/state/AppState";
+import { LocalMessageItemStreamingState } from "../../../types/messaging/LocalMessageItem";
+import InlineError from "./InlineError";
+import { MarkdownWithDefaults } from "./MarkdownWithDefaults";
+import { TextItem } from "../../../types/messaging/Messages";
 
-interface StreamingRichTextProps {
+interface MarkdownWithErrorHandlingProps {
   /**
    * The full text of the item to render. This is used once the streaming is done.
    */
@@ -43,7 +43,7 @@ interface StreamingRichTextProps {
  * This item renders some text that may contain rich content. This component also supports the display of text as it
  * is streaming in chunks (currently only TextItem chunks are supported).
  */
-function StreamingRichText(props: StreamingRichTextProps) {
+function MarkdownWithErrorHandling(props: MarkdownWithErrorHandlingProps) {
   const { text, streamingState, removeHTML, isStreamingError } = props;
 
   const languagePack = useSelector(
@@ -79,4 +79,4 @@ function StreamingRichText(props: StreamingRichTextProps) {
   );
 }
 
-export { StreamingRichText };
+export { MarkdownWithErrorHandling };


### PR DESCRIPTION
Closes #1435

Rename `StreamingRichText` to `MarkdownWithErrorHandling` and relocate it from `components-legacy/responseTypes/util/` to `components/util/`, alongside `MarkdownWithDefaults` and `InlineError` which it composes.

#### Changelog

**Changed**

- `StreamingRichText` renamed to `MarkdownWithErrorHandling` and moved to `packages/ai-chat/src/chat/components/util/`

**Removed**

- `packages/ai-chat/src/chat/components-legacy/responseTypes/util/StreamingRichText.tsx` (replaced by the above)

#### Testing / Reviewing

- Confirm `MessageTypeComponent` renders rich text and streaming error states as before
- `npm run test --workspace=@carbon/ai-chat` — all 1012 tests pass
- `npm run build --workspace=@carbon/ai-chat` — no errors