### PR TITLE
docs: apply tone guide to AddMessageChunk.md

### DIFF
--- a/packages/ai-chat/docs/AddMessageChunk.md
+++ b/packages/ai-chat/docs/AddMessageChunk.md
@@ -4,23 +4,23 @@ title: Adding messages (legacy)
 
 ## Overview
 
-Stream a response onto the screen as your assistant produces it with {@link ChatInstanceMessaging.addMessageChunk}. The examples below call `instance.messaging`, so you need a {@link ChatInstance} first — get one from the `onBeforeRender` prop. It uses three types of chunks ({@link StreamChunk}) to progressively build and finalize a message response:
+Stream a response onto the screen as your assistant produces it with {@link ChatInstanceMessaging.addMessageChunk | addMessageChunk}. The examples below call `instance.messaging`, so you need a {@link ChatInstance} first — get one from the `onBeforeRender` prop. It uses three chunk types ({@link StreamChunk | StreamChunk}) to build and finish a message response step by step:
 
-- **Partial item chunks** — incremental updates to an individual item.
+- **Partial item chunks** — step-by-step updates to one item.
 - **Complete item chunks** — finalize one item while others keep streaming.
 - **Final response chunks** — the authoritative final state for the whole message.
 
-For one-shot, non-streaming inserts use {@link ChatInstanceMessaging.addMessage} instead; your assistant can return responses in either format and switch between them. To accumulate state in your app and apply it with one call per update, see [Adding messages (experimental)](./UpsertMessage.md). It also covers regenerate and optimistic updates.
+For a one-shot, non-streaming insert, use {@link ChatInstanceMessaging.addMessage | addMessage} instead; your assistant can return either format and switch between them. To build up state in your app and apply it with one call per update, see [Adding messages (experimental)](./UpsertMessage.md). It also covers regenerate and optimistic updates.
 
-> **Note:** Before building on `addMessageChunk`, investigate {@link ChatInstanceMessaging.upsertMessage}. It inserts or updates a message by ID via an updater function, covering streaming, regenerate, post-stream corrections, and optimistic updates with one method. It is the recommended direction for new code, but experimental — its semantics and updater signature may still evolve. See [Adding messages (experimental)](./UpsertMessage.md).
+> **Note:** Before you build on `addMessageChunk`, look at {@link ChatInstanceMessaging.upsertMessage | upsertMessage}. A single method inserts or updates a message by ID through an updater function, covering streaming, regenerate, post-stream corrections, and optimistic updates. It's the recommended path for new code, but experimental — its semantics and updater signature may still change. See [Adding messages (experimental)](./UpsertMessage.md).
 
-The item and response shapes referenced below are documented in [Message format](./MessageFormat.md).
+[Message format](./MessageFormat.md) documents the item and response shapes used below.
 
 ## Partial item chunks
 
-Stream incremental updates to individual message items with a {@link PartialItemChunk}. Each chunk carries a {@link DeepPartial} of a {@link GenericItem} in `partial_item`, a per-message `streaming_metadata.response_id`, and a `streaming_metadata` on the item whose `id` picks the item to update and whose optional `cancellable` flag shows the "stop streaming" button. See {@link PartialItemChunk} and {@link StreamChunk} for the full field reference.
+Stream updates to single message items with a {@link PartialItemChunk | PartialItemChunk}. Each chunk carries a {@link DeepPartial} of a {@link GenericItem} in `partial_item`, a per-message `streaming_metadata.response_id`, and a `streaming_metadata` on the item whose `id` picks the item to update and whose optional `cancellable` flag shows the "stop streaming" button. See {@link PartialItemChunk} and {@link StreamChunk} for the full field reference.
 
-Partial chunks are stored raw in the item's internal chunks list. The render layer joins them at draw time for {@link TextItem} and {@link ConversationalSearchItem} only, concatenating `text` fields. Other response types are not auto-joined. If you stream non-text items, include the fully assembled state in the {@link CompleteItemChunk} or {@link FinalResponseChunk}. Multiple items can stream in parallel within the same message by using different item IDs.
+The chat stores partial chunks raw in the item's internal chunks list. At draw time, the render layer joins them for {@link TextItem | TextItem} and {@link ConversationalSearchItem | ConversationalSearchItem} only, concatenating the `text` fields; it doesn't auto-join other response types. If you stream non-text items, include the fully built state in the {@link CompleteItemChunk | CompleteItemChunk} or {@link FinalResponseChunk | FinalResponseChunk}. To stream several items at once in one message, give each a different item ID.
 
 Example:
 
@@ -49,13 +49,13 @@ await instance.messaging.addMessageChunk(chunk);
 
 ## Complete item chunks
 
-A complete item chunk ({@link CompleteItemChunk}) finalizes a specific item before the entire message is done. Use a complete item chunk when you:
+A complete item chunk ({@link CompleteItemChunk | CompleteItemChunk}) finalizes one item before the whole message is done. Use one when you:
 
-- Need to correct or finalize one item while others are still streaming
-- Are streaming multiple different items and want to mark one as complete
-- Want to run post-processing (such as safety checks) on an item
+- Need to correct or finalize one item while others still stream
+- Stream several different items and want to mark one complete
+- Want to run post-processing on an item, such as safety checks
 
-The complete item should contain all final data for that item, including any corrections to previous chunks.
+The complete item should hold all final data for that item, including any fixes to earlier chunks.
 
 Example:
 
