### PR TITLE
fix(prompt-line): remove trailing space from autocomplete insert

### DIFF
--- a/packages/ai-chat-components/src/components/input/src/autocomplete-controller.ts
+++ b/packages/ai-chat-components/src/components/input/src/autocomplete-controller.ts
@@ -303,10 +303,7 @@ export class AutocompleteController {
       editor
         .chain()
         .focus()
-        .insertContentAt(range, [
-          { type: "text", text },
-          { type: "text", text: " " },
-        ])
+        .insertContentAt(range, [{ type: "text", text }])
         .run();
       this._autocomplete?.onSelect?.(item);
     }

--- a/packages/ai-chat-components/src/components/input/src/tiptap/carbon-autocomplete.ts
+++ b/packages/ai-chat-components/src/components/input/src/tiptap/carbon-autocomplete.ts
@@ -76,10 +76,7 @@ export function carbonAutocomplete(config: AutocompleteConfig): Extension {
             const insertText = item.value ?? item.label;
             ed.chain()
               .focus()
-              .insertContentAt(range, [
-                { type: "text", text: insertText },
-                { type: "text", text: " " },
-              ])
+              .insertContentAt(range, [{ type: "text", text: insertText }])
               .run();
             config.onSelect?.(item);
           },


### PR DESCRIPTION
Closes #1620 

Currently, whenever `editor.commands.insertContentAt()` is called to insert a mention, command, or text into the prompt line from the autocomplete list, a trailing (" ") is added to the content. This doesn't create any issue when using mentions or commands because they get individually extracted from the message request. For regular text autocomplete suggestions, this extra space is unnecessary and creates an issue when an exact match is required, like in our demo app ("button " won't trigger the example "button" response unless you delete the trailing space before sending).

#### Changelog

**Changed**

- Removed the trailing " " text when inserting a non-mentions/commands autocomplete item to the prompt line:
  - `packages/ai-chat-components/src/components/input/src/tiptap/carbon-autocomplete.ts` makes this update when using tiptap
  - `packages/ai-chat-components/src/components/input/src/autocomplete-controller.ts`  makes the update in non-tiptap mode

#### Testing / Reviewing

- Go to demo deploy preview
- Switch Chat config -> Input -> Enable autocomplete suggestions to true
- Select any item from the autocomplete suggestions and ensure there is no trailing space added. Sending from the prompt line after selecting the message should trigger the appropriate response.
- Verify that mentions & commands insertion is left unchanged (can test by running the `input-mentions-and-commands` example).