### PR TITLE
docs: apply tone guide to Layout.md

### DIFF
--- a/packages/ai-chat/docs/Layout.md
+++ b/packages/ai-chat/docs/Layout.md
@@ -4,19 +4,19 @@ title: Layout
 
 ## Overview
 
-Control where the chat renders, size it through CSS custom properties, float it in the corner of the page, and round its corners.
+Control where the chat renders. Size it with CSS custom properties. Float it in a corner of the page. Round its corners.
 
 ## Layout modes
 
-The standard way to use Carbon AI Chat is the custom element — {@link ChatCustomElement} in React or `cds-aichat-custom-element` as a web component. You size and place the element in your DOM and the chat grows to fill it: a sidebar, a full-screen view, or a panel nested in your UI.
+The standard way to use Carbon AI Chat is the custom element. Use {@link ChatCustomElement} in React, or `cds-aichat-custom-element` as a web component. You size and place the element in your DOM. The chat grows to fill it. Use it as a sidebar, a full-screen view, or a panel nested in your UI.
 
-The classic floating widget — a launcher in the corner and a window that opens on click — is the same custom element with the exported [float layout classes](#floating-layout) applied. Those classes are exported precisely so you can apply them yourself and drive the open and close behavior. {@link ChatContainer} and `cds-aichat-container` are a convenience that wire those classes for you; reach for them only when you'd rather skip that work.
+The classic floating widget is the same custom element with the exported [float layout classes](#floating-layout) applied. It's a launcher in the corner and a window that opens on click. The classes are exported on purpose. Apply them yourself to drive the open and close behavior. {@link ChatContainer} and `cds-aichat-container` wire those classes for you. Reach for them only when you'd rather skip that work.
 
-For more information, see the documentation for [React](./React.md) and [web components](./WebComponent.md).
+For more, see the [React](./React.md) and [web components](./WebComponent.md) guides.
 
 ## Layout CSS custom properties
 
-Size and place the chat by overriding its `--cds-aichat-*` custom properties in your own stylesheet. The properties inherit through the chat's shadow boundary, so setting them on a host element flows into the chat:
+Size and place the chat by overriding its `--cds-aichat-*` custom properties in your own stylesheet. The properties inherit through the chat's shadow boundary. Set them on a host element and they flow into the chat:
 
 ```css
 .my-chat-host {
@@ -35,11 +35,11 @@ These shared tokens apply to both the floating and custom-element layouts:
 | `--cds-aichat-history-width`       | `320px` | Width of the history / conversation list panel                |
 | `--cds-aichat-card-max-width`      | `424px` | Maximum width for card components                             |
 
-You can also set these tokens from config through {@link LayoutConfig.customProperties} (keys come from {@link LayoutCustomProperties}) if you'd rather keep them out of a stylesheet.
+You can also set these tokens from config through {@link LayoutConfig.customProperties | customProperties}, with keys from {@link LayoutCustomProperties}. Do this if you'd rather keep them out of a stylesheet.
 
 ## Floating layout
 
-To float the chat, apply the exported float classes to your custom element and import the float stylesheet:
+To float the chat, apply the exported float classes to your custom element. Also import the float stylesheet:
 
 ```css
 @import "@carbon/ai-chat/css/chat-float-layout.css";
@@ -53,7 +53,7 @@ The classes drive the floating widget:
 - `cds-aichat-float--close` — hidden.
 - `cds-aichat-float--mobile` — mobile placement.
 
-Toggle the classes as the chat opens and closes using the {@link ChatCustomElementProps.onViewChange} and {@link ChatCustomElementProps.onViewPreChange} methods — prefer these over the {@link BusEventType.VIEW_CHANGE} and {@link BusEventType.VIEW_PRE_CHANGE} bus events. For a full working pattern with open and close animations, see the custom-element-as-float examples: [React](https://github.com/carbon-design-system/carbon-ai-chat/tree/main/examples/react/custom-element-as-float) and [web component](https://github.com/carbon-design-system/carbon-ai-chat/tree/main/examples/web-components/custom-element-as-float). {@link ChatContainer} applies these classes for you if you'd rather not wire them yourself.
+Toggle the classes as the chat opens and closes. Use the {@link ChatCustomElementProps.onViewChange | onViewChange} and {@link ChatCustomElementProps.onViewPreChange | onViewPreChange} methods. Prefer these over the {@link BusEventType.VIEW_CHANGE | VIEW_CHANGE} and {@link BusEventType.VIEW_PRE_CHANGE | VIEW_PRE_CHANGE} bus events. For a full working pattern, see the custom-element-as-float examples. They cover open and close animations: [React](https://github.com/carbon-design-system/carbon-ai-chat/tree/main/examples/react/custom-element-as-float) and [web component](https://github.com/carbon-design-system/carbon-ai-chat/tree/main/examples/web-components/custom-element-as-float). {@link ChatContainer} applies these classes for you, if you'd rather not wire them yourself.
 
 Size and placement of the floating container come from these tokens:
 
@@ -70,18 +70,18 @@ Size and placement of the floating container come from these tokens:
 | `--cds-aichat-top-position`    | `auto`                                                                    | Distance from the top of the viewport         |
 | `--cds-aichat-left-position`   | `auto`                                                                    | Distance from the left of the viewport        |
 
-> **Note:** RTL uses logical `inset-inline` placement while still reading the same `--cds-aichat-right-position` and `--cds-aichat-left-position` tokens. Override those tokens under `[dir="rtl"]` if you want mirrored placement.
+> **Note:** In RTL, placement uses logical `inset-inline`. It still reads the same `--cds-aichat-right-position` and `--cds-aichat-left-position` tokens. To mirror placement, override those tokens under `[dir="rtl"]`.
 
-The launcher that opens the floating window has its own configuration and styling tokens — see [Launcher](./Launcher.md).
+The launcher that opens the floating window has its own configuration and styling tokens. See [Launcher](./Launcher.md).
 
 ## Rounded corners
 
-AI Chat components use a shared rounded modifier system to keep corners consistent across slotted content. There are two ways to use it:
+AI Chat components share a rounded-modifier system that keeps corners consistent across slotted content. You can use it two ways:
 
 1. Read the rounded modifier tokens in your own CSS.
 2. Add `data-rounded` (and `data-stacked` when needed) so the system applies rounding for you.
 
-Built-in components already carry these attributes; add `data-rounded` / `data-stacked` yourself only on your own slotted content.
+Built-in components already carry these attributes. Add `data-rounded` and `data-stacked` yourself only on your own slotted content.
 
 **Quick guide**
 
@@ -98,11 +98,11 @@ Supported values for `data-rounded`:
 - `top`, `top-left`, `top-right`
 - `bottom`, `bottom-left`, `bottom-right`
 
-Use `data-stacked` when children are arranged in a vertical stack. Without `data-stacked`, `data-rounded="top"` and `data-rounded="bottom"` round the first and last child in a horizontal row.
+Use `data-stacked` when children stack vertically. Without `data-stacked`, `data-rounded="top"` and `data-rounded="bottom"` round the first and last child in a horizontal row.
 
 ### Per-corner configuration
 
-You can configure corners individually using {@link LayoutConfig.corners}. Pass a single {@link CornersType} value to round every corner, or a {@link PerCornerConfig} object to control each corner:
+Configure corners one at a time with {@link LayoutConfig.corners | corners}. Pass a single {@link CornersType} value to round every corner. Or pass a {@link PerCornerConfig} object to control each corner:
 
 **Simple configuration (all corners the same):**
 
@@ -145,7 +145,7 @@ import { CornersType, PerCornerConfig } from '@carbon/ai-chat';
 }
 ```
 
-> **Note:** Corner names use CSS logical properties for RTL support. `startStart` means "block-start inline-start" which automatically maps to the correct physical corner based on text direction.
+> **Note:** Corner names use CSS logical properties for RTL support. `startStart` means "block-start inline-start". It maps automatically to the correct physical corner based on text direction.
 
 ### Corner CSS custom properties
 
@@ -173,7 +173,7 @@ Apply them with the matching logical `border-*-radius` properties so rounding fo
 }
 ```
 
-Or let the system apply rounding for you with `data-rounded`. Render this into a footer slot so it inherits the correct rounding for the current layout:
+Or let the system apply rounding for you with `data-rounded`. Render this into a footer slot. It then inherits the correct rounding for the current layout:
 
 ```html
 <div class="my-footer-actions" data-rounded="bottom" data-stacked>

--- a/packages/ai-chat/docs/Layout.md
+++ b/packages/ai-chat/docs/Layout.md
@@ -4,13 +4,13 @@ title: Layout
 
 ## Overview
 
-Control where the chat renders. Size it with CSS custom properties. Float it in a corner of the page. Round its corners.
+Control where the chat renders, size it through CSS custom properties, float it in the corner of the page, and round its corners.
 
 ## Layout modes
 
-The standard way to use Carbon AI Chat is the custom element. Use {@link ChatCustomElement} in React, or `cds-aichat-custom-element` as a web component. You size and place the element in your DOM. The chat grows to fill it. Use it as a sidebar, a full-screen view, or a panel nested in your UI.
+The standard way to use Carbon AI Chat is the custom element. Use {@link ChatCustomElement} in React, or `cds-aichat-custom-element` as a web component. You size and place the element in your DOM and the chat grows to fill it. Use it as a sidebar, a full-screen view, or a panel nested in your UI.
 
-The classic floating widget is the same custom element with the exported [float layout classes](#floating-layout) applied. It's a launcher in the corner and a window that opens on click. The classes are exported on purpose. Apply them yourself to drive the open and close behavior. {@link ChatContainer} and `cds-aichat-container` wire those classes for you. Reach for them only when you'd rather skip that work.
+The classic floating widget is the same custom element with the exported [float layout classes](#floating-layout) applied. It's a launcher in the corner and a window that opens on click. The classes are exported on purpose so that you can apply them yourself to drive the open and close behavior. {@link ChatContainer} and `cds-aichat-container` wire those classes for you. Reach for them only when you'd rather skip that work.
 
 For more, see the [React](./React.md) and [web components](./WebComponent.md) guides.
 
@@ -39,7 +39,7 @@ You can also set these tokens from config through {@link LayoutConfig.customProp
 
 ## Floating layout
 
-To float the chat, apply the exported float classes to your custom element. Also import the float stylesheet:
+To float the chat, apply the exported float classes to your custom element and import the float stylesheet:
 
 ```css
 @import "@carbon/ai-chat/css/chat-float-layout.css";
@@ -53,7 +53,7 @@ The classes drive the floating widget:
 - `cds-aichat-float--close` — hidden.
 - `cds-aichat-float--mobile` — mobile placement.
 
-Toggle the classes as the chat opens and closes. Use the {@link ChatCustomElementProps.onViewChange | onViewChange} and {@link ChatCustomElementProps.onViewPreChange | onViewPreChange} methods. Prefer these over the {@link BusEventType.VIEW_CHANGE | VIEW_CHANGE} and {@link BusEventType.VIEW_PRE_CHANGE | VIEW_PRE_CHANGE} bus events. For a full working pattern, see the custom-element-as-float examples. They cover open and close animations: [React](https://github.com/carbon-design-system/carbon-ai-chat/tree/main/examples/react/custom-element-as-float) and [web component](https://github.com/carbon-design-system/carbon-ai-chat/tree/main/examples/web-components/custom-element-as-float). {@link ChatContainer} applies these classes for you, if you'd rather not wire them yourself.
+Toggle the classes as the chat opens and closes. Use the {@link ChatCustomElementProps.onViewChange | onViewChange} and {@link ChatCustomElementProps.onViewPreChange | onViewPreChange} methods. Prefer these over the {@link BusEventType.VIEW_CHANGE | VIEW_CHANGE} and {@link BusEventType.VIEW_PRE_CHANGE | VIEW_PRE_CHANGE} bus events. For a full working pattern with open and close animations, see the [React](https://github.com/carbon-design-system/carbon-ai-chat/tree/main/examples/react/custom-element-as-float) and [web component](https://github.com/carbon-design-system/carbon-ai-chat/tree/main/examples/web-components/custom-element-as-float) custom-element-as-float examples. {@link ChatContainer} applies these classes for you, if you'd rather not wire them yourself.
 
 Size and placement of the floating container come from these tokens:
 
@@ -70,7 +70,7 @@ Size and placement of the floating container come from these tokens:
 | `--cds-aichat-top-position`    | `auto`                                                                    | Distance from the top of the viewport         |
 | `--cds-aichat-left-position`   | `auto`                                                                    | Distance from the left of the viewport        |
 
-> **Note:** In RTL, placement uses logical `inset-inline`. It still reads the same `--cds-aichat-right-position` and `--cds-aichat-left-position` tokens. To mirror placement, override those tokens under `[dir="rtl"]`.
+> **Note:** RTL uses logical `inset-inline` placement while still reading the same `--cds-aichat-right-position` and `--cds-aichat-left-position` tokens. To mirror placement, override those tokens under `[dir="rtl"]`.
 
 The launcher that opens the floating window has its own configuration and styling tokens. See [Launcher](./Launcher.md).
 
@@ -102,7 +102,7 @@ Use `data-stacked` when children stack vertically. Without `data-stacked`, `data
 
 ### Per-corner configuration
 
-Configure corners one at a time with {@link LayoutConfig.corners | corners}. Pass a single {@link CornersType} value to round every corner. Or pass a {@link PerCornerConfig} object to control each corner:
+Configure corners one at a time with {@link LayoutConfig.corners | corners}. Pass a single {@link CornersType} value to round every corner or pass a {@link PerCornerConfig} object to control each corner:
 
 **Simple configuration (all corners the same):**
 


### PR DESCRIPTION
Closes #

Tone pass on `Layout.md` (Layout) per `references/tone.md`. Prose only — code blocks and page structure unchanged.

#### Changelog

**Changed**

- Reword `Layout.md` for voice and reading level.

#### Testing / Reviewing

- Flesch-Kincaid grade: 9.3 (target 8–11). Measured with `npm run reading-level`, which ships in #1740.
- Confirm the reword kept every fact, default, and qualifier.
