### PR TITLE
refactor: button response types

### DIFF
--- a/packages/ai-chat/src/chat/components-legacy/MessageTypeComponent.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/MessageTypeComponent.tsx
@@ -34,7 +34,7 @@ import prefix from "@carbon/ai-chat-components/es/globals/settings.js";
 import { SystemMessage } from "../components/SystemMessage.js";
 import { ConnectToHumanAgent } from "./responseTypes/humanAgent/ConnectToHumanAgent";
 import { AudioComponent } from "../components/messages/AudioComponent";
-import { ButtonItemComponent } from "./responseTypes/buttonItem/ButtonItemComponent";
+import { ButtonItemComponent } from "../components/ButtonItemComponent";
 import { CardItemComponent } from "../components/messages/CardItemComponent";
 import { PreviewCardComponent } from "./responseTypes/previewCard/PreviewCardComponent";
 import { CarouselItemComponent } from "../components/messages/CarouselItemComponent";

--- a/packages/ai-chat/src/chat/components/BaseButtonItemComponent.tsx
+++ b/packages/ai-chat/src/chat/components/BaseButtonItemComponent.tsx
@@ -13,15 +13,12 @@ import ChatButton, {
 } from "@carbon/ai-chat-components/es/react/chat-button.js";
 import cx from "classnames";
 import React from "react";
-import { useSelector } from "../../../hooks/useSelector";
+import { useSelector } from "../hooks/useSelector";
 
