### PR TITLE
feat: add framework-agnostic slot-state value stores

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -41271,9 +41271,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
-      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.10.0.tgz",
+      "integrity": "sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"

--- a/package.json
+++ b/package.json
@@ -236,6 +236,7 @@
     "@carbon/ai-chat": "^0.0.0"
   },
   "overrides": {
-    "tar": "^7.5.10"
+    "tar": "^7.5.10",
+    "shell-quote": "^1.10.0"
   }
 }

--- a/packages/ai-chat/src/chat/sdk/slotStates.ts
+++ b/packages/ai-chat/src/chat/sdk/slotStates.ts
@@ -1,0 +1,135 @@
+/*
+ *  Copyright IBM Corp. 2025, 2026
+ *
+ *  This source code is licensed under the Apache-2.0 license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ *  @license
+ */
+
+import type { ServiceManager } from "../services/ServiceManager";
+import { createValueStore, ReadableValueStore, ValueStore } from "./valueStore";
+import {
+  BusEventChunkUserDefinedResponse,
+  BusEventCustomFooterSlot,
+  BusEventType,
+  BusEventUserDefinedResponse,
+} from "../../types/events/eventBusTypes";
+import {
+  RenderCustomMessageFooterState,
+  RenderUserDefinedState,
+} from "../../types/component/slotStates";
+
+/**
+ * Framework-agnostic slot-projection state for the two portal surfaces (user-defined responses and
+ * custom message footers), keyed by slot. The core owns these value stores and reduces the relevant
+ * bus events into them; the React (and, later, Lit) view layer subscribes for rendering. Because
+ * the stores hang off the {@link ServiceManager}, the accumulated state survives a host remount —
+ * a remounting subscriber reads the current value on first `get()`, no setter repointing required.
+ */
+export interface ChatSlotStates {
+  /** User-defined-response state by slot, reduced from the USER_DEFINED_RESPONSE event family. */
+  userDefinedBySlot: ReadableValueStore<Record<string, RenderUserDefinedState>>;
+  /** Custom-message-footer state by slot, reduced from the CUSTOM_FOOTER_SLOT event. */
+  customFooterBySlot: ReadableValueStore<
+    Record<string, RenderCustomMessageFooterState>
+  >;
+}
+
+/**
+ * Registers the USER_DEFINED_RESPONSE / CHUNK_USER_DEFINED_RESPONSE / CUSTOM_FOOTER_SLOT /
+ * RESTART_CONVERSATION handlers on the instance's event bus (once, idempotently) and reduces them
+ * into two {@link ValueStore}s. Called during boot so events fired before the view subscribes are
+ * still captured. On a re-call for a manager that already has `slotStates`, returns the existing
+ * stores without re-registering handlers.
+ */
+export function attachSlotStateTracking(
+  serviceManager: ServiceManager,
+): ChatSlotStates {
+  if (serviceManager.slotStates) {
+    return serviceManager.slotStates;
+  }
+
+  const userDefinedBySlot: ValueStore<Record<string, RenderUserDefinedState>> =
+    createValueStore({});
+  const customFooterBySlot: ValueStore<
+    Record<string, RenderCustomMessageFooterState>
+  > = createValueStore({});
+
+  function userDefinedResponseHandler(event: BusEventUserDefinedResponse) {
+    userDefinedBySlot.set((bySlot) => ({
+      ...bySlot,
+      [event.data.slot]: {
+        fullMessage: event.data.fullMessage,
+        messageItem: event.data.message,
+        state: event.data.state,
+      },
+    }));
+  }
+
+  function userDefinedChunkHandler(event: BusEventChunkUserDefinedResponse) {
+    if ("complete_item" in event.data.chunk) {
+      const messageItem = event.data.chunk.complete_item;
+      userDefinedBySlot.set((bySlot) => ({
+        ...bySlot,
+        [event.data.slot]: {
+          messageItem,
+        },
+      }));
+    } else if ("partial_item" in event.data.chunk) {
+      const itemChunk = event.data.chunk.partial_item;
+      userDefinedBySlot.set((bySlot) => ({
+        ...bySlot,
+        [event.data.slot]: {
+          partialItems: [
+            ...(bySlot[event.data.slot]?.partialItems || []),
+            itemChunk,
+          ],
+        },
+      }));
+    }
+  }
+
+  function customFooterSlotHandler(event: BusEventCustomFooterSlot) {
+    customFooterBySlot.set((bySlot) => ({
+      ...bySlot,
+      [event.data.slotName]: {
+        slotName: event.data.slotName,
+        message: event.data.message,
+        messageItem: event.data.messageItem,
+        additionalData: event.data.additionalData as
+          | Record<string, unknown>
+          | undefined,
+      },
+    }));
+  }
+
+  function restartHandler() {
+    userDefinedBySlot.set({});
+    customFooterBySlot.set({});
+  }
+
+  serviceManager.instance.on({
+    type: BusEventType.CHUNK_USER_DEFINED_RESPONSE,
+    handler: userDefinedChunkHandler,
+  });
+  serviceManager.instance.on({
+    type: BusEventType.USER_DEFINED_RESPONSE,
+    handler: userDefinedResponseHandler,
+  });
+  serviceManager.instance.on({
+    type: BusEventType.CUSTOM_FOOTER_SLOT,
+    handler: customFooterSlotHandler,
+  });
+  serviceManager.instance.on({
+    type: BusEventType.RESTART_CONVERSATION,
+    handler: restartHandler,
+  });
+
+  const slotStates: ChatSlotStates = {
+    userDefinedBySlot,
+    customFooterBySlot,
+  };
+  serviceManager.slotStates = slotStates;
+  return slotStates;
+}