@@ -82,15 +82,15 @@ const chunk: StreamChunk = {
 await instance.messaging.addMessageChunk(chunk);
 ```
 
-If you're only streaming a single item, you can skip this step and go directly to the final response.
+If you stream only one item, skip this step and go straight to the final response.
 
 ## Final response chunks
 
-The final response chunk ({@link FinalResponseChunk}) signals the end of all streaming and provides the authoritative final state. It carries the complete {@link MessageResponse} with all items. See {@link FinalResponseChunk} for the full field reference. When you send it:
+The final response chunk ({@link FinalResponseChunk | FinalResponseChunk}) signals the end of all streaming and provides the authoritative final state. It carries the full {@link MessageResponse | MessageResponse} with all items. See {@link FinalResponseChunk} for the full field reference. When you send it:
 
-- It triggers cleanup of streaming UI states (such as hiding "stop streaming" buttons)
-- Set its `id` to match the `response_id` from previous chunks
-- For any item that was streamed, include `streaming_metadata.id` to preserve identity
+- It clears streaming UI state, such as hiding the "stop streaming" buttons
+- Set its `id` to match the `response_id` from earlier chunks
+- For any streamed item, include `streaming_metadata.id` to keep its identity
 - Save this in your history store
 
 Example:
@@ -125,16 +125,16 @@ await instance.messaging.addMessageChunk({
 
 ## Typical streaming flow
 
-Generate a unique `response_id` for the message, then loop through your streaming source, sending a partial item chunk for each update. Optionally send complete item chunks as individual items are finalized. Finish with a final response chunk carrying the complete message.
+Generate a unique `response_id` for the message, then loop through your streaming source and send a partial item chunk for each update. As individual items finalize, you can send complete item chunks. Finish with a final response chunk that carries the complete message.
 
-The Carbon AI Chat appends partial text updates at draw time (for {@link TextItem} and {@link ConversationalSearchItem}), renders streaming text, and transitions to the final state when the final response chunk arrives.
+At draw time, Carbon AI Chat appends partial text updates for {@link TextItem} and {@link ConversationalSearchItem}, renders the streaming text, and moves to the final state when the final response chunk arrives.
 
 ## Cancellation
 
-The "stop streaming" button appears when a partial item chunk has `streaming_metadata.cancellable: true`, and the abort signal lets you stop your stream. The cancellation mechanism is identical across delivery flows — see [Cancelling request (stop streaming)](./CustomServer.md#cancelling-request-stop-streaming) on the Server communication page for the full pattern, including how to deliver the final state with either `addMessageChunk` or `upsertMessage`.
+The "stop streaming" button appears when a partial item chunk sets `streaming_metadata.cancellable: true`, and the abort signal lets you stop your stream. Cancellation works the same across delivery flows — see [Cancelling request (stop streaming)](./CustomServer.md#cancelling-request-stop-streaming) on the Server communication page for the full pattern, including how to deliver the final state with either `addMessageChunk` or `upsertMessage`.
 
 ## Related
 
-- [Adding messages (experimental)](./UpsertMessage.md) — accumulate state in your app and apply one update per call.
+- [Adding messages (experimental)](./UpsertMessage.md) — build up state in your app and apply one update per call.
 - [Message format](./MessageFormat.md) — the item and response shapes used here.
 - [Server communication](./CustomServer.md#cancelling-request-stop-streaming) — the shared cancellation pattern.

--- a/packages/ai-chat/docs/AddMessageChunk.md
+++ b/packages/ai-chat/docs/AddMessageChunk.md
@@ -20,7 +20,7 @@ For a one-shot, non-streaming insert, use {@link ChatInstanceMessaging.addMessag
 
 Stream updates to single message items with a {@link PartialItemChunk | PartialItemChunk}. Each chunk carries a {@link DeepPartial} of a {@link GenericItem} in `partial_item`, a per-message `streaming_metadata.response_id`, and a `streaming_metadata` on the item whose `id` picks the item to update and whose optional `cancellable` flag shows the "stop streaming" button. See {@link PartialItemChunk} and {@link StreamChunk} for the full field reference.
 
-The chat stores partial chunks raw in the item's internal chunks list. At draw time, the render layer joins them for {@link TextItem | TextItem} and {@link ConversationalSearchItem | ConversationalSearchItem} only, concatenating the `text` fields; it doesn't auto-join other response types. If you stream non-text items, include the fully built state in the {@link CompleteItemChunk | CompleteItemChunk} or {@link FinalResponseChunk | FinalResponseChunk}. To stream several items at once in one message, give each a different item ID.
+The chat stores partial chunks raw in the item's internal chunks list. At draw time, the render layer joins them for {@link TextItem | TextItem} and {@link ConversationalSearchItem | ConversationalSearchItem} only, concatenating the `text` fields. Other response types are not auto-joined. If you stream non-text items, include the fully built state in the {@link CompleteItemChunk | CompleteItemChunk} or {@link FinalResponseChunk | FinalResponseChunk}. To stream several items at once in one message, give each a different item ID.
 
 Example:
 


### PR DESCRIPTION
Closes #

Tone pass on `AddMessageChunk.md` (Adding messages (legacy)) per `references/tone.md`. Prose only — code blocks and page structure unchanged.

#### Changelog

**Changed**

- Reword `AddMessageChunk.md` for voice and reading level.

#### Testing / Reviewing

- Flesch-Kincaid grade: 8.5 (target 8–11). Measured with `npm run reading-level`, which ships in #1740.
- Confirm the reword kept every fact, default, and qualifier.
