### PR TITLE
fix: updating view state during hydration broke hydration

### DIFF
--- a/packages/ai-chat/src/chat/services/ChatActionsImpl.ts
+++ b/packages/ai-chat/src/chat/services/ChatActionsImpl.ts
@@ -1793,14 +1793,26 @@ class ChatActionsImpl {
     let newViewState = constructViewState(newView, store.getState());
 
     if (!isEqual(newViewState, viewState) || forceViewChange) {
+      // Snapshot what was actually requested before any view:pre:change/view:change listener gets a
+      // chance to mutate newViewState (in place or by replacement) via the event payload.
+      const requestedMainWindow = newViewState.mainWindow;
+
       // If the newViewState is different from the current viewState, or the viewChange is being forced to happen, fire
       // the view:change events and change which views are visible.
       await this.fireViewChangeEventsAndChangeView(newViewState, reason);
 
       // Check and see if the chat should be hydrated.
       newViewState = store.getState().persistedToBrowserStorage.viewState;
+
+      // A host's view:pre:change/view:change handler may force the main window open (for example by
+      // mutating event.newViewState.mainWindow) even when the caller didn't request it and passed
+      // tryHydrating false (the deferred-hydration cold-boot path). Hydrate anyway in that case, or
+      // customSendMessage/customLoadHistory would never run for the newly-visible window.
+      const hostForcedMainWindowOpen =
+        newViewState.mainWindow && !requestedMainWindow;
+
       if (
-        tryHydrating &&
+        (tryHydrating || hostForcedMainWindowOpen) &&
         newViewState.mainWindow &&
         !store.getState().isHydrated
       ) {

--- a/packages/ai-chat/tests/instance/spec/changeView_spec.ts
+++ b/packages/ai-chat/tests/instance/spec/changeView_spec.ts
@@ -1,5 +1,5 @@
 /*
- *  Copyright IBM Corp. 2025
+ *  Copyright IBM Corp. 2025, 2026
  *
  *  This source code is licensed under the Apache-2.0 license found in the
  *  LICENSE file in the root directory of this source tree.
@@ -7,7 +7,18 @@
  *  @license
  */
 
-import { ViewState, ViewType } from "../../../src/aiChatEntry";
+import React from "react";
+import { render, waitFor } from "@testing-library/react";
+
+import {
+  BusEventType,
+  BusEventViewPreChange,
+  EventBusHandler,
+  ViewChangeReason,
+  ViewState,
+  ViewType,
+} from "../../../src/aiChatEntry";
+import { ChatContainer } from "../../../src/react/ChatContainer";
 import {
   createBaseConfig,
   renderChatAndGetInstance,
@@ -195,6 +206,90 @@ describe("ChatInstance.changeView", () => {
       const state = store.getState();
       expect(state.persistedToBrowserStorage.viewState.launcher).toBe(false);
       expect(state.persistedToBrowserStorage.viewState.mainWindow).toBe(false);
+    });
+  });
+
+  describe("hydration when a view:pre:change handler forces mainWindow open", () => {
+    // Regression coverage for https://github.com/carbon-design-system/carbon-ai-chat/issues/1679:
+    // a host that mutates event.newViewState.mainWindow directly inside onViewPreChange (rather than
+    // calling changeView itself) was never hydrated, so customSendMessage/customLoadHistory never ran.
+    it("hydrates when a view:pre:change handler mutates newViewState.mainWindow to true", async () => {
+      const config = createBaseConfig();
+      const { instance, store, serviceManager } =
+        await renderChatAndGetInstanceWithStore(config);
+      const hydrateSpy = jest
+        .spyOn(serviceManager.actions, "hydrateChat")
+        .mockResolvedValue(undefined);
+
+      instance.on({
+        type: BusEventType.VIEW_PRE_CHANGE,
+        handler: ((event: BusEventViewPreChange) => {
+          event.newViewState.mainWindow = true;
+        }) as EventBusHandler,
+      });
+
+      // Mirrors chatBoot.ts's deferred-hydration cold-boot call: the caller requests the window stay
+      // closed and explicitly opts out of hydration, since it expects a later, user-initiated
+      // changeView call to hydrate instead.
+      await serviceManager.actions.changeView(
+        { launcher: true, mainWindow: false },
+        { viewChangeReason: ViewChangeReason.WEB_CHAT_LOADED },
+        /* tryHydrating */ false,
+        /* forceViewChange */ true,
+      );
+
+      expect(
+        store.getState().persistedToBrowserStorage.viewState.mainWindow,
+      ).toBe(true);
+      expect(hydrateSpy).toHaveBeenCalled();
+    });
+
+    it("does not hydrate when no handler mutates newViewState during a deferred-hydration change", async () => {
+      const config = createBaseConfig();
+      const { store, serviceManager } =
+        await renderChatAndGetInstanceWithStore(config);
+      const hydrateSpy = jest
+        .spyOn(serviceManager.actions, "hydrateChat")
+        .mockResolvedValue(undefined);
+
+      await serviceManager.actions.changeView(
+        { launcher: true, mainWindow: false },
+        { viewChangeReason: ViewChangeReason.WEB_CHAT_LOADED },
+        /* tryHydrating */ false,
+        /* forceViewChange */ true,
+      );
+
+      expect(
+        store.getState().persistedToBrowserStorage.viewState.mainWindow,
+      ).toBe(false);
+      expect(hydrateSpy).not.toHaveBeenCalled();
+    });
+
+    it("calls customSendMessage and customLoadHistory when onViewPreChange forces the window open during cold boot", async () => {
+      window.sessionStorage.clear();
+
+      const customLoadHistory = jest.fn().mockResolvedValue([]);
+      const customSendMessage = jest.fn();
+
+      const config = createBaseConfig();
+      render(
+        React.createElement(ChatContainer, {
+          ...config,
+          messaging: {
+            ...config.messaging,
+            customLoadHistory,
+            customSendMessage,
+          },
+          onViewPreChange: (event) => {
+            event.newViewState.mainWindow = true;
+          },
+        }),
+      );
+
+      await waitFor(() => {
+        expect(customLoadHistory).toHaveBeenCalled();
+      });
+      expect(customSendMessage).toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
Closes #1679

`ChatActionsImpl.changeView()` skipped hydration whenever the caller passed `tryHydrating: false` — the deferred-hydration cold-boot path used by `chatBoot.ts`'s `performInitialViewChange()` when the persisted view is closed. If a host's `view:pre:change`/`view:change` handler forced `mainWindow` open anyway (e.g. by mutating `event.newViewState.mainWindow` instead of calling `changeView` itself), the chat became visible but was never hydrated, so `customSendMessage`/`customLoadHistory` never ran for it.

- [`packages/ai-chat/src/chat/services/ChatActionsImpl.ts`](packages/ai-chat/src/chat/services/ChatActionsImpl.ts) — `changeView()` now snapshots the caller's originally requested `mainWindow` value before the `view:pre:change`/`view:change` events fire, then hydrates if the final state shows `mainWindow` flipped from falsy to `true` even though `tryHydrating` was `false`. This is additive: a caller that explicitly requests `mainWindow: true` while passing `tryHydrating: false` still has that opt-out respected, since `mainWindow` didn't change as a result of a handler forcing it.

#### Changelog

**Changed**

- Fixed: a `view:pre:change`/`view:change` handler that forces `mainWindow` open during the deferred-hydration cold-boot flow now correctly triggers hydration, instead of leaving the window open but never hydrated.

#### Testing / Reviewing

Not reachable through the demo's existing config toggles — reproducing it requires a host `onViewPreChange` handler that mutates `event.newViewState.mainWindow` directly during the closed-on-load cold-boot path, which isn't wired to any demo switcher today.

- `npx jest packages/ai-chat/tests/instance/spec/changeView_spec.ts` — new `describe("hydration when a view:pre:change handler forces mainWindow open")` block, 3 cases, all passing:
  - Unit-level: a `view:pre:change` handler mutating `newViewState.mainWindow` to `true` during a `tryHydrating: false` call now calls `hydrateChat`.
  - Negative case: an unrelated `tryHydrating: false` deferred-hydration call with no handler mutation still does *not* hydrate (confirms no regression on the common path).
  - Full-render integration case: renders `ChatContainer` with an `onViewPreChange` handler forcing `mainWindow` open and asserts `customSendMessage`/`customLoadHistory` are actually invoked — this is the consumer-visible symptom from the original bug report.
- Manual check: in a basic example page with the chat closed on load, register `instance.on({ type: "view:pre:change", handler: (e) => { e.newViewState.mainWindow = true; } })` before boot, reload, and confirm the chat opens *and* the assistant loads history / sends its greeting rather than sitting hydration-less.
