### PR TITLE
docs: apply tone guide to CustomHistory.md

### DIFF
--- a/packages/ai-chat/docs/CustomHistory.md
+++ b/packages/ai-chat/docs/CustomHistory.md
@@ -4,21 +4,21 @@ title: Conversation history
 
 ## Overview
 
-Restore previous conversations by loading custom history when the chat opens. History is an array of {@link HistoryItem} objects, where each item contains either a {@link MessageRequest} or {@link MessageResponse} along with a timestamp.
+Restore past conversations by loading custom history when the chat opens. History is an array of {@link HistoryItem | history items}. Each item holds a {@link MessageRequest | request} or {@link MessageResponse | response}, plus a timestamp.
 
-> **Note**: The Carbon AI Chat handles only UI-level history (displaying previous messages); it has no recommended strategy for storing LLM-friendly conversation history.
+> **Note**: The Carbon AI Chat handles only UI-level history, which displays past messages. It has no recommended way to store LLM-friendly conversation history.
 
-This guide covers loading history data into the chat and showing the built-in history panel that lets users browse and switch between past conversations.
+This guide covers loading history data into the chat. It also covers the built-in history panel. That panel lets users browse and switch between past conversations.
 
 ## History data structure
 
-Each {@link HistoryItem} pairs a message ({@link MessageRequest} or {@link MessageResponse}) with an ISO 8601 {@link HistoryItem.time} (e.g. `2020-03-15T08:59:56.952Z`). See {@link HistoryItem} for the full shape.
+Each {@link HistoryItem | history item} pairs a message with a timestamp. The message is a {@link MessageRequest | request} or {@link MessageResponse | response}. The timestamp is an ISO 8601 {@link HistoryItem.time | time} (e.g. `2020-03-15T08:59:56.952Z`). See {@link HistoryItem} for the full shape.
 
-Include the message's {@link MessageRequest.history} property ({@link MessageRequestHistory} or {@link MessageResponseHistory}); it stores metadata like timestamps, labels, error states, and feedback.
+Include the message's {@link MessageRequest.history | history} property. Its type is {@link MessageRequestHistory | request history} or {@link MessageResponseHistory | response history}. It stores metadata like timestamps, labels, error states, and feedback.
 
 ## Loading history on startup
 
-To load history when the chat opens, define a {@link PublicConfigMessaging.customLoadHistory} function in your {@link PublicConfig}:
+To load history when the chat opens, define a {@link PublicConfigMessaging.customLoadHistory | customLoadHistory} function in your {@link PublicConfig | config}:
 
 ```typescript
 import { ChatInstance, HistoryItem } from "@carbon/ai-chat";
@@ -38,16 +38,16 @@ const config = {
 
 This function:
 
-- Receives the {@link ChatInstance} as a parameter
+- Receives the {@link ChatInstance | chat instance} as a parameter
 - Returns a `Promise<HistoryItem[]>`
-- Is called once during the chat's hydration process
-- Cannot be changed after initial load
+- Runs once while the chat hydrates
+- Can't change after the initial load
 
-The Carbon AI Chat automatically calls {@link ChatInstanceMessaging.insertHistory} with the returned items.
+The Carbon AI Chat calls {@link ChatInstanceMessaging.insertHistory | insertHistory} with the returned items for you.
 
 ## Manually loading history
 
-For advanced use cases (like switching between conversations), you can skip {@link PublicConfigMessaging.customLoadHistory} and directly call {@link ChatInstanceMessaging.insertHistory}:
+For advanced cases like switching between conversations, skip {@link PublicConfigMessaging.customLoadHistory | customLoadHistory} and call {@link ChatInstanceMessaging.insertHistory | insertHistory} directly:
 
 ```typescript
 // Load history manually
@@ -56,13 +56,13 @@ await instance.messaging.insertHistory(historyItems);
 
 This method:
 
-- Fires {@link BusEventType.HISTORY_BEGIN} and {@link BusEventType.HISTORY_END} events
-- Can be called multiple times
-- Does not clear existing messages (use {@link ChatInstanceMessaging.clearConversation} first if needed)
+- Fires {@link BusEventType.HISTORY_BEGIN | HISTORY_BEGIN} and {@link BusEventType.HISTORY_END | HISTORY_END} events
+- Can run multiple times
+- Doesn't clear existing messages (call {@link ChatInstanceMessaging.clearConversation | clearConversation} first if needed)
 
 ## Switching between conversations
 
-When users need to switch between different conversations:
+To switch between conversations:
 
 ```typescript
 // Clear the current conversation
@@ -72,18 +72,18 @@ await instance.messaging.clearConversation();
 await instance.messaging.insertHistory(newConversationHistory);
 ```
 
-{@link ChatInstanceMessaging.clearConversation}:
+{@link ChatInstanceMessaging.clearConversation | clearConversation}:
 
-- Triggers a restart of the conversation
+- Restarts the conversation
 - Clears all current assistant messages from the view
 - Cancels any outstanding messages
-- Does not start a new hydration process
+- Doesn't start a new hydration process
 
 ## History loading indicators
 