-import { AppState } from "../../../../types/state/AppState";
-import { HasClassName } from "../../../../types/utilities/HasClassName";
-import { ClickableImage } from "../util/ClickableImage";
-import Button, {
-  BUTTON_KIND,
-  BUTTON_SIZE,
-} from "../../../components/carbon/Button";
+import { AppState } from "../../types/state/AppState";
+import { HasClassName } from "../../types/utilities/HasClassName";
+import { ClickableImage } from "../components-legacy/responseTypes/util/ClickableImage";
+import Button, { BUTTON_KIND, BUTTON_SIZE } from "./carbon/Button";
 
 interface BaseButtonComponentProps extends HasClassName {
   /**

--- a/packages/ai-chat/src/chat/components/ButtonItemComponent.tsx
+++ b/packages/ai-chat/src/chat/components/ButtonItemComponent.tsx
@@ -1,5 +1,5 @@
 /*
- *  Copyright IBM Corp. 2025
+ *  Copyright IBM Corp. 2025, 2026
  *
  *  This source code is licensed under the Apache-2.0 license found in the
  *  LICENSE file in the root directory of this source tree.
@@ -9,8 +9,8 @@
 
 import React from "react";
 
-import { HasRequestFocus } from "../../../../types/utilities/HasRequestFocus";
-import { LocalMessageItem } from "../../../../types/messaging/LocalMessageItem";
+import { HasRequestFocus } from "../../types/utilities/HasRequestFocus";
+import { LocalMessageItem } from "../../types/messaging/LocalMessageItem";
 import { ButtonItemCustomEventComponent } from "./ButtonItemCustomEventComponent";
 import { ButtonItemPostBackComponent } from "./ButtonItemPostBackComponent";
 import { ButtonItemShowPanelComponent } from "./ButtonItemShowPanelComponent";
@@ -19,7 +19,7 @@ import {
   ButtonItem,
   ButtonItemType,
   MessageResponse,
-} from "../../../../types/messaging/Messages";
+} from "../../types/messaging/Messages";
 
 interface ButtonItemComponentProps extends HasRequestFocus {
   localMessageItem: LocalMessageItem<ButtonItem>;

--- a/packages/ai-chat/src/chat/components/ButtonItemCustomEventComponent.tsx
+++ b/packages/ai-chat/src/chat/components/ButtonItemCustomEventComponent.tsx
@@ -8,18 +8,15 @@
  */
 
 import TouchInteraction16 from "@carbon/icons/es/touch--interaction/16.js";
-import { carbonIconToReact } from "../../../utils/carbonIcon";
+import { carbonIconToReact } from "../utils/carbonIcon";
 import React, { useCallback } from "react";
-import { useSelector } from "../../../hooks/useSelector";
+import { useSelector } from "../hooks/useSelector";
 
-import { useServiceManager } from "../../../hooks/useServiceManager";
-import { selectInputIsReadonly } from "../../../store/selectors";
-import { LocalMessageItem } from "../../../../types/messaging/LocalMessageItem";
-import {
-  ButtonItem,
-  MessageResponse,
-} from "../../../../types/messaging/Messages";
-import { BusEventType } from "../../../../types/events/eventBusTypes";
+import { useServiceManager } from "../hooks/useServiceManager";
+import { selectInputIsReadonly } from "../store/selectors";
+import { LocalMessageItem } from "../../types/messaging/LocalMessageItem";
+import { ButtonItem, MessageResponse } from "../../types/messaging/Messages";
+import { BusEventType } from "../../types/events/eventBusTypes";
 import { BaseButtonItemComponent } from "./BaseButtonItemComponent";
 
 /**

--- a/packages/ai-chat/src/chat/components/ButtonItemPostBackComponent.tsx
+++ b/packages/ai-chat/src/chat/components/ButtonItemPostBackComponent.tsx
@@ -8,20 +8,20 @@
  */
 
 import Send16 from "@carbon/icons/es/send/16.js";
-import { carbonIconToReact } from "../../../utils/carbonIcon";
+import { carbonIconToReact } from "../utils/carbonIcon";
 import React, { useCallback } from "react";
-import { useSelector } from "../../../hooks/useSelector";
+import { useSelector } from "../hooks/useSelector";
 
-import { useServiceManager } from "../../../hooks/useServiceManager";
-import { selectInputIsReadonly } from "../../../store/selectors";
-import { HasRequestFocus } from "../../../../types/utilities/HasRequestFocus";
-import { LocalMessageItem } from "../../../../types/messaging/LocalMessageItem";
-import { WA_CONSOLE_PREFIX } from "../../../utils/constants";
-import { createMessageRequestForButtonItemOption } from "../../../utils/messageUtils";
-import { consoleError } from "../../../utils/miscUtils";
-import actions from "../../../store/actions";
-import { MessageSendSource } from "../../../../types/events/eventBusTypes";
-import { ButtonItem } from "../../../../types/messaging/Messages";
+import { useServiceManager } from "../hooks/useServiceManager";
+import { selectInputIsReadonly } from "../store/selectors";
+import { HasRequestFocus } from "../../types/utilities/HasRequestFocus";
+import { LocalMessageItem } from "../../types/messaging/LocalMessageItem";
+import { WA_CONSOLE_PREFIX } from "../utils/constants";
+import { createMessageRequestForButtonItemOption } from "../utils/messageUtils";
+import { consoleError } from "../utils/miscUtils";
+import actions from "../store/actions";
+import { MessageSendSource } from "../../types/events/eventBusTypes";
+import { ButtonItem } from "../../types/messaging/Messages";
 import { BaseButtonItemComponent } from "./BaseButtonItemComponent";
 
 interface ButtonItemPostBackComponentProps extends HasRequestFocus {

--- a/packages/ai-chat/src/chat/components/ButtonItemShowPanelComponent.tsx
+++ b/packages/ai-chat/src/chat/components/ButtonItemShowPanelComponent.tsx
@@ -8,15 +8,15 @@
  */
 
 import ArrowRight16 from "@carbon/icons/es/arrow--right/16.js";
-import { carbonIconToReact } from "../../../utils/carbonIcon";
+import { carbonIconToReact } from "../utils/carbonIcon";
 import React, { useCallback } from "react";
-import { useSelector } from "../../../hooks/useSelector";
+import { useSelector } from "../hooks/useSelector";
 
-import { useServiceManager } from "../../../hooks/useServiceManager";
-import actions from "../../../store/actions";
-import { selectInputIsReadonly } from "../../../store/selectors";
-import { LocalMessageItem } from "../../../../types/messaging/LocalMessageItem";
-import { ButtonItem } from "../../../../types/messaging/Messages";
+import { useServiceManager } from "../hooks/useServiceManager";
+import actions from "../store/actions";
+import { selectInputIsReadonly } from "../store/selectors";
+import { LocalMessageItem } from "../../types/messaging/LocalMessageItem";
+import { ButtonItem } from "../../types/messaging/Messages";
 import { BaseButtonItemComponent } from "./BaseButtonItemComponent";
 
 interface ButtonItemShowPanelComponentProps {

--- a/packages/ai-chat/src/chat/components/ButtonItemURLComponent.tsx
+++ b/packages/ai-chat/src/chat/components/ButtonItemURLComponent.tsx
@@ -1,5 +1,5 @@
 /*
- *  Copyright IBM Corp. 2025
+ *  Copyright IBM Corp. 2025, 2026
  *
  *  This source code is licensed under the Apache-2.0 license found in the
  *  LICENSE file in the root directory of this source tree.
@@ -8,12 +8,12 @@
  */
 
 import Launch16 from "@carbon/icons/es/launch/16.js";
-import Link from "../../../components/carbon/Link";
-import { carbonIconToReact } from "../../../utils/carbonIcon";
+import Link from "./carbon/Link";
+import { carbonIconToReact } from "../utils/carbonIcon";
 import React from "react";
 
-import { LocalMessageItem } from "../../../../types/messaging/LocalMessageItem";
-import { ButtonItem } from "../../../../types/messaging/Messages";
+import { LocalMessageItem } from "../../types/messaging/LocalMessageItem";
+import { ButtonItem } from "../../types/messaging/Messages";
 import { BaseButtonItemComponent } from "./BaseButtonItemComponent";
 
 const LaunchIcon = carbonIconToReact(Launch16);


### PR DESCRIPTION
Closes #1437

Relocates the six `buttonItem` response-type components out of `components-legacy/responseTypes/buttonItem/` into `components/`

#### Changelog

**Changed**

- `BaseButtonItemComponent`, `ButtonItemComponent`, `ButtonItemCustomEventComponent`, `ButtonItemPostBackComponent`, `ButtonItemShowPanelComponent`, `ButtonItemURLComponent` moved from `components-legacy/responseTypes/buttonItem/` to `components/`
- `MessageTypeComponent` import updated to point to new location

**Removes**
- `components-legacy/responseTypes/buttonItem/` directory removed

#### Testing / Reviewing

No behavioural changes — pure file relocation with import path updates. Verify with:

```bash
npm run test --workspace=@carbon/ai-chat
npm run lint