### PR TITLE
fix: correct off-by-one loop bound in isUnmappingEqual memoizer

### DIFF
--- a/packages/ai-chat/src/chat/utils/memoizerUtils.ts
+++ b/packages/ai-chat/src/chat/utils/memoizerUtils.ts
@@ -1,5 +1,5 @@
 /*
- *  Copyright IBM Corp. 2025
+ *  Copyright IBM Corp. 2025, 2026
  *
  *  This source code is licensed under the Apache-2.0 license found in the
  *  LICENSE file in the root directory of this source tree.
@@ -97,7 +97,7 @@ function isUnmappingEqual<V>(
   }
 
   // Check each value one by one.
-  for (let index = 0; index <= keys1.length; index++) {
+  for (let index = 0; index < keys1.length; index++) {
     const key1 = keys1[index];
     const key2 = keys2[index];
 

--- a/packages/ai-chat/tests/utils/spec/memoizerUtils_spec.ts
+++ b/packages/ai-chat/tests/utils/spec/memoizerUtils_spec.ts
@@ -1,0 +1,77 @@
+/*
+ *  Copyright IBM Corp. 2026
+ *
+ *  This source code is licensed under the Apache-2.0 license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ *  @license
+ */
+
+import {
+  createUnmappingMemoizer,
+  memoizeFunction,
+} from "../../../src/chat/utils/memoizerUtils";
+
+describe("memoizeFunction", () => {
+  it("recomputes only when arguments change by reference", () => {
+    const fn = jest.fn((a: number, b: number) => a + b);
+    const memoized = memoizeFunction(fn);
+
+    expect(memoized(1, 2)).toBe(3);
+    expect(memoized(1, 2)).toBe(3);
+    expect(fn).toHaveBeenCalledTimes(1);
+
+    expect(memoized(2, 2)).toBe(4);
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("createUnmappingMemoizer", () => {
+  it("maps keys to their values", () => {
+    const unmap = createUnmappingMemoizer<string>();
+    expect(unmap(["a", "b"], { a: "1", b: "2", c: "3" })).toEqual(["1", "2"]);
+  });
+
+  it("returns the same array reference when keys and mapped values are unchanged", () => {
+    const unmap = createUnmappingMemoizer<string>();
+    const first = unmap(["a", "b"], { a: "1", b: "2" });
+    // Fresh key array + fresh map object, identical content: identity must be preserved so
+    // downstream === selectors (React, the value stores) see no change.
+    const second = unmap(["a", "b"], { a: "1", b: "2" });
+    expect(second).toBe(first);
+  });
+
+  it("returns a new array when the last key's value changes", () => {
+    // Regression guard for the loop bound: the final element must be compared. An `index <=
+    // length` bound compared one-past-the-end (always undefined) and could mask a real change to
+    // the last value depending on inputs; `index < length` compares exactly the real elements.
+    const unmap = createUnmappingMemoizer<string>();
+    const first = unmap(["a", "b"], { a: "1", b: "2" });
+    const second = unmap(["a", "b"], { a: "1", b: "CHANGED" });
+    expect(second).not.toBe(first);
+    expect(second).toEqual(["1", "CHANGED"]);
+  });
+
+  it("returns a new array when a key changes", () => {
+    const unmap = createUnmappingMemoizer<string>();
+    const first = unmap(["a", "b"], { a: "1", b: "2" });
+    const second = unmap(["a", "c"], { a: "1", c: "2" });
+    expect(second).not.toBe(first);
+    expect(second).toEqual(["1", "2"]);
+  });
+
+  it("returns a new array when the key list length changes", () => {
+    const unmap = createUnmappingMemoizer<string>();
+    const first = unmap(["a"], { a: "1" });
+    const second = unmap(["a", "b"], { a: "1", b: "2" });
+    expect(second).not.toBe(first);
+    expect(second).toEqual(["1", "2"]);
+  });
+
+  it("treats two empty key lists as unchanged", () => {
+    const unmap = createUnmappingMemoizer<string>();
+    const first = unmap([], {});
+    const second = unmap([], {});
+    expect(second).toBe(first);
+  });
+});


### PR DESCRIPTION
Closes #1729

Part of the persist/SDK decomposition epic #1728 (Wave A). Corrects an off-by-one loop bound in `isUnmappingEqual` (the unmapping memoizer's equality check): the loop ran `index <= keys1.length`, reading one element past the end of the key array on every comparison. Changed to `index < keys1.length` so it compares exactly the real key/value pairs. Also adds the first spec for `memoizerUtils`, with a regression guard for the bound.

#### Changelog

**Changed**

- `isUnmappingEqual` loop bound `<=` → `<` — the unmapping memoizer now compares only real key/value pairs, with no past-the-end read.

**New**

- `memoizerUtils_spec.ts` — covers `memoizeFunction` reference-equality memoization and `createUnmappingMemoizer` identity preservation, including a regression guard for the loop bound.

#### Testing / Reviewing

- `cd packages/ai-chat && npx jest tests/utils/spec/memoizerUtils_spec.ts` — 7 passing, including "returns a new array when the last key's value changes" (the bound regression).
- Not demo-reachable — internal memoization utility.
