### PR TITLE
feat: implement ChatInstance.destroy() and unloadServices() teardown

### DIFF
--- a/packages/ai-chat/src/chat/instance/ChatInstanceImpl.ts
+++ b/packages/ai-chat/src/chat/instance/ChatInstanceImpl.ts
@@ -358,6 +358,11 @@ function createChatInstance({
       debugLog("Called instance.destroySession", keepOpenState);
       return serviceManager.actions.destroySession(keepOpenState);
     },
+
+    destroy: () => {
+      debugLog("Called instance.destroy");
+      serviceManager.actions.unloadServices();
+    },
   };
 
   // Add serviceManager for testing if the flag is enabled (exclude instance to avoid circular reference)

--- a/packages/ai-chat/src/chat/services/ChatActionsImpl.ts
+++ b/packages/ai-chat/src/chat/services/ChatActionsImpl.ts
@@ -230,7 +230,7 @@ class ChatActionsImpl {
       this.hydrating = false;
     }
 
-    if (fireReady) {
+    if (fireReady && !this.serviceManager.disposed) {
       await this.serviceManager.fire({ type: BusEventType.CHAT_READY });
     }
   }
@@ -264,6 +264,14 @@ class ChatActionsImpl {
     if (!this.alreadyHydrated) {
       history = await this.serviceManager.historyService.loadHistory();
 
+      if (serviceManager.disposed) {
+        // The chat was torn down while the consumer's customLoadHistory was pending. Stop here:
+        // the continuation would otherwise initialize the human agent service (invoking the
+        // consumer's serviceDeskFactory on a destroyed chat), send the welcome request, or
+        // reconnect a service desk that nothing would ever end.
+        return;
+      }
+
       if (
         serviceManager.humanAgentService &&
         !serviceManager.humanAgentService.hasInitialized
@@ -272,6 +280,9 @@ class ChatActionsImpl {
         // initialize the human agent service.
         debugLog("Initializing the human agent service");
         await serviceManager.humanAgentService.initialize();
+        if (serviceManager.disposed) {
+          return;
+        }
       } else {
         debugLog("No service desk integrations present");
       }
@@ -324,6 +335,12 @@ class ChatActionsImpl {
       if (history.latestPanelLocalMessageItem) {
         this.openResponsePanel(history.latestPanelLocalMessageItem, true);
       }
+    }
+
+    if (serviceManager.disposed) {
+      // Torn down while the welcome request or the user-defined-response elements were pending —
+      // do not reconnect the service desk or dispatch into the disposed store.
+      return;
     }
 
     // After both history and welcome are loaded indicate we've got everything.
@@ -664,12 +681,19 @@ class ChatActionsImpl {
       if (!ignoreHydration) {
         await this.hydrationPromise;
       }
+      if (this.serviceManager.disposed) {
+        // Torn down while awaiting hydration — do not send on the disposed chat.
+        return;
+      }
       await this.doSend(messageRequest, source, options);
     } else {
       // If no hydration has started, then we need to start the hydration and use this message as the alternate for
       // the welcome node.
       this.serviceManager.store.dispatch(actions.setHomeScreenIsOpen(false));
       await this.hydrateChat(messageRequest, source, options);
+      if (this.serviceManager.disposed) {
+        return;
+      }
       await this.doSend(messageRequest, source, options);
     }
   }
@@ -1035,7 +1059,8 @@ class ChatActionsImpl {
 
     // If not in chunk, try to get from stored message (fallback)
     const message = store.getState().allMessagesByID[messageID] as
-      MessageResponse | undefined;
+      | MessageResponse
+      | undefined;
 
     // Create a temporary message object with the profile from chunk if available
     const messageWithProfile: MessageResponse | undefined = chunkProfile
@@ -1081,7 +1106,8 @@ class ChatActionsImpl {
 
     // If not in chunk, try to get from stored message (fallback)
     const message = store.getState().allMessagesByID[messageID] as
-      MessageResponse | undefined;
+      | MessageResponse
+      | undefined;
 
     // Create a temporary message object with the profile from chunk if available
     const messageWithProfile: MessageResponse | undefined = chunkProfile
@@ -2068,6 +2094,75 @@ class ChatActionsImpl {
         newPersistedToBrowserStorage,
       ),
     );
+  }
+
+  /**
+   * Tears down the services and subscriptions created for this instance and marks the service
+   * manager disposed. This is the disposal half of the lifecycle: it silently ends any active
+   * human-agent chat, unsubscribes the store listeners registered in `loadServices`, clears the
+   * event bus, stops the theme watcher, disposes the message service, and clears the upsert
+   * coordinator. Distinct from `destroySession`, which only clears the conversation/session.
+   *
+   * Safe to call more than once, and must not throw even if the instance was only partially
+   * initialized.
+   */
+  unloadServices() {
+    const { serviceManager } = this;
+    if (!serviceManager || serviceManager.disposed) {
+      return;
+    }
+    serviceManager.disposed = true;
+
+    const safe = (fn: () => void) => {
+      try {
+        fn();
+      } catch {
+        // Disposal must never throw; ignore teardown errors.
+      }
+    };
+
+    // Silently end any active human-agent chat (no user-facing "agent ended" message),
+    // mirroring the restart teardown. Fire-and-forget so disposal stays synchronous. `forceEnd`
+    // skips the cancellable pre:endChat event: a host listener gating disconnects behind a
+    // confirmation dialog must not be able to veto teardown and strand a live agent socket on a
+    // disposed chat.
+    safe(() => {
+      const state = serviceManager.store?.getState();
+      const isConnecting = state?.humanAgentState?.isConnecting;
+      const isConnected =
+        state?.persistedToBrowserStorage?.humanAgentState?.isConnected;
+      if (isConnecting || isConnected) {
+        serviceManager.humanAgentService
+          ?.endChat(true, false, false, { forceEnd: true })
+          ?.catch(() => {});
+      }
+    });
+
+    // Abort any in-flight file uploads so a disposed chat leaves no dangling upload requests.
+    this.uploadAbortControllers?.forEach((controller) =>
+      safe(() => controller.abort()),
+    );
+    this.uploadAbortControllers?.clear();
+
+    // Unsubscribe the store listeners registered in loadServices.
+    serviceManager.storeUnsubscribers?.forEach((unsubscribe) =>
+      safe(() => unsubscribe?.()),
+    );
+    serviceManager.storeUnsubscribers = [];
+
+    // Tear down the remaining services.
+    safe(() => serviceManager.eventBus?.clear());
+    safe(() => serviceManager.themeWatcherService?.stopWatching());
+    safe(() => serviceManager.messageService?.dispose());
+    safe(() => serviceManager.messageUpsertCoordinator?.clearAll());
+
+    // Drop cross-references so nothing keeps the disposed graph alive.
+    serviceManager.instance = undefined;
+    serviceManager.mainWindow = undefined;
+    serviceManager.appWindow = undefined;
+    serviceManager.inputComponent = undefined;
+    serviceManager.container = undefined;
+    serviceManager.customHostElement = undefined;
   }
 
   /**

--- a/packages/ai-chat/src/chat/services/MessageService.ts
+++ b/packages/ai-chat/src/chat/services/MessageService.ts
@@ -1,5 +1,5 @@
 /*
- *  Copyright IBM Corp. 2025
+ *  Copyright IBM Corp. 2025, 2026
  *
  *  This source code is licensed under the Apache-2.0 license found in the
  *  LICENSE file in the root directory of this source tree.
@@ -614,6 +614,12 @@ class MessageService {
     localMessageID?: string,
     requestOptions?: SendOptions,
   ): Promise<MessageResponse | any> {
+    if (this.serviceManager.disposed) {
+      // A continuation that survived teardown (e.g. a hydration that was awaiting the consumer's
+      // customLoadHistory) is trying to send on the disposed chat. Its AbortController would be
+      // registered in a map dispose() already cleared, so nothing could ever cancel it.
+      return Promise.resolve();
+    }
     message.history.timestamp = message.history.timestamp || Date.now();
 
     // The messageService does different things based off the message type so lets make sure one exists.
@@ -658,6 +664,42 @@ class MessageService {
         false,
         reason,
       );
+      this.clearCurrentQueueItem();
+    }
+  }
+
+  /**
+   * Aborts any in-flight or queued message requests and drops their AbortControllers. Called from
+   * the service teardown (`ChatActionsImpl.unloadServices`) so a disposed chat leaves no dangling
+   * network requests. Safe to call more than once.
+   */
+  public dispose(): void {
+    // Disarm the loading-manager timers: a host customSendMessage that ignores the AbortSignal
+    // would otherwise leave onMaxAttempt armed to fire a cancellation into the disposed chat.
+    this.messageLoadingManager.end();
+    this.messageAbortControllers.forEach((controller) => {
+      try {
+        controller.abort();
+      } catch {
+        // The controller may already be aborted.
+      }
+    });
+    this.messageAbortControllers.clear();
+    // Mark every pending request processed — the same flag every cancellation path sets — so a
+    // continuation suspended mid-send (awaiting a pre:send handler, or a customSendMessage whose
+    // rejection lands after this abort) exits at its isProcessed guard instead of resuming the
+    // pipeline: dispatching into the disposed store, re-arming the loading timers just disarmed
+    // above, or invoking customSendMessage/config.onError after teardown.
+    // Settle pending send() promises the way cancellation does (resolve, not reject) so consumer
+    // awaits don't hang forever on a disposed chat.
+    this.queue.waiting.forEach((item) => {
+      item.isProcessed = true;
+      item.sendMessagePromise.doResolve();
+    });
+    this.queue.waiting.length = 0;
+    if (this.queue.current) {
+      this.queue.current.isProcessed = true;
+      this.queue.current.sendMessagePromise.doResolve();
       this.clearCurrentQueueItem();
     }
   }

--- a/packages/ai-chat/src/chat/services/ServiceManager.ts
+++ b/packages/ai-chat/src/chat/services/ServiceManager.ts
@@ -154,6 +154,19 @@ class ServiceManager {
   restartCount = 0;
 
   /**
+   * Unsubscribe handles for the store subscriptions registered in `loadServices`. Captured so that
+   * `ChatActionsImpl.unloadServices` can tear them down on disposal; a disposed instance leaves zero
+   * live store listeners.
+   */
+  storeUnsubscribers: Array<() => void> = [];
+
+  /**
+   * Set once this service manager has been disposed via `unloadServices`. Guards against
+   * double-teardown so disposal is idempotent.
+   */
+  disposed = false;
+
+  /**
    * An instance of the custom I18n formatter that can be used for formatting messages. This instance is available
    * both here and through the React IntlProvider that makes it available to components via useIntl() hook.
    * This replaces the previous react-intl IntlShape.

--- a/packages/ai-chat/src/chat/services/haa/HumanAgentService.ts
+++ b/packages/ai-chat/src/chat/services/haa/HumanAgentService.ts
@@ -1,5 +1,5 @@
 /*
- *  Copyright IBM Corp. 2025
+ *  Copyright IBM Corp. 2025, 2026
  *
  *  This source code is licensed under the Apache-2.0 license found in the
  *  LICENSE file in the root directory of this source tree.
@@ -66,12 +66,16 @@ interface HumanAgentService {
    * programmatically from an instance method.
    * @param showHumanAgentLeftMessage Indicates if the chat should show the "agent left" message.
    * @param showAssistantReturnMessage Indicates if the chat should show the "bot return" message.
+   * @param options Optional settings for how the chat is ended.
+   * @param options.forceEnd When true, skips the cancellable pre:endChat event so the chat always
+   * ends. Used by service teardown, where a host listener must not be able to veto the disconnect.
    * @returns Returns a Promise that resolves when the service desk has successfully handled the call.
    */
   endChat(
     endedByUser: boolean,
     showHumanAgentLeftMessage?: boolean,
     showAssistantReturnMessage?: boolean,
+    options?: { forceEnd?: boolean },
   ): Promise<void>;
 
   /**

--- a/packages/ai-chat/src/chat/services/haa/HumanAgentServiceImpl.ts
+++ b/packages/ai-chat/src/chat/services/haa/HumanAgentServiceImpl.ts
@@ -382,12 +382,16 @@ class HumanAgentServiceImpl implements HumanAgentService {
    * programmatically from an instance method.
    * @param showHumanAgentLeftMessage Indicates if the chat should show the "agent left" message.
    * @param showAssistantReturnMessage Indicates if the chat should show the "bot return" message.
+   * @param options Optional settings for how the chat is ended.
+   * @param options.forceEnd When true, skips the cancellable pre:endChat event so the chat always
+   * ends. Used by service teardown, where a host listener must not be able to veto the disconnect.
    * @returns Returns a Promise that resolves when the service desk has successfully handled the call.
    */
   public async endChat(
     endedByUser: boolean,
     showHumanAgentLeftMessage = true,
     showAssistantReturnMessage = true,
+    options: { forceEnd?: boolean } = {},
   ): Promise<void> {
     if (!this.chatStarted || !this.serviceDesk) {
       // Already ended or no service desk.
@@ -396,7 +400,7 @@ class HumanAgentServiceImpl implements HumanAgentService {
 
     const { isConnected } = this.persistedHumanAgentState();
     let event: BusEventHumanAgentPreEndChat;
-    if (isConnected) {
+    if (isConnected && !options.forceEnd) {
       event = await this.firePreEndChat(false);
       if (event.cancelEndChat) {
         return;

--- a/packages/ai-chat/src/chat/services/loadServices.ts
+++ b/packages/ai-chat/src/chat/services/loadServices.ts
@@ -56,27 +56,33 @@ function createServiceManager(appConfig: AppConfig) {
     serviceManager,
     publicConfig,
   );
-  serviceManager.store.subscribe(copyToSessionStorage(serviceManager));
-  serviceManager.store.subscribe(fireStateChangeEvent(serviceManager));
-  // Single post-boot owner of `serviceManager.intl`: rebuild it whenever the
-  // strings or locale change. Boot's `setIntl` below seeds the formatter before
-  // first paint (no dispatch fires during boot, so this subscription can't).
-  serviceManager.store.subscribe(refreshLocalizationOnChange(serviceManager));
+  // Capture every store-subscription handle in `storeUnsubscribers` so `unloadServices` can tear
+  // them down on disposal.
+  serviceManager.storeUnsubscribers.push(
+    serviceManager.store.subscribe(copyToSessionStorage(serviceManager)),
+    serviceManager.store.subscribe(fireStateChangeEvent(serviceManager)),
+    // Single post-boot owner of `serviceManager.intl`: rebuild it whenever the
+    // strings or locale change. Boot's `setIntl` below seeds the formatter before
+    // first paint (no dispatch fires during boot, so this subscription can't).
+    serviceManager.store.subscribe(refreshLocalizationOnChange(serviceManager)),
+  );
 
   // Subscribe to theme changes to start/stop the theme watcher as needed
   let currentOriginalTheme =
     serviceManager.store.getState().config.derived.themeWithDefaults
       .originalCarbonTheme;
 
-  serviceManager.store.subscribe(() => {
-    const newOriginalTheme =
-      serviceManager.store.getState().config.derived.themeWithDefaults
-        .originalCarbonTheme;
-    if (newOriginalTheme !== currentOriginalTheme) {
-      serviceManager.themeWatcherService.onThemeChange(newOriginalTheme);
-      currentOriginalTheme = newOriginalTheme;
-    }
-  });
+  serviceManager.storeUnsubscribers.push(
+    serviceManager.store.subscribe(() => {
+      const newOriginalTheme =
+        serviceManager.store.getState().config.derived.themeWithDefaults
+          .originalCarbonTheme;
+      if (newOriginalTheme !== currentOriginalTheme) {
+        serviceManager.themeWatcherService.onThemeChange(newOriginalTheme);
+        currentOriginalTheme = newOriginalTheme;
+      }
+    }),
+  );
   serviceManager.customPanelManager = createCustomPanelManager(serviceManager);
   serviceManager.themeWatcherService = new ThemeWatcherService(
     serviceManager.store,

--- a/packages/ai-chat/src/types/instance/ChatInstance.ts
+++ b/packages/ai-chat/src/types/instance/ChatInstance.ts
@@ -479,6 +479,19 @@ interface ChatActions {
    * chat is open.
    */
   destroySession: (keepOpenState?: boolean) => Promise<void>;
+
+  /**
+   * Disposes this chat instance and tears down all of its services immediately: the store
+   * subscriptions, the event bus, the theme watcher, any in-flight message requests, and any
+   * active human-agent connection. Call this when the chat is being removed for good. Unlike
+   * {@link ChatInstance.destroySession}, which only clears the current conversation, `destroy`
+   * releases the instance itself; the instance must not be used afterward.
+   *
+   * @example
+   * // Tear the chat down completely when your application removes it for good.
+   * chatInstance.destroy();
+   */
+  destroy: () => void;
 }
 
 /**

--- a/packages/ai-chat/tests/services/spec/MessageService_spec.ts
+++ b/packages/ai-chat/tests/services/spec/MessageService_spec.ts
@@ -289,6 +289,109 @@ describe("MessageService", () => {
     expect((messageService as any).queue.current).toBeNull();
   });
 
+  describe("dispose", () => {
+    it("disarms the loading-manager timers and settles pending sends", async () => {
+      const customSendMessage = jest.fn(
+        () => new Promise<void>(() => undefined), // never resolves, ignores the abort signal
+      );
+      const serviceManager = createServiceManagerStub(customSendMessage);
+      const messageService = new MessageService(serviceManager, {
+        messaging: {
+          customSendMessage,
+          messageTimeoutSecs: 30,
+          messageLoadingIndicatorTimeoutSecs: 0,
+        },
+      } as any);
+
+      const endSpy = jest.spyOn(messageService.messageLoadingManager, "end");
+
+      const currentPromise = resolvablePromise<void>();
+      const waitingPromise = resolvablePromise<void>();
+      (messageService as any).queue.current = {
+        localMessageID: "local-current",
+        message: createMessage("m-current"),
+        sendMessagePromise: currentPromise,
+        requestOptions: {},
+        timeFirstRequest: 0,
+        timeLastRequest: 0,
+        trackData: { numErrors: 0, lastRequestTime: 0, totalRequestTime: 0 },
+        isProcessed: false,
+        source: MessageSendSource.MESSAGE_INPUT,
+        sendMessageController: new AbortController(),
+      };
+      (messageService as any).queue.waiting = [
+        {
+          localMessageID: "local-waiting",
+          message: createMessage("m-waiting"),
+          sendMessagePromise: waitingPromise,
+          requestOptions: {},
+          timeFirstRequest: 0,
+          timeLastRequest: 0,
+          trackData: { numErrors: 0, lastRequestTime: 0, totalRequestTime: 0 },
+          isProcessed: false,
+          source: MessageSendSource.MESSAGE_INPUT,
+          sendMessageController: new AbortController(),
+        },
+      ];
+      const controller = new AbortController();
+      (messageService as any).messageAbortControllers.set(
+        "m-current",
+        controller,
+      );
+
+      const currentItem = (messageService as any).queue.current;
+      const waitingItem = (messageService as any).queue.waiting[0];
+
+      messageService.dispose();
+
+      // Timers cleared (so a stale onMaxAttempt can't fire into the disposed chat), in-flight
+      // requests aborted, queue drained, and both pending send() promises settled.
+      expect(endSpy).toHaveBeenCalled();
+      expect(controller.signal.aborted).toBe(true);
+      expect((messageService as any).queue.current).toBeNull();
+      expect((messageService as any).queue.waiting).toHaveLength(0);
+      await expect(currentPromise).resolves.toBeUndefined();
+      await expect(waitingPromise).resolves.toBeUndefined();
+
+      // Both items are marked processed so a continuation suspended mid-send (awaiting a
+      // pre:send handler, or a customSendMessage rejection landing after this abort) exits at
+      // its isProcessed guard instead of resuming the pipeline on the disposed chat.
+      expect(currentItem.isProcessed).toBe(true);
+      expect(waitingItem.isProcessed).toBe(true);
+    });
+
+    it("refuses to send once the manager is disposed", async () => {
+      const customSendMessage = jest.fn().mockResolvedValue(undefined);
+      const serviceManager = createServiceManagerStub(customSendMessage);
+      const messageService = new MessageService(serviceManager, {
+        messaging: {
+          customSendMessage,
+          messageTimeoutSecs: 0,
+          messageLoadingIndicatorTimeoutSecs: 0,
+        },
+      } as any);
+
+      (serviceManager as any).disposed = true;
+
+      await expect(
+        messageService.send(
+          createMessage("m-after-dispose"),
+          MessageSendSource.MESSAGE_INPUT,
+          "local-after-dispose",
+          { silent: false },
+        ),
+      ).resolves.toBeUndefined();
+
+      // Nothing was queued and no request left for the network — a post-teardown continuation
+      // (e.g. a hydration that was awaiting the consumer's customLoadHistory) cannot register a
+      // new AbortController that dispose() already cleared and could never cancel.
+      expect(customSendMessage).not.toHaveBeenCalled();
+      expect((messageService as any).queue.waiting).toHaveLength(0);
+      expect((messageService as any).queue.current).toBeNull();
+      expect((messageService as any).messageAbortControllers.size).toBe(0);
+    });
+  });
+
   describe("Message cancellation with system messages", () => {
     it("creates system message when cancelling before streaming starts", async () => {
       const customSendMessage = jest.fn().mockImplementation(

--- a/packages/ai-chat/tests/services/spec/humanAgentEndChatForce_spec.ts
+++ b/packages/ai-chat/tests/services/spec/humanAgentEndChatForce_spec.ts
@@ -1,0 +1,61 @@
+/*
+ *  Copyright IBM Corp. 2026
+ *
+ *  This source code is licensed under the Apache-2.0 license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ *  @license
+ */
+
+import createHumanAgentService from "../../../src/chat/services/haa/HumanAgentServiceImpl";
+import { ServiceManager } from "../../../src/chat/services/ServiceManager";
+
+/**
+ * A stub manager whose store reports a live agent connection, enough for endChat to reach the
+ * pre:endChat decision point.
+ */
+const createManagerStub = () =>
+  ({
+    store: {
+      getState: () => ({
+        persistedToBrowserStorage: {
+          humanAgentState: { isConnected: true, isSuspended: false },
+        },
+      }),
+    },
+  }) as unknown as ServiceManager;
+
+/**
+ * Builds a service with a started chat and a stub service desk, with firePreEndChat and doEndChat
+ * spied so the test can assert which path endChat took without a real service-desk connection.
+ */
+const createStartedService = (cancelEndChat: boolean) => {
+  const service = createHumanAgentService(createManagerStub()) as any;
+  service.chatStarted = true;
+  service.serviceDesk = {};
+  service.firePreEndChat = jest.fn().mockResolvedValue({ cancelEndChat });
+  service.doEndChat = jest.fn().mockResolvedValue(undefined);
+  return service;
+};
+
+describe("HumanAgentService.endChat forceEnd", () => {
+  it("honors a pre:endChat veto on the normal path", async () => {
+    const service = createStartedService(true);
+
+    await service.endChat(true, false, false);
+
+    // A listener set cancelEndChat, so the disconnect is vetoed.
+    expect(service.firePreEndChat).toHaveBeenCalledTimes(1);
+    expect(service.doEndChat).not.toHaveBeenCalled();
+  });
+
+  it("skips the cancellable pre:endChat event and always ends when forceEnd is set", async () => {
+    const service = createStartedService(true);
+
+    await service.endChat(true, false, false, { forceEnd: true });
+
+    // Teardown must not be vetoable: the pre event is never fired and the chat ends regardless.
+    expect(service.firePreEndChat).not.toHaveBeenCalled();
+    expect(service.doEndChat).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/ai-chat/tests/services/spec/unloadServices_spec.ts
+++ b/packages/ai-chat/tests/services/spec/unloadServices_spec.ts
@@ -1,0 +1,88 @@
+/*
+ *  Copyright IBM Corp. 2025, 2026
+ *
+ *  This source code is licensed under the Apache-2.0 license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ *  @license
+ */
+
+import {
+  createBaseConfig,
+  renderChatAndGetInstance,
+  renderChatAndGetInstanceWithStore,
+  setupBeforeEach,
+  setupAfterEach,
+} from "../../test_helpers";
+
+describe("ChatInstance.destroy / unloadServices", () => {
+  beforeEach(setupBeforeEach);
+  afterEach(setupAfterEach);
+
+  it("exposes destroy alongside destroySession", async () => {
+    const instance = await renderChatAndGetInstance(createBaseConfig());
+
+    expect(typeof instance.destroy).toBe("function");
+    expect(typeof instance.destroySession).toBe("function");
+  });
+
+  it("tears down every service on destroy", async () => {
+    const { instance, serviceManager } =
+      await renderChatAndGetInstanceWithStore(createBaseConfig());
+
+    const clearBus = jest.spyOn(serviceManager.eventBus, "clear");
+    const stopWatching = jest.spyOn(
+      serviceManager.themeWatcherService,
+      "stopWatching",
+    );
+    const disposeMessages = jest.spyOn(
+      serviceManager.messageService,
+      "dispose",
+    );
+    const clearUpserts = jest.spyOn(
+      serviceManager.messageUpsertCoordinator,
+      "clearAll",
+    );
+
+    instance.destroy();
+
+    expect(clearBus).toHaveBeenCalledTimes(1);
+    expect(stopWatching).toHaveBeenCalledTimes(1);
+    expect(disposeMessages).toHaveBeenCalledTimes(1);
+    expect(clearUpserts).toHaveBeenCalledTimes(1);
+  });
+
+  it("is idempotent — a second destroy tears nothing down again and does not throw", async () => {
+    const { instance, serviceManager } =
+      await renderChatAndGetInstanceWithStore(createBaseConfig());
+
+    const clearBus = jest.spyOn(serviceManager.eventBus, "clear");
+
+    instance.destroy();
+    expect(clearBus).toHaveBeenCalledTimes(1);
+
+    expect(() => instance.destroy()).not.toThrow();
+    expect(clearBus).toHaveBeenCalledTimes(1);
+  });
+
+  it("unsubscribes every captured store subscription on teardown", async () => {
+    const { instance, serviceManager } =
+      await renderChatAndGetInstanceWithStore(createBaseConfig());
+
+    // Boot registers four store subscriptions (copy-to-session-storage, fire-state-change,
+    // refresh-localization, and the theme watcher). The exposed serviceManager shares the same
+    // `storeUnsubscribers` array as the live manager, so mutate it in place to wrap each handle
+    // (reassigning would only swap this copy's reference).
+    const handles = serviceManager.storeUnsubscribers;
+    expect(handles).toHaveLength(4);
+    const wrapped = handles.map((unsubscribe) => jest.fn(unsubscribe));
+    handles.length = 0;
+    handles.push(...wrapped);
+
+    instance.destroy();
+
+    wrapped.forEach((unsubscribe) =>
+      expect(unsubscribe).toHaveBeenCalledTimes(1),
+    );
+  });
+});


### PR DESCRIPTION
Closes #1681

Part of the persist/SDK decomposition epic #1728 (Wave A). Implements the `ChatInstance.destroy()` / `unloadServices()` teardown that the guidance docs already referenced but that didn't exist. `destroy()` disposes the instance entirely — distinct from `destroySession`, which only clears the conversation.

- [`ChatActionsImpl.ts`](packages/ai-chat/src/chat/services/ChatActionsImpl.ts) — the new `unloadServices()` does the teardown (silently force-ends any agent chat, aborts uploads, unsubscribes the store listeners captured in `loadServices`, clears the bus, stops the theme watcher, disposes the message service, drops cross-refs) and is idempotent; plus `disposed` guards after each `await` boundary in the hydrate/welcome/send paths so a continuation that survives teardown can't dispatch into a torn-down store.

In this PR `destroy()` calls `unloadServices()` directly; the later ChatSDK PR re-routes it through `serviceManager.sdk.destroy()` (which adds reuse-registry eviction).

#### Changelog

**New**

- `ChatInstance.destroy(): void` — public API; tears the instance down entirely (store subscriptions, event bus, theme watcher, in-flight requests, active human-agent connection).
- `ChatActionsImpl.unloadServices()` — the disposal path; idempotent, never throws.
- `MessageService.dispose()` — disarms loading-manager timers, aborts in-flight/queued requests, settles pending sends.
- `HumanAgentService.endChat(..., { forceEnd })` — internal option that skips the cancellable `pre:endChat` veto so teardown always ends the chat.

**Changed**

- `ServiceManager` gains `disposed` + `storeUnsubscribers`; `loadServices` captures every store-subscription handle into `storeUnsubscribers`.

#### Testing / Reviewing

- `cd packages/ai-chat && npx jest tests/services/spec/unloadServices_spec.ts tests/services/spec/humanAgentEndChatForce_spec.ts tests/services/spec/MessageService_spec.ts` — 16 passing (destroy exposed, tears down every service, idempotent, unsubscribes all captured subscriptions; `forceEnd` skips the veto; `dispose` disarms timers + settles pending sends).
- `npx tsc --noEmit` — clean (additive public API).
- Not demo-reachable in isolation (lifecycle API).

**Reviewer note (Important, not addressed here):** `unloadServices` decides whether to force-end the agent chat from the store's `isConnecting`/`isConnected` flags. A connect-to-agent suspended inside an async `pre:startChat` handler has `chatStarted` set but those flags still `false`, so a `destroy()` in that narrow window would skip `endChat` and let the resuming `startChat` open a live service-desk socket. Pre-existing behavior in the extracted code; left as a follow-up to keep this PR a faithful extraction. Fix would be to also key the decision off `humanAgentService.chatStarted` (or guard `startChat` after its awaits).
