### PR TITLE
docs: apply tone guide to CustomServiceDesks.md

### DIFF
--- a/packages/ai-chat/docs/CustomServiceDesks.md
+++ b/packages/ai-chat/docs/CustomServiceDesks.md
@@ -4,14 +4,14 @@ title: Service desks
 
 ## Overview
 
-Integrate a custom service desk or contact center so users can talk to human agents. Create an object or class that satisfies the {@link ServiceDesk} interface, then return it from a factory function in your configuration. The Carbon AI Chat calls that factory when it needs an instance of your integration.
+Connect a custom service desk or contact center so users can talk to human agents. Create an object or class that meets the {@link ServiceDesk} interface, then return it from a factory function in your config. Carbon AI Chat calls that factory when it needs an instance of your integration.
 
 An integration takes two steps:
 
-1. Write code to communicate with the service desk, for actions like starting a conversation or sending messages to a human agent. Make sure the code meets the API the Carbon AI Chat specifies.
-2. Give the Carbon AI Chat access to that code through a factory function so it can run it.
+1. Write code that talks to the service desk to handle actions like starting a conversation or sending messages to a human agent. Make sure the code meets the API that Carbon AI Chat specifies.
+2. Give Carbon AI Chat access to that code through a factory function so it can run it.
 
-Provide your service desk integration to the container components as top‑level props. If you haven't set up a container yet, see [React](./React.md) or [Web component](./WebComponent.md) first.
+Pass your service desk integration to the container components as top‑level props. If you haven't set up a container yet, see [React](./React.md) or [Web component](./WebComponent.md) first.
 
 - React: `<ChatContainer serviceDeskFactory={...} serviceDesk={{ ... }} />`
 - Web component (float): `<cds-aichat-container .serviceDeskFactory=${'{}'} .serviceDesk=${'{}'} />`
@@ -19,15 +19,15 @@ Provide your service desk integration to the container components as top‑level
 
 ## Service desk requirements
 
-To create an integration between the Carbon AI Chat and a service desk, the service desk must fulfill the Carbon AI Chat service desk API. Use the HTTP endpoints that the service desk or the web socket interface provides. The service desk must let you start a chat, receive user messages, and deliver agent messages to the user.
+To connect Carbon AI Chat to a service desk, the service desk must fulfill the Carbon AI Chat service desk API. Use the HTTP endpoints or web socket interface that the service desk provides. The service desk must let you start a chat, receive user messages, and deliver agent messages to the user.
 
-If the service desk requires calls to include secrets that cannot be exposed to end users, such as API keys, use middleware on your server to handle the calls. Proxy the calls from the Carbon AI Chat. This middleware receives the calls from the Carbon AI Chat and forwards them to the service desk along with the additional secret.
+Some service desk calls must include secrets you can't expose to end users, like API keys. For those calls, use middleware on your server to handle them. The middleware proxies the call from Carbon AI Chat, receiving it and then forwarding it to the service desk with the added secret.
 
-If the service desk operates on a domain different from your website, make sure that it supports CORS to handle requests from a web browser. Without CORS support, you can proxy the requests through your own server, eliminating the need for CORS.
+If the service desk runs on a different domain from your website, make sure it supports CORS to handle requests from a web browser. Without CORS support, you can proxy the requests through your own server, which removes the need for CORS.
 
 ## Basic example
 
