### PR TITLE
refactor: remove React from framework-agnostic core modules

### DIFF
--- a/packages/ai-chat/src/chat/AppShell.tsx
+++ b/packages/ai-chat/src/chat/AppShell.tsx
@@ -91,11 +91,9 @@ import {
   ChatWidthBreakpoint,
   PendingUpload,
 } from "../types/state/AppState";
-import {
-  AutoScrollOptions,
-  HasDoAutoScroll,
-} from "../types/utilities/HasDoAutoScroll";
+import { AutoScrollOptions } from "../types/utilities/HasDoAutoScroll";
 import { HasRequestFocus } from "../types/utilities/HasRequestFocus";
+import { MainWindowFunctions } from "./utils/viewHandles.js";
 import { MessageSendSource, BusEventType } from "../types/events/eventBusTypes";
 import { CarbonTheme } from "../types/config/PublicConfig";
 import { FileStatusValue } from "./utils/constants";
@@ -165,25 +163,8 @@ interface AppShellProps extends HasServiceManager {
   writeableElementsPresentKeys?: string;
 }
 
-/**
- * These are the public imperative functions that are available on the MainWindow component. This interface is
- * declared here to avoid taking a dependency on a specific React component implementation elsewhere.
- */
-export interface MainWindowFunctions extends HasRequestFocus, HasDoAutoScroll {
-  /**
-   * Scrolls to the (full) message with the given ID. Since there may be multiple message items in a given
-   * message, this will scroll the first message to the top of the message window.
-   *
-   * @param messageID The (full) message ID to scroll to.
-   * @param animate Whether or not the scroll should be animated. Defaults to true.
-   */
-  doScrollToMessage(messageID: string, animate?: boolean): void;
-
-  /**
-   * Returns the current scrollBottom value for the message scroll panel.
-   */
-  getMessagesScrollBottom(): number;
-}
+// Re-exported from `utils/viewHandles.ts` so existing `AppShell` importers are unaffected.
+export type { MainWindowFunctions };
 
 /**
  * The store-driven application shell. This is the heavy, memoized boundary of

--- a/packages/ai-chat/src/chat/components-legacy/MessageComponent.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/MessageComponent.tsx
@@ -15,7 +15,7 @@ import ReasoningStepComponent from "@carbon/ai-chat-components/es/react/reasonin
 import ReasoningStepsToggle from "@carbon/ai-chat-components/es/react/reasoning-steps-toggle.js";
 import type CDSAIChatReasoningSteps from "@carbon/ai-chat-components/es/components/reasoning-steps/src/reasoning-steps.js";
 import { type ReasoningStepsToggleEventDetail } from "@carbon/ai-chat-components/es/components/reasoning-steps/src/reasoning-steps-toggle.js";
-import { carbonIconToReact } from "../utils/carbonIcon";
+import { carbonIconToReact } from "../utils-react/carbonIcon";
 import Loading from "../components/carbon/Loading";
 import cx from "classnames";
 import React, { KeyboardEvent, PureComponent } from "react";

--- a/packages/ai-chat/src/chat/components-legacy/MessageTypeComponent.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/MessageTypeComponent.tsx
@@ -10,7 +10,7 @@
 /* eslint-disable react/no-array-index-key */
 
 import Attachment16 from "@carbon/icons/es/attachment/16.js";