-When using {@link PublicConfigMessaging.customLoadHistory}, the Carbon AI Chat automatically shows a fullscreen loading indicator during the hydration process. You do not need to manually control the loading state.
+With {@link PublicConfigMessaging.customLoadHistory | customLoadHistory}, the Carbon AI Chat shows a fullscreen loading indicator during hydration. You don't need to control the loading state yourself.
 
-However, if you manually call {@link ChatInstanceMessaging.clearConversation} or {@link ChatInstanceMessaging.insertHistory} (for example, when switching conversations), you may want to show a loading indicator while fetching data:
+But if you call {@link ChatInstanceMessaging.clearConversation | clearConversation} or {@link ChatInstanceMessaging.insertHistory | insertHistory} yourself, you may want to show a loading indicator while you fetch data. Switching conversations is one example:
 
 ```typescript
 async function switchToConversation(conversationId: string) {
@@ -104,15 +104,15 @@ async function switchToConversation(conversationId: string) {
 }
 ```
 
-{@link ChatInstance.updateIsChatLoadingCounter} controls the fullscreen hydration loading state. The indicator shows when the internal counter is greater than zero. Always pair "increase" with "decrease" so the counter resets.
+{@link ChatInstance.updateIsChatLoadingCounter | updateIsChatLoadingCounter} controls the fullscreen hydration loading state. The indicator shows when the internal counter is above zero. Always pair "increase" with "decrease" so the counter resets.
 
 ## The history panel
 
-The sections above load history into the current conversation. The history panel is the UI that lets users browse past conversations and switch between them. You enable it through configuration and render its contents yourself through a slot.
+The sections above load history into the current conversation. The history panel is the UI for browsing past conversations and switching between them. You enable it through config. You render its contents yourself through a slot.
 
 ### Enabling the panel
 
-Turn the panel on with {@link HistoryConfig} in your {@link PublicConfig}:
+Turn the panel on with {@link HistoryConfig | history config} in your {@link PublicConfig | config}:
 
 ```ts
 const config = {
@@ -124,13 +124,13 @@ const config = {
 };
 ```
 
-- {@link HistoryConfig.isOn} enables the feature and renders the panel slot. It does not, by itself, control panel visibility at the mobile breakpoint.
-- {@link HistoryConfig.showMobileMenu} (default `true`) shows the built-in "New chat" and "View chats" options in the header on small screens. Set it to `false` when you provide your own controls.
-- {@link HistoryConfig.startClosed} (default `false`) starts the panel open on desktop and closed on mobile, resetting to that default when the viewport crosses the breakpoint. Set it to `true` to start closed in both modes and preserve the user's open/closed choice across breakpoint changes — useful when you drive the panel programmatically.
+- {@link HistoryConfig.isOn | isOn} enables the feature and renders the panel slot. On its own, it doesn't control panel visibility at the mobile breakpoint.
+- {@link HistoryConfig.showMobileMenu | showMobileMenu} (default `true`) shows the built-in "New chat" and "View chats" options. They appear in the header on small screens. Set it to `false` when you provide your own controls.
+- {@link HistoryConfig.startClosed | startClosed} (default `false`) starts the panel open on desktop and closed on mobile. It resets to that default when the viewport crosses the breakpoint. Set it to `true` to start closed in both modes. This also keeps the user's open or closed choice across breakpoint changes. That helps when you drive the panel from code.
 
 ### Rendering your panel content
 
-The panel body is a slot. Render your own conversation list into the {@link WriteableElementName.HISTORY_PANEL_ELEMENT} slot (`"historyPanelElement"`). With a web component, slot your content into the host element:
+The panel body is a slot. Render your own conversation list into the {@link WriteableElementName.HISTORY_PANEL_ELEMENT | historyPanelElement} slot (`"historyPanelElement"`). With a web component, slot your content into the host element:
 
 ```html
 <cds-aichat-custom-element>
@@ -140,11 +140,11 @@ The panel body is a slot. Render your own conversation list into the {@link Writ
 </cds-aichat-custom-element>
 ```
 
