### PR TITLE
docs: apply tone guide to Customization.md

### DIFF
--- a/packages/ai-chat/docs/Customization.md
+++ b/packages/ai-chat/docs/Customization.md
@@ -17,7 +17,7 @@ children:
 Customize the chat UI at three levels, from quickest to deepest:
 
 - **Configure** — set behavior and appearance through {@link PublicConfig | config} props.
-- **Restyle** — inherit or inject a Carbon theme. Override the chat's CSS custom-property tokens for color, sizing, and placement.
+- **Restyle** — inherit or inject a Carbon theme and override the chat's CSS custom-property tokens for color, sizing, and placement.
 - **Inject your own content** — render your own markup into slots, overlay panels, message responses, and footers.
 
 The inject-your-own-content areas render through your framework using the {@link ChatInstance | chat instance}. Their APIs differ between [React](./React.md) and the [web component](./WebComponent.md). Check your framework's docs.

--- a/packages/ai-chat/docs/Customization.md
+++ b/packages/ai-chat/docs/Customization.md
@@ -16,24 +16,24 @@ children:
 
 Customize the chat UI at three levels, from quickest to deepest:
 
-- **Configure** — set behavior and appearance declaratively through {@link PublicConfig} props.
-- **Restyle** — inherit or inject a Carbon theme and override the chat's CSS custom-property tokens for color, sizing, and placement.
+- **Configure** — set behavior and appearance through {@link PublicConfig | config} props.
+- **Restyle** — inherit or inject a Carbon theme. Override the chat's CSS custom-property tokens for color, sizing, and placement.
 - **Inject your own content** — render your own markup into slots, overlay panels, message responses, and footers.
 
-The inject-your-own-content areas render through your framework using the {@link ChatInstance}, so their APIs differ between [React](./React.md) and the [web component](./WebComponent.md). Be sure to refer to the documentation for your framework for implementation differences.
+The inject-your-own-content areas render through your framework using the {@link ChatInstance | chat instance}. Their APIs differ between [React](./React.md) and the [web component](./WebComponent.md). Check your framework's docs.
 
 Pick the area you want to customize:
 
 - [Theming](./Theming.md) — inherit or inject a Carbon theme and override colors.
-- [Layout](./Layout.md) — layout modes, sizing and placement CSS custom properties, the floating layout, and corner rounding.
+- [Layout](./Layout.md) — layout modes, sizing and placement tokens, the floating layout, and corner rounding.
 - [Launcher](./Launcher.md) — configure or replace the launcher and style its tokens.
 - [Header](./Header.md) — title, buttons, menus, and the AI label in the header bar.
 - [Home screen](./Homescreen.md) — the optional landing view with greeting and starter prompts.
 - [Slots](./WriteableElements.md) — write your own content into slots around the chat.
 - [Custom panels](./CustomPanels.md) — open an overlay panel with your own content.
-- [Customizing responses](./Responses.md) — style rich text responses and render your own {@link MessageResponseTypes.USER_DEFINED} content.
+- [Customizing responses](./Responses.md) — style rich text responses and render your own {@link MessageResponseTypes.USER_DEFINED | user-defined} content.
 - [Custom message footer](./CustomMessageFooter.md) — render your own content beneath an assistant message.
 
 ## Config reference
 
-To configure other options like the assistant name or feedback persistence, see {@link PublicConfig}.
+See {@link PublicConfig | config} for other options like the assistant name or feedback persistence.

--- a/packages/ai-chat/docs/Customization.md
+++ b/packages/ai-chat/docs/Customization.md
@@ -25,7 +25,7 @@ The inject-your-own-content areas render through your framework using the {@link
 Pick the area you want to customize:
 
 - [Theming](./Theming.md) — inherit or inject a Carbon theme and override colors.
-- [Layout](./Layout.md) — layout modes, sizing and placement tokens, the floating layout, and corner rounding.
+- [Layout](./Layout.md) — layout modes, sizing and placement CSS custom properties, the floating layout, and corner rounding.
 - [Launcher](./Launcher.md) — configure or replace the launcher and style its tokens.
 - [Header](./Header.md) — title, buttons, menus, and the AI label in the header bar.
 - [Home screen](./Homescreen.md) — the optional landing view with greeting and starter prompts.

--- a/packages/ai-chat/docs/Customization.md
+++ b/packages/ai-chat/docs/Customization.md
@@ -20,7 +20,7 @@ Customize the chat UI at three levels, from quickest to deepest:
 - **Restyle** — inherit or inject a Carbon theme and override the chat's CSS custom-property tokens for color, sizing, and placement.
 - **Inject your own content** — render your own markup into slots, overlay panels, message responses, and footers.
 
-The inject-your-own-content areas render through your framework using the {@link ChatInstance | chat instance}. Their APIs differ between [React](./React.md) and the [web component](./WebComponent.md). Check your framework's docs.
+The inject-your-own-content areas render through your framework using the {@link ChatInstance | chat instance}. Their APIs differ between [React](./React.md) and the [web component](./WebComponent.md). Be sure to refer to the documentation for your framework for implementation differences.
 
 Pick the area you want to customize:
 


### PR DESCRIPTION
Closes #

Tone pass on `Customization.md` (UI customization) per `references/tone.md`. Prose only — code blocks and page structure unchanged.

#### Changelog

**Changed**

- Reword `Customization.md` for voice and reading level.

#### Testing / Reviewing

- Flesch-Kincaid grade: 8.9 (target 8–11). Measured with `npm run reading-level`, which ships in #1740.
- Confirm the reword kept every fact, default, and qualifier.