--- a/packages/ai-chat/src/chat/sdk/valueStore.ts
+++ b/packages/ai-chat/src/chat/sdk/valueStore.ts
@@ -1,0 +1,64 @@
+/*
+ *  Copyright IBM Corp. 2025, 2026
+ *
+ *  This source code is licensed under the Apache-2.0 license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ *  @license
+ */
+
+/**
+ * A framework-agnostic, value-holding subscribable. Unlike the app store (which notifies every
+ * listener on any dispatch), a value store notifies only its own subscribers and only when its
+ * value actually changes. A remounting subscriber gets the current value for free on its first
+ * `get()`, so host-projection state (slot portals) survives a remount without setter repointing.
+ *
+ * The `get`/`subscribe` pair is `useSyncExternalStore`-compatible: `subscribe(listener)` registers
+ * a change callback and returns an unsubscribe; `get()` returns the current snapshot.
+ */
+export interface ReadableValueStore<T> {
+  /** Returns the current value. */
+  get(): T;
+  /** Registers a change listener; returns an unsubscribe function. */
+  subscribe(listener: () => void): () => void;
+}
+
+/**
+ * A {@link ReadableValueStore} that can also be written. `set` accepts a next value or an updater
+ * that receives the previous value; a value equal (`Object.is`) to the current one is a no-op and
+ * does not notify.
+ */
+export interface ValueStore<T> extends ReadableValueStore<T> {
+  /** Replaces the value (or derives it from the previous value); notifies on a real change. */
+  set(next: T | ((previous: T) => T)): void;
+}
+
+/**
+ * Creates a {@link ValueStore} seeded with `initial`. Backed by a `Set` of listeners; `set` skips
+ * notification when the next value is `Object.is`-equal to the current one.
+ */
+export function createValueStore<T>(initial: T): ValueStore<T> {
+  let value = initial;
+  const listeners = new Set<() => void>();
+
+  return {
+    get(): T {
+      return value;
+    },
+    subscribe(listener: () => void): () => void {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+    set(next: T | ((previous: T) => T)): void {
+      const nextValue =
+        typeof next === "function" ? (next as (previous: T) => T)(value) : next;
+      if (Object.is(nextValue, value)) {
+        return;
+      }
+      value = nextValue;
+      listeners.forEach((listener) => listener());
+    },
+  };
+}

--- a/packages/ai-chat/src/chat/services/ServiceManager.ts
+++ b/packages/ai-chat/src/chat/services/ServiceManager.ts
@@ -32,6 +32,7 @@ import {
 import { BusEvent } from "../../types/events/eventBusTypes";
 import { ChatActionsImpl } from "./ChatActionsImpl";
 import { HasRequestFocus } from "../../types/utilities/HasRequestFocus";
+import { ChatSlotStates } from "../sdk/slotStates.js";
 
 export interface UserDefinedElementRegistryItem {
   slotName: string;
@@ -167,6 +168,14 @@ class ServiceManager {
    * double-teardown so disposal is idempotent.
    */
   disposed = false;
+
+  /**
+   * Framework-agnostic slot-projection state for the user-defined-response and custom-footer portal
+   * surfaces. Created once via `attachSlotStateTracking` during boot; the value stores hang off the
+   * manager so the accumulated slot state survives a host remount — a remounting subscriber reads
+   * the current value on first `get()`.
+   */
+  slotStates?: ChatSlotStates;
 
   /**
    * An instance of the custom I18n formatter that can be used for formatting messages. This instance is available

--- a/packages/ai-chat/src/types/component/ChatContainer.ts
+++ b/packages/ai-chat/src/types/component/ChatContainer.ts
@@ -24,51 +24,16 @@ import type {
   TokenTree as _TokenTree,
 } from "@carbon/ai-chat-components/es/components/markdown/index.js";
 import { type ChatInstance, WriteableElements } from "../instance/ChatInstance";
-import { GenericItem, Message, MessageResponse } from "../messaging/Messages";
+import { GenericItem, MessageResponse } from "../messaging/Messages";
 import { PublicConfig, PublicConfigMarkdown } from "../config/PublicConfig";
-import { DeepPartial } from "../utilities/DeepPartial";
 import {
   BusEventViewChange,
   BusEventViewPreChange,
 } from "../events/eventBusTypes";
-import { MessageState } from "../config/MessagingConfig";
-
-/**
- * The user_defined message object passed into the renderUserDefinedResponse property on the main chat components.
- *
- * @category React
- */
-interface RenderUserDefinedState {
-  /**
-   * The entire message object received when the entire message (not just the individual messageItem) has finished processing.
-   */
-  fullMessage?: Message;
-
-  /**
-   * The messageItem after all partial chunks are received. This will first be set to the value of the `complete_item`
-   * chunk.
-   * Once the fullMessage is resolved, this value will update to the value of the item in the fullMessage, which will
-   * be the same value unless you have done any post-processing mutations.
-   */
-  messageItem?: GenericItem;
-
-  /**
-   * An array of each user defined item partial chunk. Each chunk contains the new chunk information, they are not
-   * concatenated for you. When messageItem has been set an no more chunks are expected, this property is removed
-   * to avoid memory leaks.
-   */
-  partialItems?: DeepPartial<GenericItem>[];
-
-  /**
-   * The current {@link MessageState} of the containing message at the moment the renderer
-   * was invoked. Use this to drive in-widget streaming indicators or error treatments
-   * without inspecting the message items directly.
-   *
-   * @experimental Field is additive; its presence and semantics may evolve as the
-   * lifecycle model stabilizes.
-   */
-  state?: MessageState;
-}
+import {
+  RenderCustomMessageFooterState,
+  RenderUserDefinedState,
+} from "./slotStates";
 
 /**
  * The type of the render function that is used to render a custom footer. This function should return a
@@ -123,26 +88,6 @@ type WCRenderUserDefinedResponse = (
   state: RenderUserDefinedState,
   instance: ChatInstance,
 ) => HTMLElement | null;
-
-/**
- * The accumulated state for one custom message footer slot, passed to the
- * web component {@link WCRenderCustomMessageFooter} callback.
- *
- * @category Web component
- */
-interface RenderCustomMessageFooterState {
-  /** The unique identifier for this footer slot. */
-  slotName: string;
-
-  /** The assistant response object that contains the messageItem. */
-  message: MessageResponse;
-
-  /** The message item that the footer is attached to. */
-  messageItem: GenericItem;
-
-  /** Optional application data supplied with the footer slot. */
-  additionalData?: Record<string, unknown>;
-}
 
 /**
  * The render function used to render a custom message footer in web

--- a/packages/ai-chat/src/types/component/slotStates.ts
+++ b/packages/ai-chat/src/types/component/slotStates.ts
@@ -1,0 +1,79 @@
+/*
+ *  Copyright IBM Corp. 2026
+ *
+ *  This source code is licensed under the Apache-2.0 license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ *  @license
+ */
+
+/**
+ * The framework-neutral slot-projection state shapes shared by every surface: the React render
+ * callbacks, the web-component render callbacks, and the core slot-state stores
+ * (`src/chat/sdk/slotStates.ts`) all exchange these. Homed here — away from the ReactNode-bearing
+ * callback types in `ChatContainer.ts` — so the SDK core can import them without reaching a file
+ * that imports React.
+ */
+
+import { GenericItem, Message, MessageResponse } from "../messaging/Messages";
+import { DeepPartial } from "../utilities/DeepPartial";
+import { MessageState } from "../config/MessagingConfig";
+
+/**
+ * The user_defined message object passed into the renderUserDefinedResponse property on the main chat components.
+ *
+ * @category React
+ */
+interface RenderUserDefinedState {
+  /**
+   * The entire message object received when the entire message (not just the individual messageItem) has finished processing.
+   */
+  fullMessage?: Message;
+
+  /**
+   * The messageItem after all partial chunks are received. This will first be set to the value of the `complete_item`
+   * chunk.
+   * Once the fullMessage is resolved, this value will update to the value of the item in the fullMessage, which will
+   * be the same value unless you have done any post-processing mutations.
+   */
+  messageItem?: GenericItem;
+
+  /**
+   * An array of each user defined item partial chunk. Each chunk contains the new chunk information, they are not
+   * concatenated for you. When messageItem has been set an no more chunks are expected, this property is removed
+   * to avoid memory leaks.
+   */
+  partialItems?: DeepPartial<GenericItem>[];
+
+  /**
+   * The current {@link MessageState} of the containing message at the moment the renderer
+   * was invoked. Use this to drive in-widget streaming indicators or error treatments
+   * without inspecting the message items directly.
+   *
+   * @experimental Field is additive; its presence and semantics may evolve as the
+   * lifecycle model stabilizes.
+   */
+  state?: MessageState;
+}
+
+/**
+ * The accumulated state for one custom message footer slot, passed to the
+ * web component {@link WCRenderCustomMessageFooter} callback.
+ *
+ * @category Web component
+ */
+interface RenderCustomMessageFooterState {
+  /** The unique identifier for this footer slot. */
+  slotName: string;
+
+  /** The assistant response object that contains the messageItem. */
+  message: MessageResponse;
+
+  /** The message item that the footer is attached to. */
+  messageItem: GenericItem;
+
+  /** Optional application data supplied with the footer slot. */
+  additionalData?: Record<string, unknown>;
+}
+
+export { RenderCustomMessageFooterState, RenderUserDefinedState };

--- a/packages/ai-chat/tests/sdk/spec/slotStates_spec.ts
+++ b/packages/ai-chat/tests/sdk/spec/slotStates_spec.ts
@@ -1,0 +1,168 @@
+/*
+ *  Copyright IBM Corp. 2025, 2026
+ *
+ *  This source code is licensed under the Apache-2.0 license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ *  @license
+ */
+
+import { createValueStore } from "../../../src/chat/sdk/valueStore";
+import { attachSlotStateTracking } from "../../../src/chat/sdk/slotStates";
+import { BusEventType } from "../../../src/types/events/eventBusTypes";
+
+/**
+ * Builds a fake ServiceManager whose `instance.on` records the registered handlers by event type
+ * and counts registrations, so the reduction and idempotency can be exercised without a real boot.
+ */
+function makeFakeManager() {
+  const handlers: Record<string | number, (event: any) => void> = {};
+  let onCallCount = 0;
+  const manager: any = {
+    instance: {
+      on: ({ type, handler }: any) => {
+        onCallCount += 1;
+        handlers[type] = handler;
+      },
+    },
+  };
+  return {
+    manager,
+    handlers,
+    onCallCount: () => onCallCount,
+  };
+}
+
+describe("valueStore", () => {
+  it("returns the initial value from get()", () => {
+    const store = createValueStore({ a: 1 });
+    expect(store.get()).toEqual({ a: 1 });
+  });
+
+  it("notifies subscribers on a real change", () => {
+    const store = createValueStore(0);
+    const listener = jest.fn();
+    store.subscribe(listener);
+
+    store.set(1);
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(store.get()).toBe(1);
+  });
+
+  it("does not notify when the next value is Object.is-equal", () => {
+    const same = { a: 1 };
+    const store = createValueStore(same);
+    const listener = jest.fn();
+    store.subscribe(listener);
+
+    store.set(same);
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it("supports updater functions and stops notifying after unsubscribe", () => {
+    const store = createValueStore(1);
+    const listener = jest.fn();
+    const unsubscribe = store.subscribe(listener);
+
+    store.set((prev) => prev + 1);
+    expect(store.get()).toBe(2);
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    unsubscribe();
+    store.set(3);
+    expect(store.get()).toBe(3);
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("attachSlotStateTracking", () => {
+  it("reduces the user-defined-response event family into userDefinedBySlot", () => {
+    const { manager, handlers } = makeFakeManager();
+    const { userDefinedBySlot } = attachSlotStateTracking(manager);
+
+    handlers[BusEventType.USER_DEFINED_RESPONSE]({
+      data: { slot: "s1", fullMessage: { id: "m1" }, message: { id: "i1" } },
+    });
+    expect(userDefinedBySlot.get().s1.fullMessage).toEqual({ id: "m1" });
+    expect(userDefinedBySlot.get().s1.messageItem).toEqual({ id: "i1" });
+
+    // Partial chunks accumulate.
+    handlers[BusEventType.CHUNK_USER_DEFINED_RESPONSE]({
+      data: { slot: "s1", chunk: { partial_item: { t: "p1" } } },
+    });
+    handlers[BusEventType.CHUNK_USER_DEFINED_RESPONSE]({
+      data: { slot: "s1", chunk: { partial_item: { t: "p2" } } },
+    });
+    expect(userDefinedBySlot.get().s1.partialItems).toEqual([
+      { t: "p1" },
+      { t: "p2" },
+    ]);
+
+    // A complete item replaces the slot value.
+    handlers[BusEventType.CHUNK_USER_DEFINED_RESPONSE]({
+      data: { slot: "s1", chunk: { complete_item: { id: "i2" } } },
+    });
+    expect(userDefinedBySlot.get().s1).toEqual({ messageItem: { id: "i2" } });
+  });
+
+  it("reduces custom-footer-slot events into customFooterBySlot", () => {
+    const { manager, handlers } = makeFakeManager();
+    const { customFooterBySlot } = attachSlotStateTracking(manager);
+
+    handlers[BusEventType.CUSTOM_FOOTER_SLOT]({
+      data: {
+        slotName: "footer1",
+        message: { id: "msg1" },
+        messageItem: { id: "item1", text: "Hello" },
+        additionalData: { customKey: "customValue", count: 42 },
+      },
+    });
+
+    expect(customFooterBySlot.get().footer1).toEqual({
+      slotName: "footer1",
+      message: { id: "msg1" },
+      messageItem: { id: "item1", text: "Hello" },
+      additionalData: { customKey: "customValue", count: 42 },
+    });
+    expect(Object.keys(customFooterBySlot.get())).toEqual(["footer1"]);
+  });
+
+  it("clears both stores on restart", () => {
+    const { manager, handlers } = makeFakeManager();
+    const { userDefinedBySlot, customFooterBySlot } =
+      attachSlotStateTracking(manager);
+
+    handlers[BusEventType.USER_DEFINED_RESPONSE]({
+      data: { slot: "s1", fullMessage: { id: "m1" }, message: { id: "i1" } },
+    });
+    handlers[BusEventType.CUSTOM_FOOTER_SLOT]({
+      data: { slotName: "footer1", message: {}, messageItem: {} },
+    });
+
+    handlers[BusEventType.RESTART_CONVERSATION]({});
+    expect(userDefinedBySlot.get()).toEqual({});
+    expect(customFooterBySlot.get()).toEqual({});
+  });
+
+  it("notifies subscribers when a slot event arrives", () => {
+    const { manager, handlers } = makeFakeManager();
+    const { userDefinedBySlot } = attachSlotStateTracking(manager);
+    const listener = jest.fn();
+    userDefinedBySlot.subscribe(listener);
+
+    handlers[BusEventType.USER_DEFINED_RESPONSE]({
+      data: { slot: "s1", fullMessage: {}, message: {} },
+    });
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it("is idempotent: a second attach reuses the stores and registers no new handlers", () => {
+    const { manager, onCallCount } = makeFakeManager();
+    const first = attachSlotStateTracking(manager);
+    const countAfterFirst = onCallCount();
+
+    const second = attachSlotStateTracking(manager);
+    expect(second).toBe(first);
+    expect(onCallCount()).toBe(countAfterFirst);
+  });
+});


### PR DESCRIPTION
Closes #1741

THIS PR DOESN'T ACTUALLY DO ANYTHING, ITS JUST SPLITTING UP WORK INTO SMALLER PRs, the next PR will wire it up as well as other related parts.

Part of the persist/SDK decomposition epic #1728 — the slot-state store module, split out of #1732 (ChatSDK facade) so it reviews on its own ahead of the ~2,200-line boot refactor. Lands **inert**: nothing calls `attachSlotStateTracking` yet; #1732 wires it into boot and the web-components.

- `sdk/valueStore.ts` — a framework-agnostic, `Object.is`-gated subscribable (`useSyncExternalStore`-compatible). Notifies only its own subscribers, only on a real change; a remounting subscriber reads the current value on first `get()`.
- `sdk/slotStates.ts` — `attachSlotStateTracking` reduces the `USER_DEFINED_RESPONSE` / `CHUNK_USER_DEFINED_RESPONSE` / `CUSTOM_FOOTER_SLOT` / `RESTART_CONVERSATION` bus events into two per-slot value stores hung off the `ServiceManager`; idempotent per manager.
- Relocates `RenderUserDefinedState` / `RenderCustomMessageFooterState` from `ChatContainer.ts` into `types/component/slotStates.ts`, re-exported from `ChatContainer` — public shape unchanged.
- `ServiceManager` gains `slotStates?`.

#### Changelog

**New**

- `sdk/valueStore.ts`, `sdk/slotStates.ts` — framework-agnostic slot-state value stores (not yet wired in).
- `ServiceManager.slotStates` field.

**Changed**

- `RenderUserDefinedState` / `RenderCustomMessageFooterState` relocated to `types/component/slotStates.ts`, re-exported from `ChatContainer` (no public API change).

#### Testing / Reviewing

- `cd packages/ai-chat && npx jest tests/sdk/spec/slotStates_spec.ts` — 9 passing (valueStore get/subscribe/`Object.is` no-op; per-slot reduction; idempotent re-attach — all against a fake manager, no boot).
- `npx tsc --noEmit` clean; `npm run build --workspace=@carbon/ai-chat` clean (TypeDoc validates the relocated public types; 0 errors).
- Inert module — nothing calls it yet, so no runtime behavior change.

---

_Also bundles the `shell-quote@^1.10.0` root override (CVE-2026-13311 DoS, pulled in transitively by `concurrently`) so this branch's security checks pass — the same override is going to `main` standalone in #1743._
