### PR TITLE
fix: improved no avatar padding

### DIFF
--- a/packages/ai-chat/src/chat/components-legacy/MessageComponent.scss
+++ b/packages/ai-chat/src/chat/components-legacy/MessageComponent.scss
@@ -601,17 +601,16 @@ svg.cds-aichat--sent-file-icon {
   margin-block-start: layout.$spacing-03;
 }
 
-.cds-aichat--message--hide-avatar {
-  .cds-aichat--received.cds-aichat--message-vertical-padding.cds-aichat--received--text,
-  .cds-aichat--received.cds-aichat--message-vertical-padding.cds-aichat--received--options {
-    margin-inline: 0;
-  }
+.cds-aichat--container--render
+  :where(cds-aichat-shell).cds-aichat--wide-width
+  .cds-aichat--message.cds-aichat--message--hide-avatar
+  .cds-aichat--received {
+  margin-inline-start: 1rem;
+}
 
-  .cds-aichat--message__avatar-line {
-    padding-inline: 0;
-
-    .cds-aichat--message__label {
-      padding-inline-start: 0;
-    }
-  }
+.cds-aichat--container--render
+  :where(cds-aichat-shell).cds-aichat--standard-width
+  .cds-aichat--message.cds-aichat--message--hide-avatar
+  .cds-aichat--received {
+  margin-inline-start: 1rem;
 }


### PR DESCRIPTION
Closes #1734 

improves the css selectors for messages when avatars are hidden so that the correct padding is being used

#### Changelog

**Changed**

- `packages/ai-chat/src/chat/components-legacy/MessageComponent.scss` enhanced the no avatar css selectors

#### Testing / Reviewing

visual testing. open the demo - enable `hide avatar` - verify that padding is correct