-import { carbonIconToReact } from "./../utils/carbonIcon";
+import { carbonIconToReact } from "./../utils-react/carbonIcon";
 import React, {
   useCallback,
   useEffect,

--- a/packages/ai-chat/src/chat/components-legacy/MessagesComponent.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/MessagesComponent.tsx
@@ -68,7 +68,7 @@ import { Message } from "../../types/messaging/Messages";
 import { LanguagePack } from "../../types/config/PublicConfig";
 import { CarbonTheme } from "../../types/config/PublicConfig";
 import { ChatShortcutConfig } from "../../types/config/ShortcutConfig";
-import { carbonIconToReact } from "../utils/carbonIcon";
+import { carbonIconToReact } from "../utils-react/carbonIcon";
 
 const DownToBottom = carbonIconToReact(DownToBottom16);
 

--- a/packages/ai-chat/src/chat/components-legacy/ResponseUserAvatar.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/ResponseUserAvatar.tsx
@@ -12,7 +12,7 @@
  */
 
 import UserAvatar32 from "@carbon/icons/es/user--avatar/32.js";
-import { carbonIconToReact } from "../utils/carbonIcon";
+import { carbonIconToReact } from "../utils-react/carbonIcon";
 import React, { useEffect, useLayoutEffect, useRef, useState } from "react";
 
 import { ResponseUserProfile } from "../../types/messaging/Messages";

--- a/packages/ai-chat/src/chat/components-legacy/humanAgent/HumanAgentBanner.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/humanAgent/HumanAgentBanner.tsx
@@ -8,7 +8,7 @@
  */
 
 import ScreenOff16 from "@carbon/icons/es/screen--off/16.js";
-import { carbonIconToReact } from "../../utils/carbonIcon";
+import { carbonIconToReact } from "../../utils-react/carbonIcon";
 import Button, { BUTTON_KIND } from "../../components/carbon/Button";
 import CDSButton from "@carbon/web-components/es/components/button/button.js";
 import cx from "classnames";

--- a/packages/ai-chat/src/chat/components-legacy/input/Input.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/input/Input.tsx
@@ -10,11 +10,12 @@
 import Button from "../../components/carbon/Button";
 import Send16 from "@carbon/icons/es/send/16.js";
 import SendFilled16 from "@carbon/icons/es/send--filled/16.js";
-import { carbonIconToReact } from "../../utils/carbonIcon";
+import { carbonIconToReact } from "../../utils-react/carbonIcon";
 import Attachment16 from "@carbon/icons/es/attachment/16.js";
 import { matchesShortcut } from "../../utils/keyboardUtils";
 import { getDeepActiveElement } from "../../utils/domUtils";
 import { DEFAULT_MESSAGE_FOCUS_TOGGLE_SHORTCUT } from "../../../types/config/ShortcutConfig";
+import type { InputFunctions } from "../../utils/viewHandles.js";
 import FileUploaderItem, {
   FILE_UPLOADER_ITEM_SIZE,
 } from "../../components/carbon/FileUploaderItem";
@@ -179,28 +180,6 @@ interface InputProps extends HasServiceManager {
    * When enabled, the component will publish raw/display values to the store and respond to external updates.
    */
   trackInputState?: boolean;
-}
-
-interface InputFunctions {
-  /**
-   * Instructs the text area to take focus.
-   * @deprecated Use requestFocus() instead for consistency with focus management pattern
-   */
-  takeFocus: () => void;
-
-  /**
-   * Requests focus on the input field.
-   * Follows the generic focus management pattern for web components.
-   * @returns {boolean} True if focus was successfully set, false otherwise
-   */
-  requestFocus: () => boolean;
-
-  /**
-   * Returns true if the input field currently has focus.
-   * Encapsulates internal focus detection logic.
-   * @returns {boolean} True if the input field has focus
-   */
-  hasFocus: () => boolean;
 }
 
 function Input(props: InputProps, ref: Ref<InputFunctions>) {
@@ -744,4 +723,5 @@ function Input(props: InputProps, ref: Ref<InputFunctions>) {
 }
 
 const InputExport = React.memo(forwardRef(Input));
-export { InputExport as Input, InputFunctions };
+export { InputExport as Input };
+export type { InputFunctions };

--- a/packages/ai-chat/src/chat/components-legacy/launcher/Launcher.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/launcher/Launcher.tsx
@@ -1,5 +1,5 @@
 /*
- *  Copyright IBM Corp. 2025
+ *  Copyright IBM Corp. 2025, 2026
  *
  *  This source code is licensed under the Apache-2.0 license found in the
  *  LICENSE file in the root directory of this source tree.
@@ -11,7 +11,7 @@ import CDSButton from "@carbon/web-components/es/components/button/button.js";
 import AiLaunch24 from "@carbon/icons/es/ai-launch/24.js";
 import ChatLaunch24 from "@carbon/icons/es/chat--launch/24.js";
 import Close16 from "@carbon/icons/es/close/16.js";
-import { carbonIconToReact } from "../../utils/carbonIcon";
+import { carbonIconToReact } from "../../utils-react/carbonIcon";
 import cx from "classnames";
 import React, {
   RefObject,

--- a/packages/ai-chat/src/chat/components-legacy/responseTypes/buttonItem/ButtonItemCustomEventComponent.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/responseTypes/buttonItem/ButtonItemCustomEventComponent.tsx
@@ -8,7 +8,7 @@
  */
 
 import TouchInteraction16 from "@carbon/icons/es/touch--interaction/16.js";
-import { carbonIconToReact } from "../../../utils/carbonIcon";
+import { carbonIconToReact } from "../../../utils-react/carbonIcon";
 import React, { useCallback } from "react";
 import { useSelector } from "../../../hooks/useSelector";
 

--- a/packages/ai-chat/src/chat/components-legacy/responseTypes/buttonItem/ButtonItemPostBackComponent.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/responseTypes/buttonItem/ButtonItemPostBackComponent.tsx
@@ -8,7 +8,7 @@
  */
 
 import Send16 from "@carbon/icons/es/send/16.js";
-import { carbonIconToReact } from "../../../utils/carbonIcon";
+import { carbonIconToReact } from "../../../utils-react/carbonIcon";
 import React, { useCallback } from "react";
 import { useSelector } from "../../../hooks/useSelector";
 

--- a/packages/ai-chat/src/chat/components-legacy/responseTypes/buttonItem/ButtonItemShowPanelComponent.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/responseTypes/buttonItem/ButtonItemShowPanelComponent.tsx
@@ -8,7 +8,7 @@
  */
 
 import ArrowRight16 from "@carbon/icons/es/arrow--right/16.js";
-import { carbonIconToReact } from "../../../utils/carbonIcon";
+import { carbonIconToReact } from "../../../utils-react/carbonIcon";
 import React, { useCallback } from "react";
 import { useSelector } from "../../../hooks/useSelector";
 

--- a/packages/ai-chat/src/chat/components-legacy/responseTypes/buttonItem/ButtonItemURLComponent.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/responseTypes/buttonItem/ButtonItemURLComponent.tsx
@@ -1,5 +1,5 @@
 /*
- *  Copyright IBM Corp. 2025
+ *  Copyright IBM Corp. 2025, 2026
  *
  *  This source code is licensed under the Apache-2.0 license found in the
  *  LICENSE file in the root directory of this source tree.
@@ -9,7 +9,7 @@
 
 import Launch16 from "@carbon/icons/es/launch/16.js";
 import Link from "../../../components/carbon/Link";
-import { carbonIconToReact } from "../../../utils/carbonIcon";
+import { carbonIconToReact } from "../../../utils-react/carbonIcon";
 import React from "react";
 
 import { LocalMessageItem } from "../../../../types/messaging/LocalMessageItem";

--- a/packages/ai-chat/src/chat/components-legacy/responseTypes/conversationalSearch/ConversationalSearchText.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/responseTypes/conversationalSearch/ConversationalSearchText.tsx
@@ -24,7 +24,7 @@ import { useSelector } from "../../../hooks/useSelector";
 import { useServiceManager } from "../../../hooks/useServiceManager";
 import { shallowEqual } from "../../../store/appStore";
 import OperationalTag from "../../../components/carbon/OperationalTag";
-import { carbonIconToReact } from "../../../utils/carbonIcon";
+import { carbonIconToReact } from "../../../utils-react/carbonIcon";
 
 const ChevronDown = carbonIconToReact(ChevronDown16);
 const ChevronUp = carbonIconToReact(ChevronUp16);

--- a/packages/ai-chat/src/chat/components-legacy/responseTypes/datePicker/DatePickerComponent.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/responseTypes/datePicker/DatePickerComponent.tsx
@@ -1,5 +1,5 @@
 /*
- *  Copyright IBM Corp. 2025
+ *  Copyright IBM Corp. 2025, 2026
  *
  *  This source code is licensed under the Apache-2.0 license found in the
  *  LICENSE file in the root directory of this source tree.
@@ -8,7 +8,7 @@
  */
 
 import Checkmark32 from "@carbon/icons/es/checkmark/32.js";
-import { carbonIconToReact } from "../../../utils/carbonIcon";
+import { carbonIconToReact } from "../../../utils-react/carbonIcon";
 import Button from "../../../components/carbon/Button";
 import {
   DatePickerInput,

--- a/packages/ai-chat/src/chat/components-legacy/responseTypes/humanAgent/RealConnectToHumanAgent.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/responseTypes/humanAgent/RealConnectToHumanAgent.tsx
@@ -11,7 +11,7 @@ import Checkmark16 from "@carbon/icons/es/checkmark/16.js";
 import Headset16 from "@carbon/icons/es/headset/16.js";
 import HelpDesk16 from "@carbon/icons/es/help-desk/16.js";
 import Logout16 from "@carbon/icons/es/logout/16.js";
-import { carbonIconToReact } from "../../../utils/carbonIcon";
+import { carbonIconToReact } from "../../../utils-react/carbonIcon";
 import Card from "@carbon/ai-chat-components/es/react/card.js";
 import Button from "../../../components/carbon/Button";
 import React, { ReactNode, useState } from "react";

--- a/packages/ai-chat/src/chat/components-legacy/responseTypes/iframe/IFramePreviewCard.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/responseTypes/iframe/IFramePreviewCard.tsx
@@ -8,7 +8,7 @@
  */
 
 import ArrowRight16 from "@carbon/icons/es/arrow--right/16.js";
-import { carbonIconToReact } from "../../../utils/carbonIcon";
+import { carbonIconToReact } from "../../../utils-react/carbonIcon";
 import React from "react";
 import { useIntl } from "../../../hooks/useIntl";
 import { useSelector } from "../../../hooks/useSelector";

--- a/packages/ai-chat/src/chat/components-legacy/responseTypes/util/TranscriptComponent.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/responseTypes/util/TranscriptComponent.tsx
@@ -9,7 +9,7 @@
 
 import ChevronDown16 from "@carbon/icons/es/chevron--down/16.js";
 import ChevronUp16 from "@carbon/icons/es/chevron--up/16.js";
-import { carbonIconToReact } from "../../../utils/carbonIcon";
+import { carbonIconToReact } from "../../../utils-react/carbonIcon";
 import React, { useState } from "react";
 import cx from "classnames";
 import { useSelector } from "../../../hooks/useSelector";

--- a/packages/ai-chat/src/chat/components-legacy/responseTypes/util/citations/CitationCardContent.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/responseTypes/util/citations/CitationCardContent.tsx
@@ -9,7 +9,7 @@
 
 import Link16 from "@carbon/icons/es/link/16.js";
 import Maximize16 from "@carbon/icons/es/maximize/16.js";
-import { carbonIconToReact } from "../../../../utils/carbonIcon";
+import { carbonIconToReact } from "../../../../utils-react/carbonIcon";
 import React, { useLayoutEffect, useRef } from "react";
 
 import { useSelector } from "../../../../hooks/useSelector";

--- a/packages/ai-chat/src/chat/components/homeScreen/HomeScreen.tsx
+++ b/packages/ai-chat/src/chat/components/homeScreen/HomeScreen.tsx
@@ -12,7 +12,7 @@ import ChatButton, {
   CHAT_BUTTON_SIZE,
 } from "@carbon/ai-chat-components/es/react/chat-button.js";
 import ArrowRight16 from "@carbon/icons/es/arrow--right/16.js";
-import { carbonIconToReact } from "../../utils/carbonIcon";
+import { carbonIconToReact } from "../../utils-react/carbonIcon";
 import cx from "classnames";
 import React from "react";
 import { useSelector } from "../../hooks/useSelector";

--- a/packages/ai-chat/src/chat/components/panels/CatastrophicErrorPanel.tsx
+++ b/packages/ai-chat/src/chat/components/panels/CatastrophicErrorPanel.tsx
@@ -18,7 +18,7 @@ import ChatButton, {
 import { ErrorMessage } from "../../components-legacy/ErrorMessage";
 import { MarkdownWithDefaults } from "../util/MarkdownWithDefaults";
 import { useCarbonTheme } from "../../hooks/useCarbonTheme";
-import { carbonIconToReact } from "../../utils/carbonIcon";
+import { carbonIconToReact } from "../../utils-react/carbonIcon";
 import { LanguagePack } from "../../../types/config/PublicConfig";
 import { AppState } from "../../../types/state/AppState";
 import { useIntl } from "../../hooks/useIntl";

--- a/packages/ai-chat/src/chat/components/panels/PanelHeader.tsx
+++ b/packages/ai-chat/src/chat/components/panels/PanelHeader.tsx
@@ -17,7 +17,7 @@ import IconButton from "../carbon/IconButton";
 import { BUTTON_KIND } from "@carbon/web-components/es/components/button/defs.js";
 import { MarkdownWithDefaults } from "../util/MarkdownWithDefaults";
 import { isDirectionRTL } from "../../utils/domUtils";
-import { carbonIconToReact } from "../../utils/carbonIcon";
+import { carbonIconToReact } from "../../utils-react/carbonIcon";
 
 const ChevronDown = carbonIconToReact(ChevronDown16);
 const ChevronLeft = carbonIconToReact(ChevronLeft16);

--- a/packages/ai-chat/src/chat/components/util/ErrorIcon.tsx
+++ b/packages/ai-chat/src/chat/components/util/ErrorIcon.tsx
@@ -8,7 +8,7 @@
  */
 
 import ErrorFilled16 from "@carbon/icons/es/error--filled/16.js";
-import { carbonIconToReact } from "../../utils/carbonIcon";
+import { carbonIconToReact } from "../../utils-react/carbonIcon";
 import cx from "classnames";
 import React from "react";
 

--- a/packages/ai-chat/src/chat/contexts/AriaAnnouncerContext.ts
+++ b/packages/ai-chat/src/chat/contexts/AriaAnnouncerContext.ts
@@ -1,5 +1,5 @@
 /*
- *  Copyright IBM Corp. 2025
+ *  Copyright IBM Corp. 2025, 2026
  *
  *  This source code is licensed under the Apache-2.0 license found in the
  *  LICENSE file in the root directory of this source tree.
@@ -9,23 +9,16 @@
 
 import React from "react";
 
-import { AnnounceMessage } from "../../types/state/AppState";
+import type { AriaAnnouncerFunctionType } from "../utils/viewHandles.js";
 
 /**
  * This file contains the instance of the {@link AriaAnnouncerContext} which is used to provide access to the
- * {@link AriaAnnouncerProvider}.
+ * {@link AriaAnnouncerProvider}. `AriaAnnouncerFunctionType` is declared in the framework-neutral
+ * `utils/viewHandles.ts` and re-exported here so existing importers are unaffected.
  */
-
-/**
- * This is the function that will be used to trigger an announcement of a given value.
- *
- * @see AriaAnnouncerProvider
- */
-type AriaAnnouncerFunctionType = (
-  value: Node | AnnounceMessage | string,
-) => void;
 
 const AriaAnnouncerContext =
   React.createContext<AriaAnnouncerFunctionType>(null);
 
-export { AriaAnnouncerContext, AriaAnnouncerFunctionType };
+export { AriaAnnouncerContext };
+export type { AriaAnnouncerFunctionType };

--- a/packages/ai-chat/src/chat/services/ServiceManager.ts
+++ b/packages/ai-chat/src/chat/services/ServiceManager.ts
@@ -9,7 +9,11 @@
 
 import type { AppStore } from "../store/appStore";
 import { IntlShape } from "../utils/i18n";
-import { AriaAnnouncerFunctionType } from "../contexts/AriaAnnouncerContext";
+import {
+  AriaAnnouncerFunctionType,
+  InputFunctions,
+  MainWindowFunctions,
+} from "../utils/viewHandles.js";
 
 import { EventBus } from "../events/EventBus";
 import { AppState } from "../../types/state/AppState";
@@ -26,10 +30,8 @@ import {
   WriteableElements,
 } from "../../types/instance/ChatInstance";
 import { BusEvent } from "../../types/events/eventBusTypes";
-import { MainWindowFunctions } from "../AppShell";
 import { ChatActionsImpl } from "./ChatActionsImpl";
 import { HasRequestFocus } from "../../types/utilities/HasRequestFocus";
-import type { InputFunctions } from "../components-legacy/input/Input";
 
 export interface UserDefinedElementRegistryItem {
   slotName: string;

--- a/packages/ai-chat/src/chat/utils-react/carbonIcon.ts
+++ b/packages/ai-chat/src/chat/utils-react/carbonIcon.ts
@@ -1,5 +1,5 @@
 /*
- *  Copyright IBM Corp. 2025
+ *  Copyright IBM Corp. 2025, 2026
  *
  *  This source code is licensed under the Apache-2.0 license found in the
  *  LICENSE file in the root directory of this source tree.

--- a/packages/ai-chat/src/chat/utils/domUtils.ts
+++ b/packages/ai-chat/src/chat/utils/domUtils.ts
@@ -1,5 +1,5 @@
 /*
- *  Copyright IBM Corp. 2025
+ *  Copyright IBM Corp. 2025, 2026
  *
  *  This source code is licensed under the Apache-2.0 license found in the
  *  LICENSE file in the root directory of this source tree.
@@ -9,9 +9,29 @@
 
 import { compute } from "compute-scroll-into-view";
 import { memoizeFunction } from "./memoizerUtils";
-import { KeyboardEvent as ReactKeyboardEvent, RefObject } from "react";
 import { tabbable } from "tabbable";
 import { setVarsForSelector } from "@carbon/ai-chat-components/es/components/shared/dynamic-css-var-sheet.js";
+
+/**
+ * A minimal ref shape — structurally identical to React's `RefObject<HTMLElement | null>` for the
+ * fields `doFocusRef` reads. Declared here so this util stays free of a React import.
+ */
+interface ElementRef {
+  current: HTMLElement | null;
+}
+
+/**
+ * The subset of a keyboard event read by {@link isEnterKey} / {@link hasModifiers}. Both the DOM
+ * `KeyboardEvent` and React's synthetic keyboard event satisfy this, so callers pass either.
+ */
+interface StructuralKeyboardEvent {
+  key: string;
+  keyCode: number;
+  shiftKey: boolean;
+  altKey: boolean;
+  metaKey: boolean;
+  ctrlKey: boolean;
+}
 
 let scrollbarMeasureRuleInstalled = false;
 
@@ -140,11 +160,7 @@ function doFocus(element: HTMLElement | SVGElement, preventScroll = false) {
  * @param defer Indicates if the focus should be executed now or if it should be deferred to another event loop.
  * @param preventScroll Indicates if scrolling should be prevented as a result of the focus change.
  */
-function doFocusRef(
-  ref: RefObject<HTMLElement | null>,
-  defer = false,
-  preventScroll = false,
-) {
+function doFocusRef(ref: ElementRef, defer = false, preventScroll = false) {
   if (ref) {
     if (defer) {
       setTimeout(() => {
@@ -231,7 +247,7 @@ function focusOnFirstFocusableElement(parentElement: HTMLElement) {
  * time. This function supports both the built-in typescript KeyboardEvent type and the React version (which is
  * missing some properties).
  */
-function isEnterKey(event: ReactKeyboardEvent | KeyboardEvent) {
+function isEnterKey(event: StructuralKeyboardEvent | KeyboardEvent) {
   if (event.key === "Enter" && !hasModifiers(event)) {
     // Users using IMEs could be making a word selection when they hit enter. This check will prevent the user’s
     // message from being sent prematurely.
@@ -243,7 +259,7 @@ function isEnterKey(event: ReactKeyboardEvent | KeyboardEvent) {
 /**
  * Determines if the given keyboard event has any modifier keys pressed.
  */
-function hasModifiers(event: ReactKeyboardEvent | KeyboardEvent) {
+function hasModifiers(event: StructuralKeyboardEvent | KeyboardEvent) {
   return event.shiftKey || event.altKey || event.metaKey || event.ctrlKey;
 }
 

--- a/packages/ai-chat/src/chat/utils/miscUtils.ts
+++ b/packages/ai-chat/src/chat/utils/miscUtils.ts
@@ -1,5 +1,5 @@
 /*
- *  Copyright IBM Corp. 2025
+ *  Copyright IBM Corp. 2025, 2026
  *
  *  This source code is licensed under the Apache-2.0 license found in the
  *  LICENSE file in the root directory of this source tree.
@@ -11,12 +11,19 @@
  * Miscellaneous utilities that don't fit anywhere else.
  */
 
-import { ErrorInfo } from "react";
-
 import { FileUpload } from "../../types/config/ServiceDeskConfig";
 import { FileStatusValue, WA_CONSOLE_PREFIX } from "./constants";
 import { resolveOrTimeout } from "./lang/promiseUtils";
 import { OnErrorData, OnErrorType } from "../../types/config/PublicConfig";
+
+/**
+ * The subset of React's `ErrorInfo` that {@link createDidCatchErrorData} actually reads. Declared
+ * structurally so this util stays free of a React import; React's `ErrorInfo` is assignable to it,
+ * so error-boundary callers pass through unchanged.
+ */
+interface RenderErrorInfo {
+  componentStack?: string | null;
+}
 
 /**
  * A global flag to indicate if we want to show debug messages in the browser console. This is generally set from
@@ -106,7 +113,7 @@ async function safeFetchTextWithTimeout(response: Response): Promise<string> {
 function createDidCatchErrorData(
   component: string,
   error: Error,
-  errorInfo: ErrorInfo,
+  errorInfo: RenderErrorInfo,
   isCatastrophicError?: boolean,
 ): OnErrorData {
   return {

--- a/packages/ai-chat/src/chat/utils/viewHandles.ts
+++ b/packages/ai-chat/src/chat/utils/viewHandles.ts
@@ -1,0 +1,74 @@
+/*
+ *  Copyright IBM Corp. 2025, 2026
+ *
+ *  This source code is licensed under the Apache-2.0 license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ *  @license
+ */
+
+/**
+ * Framework-neutral view-handle interfaces referenced by the core (`ServiceManager`) but
+ * implemented by the view layer. Kept in `utils/` (which the SDK core may import) so the non-view
+ * core does not depend on view modules (`AppShell`, `components-legacy/`, `contexts/`); those view
+ * files re-export these so their public import shape is unchanged.
+ */
+
+import { HasDoAutoScroll } from "../../types/utilities/HasDoAutoScroll";
+import { HasRequestFocus } from "../../types/utilities/HasRequestFocus";
+import { AnnounceMessage } from "../../types/state/AppState";
+
+/**
+ * These are the public imperative functions that are available on the MainWindow component. This
+ * interface is declared here to avoid taking a dependency on a specific React component
+ * implementation elsewhere.
+ */
+export interface MainWindowFunctions extends HasRequestFocus, HasDoAutoScroll {
+  /**
+   * Scrolls to the (full) message with the given ID. Since there may be multiple message items in a given
+   * message, this will scroll the first message to the top of the message window.
+   *
+   * @param messageID The (full) message ID to scroll to.
+   * @param animate Whether or not the scroll should be animated. Defaults to true.
+   */
+  doScrollToMessage(messageID: string, animate?: boolean): void;
+
+  /**
+   * Returns the current scrollBottom value for the message scroll panel.
+   */
+  getMessagesScrollBottom(): number;
+}
+
+/**
+ * The public imperative functions exposed on the Input component.
+ */
+export interface InputFunctions {
+  /**
+   * Instructs the text area to take focus.
+   * @deprecated Use requestFocus() instead for consistency with focus management pattern
+   */
+  takeFocus: () => void;
+
+  /**
+   * Requests focus on the input field.
+   * Follows the generic focus management pattern for web components.
+   * @returns {boolean} True if focus was successfully set, false otherwise
+   */
+  requestFocus: () => boolean;
+
+  /**
+   * Returns true if the input field currently has focus.
+   * Encapsulates internal focus detection logic.
+   * @returns {boolean} True if the input field has focus
+   */
+  hasFocus: () => boolean;
+}
+
+/**
+ * The function used to trigger a screen-reader announcement of a given value.
+ *
+ * @see AriaAnnouncerProvider
+ */
+export type AriaAnnouncerFunctionType = (
+  value: Node | AnnounceMessage | string,
+) => void;

--- a/packages/ai-chat/src/types/messaging/Messages.ts
+++ b/packages/ai-chat/src/types/messaging/Messages.ts
@@ -18,12 +18,10 @@ import { HumanAgentsOnlineStatus } from "../config/ServiceDeskConfig";
 import { FileStatusValue } from "../config/ServiceDeskConfig";
 import {
   BUTTON_KIND,
+  BUTTON_KIND as CHAT_BUTTON_KIND,
   BUTTON_SIZE,
 } from "@carbon/web-components/es/components/button/defs.js";
-import {
-  CHAT_BUTTON_KIND,
-  CHAT_BUTTON_SIZE,
-} from "@carbon/ai-chat-components/es/react/chat-button.js";
+import { CHAT_BUTTON_SIZE } from "@carbon/ai-chat-components/es/components/chat-button/defs.js";
 import { ChainOfThoughtStepStatus } from "@carbon/ai-chat-components/es/components/chain-of-thought/defs.js";
 import { WorkspaceCustomPanelConfigOptions } from "../instance/apiTypes";
 
@@ -652,7 +650,9 @@ export enum HumanAgentMessageType {
  * @category Messaging
  */
 export type Message =
-  MessageRequest<MessageInput> | MessageRequest<EventInput> | MessageResponse;
+  | MessageRequest<MessageInput>
+  | MessageRequest<EventInput>
+  | MessageResponse;
 
 /**
  * @category Messaging

--- a/packages/ai-chat/tests/utils/spec/carbonIcon_spec.ts
+++ b/packages/ai-chat/tests/utils/spec/carbonIcon_spec.ts
@@ -1,5 +1,5 @@
 /*
- *  Copyright IBM Corp. 2025
+ *  Copyright IBM Corp. 2025, 2026
  *
  *  This source code is licensed under the Apache-2.0 license found in the
  *  LICENSE file in the root directory of this source tree.
@@ -9,7 +9,7 @@
 
 import { render } from "@testing-library/react";
 import { createElement } from "react";
-import { carbonIconToReact } from "../../../src/chat/utils/carbonIcon";
+import { carbonIconToReact } from "../../../src/chat/utils-react/carbonIcon";
 
 const mockIcon = {
   elem: "svg" as const,


### PR DESCRIPTION
Closes #1731

Part of the persist/SDK decomposition epic #1728 (Wave A). Mechanical decoupling of React from the framework-agnostic, core-reachable modules — the groundwork for the SDK boundary. No runtime behavior change. The ESLint fence + AGENTS.md note + import-graph guard that _enforce_ the boundary land with the `sdk/` core in #1732.

- Moves `carbonIcon` (a React helper) out of `utils/` into `utils-react/` so core-reachable code can import `utils/` without pulling in React; updates all ~20 importers.
- `domUtils`/`miscUtils` drop their `react` imports in favor of structural interfaces (`ElementRef`, `StructuralKeyboardEvent`, `RenderErrorInfo`).
- Extracts `MainWindowFunctions`/`InputFunctions`/`AriaAnnouncerFunctionType` into `utils/viewHandles.ts`, re-exported from `AppShell`/`Input`/`AriaAnnouncerContext` (import shapes unchanged); `ServiceManager` imports them from there instead of the view modules.
- `Messages.ts` imports the chat-button enums from the import-free `defs.js` instead of the React barrel (same enum values).

#### Changelog

**Changed**

- `carbonIcon` moved `utils/` → `utils-react/`; all importers updated.
- `domUtils`/`miscUtils` no longer import React (structural types).
- `Messages.ts` button enums imported from `defs.js`, off the React barrel.

**New**

- `utils/viewHandles.ts` — framework-neutral `MainWindowFunctions` / `InputFunctions` / `AriaAnnouncerFunctionType`, re-exported from their former homes so existing importers are unaffected.

#### Testing / Reviewing

- `cd packages/ai-chat && npx tsc --noEmit` — clean (all import-path swaps resolve).
- `npx jest tests/utils/spec/carbonIcon_spec.ts` — passes.
- `npm run build --workspace=@carbon/ai-chat` — passes (rollup + TypeDoc link validation).
- Pure refactor — no behavior change; nothing demo-specific to exercise.
