### PR TITLE
fix: apply locale per-call in timestampToTimeString

### DIFF
--- a/packages/ai-chat/src/chat/components-legacy/MessageComponent.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/MessageComponent.tsx
@@ -511,9 +511,10 @@ class MessageComponent extends PureComponent<MessageProps, MessageState> {
       useAITheme,
       carbonTheme,
       hideAvatar,
+      locale,
     } = this.props;
 
-    const timestamp = timestampToTimeString(message.history.timestamp);
+    const timestamp = timestampToTimeString(message.history.timestamp, locale);
 
     let label;
     let actorName;

--- a/packages/ai-chat/src/chat/utils/timeUtils.ts
+++ b/packages/ai-chat/src/chat/utils/timeUtils.ts
@@ -1,5 +1,5 @@
 /*
- *  Copyright IBM Corp. 2025
+ *  Copyright IBM Corp. 2025, 2026
  *
  *  This source code is licensed under the Apache-2.0 license found in the
  *  LICENSE file in the root directory of this source tree.
@@ -11,10 +11,20 @@ import dayjs from "dayjs";
 
 /**
  * Returns the time from the given timestamp localized into the user's current timezone and formatted with the
- * current locale.
+ * given locale.
+ *
+ * The `locale` is applied per call rather than read from dayjs's process-global default. Several chat
+ * instances can share one page (see `featureFlags.reuseInstance` and per-namespace instances), and each
+ * boot registers its locale globally; reading the global would let the last instance to boot format every
+ * other instance's timestamps. The locale is only applied when it has been registered (loaded at boot);
+ * otherwise dayjs's default is used, matching prior behavior for an unrecognized locale.
  */
-function timestampToTimeString(timestamp: number | Date | string) {
-  return dayjs(timestamp).format("LT");
+function timestampToTimeString(
+  timestamp: number | Date | string,
+  locale?: string,
+) {
+  const time = dayjs(timestamp);
+  return (locale && dayjs.Ls[locale] ? time.locale(locale) : time).format("LT");
 }
 
 export { timestampToTimeString };

--- a/packages/ai-chat/tests/utils/spec/timeUtils_spec.ts
+++ b/packages/ai-chat/tests/utils/spec/timeUtils_spec.ts
@@ -1,5 +1,5 @@
 /*
- *  Copyright IBM Corp. 2025
+ *  Copyright IBM Corp. 2025, 2026
  *
  *  This source code is licensed under the Apache-2.0 license found in the
  *  LICENSE file in the root directory of this source tree.
@@ -9,22 +9,43 @@
 
 import { timestampToTimeString } from "../../../src/chat/utils/timeUtils";
 
-// Mock dayjs to have consistent test results
+// Mock dayjs to have consistent test results. The default format is the en 12-hour "LT"; a
+// per-call `.locale("fr")` switches to a 24-hour render so a test can prove the locale is applied
+// per call rather than read from the process-global default.
 jest.mock("dayjs", () => {
   const originalDayjs = jest.requireActual("dayjs");
-  return jest.fn((timestamp) => ({
-    format: jest.fn((format) => {
-      if (format === "LT") {
-        const date = new Date(timestamp);
-        const hours = date.getHours();
-        const minutes = date.getMinutes().toString().padStart(2, "0");
-        const ampm = hours >= 12 ? "PM" : "AM";
-        const displayHours = hours % 12 || 12;
-        return `${displayHours}:${minutes} ${ampm}`;
-      }
-      return originalDayjs(timestamp).format(format);
-    }),
-  }));
+  const twelveHour = (timestamp: number | Date | string) => {
+    const date = new Date(timestamp);
+    const hours = date.getHours();
+    const minutes = date.getMinutes().toString().padStart(2, "0");
+    const ampm = hours >= 12 ? "PM" : "AM";
+    const displayHours = hours % 12 || 12;
+    return `${displayHours}:${minutes} ${ampm}`;
+  };
+  const twentyFourHour = (timestamp: number | Date | string) => {
+    const date = new Date(timestamp);
+    const hours = date.getHours().toString().padStart(2, "0");
+    const minutes = date.getMinutes().toString().padStart(2, "0");
+    return `${hours}:${minutes}`;
+  };
+  const makeInstance = (timestamp: number | Date | string) => ({
+    locale: jest.fn(() => ({
+      format: jest.fn((format) =>
+        format === "LT"
+          ? twentyFourHour(timestamp)
+          : originalDayjs(timestamp).format(format),
+      ),
+    })),
+    format: jest.fn((format) =>
+      format === "LT"
+        ? twelveHour(timestamp)
+        : originalDayjs(timestamp).format(format),
+    ),
+  });
+  const mockDayjs: any = jest.fn((timestamp) => makeInstance(timestamp));
+  // Registered-locale table dayjs exposes as `dayjs.Ls`; only "fr" is loaded here.
+  mockDayjs.Ls = { fr: {} };
+  return mockDayjs;
 });
 
 describe("timeUtils", () => {
@@ -67,6 +88,19 @@ describe("timeUtils", () => {
       const timestamp = new Date(2023, 11, 25, 15, 5, 0).getTime();
       const result = timestampToTimeString(timestamp);
       expect(result).toBe("3:05 PM");
+    });
+
+    it("applies a registered locale per call rather than the global default", () => {
+      const timestamp = new Date(2023, 11, 25, 15, 5, 0).getTime();
+      // "fr" is registered in the mock, so it is applied per call (24-hour render).
+      expect(timestampToTimeString(timestamp, "fr")).toBe("15:05");
+    });
+
+    it("falls back to the default format for an unregistered locale", () => {
+      const timestamp = new Date(2023, 11, 25, 15, 5, 0).getTime();
+      // "zz" is not in the registry, so the default (12-hour) format is used — this never
+      // silently pulls another instance's global locale.
+      expect(timestampToTimeString(timestamp, "zz")).toBe("3:05 PM");
     });
   });
 });


### PR DESCRIPTION
Closes #1730

Part of the persist/SDK decomposition epic #1728 (Wave A). `timestampToTimeString` formatted using dayjs's process-global locale default. When several chat instances share one page (per-namespace instances, `featureFlags.reuseInstance`), each boot registers its locale globally, so the last instance to boot would format every other instance's timestamps. Adds an optional `locale` applied per call — only when that locale is registered in `dayjs.Ls`, otherwise the default (unchanged behavior for an unrecognized locale). `MessageComponent` threads its existing `locale` prop through.

#### Changelog

**Changed**

- `timestampToTimeString(timestamp, locale?)` — optional per-call locale, applied only when registered; no longer reads the dayjs global default.
- `MessageComponent` passes its `locale` prop to `timestampToTimeString`.

#### Testing / Reviewing

- `cd packages/ai-chat && npx jest tests/utils/spec/timeUtils_spec.ts` — 8 passing, including "applies a registered locale per call rather than the global default" and "falls back to the default format for an unregistered locale".
- Not demo-reachable in isolation (formatting util); surfaces in message timestamps.