-If you implement a service integration that satisfies the service desk API, getting the Carbon AI Chat to use it requires a factory function to create a new instance of your integration. The example shows an empty integration (that doesn't communicate with a service desk) to show how to register an integration with the Carbon AI Chat.
+Say you built a service integration that meets the service desk API. To make Carbon AI Chat use it, write a factory function that creates a new instance of your integration. The example below shows an empty integration that doesn't talk to a service desk; it's there to show how to register an integration with Carbon AI Chat.
 
 ```tsx
 // Your custom service desk integration which can be located anywhere in your codebase.
@@ -92,61 +92,65 @@ export class MyApp extends LitElement {
 
 ## API overview
 
-The Carbon AI Chat provides a public API that your custom code implements so the Carbon AI Chat can communicate with a service desk. This communication integrates into the Carbon AI Chat visual experience. The API provides functions such as {@link ServiceDesk.startChat} to let the service desk know when a chat starts and {@link ServiceDesk.sendMessageToAgent} to send a message from the user to an agent. The Carbon AI Chat also provides a callback API so the service desk can talk back to the Carbon AI Chat. It includes functions like {@link ServiceDeskCallback.agentJoined} to let the Carbon AI Chat know when an agent joins the chat and {@link ServiceDeskCallback.sendMessageToUser} when the agent sends a message to display to the user.
+Carbon AI Chat provides a public API that your custom code implements, and it calls that API to communicate with a service desk. This communication becomes part of the Carbon AI Chat visual experience.
+
+The API provides functions for Carbon AI Chat to call. For example, {@link ServiceDesk.startChat | startChat} tells the service desk when a chat starts, and {@link ServiceDesk.sendMessageToAgent | sendMessageToAgent} sends a message from the user to an agent.
+
+Carbon AI Chat also provides a callback API so the service desk can talk back. For example, {@link ServiceDeskCallback.agentJoined | agentJoined} tells Carbon AI Chat when an agent joins the chat, and {@link ServiceDeskCallback.sendMessageToUser | sendMessageToUser} shows the user a message from the agent.
 
 ### Communicating from the Carbon AI Chat to your service desk
 
-The `serviceDeskFactory` configuration property expects a factory function that returns an object of functions or a class. The factory receives {@link ServiceDeskFactoryParameters}. The Carbon AI Chat calls the class or functions returned from the factory as needed to communicate with your integration.
+The `serviceDeskFactory` config property expects a factory function that returns an object of functions or a class and receives {@link ServiceDeskFactoryParameters}. Carbon AI Chat calls the returned class or functions as needed to communicate with your integration.
 
 ### Communicating from your service desk to the Carbon AI Chat
 
-The factory receives a callback object in {@link ServiceDeskFactoryParameters}. These callbacks are the functions you call inside your service desk code to communicate information back to the Carbon AI Chat.
+The factory receives a callback object in {@link ServiceDeskFactoryParameters}. You call these callbacks inside your service desk code to send information back to Carbon AI Chat.
 
 ### Interaction flow
 
-These are the steps that happen when a user connects to a service desk. They also show how the Carbon AI Chat interacts with the service desk integration.
+These steps happen when a user connects to a service desk, and they show how Carbon AI Chat interacts with the service desk integration.
 
-1. When the Carbon AI Chat starts, it creates a single instance of the service desk integration through the `serviceDeskFactory` prop.
-2. A user sends a message to the assistant and it returns a "Connect to Agent" response (response_type="connect_to_agent").
-3. If the service desk integration implements it, the Carbon AI Chat calls {@link ServiceDesk.areAnyAgentsOnline} to find out whether any agents are online. The result decides whether the Carbon AI Chat displays a "request agent" button or the "no agents available" message instead.
+1. When Carbon AI Chat starts, it creates a single instance of the service desk integration through the `serviceDeskFactory` prop.
+2. A user sends a message to the assistant. The assistant returns a "Connect to Agent" response (response_type="connect_to_agent").
+3. If the integration implements it, Carbon AI Chat calls {@link ServiceDesk.areAnyAgentsOnline | areAnyAgentsOnline} to check whether any agents are online. The result decides whether Carbon AI Chat shows a "request agent" button or the "no agents available" message.
 4. User clicks the "request agent" button.
-5. The Carbon AI Chat calls {@link ServiceDesk.startChat} on the integration. The integration asks the service desk to start a new chat.
-6. A banner displays to the user to indicate that the Carbon AI Chat is connecting them to an agent.
-7. If the service desk provides the capability, the integration calls {@link ServiceDeskCallback.updateAgentAvailability} to update the banner with how long the wait is.
-8. When an agent becomes available, the integration calls {@link ServiceDeskCallback.agentJoined} and the Carbon AI Chat informs the user that an agent is joining.
-9. When an agent sends a message, the integration calls {@link ServiceDeskCallback.sendMessageToUser}.
-10. When the user sends a message, the Carbon AI Chat calls {@link ServiceDesk.sendMessageToAgent}.
+5. Carbon AI Chat calls {@link ServiceDesk.startChat | startChat} on the integration. The integration asks the service desk to start a new chat.
+6. A banner tells the user that Carbon AI Chat is connecting them to an agent.
+7. If the service desk supports it, the integration calls {@link ServiceDeskCallback.updateAgentAvailability | updateAgentAvailability} to update the banner with the wait time.
+8. When an agent becomes available, the integration calls {@link ServiceDeskCallback.agentJoined | agentJoined}, and Carbon AI Chat then tells the user that an agent is joining.
+9. When an agent sends a message, the integration calls {@link ServiceDeskCallback.sendMessageToUser | sendMessageToUser}.
+10. When the user sends a message, Carbon AI Chat calls {@link ServiceDesk.sendMessageToAgent | sendMessageToAgent}.
 11. The user ends the chat.
-12. The Carbon AI Chat calls {@link ServiceDesk.endChat} on the integration, which tells the service desk that the chat is over.
+12. Carbon AI Chat calls {@link ServiceDesk.endChat | endChat} on the integration, which tells the service desk that the chat is over.
 
 ## API details
 
 Implement these methods from the {@link ServiceDesk} interface in your integration:
 
-- {@link ServiceDesk.getName}
-- {@link ServiceDesk.startChat}
-- {@link ServiceDesk.endChat}
-- {@link ServiceDesk.sendMessageToAgent}
-- {@link ServiceDesk.userReadMessages} (optional)
-- {@link ServiceDesk.areAnyAgentsOnline} (optional)
+- {@link ServiceDesk.getName | getName}
+- {@link ServiceDesk.startChat | startChat}
+- {@link ServiceDesk.endChat | endChat}
+- {@link ServiceDesk.sendMessageToAgent | sendMessageToAgent}
+- {@link ServiceDesk.userReadMessages | userReadMessages} (optional)
+- {@link ServiceDesk.areAnyAgentsOnline | areAnyAgentsOnline} (optional)
 
 Call these methods on the {@link ServiceDeskCallback} interface from your integration:
 
-- {@link ServiceDeskCallback.agentEndedChat}
-- {@link ServiceDeskCallback.agentJoined}
-- {@link ServiceDeskCallback.agentLeftChat}
-- {@link ServiceDeskCallback.agentReadMessages}
-- {@link ServiceDeskCallback.agentTyping}
-- {@link ServiceDeskCallback.beginTransferToAnotherAgent}
-- {@link ServiceDeskCallback.sendMessageToUser}
-- {@link ServiceDeskCallback.setErrorStatus}
-- {@link ServiceDeskCallback.setFileUploadStatus}
-- {@link ServiceDeskCallback.updateAgentAvailability}
-- {@link ServiceDeskCallback.updateCapabilities}
+- {@link ServiceDeskCallback.agentEndedChat | agentEndedChat}
+- {@link ServiceDeskCallback.agentJoined | agentJoined}
+- {@link ServiceDeskCallback.agentLeftChat | agentLeftChat}
+- {@link ServiceDeskCallback.agentReadMessages | agentReadMessages}
+- {@link ServiceDeskCallback.agentTyping | agentTyping}
+- {@link ServiceDeskCallback.beginTransferToAnotherAgent | beginTransferToAnotherAgent}
+- {@link ServiceDeskCallback.sendMessageToUser | sendMessageToUser}
+- {@link ServiceDeskCallback.setErrorStatus | setErrorStatus}
+- {@link ServiceDeskCallback.setFileUploadStatus | setFileUploadStatus}
+- {@link ServiceDeskCallback.updateAgentAvailability | updateAgentAvailability}
+- {@link ServiceDeskCallback.updateCapabilities | updateCapabilities}
 
 ## Supported response types
 
-The {@link ServiceDeskCallback.sendMessageToUser} function lets your integration display a message to the user. You can provide a string, which displays a basic text response to the user. You can also pass a {@link MessageResponse} object with one of these {@link MessageResponseTypes}:
+The {@link ServiceDeskCallback.sendMessageToUser | sendMessageToUser} function shows a message to the user. Pass a string to show a basic text response, or pass a {@link MessageResponse} object with one of these {@link MessageResponseTypes}:
 
 - text
 - image
@@ -155,7 +159,7 @@ The {@link ServiceDeskCallback.sendMessageToUser} function lets your integration
 - button (the link button type is the only supported type)
 - user_defined
 
-> **Note:** The Carbon AI Chat supports markdown in text responses.
+> **Note:** Carbon AI Chat supports markdown in text responses.
 
 ## File uploads
 
@@ -163,7 +167,7 @@ Users can select local files to upload to an agent. To enable uploads, your inte
 
 ### Enable file uploads
 
-First, tell the Carbon AI Chat your service desk supports uploads by calling {@link ServiceDeskCallback.updateCapabilities}. It can also tell the Carbon AI Chat whether it supports multiple files and what filter to apply to the operating system file select dialog. Call this function at any time, including to change the current capabilities. For example, if your service desk blocks uploads until an agent requests them, wait to call this function until the user receives such a message from the agent.
+First, call {@link ServiceDeskCallback.updateCapabilities | updateCapabilities} to tell Carbon AI Chat that your service desk supports uploads. It can also say whether it supports multiple files and set a filter for the operating system file select dialog. Call this function at any time, even to change the current capabilities. For example, if your service desk blocks uploads until an agent requests them, wait to call this function until the user gets such a message from the agent.
 
 ```ts
 this.callback.updateCapabilities({
@@ -175,7 +179,7 @@ this.callback.updateCapabilities({
 
 ### Validating files before uploading
 
-When a user selects files to upload, the Carbon AI Chat calls {@link ServiceDesk.filesSelectedForUpload} in your integration. Use this function to validate that the file is appropriate for uploading. Check the file's type or size and report an error if it isn't valid. The user must remove any files in error before sending a message with the files. Report the error by calling {@link ServiceDeskCallback.setFileUploadStatus}.
+When a user selects files to upload, Carbon AI Chat calls {@link ServiceDesk.filesSelectedForUpload | filesSelectedForUpload} in your integration. Use this function to check that the file is fine to upload: check its type or size, and if it isn't valid, report an error by calling {@link ServiceDeskCallback.setFileUploadStatus | setFileUploadStatus}. The user must remove any files in error before they send a message with the files.
 
 ```ts
 filesSelectedForUpload(uploads: FileUpload[]): void {
@@ -191,9 +195,9 @@ filesSelectedForUpload(uploads: FileUpload[]): void {
 
 ### Handling uploaded files
 
-After you enable file uploads, the user can select files and upload them to an agent by sending them as a "message". The Carbon AI Chat passes the {@link FileUpload} objects to your integration through {@link ServiceDesk.sendMessageToAgent} as the `additionalData.filesToUpload` argument.
+After you enable file uploads, the user can select files and send them to an agent as a "message". Carbon AI Chat passes the {@link FileUpload} objects to your integration through {@link ServiceDesk.sendMessageToAgent | sendMessageToAgent}, where they arrive as the `additionalData.filesToUpload` argument.
 
-> **Note:** The user does not need to type a message, so the `message.input.text` value can be empty.
+> **Note:** The user doesn't need to type a message, so the `message.input.text` value can be empty.
 
 Once your integration receives the files, it sends them to the service desk however your service desk requires.
 
@@ -213,7 +217,7 @@ async sendMessageToAgent(message: MessageRequest, messageID: string, additionalD
 
 ### Updating file upload status
 
-When your integration completes a file upload or stops it because of an error, report the status to the user with {@link ServiceDeskCallback.setFileUploadStatus}.
+When your integration finishes a file upload, or when an upload stops because of an error, report the status to the user with {@link ServiceDeskCallback.setFileUploadStatus | setFileUploadStatus}.
 
 ```ts
 // Called when the service desk has reported an error.
@@ -222,31 +226,31 @@ this.callback.setFileUploadStatus(file.id, true, errorMessage);
 
 ## Screen sharing
 
-You can integrate screen sharing or co-browse from your service desk. The service desk API lets your integration ask the user to approve a screen sharing request from the agent, then lets the user stop sharing whenever they want.
+You can add screen sharing or co-browse from your service desk. The service desk API lets your integration ask the user to approve the agent's screen sharing request, and it also lets the user stop sharing whenever they want.
 
-> **Note:** The Carbon AI Chat does not provide the screen sharing functions, only the request for permission from the user. The service desk integration provides the screen sharing capability.
+> **Note:** Carbon AI Chat doesn't provide the screen sharing functions, only the request for permission from the user. The service desk integration provides the screen sharing capability.
 
-To begin a screen sharing session, call {@link ServiceDeskCallback.screenShareRequest}. The Carbon AI Chat displays a modal asking the user to approve the request to begin screen sharing. This function returns a Promise that resolves when the user responds, and the resolution value is the user's response.
+To start a screen sharing session, call {@link ServiceDeskCallback.screenShareRequest | screenShareRequest}. Carbon AI Chat shows a modal that asks the user to approve the screen sharing request. The function returns a Promise that resolves when the user responds, and the resolved value is the user's response.
 
-The integration can stop screen sharing at any point, including while waiting for the user to approve a request. Use the latter to implement a timeout if you want to give the user a limited amount of time to respond before cancelling the request. An appropriate message displays to the user. To end screen sharing, call {@link ServiceDeskCallback.screenShareEnded}.
+The integration can stop screen sharing at any point, even while waiting for the user to approve a request. Use that to build a timeout: for example, give the user a limited time to respond before you cancel the request. An appropriate message displays to the user. To end screen sharing, call {@link ServiceDeskCallback.screenShareEnded | screenShareEnded}.
 
-The user can stop screen sharing at any point. When the user stops, the Carbon AI Chat calls {@link ServiceDesk.screenShareStop} on your integration.
+The user can stop screen sharing at any point, and when they do, Carbon AI Chat calls {@link ServiceDesk.screenShareStop | screenShareStop} on your integration.
 
 ## Reconnecting sessions
 
-If the service desk you connect to lets users reconnect to an agent after the page reloads, the Carbon AI Chat supports this process. The Carbon AI Chat tracks whether a user connects to an agent between page loads. If the Carbon AI Chat loads and detects that the user was previously connected to an agent, it gives the service desk integration a chance to reconnect. The Carbon AI Chat calls {@link ServiceDesk.reconnect} if it exists on the integration. The service desk then reconnects however it needs to, and once the reconnect completes or fails, {@link ServiceDesk.reconnect} resolves with a boolean to indicate whether reconnection succeeded.
+Some service desks let users reconnect to an agent after the page reloads, and Carbon AI Chat supports this. It tracks whether a user connects to an agent between page loads, so if Carbon AI Chat loads and finds the user was connected to an agent before, it gives the integration a chance to reconnect. Carbon AI Chat calls {@link ServiceDesk.reconnect | reconnect} if it exists on the integration, and the service desk then reconnects however it needs to. Once the reconnect finishes or fails, {@link ServiceDesk.reconnect | reconnect} resolves with a boolean that tells Carbon AI Chat whether reconnection succeeded.
 
-> **Note:** The user can't interact with the Carbon AI Chat until {@link ServiceDesk.reconnect} resolves or the user chooses to disconnect from the service desk.
+> **Note:** The user can't interact with Carbon AI Chat until {@link ServiceDesk.reconnect | reconnect} resolves, or the user chooses to disconnect from the service desk.
 
-If the integration needs to record state between page loads, it can use {@link ServiceDeskCallback.updatePersistedState}. {@link ServiceDeskCallback.updatePersistedState} stores the provided data in the browser's session history along with the session data the Carbon AI Chat stores. The session storage has a size limit, so avoid putting large amounts of data here.
+If the integration needs to record state between page loads, it can use {@link ServiceDeskCallback.updatePersistedState | updatePersistedState}, which stores the data in the browser's session history, next to the session data Carbon AI Chat stores. Session storage has a size limit, so don't put large amounts of data here.
 
 ### Handling service desks that don't support reconnection
 
-Not all service desks support reconnecting users to their previous agent conversations after a page refresh. The Carbon AI Chat handles these scenarios gracefully:
+Not all service desks can reconnect users to their previous agent conversations after a page refresh. Carbon AI Chat handles these cases gracefully:
 
-**Option 1: Don't implement the {@link ServiceDesk.reconnect} method (recommended for unsupported service desks)**
+**Option 1: Don't implement the {@link ServiceDesk.reconnect | reconnect} method (recommended for unsupported service desks)**
 
-If your service desk doesn't support reconnection, don't include a {@link ServiceDesk.reconnect} method in your integration. The Carbon AI Chat skips any reconnection attempts.
+If your service desk doesn't support reconnection, leave the {@link ServiceDesk.reconnect | reconnect} method out of your integration, and Carbon AI Chat then skips any reconnection attempts.
 
 ```ts
 class MyServiceDesk {
@@ -263,9 +267,9 @@ class MyServiceDesk {
 }
 ```
 
-**Option 2: Implement {@link ServiceDesk.reconnect} and return `false`**
+**Option 2: Implement {@link ServiceDesk.reconnect | reconnect} and return `false`**
 
-If you want to explicitly handle the reconnection attempt, implement the method and return `false`:
+To handle the reconnection attempt yourself, implement the method and return `false`:
 
 ```ts
 class MyServiceDesk {
@@ -276,9 +280,9 @@ class MyServiceDesk {
 }
 ```
 
-**Option 3: Disable reconnection via configuration**
+**Option 3: Disable reconnection through config**
 
-You can also disable reconnection attempts entirely through configuration:
+You can also turn off reconnection attempts entirely through config:
 
 ```tsx
 <ChatContainer
@@ -289,9 +293,9 @@ You can also disable reconnection attempts entirely through configuration:
 
 ### What happens when reconnection fails or isn't supported
 
-When reconnection is not possible, the Carbon AI Chat does the following:
+When reconnection isn't possible, Carbon AI Chat does the following:
 
-1. **Connection state is cleared**: The Carbon AI Chat ends the chat session.
+1. **Connection state is cleared**: Carbon AI Chat ends the chat session.
 2. **User notification**: The user sees the message "You disconnected from the live agent."
 3. **Assistant continues**: After a brief delay, the conversation continues with the assistant.
 4. **Fresh start**: The user can start a new agent conversation if needed.

--- a/packages/ai-chat/docs/CustomServiceDesks.md
+++ b/packages/ai-chat/docs/CustomServiceDesks.md
@@ -27,7 +27,7 @@ If the service desk runs on a different domain from your website, make sure it s
 
 ## Basic example
 
-Say you built a service integration that meets the service desk API. To make Carbon AI Chat use it, write a factory function that creates a new instance of your integration. The example below shows an empty integration that doesn't talk to a service desk; it's there to show how to register an integration with Carbon AI Chat.
+If you implement a service integration that satisfies the service desk API, getting the Carbon AI Chat to use it requires a factory function to create a new instance of your integration. The example shows an empty integration (that doesn't communicate with a service desk) to show how to register an integration with the Carbon AI Chat.
 
 ```tsx
 // Your custom service desk integration which can be located anywhere in your codebase.
@@ -104,7 +104,7 @@ The `serviceDeskFactory` config property expects a factory function that returns
 
 ### Communicating from your service desk to the Carbon AI Chat
 
-The factory receives a callback object in {@link ServiceDeskFactoryParameters}. You call these callbacks inside your service desk code to send information back to Carbon AI Chat.
+The factory receives a callback object in {@link ServiceDeskFactoryParameters}. These callbacks are the functions you call inside your service desk code to communicate information back to the Carbon AI Chat.
 
 ### Interaction flow
 


### PR DESCRIPTION
Closes #

Tone pass on `CustomServiceDesks.md` (Service desks) per `references/tone.md`. Prose only — code blocks and page structure unchanged.

#### Changelog

**Changed**

- Reword `CustomServiceDesks.md` for voice and reading level.

#### Testing / Reviewing

- Flesch-Kincaid grade: 9.2 (target 8–11). Measured with `npm run reading-level`, which ships in #1740.
- Confirm the reword kept every fact, default, and qualifier.