-See [Slots](./WriteableElements.md) for how slots work across frameworks. The [chat-history-fullscreen example](https://github.com/carbon-design-system/carbon-ai-chat/tree/main/examples/web-components/chat-history-fullscreen) builds a complete panel — pinning, search, rename, and delete — from the `cds-aichat-history-*` components in the separate `@carbon/ai-chat-components` package.
+See [Slots](./WriteableElements.md) for how slots work across frameworks. The [chat-history-fullscreen example](https://github.com/carbon-design-system/carbon-ai-chat/tree/main/examples/web-components/chat-history-fullscreen) builds a complete panel with pinning, search, rename, and delete. It uses the `cds-aichat-history-*` components from the separate `@carbon/ai-chat-components` package.
 
 ### Loading a conversation on selection
 
-When a user picks a conversation in your panel, load it the same way as [Switching between conversations](#switching-between-conversations): clear the current view, then insert the selected conversation's history.
+When a user picks a conversation in your panel, load it. Use the same steps as [Switching between conversations](#switching-between-conversations). Clear the current view, then insert the selected conversation's history.
 
 ```ts
 async function selectConversation(historyItems) {
@@ -153,11 +153,11 @@ async function selectConversation(historyItems) {
 }
 ```
 
-Your slotted panel lives outside the chat, so it needs a way to reach your loader. The example bridges the two with an app-defined `CustomEvent` (`history-panel-load-chat`) dispatched from the slotted component and handled on the host. That is one pattern, not a required API — any mechanism that calls `clearConversation()` and `insertHistory()` works.
+Your slotted panel lives outside the chat. So it needs a way to reach your loader. The example bridges the two with an app-defined `CustomEvent` (`history-panel-load-chat`). The slotted component dispatches it, and the host handles it. This is one pattern, not a required API. Any mechanism that calls `clearConversation()` and `insertHistory()` works.
 
 ### Controlling the panel programmatically
 
-Open and close the panel through {@link CustomPanels}:
+Open and close the panel through {@link CustomPanels | custom panels}:
 
 ```ts
 import { PanelType } from "@carbon/ai-chat";
@@ -166,15 +166,15 @@ instance.customPanels.getPanel(PanelType.HISTORY)?.open();
 instance.customPanels.getPanel(PanelType.HISTORY)?.close();
 ```
 
-Do not toggle {@link HistoryConfig.isOn} at runtime to show or hide the panel — use `open()` and `close()` instead.
+Don't toggle {@link HistoryConfig.isOn | isOn} at runtime to show or hide the panel. Use `open()` and `close()` instead.
 
-To read the panel's current state — for example, to build a toggle or adapt to mobile — use {@link ChatInstance.getState}; `customPanels.history` is a {@link PublicHistoryPanelState} with `isOpen` and `isMobile`. The panel instance itself does not expose an `isOpen` property.
+To read the panel's current state, use {@link ChatInstance.getState | getState}. This helps when you build a toggle or adapt to mobile. `customPanels.history` is a {@link PublicHistoryPanelState | history panel state} with `isOpen` and `isMobile`. The panel instance itself doesn't expose an `isOpen` property.
 
 ```ts
 const { isOpen, isMobile } = instance.getState().customPanels.history;
 ```
 
-To react to changes, subscribe to {@link BusEventType.STATE_CHANGE} and compare the previous and new state:
+To react to changes, subscribe to {@link BusEventType.STATE_CHANGE | STATE_CHANGE} and compare the previous and new state:
 
 ```ts
 instance.on({
@@ -191,10 +191,10 @@ instance.on({
 
 ## Related
 
-- [history example](https://github.com/carbon-design-system/carbon-ai-chat/tree/main/examples/react/history) — a complete, runnable implementation.
+- [history example](https://github.com/carbon-design-system/carbon-ai-chat/tree/main/examples/react/history) — a complete, runnable app.
 - [chat-history-fullscreen example](https://github.com/carbon-design-system/carbon-ai-chat/tree/main/examples/web-components/chat-history-fullscreen) — a fullscreen web-component layout with a custom history panel.
 - [Slots](./WriteableElements.md) — render your own content into the history panel slot.
 - [Message format](./MessageFormat.md) — the request/response shapes history items wrap.
-- [Session state persistence](./StatePersistence.md) — own where the chat's session and UI state (views, disclaimer, human-agent connection) is stored, separately from conversation messages.
+- [Session state persistence](./StatePersistence.md) — own where the chat stores its session and UI state (views, disclaimer, human-agent connection), apart from conversation messages.
 - [Adding messages (legacy)](./AddMessageChunk.md) — getting live responses onscreen.
 - [Adding messages (experimental)](./UpsertMessage.md) — revising a message after it renders.

--- a/packages/ai-chat/docs/CustomHistory.md
+++ b/packages/ai-chat/docs/CustomHistory.md
@@ -8,7 +8,7 @@ Restore past conversations by loading custom history when the chat opens. Histor
 
 > **Note**: The Carbon AI Chat handles only UI-level history, which displays past messages. It has no recommended way to store LLM-friendly conversation history.
 
-This guide covers loading history data into the chat. It also covers the built-in history panel. That panel lets users browse and switch between past conversations.
+This guide covers loading history data into the chat. It also covers the built-in history panel that lets users browse and switch between past conversations.
 
 ## History data structure
 
@@ -108,7 +108,7 @@ async function switchToConversation(conversationId: string) {
 
 ## The history panel
 
-The sections above load history into the current conversation. The history panel is the UI for browsing past conversations and switching between them. You enable it through config. You render its contents yourself through a slot.
+The sections above load history into the current conversation. The history panel is the UI for browsing past conversations and switching between them. You enable it through configuration and render its contents yourself through a slot.
 
 ### Enabling the panel
 


### PR DESCRIPTION
Closes #

Tone pass on `CustomHistory.md` (Conversation history) per `references/tone.md`. Prose only — code blocks and page structure unchanged.

#### Changelog

**Changed**

- Reword `CustomHistory.md` for voice and reading level.

#### Testing / Reviewing

- Flesch-Kincaid grade: 8.1 (target 8–11). Measured with `npm run reading-level`, which ships in #1740.
- Confirm the reword kept every fact, default, and qualifier.
