### PR TITLE
docs: apply tone guide to CustomServer.md

### DIFF
--- a/packages/ai-chat/docs/CustomServer.md
+++ b/packages/ai-chat/docs/CustomServer.md
@@ -16,7 +16,7 @@ Connect the Carbon AI Chat to your own server. It supports streaming results, no
 1. **Exchanging messages** — receive a {@link MessageRequest | message request} when a user sends a message, and deliver a {@link MessageResponse | message response} back. This page shows how to wire that up with {@link PublicConfigMessaging.customSendMessage | customSendMessage}.
 2. **Persisting history** — restore past conversations when the chat reopens. See [Conversation history](./CustomHistory.md).
 
-This page is the entry point. Where you go next depends on what you build:
+Where you go next depends on what you build:
 
 - [Message format](./MessageFormat.md) — the shape of the requests you receive and responses you return (for server / API authors).
 - [Adding messages (legacy)](./AddMessageChunk.md) — the stable chunk-based streaming flow.
@@ -39,9 +39,9 @@ The chat passes this function three parameters:
 
 The function can return nothing, or it can return a promise. If you return a promise, the chat does this:
 
-1. Sets up a message queue, passing the next message to your function only after the current one completes.
-2. Shows a loading indicator if the message takes a while to return (or to return its first chunk if streaming).
-3. Throws a visible error and passes an abort signal if the wait exceeds the `messaging.messageTimeoutSecs` timeout, which you set in your {@link PublicConfig} with {@link PublicConfigMessaging.messageTimeoutSecs | messageTimeoutSecs}.
+1. Set up a message queue, passing the next message to your function only after the current one completes.
+2. Show a loading indicator if the message takes a while to return (or to return its first chunk if streaming).
+3. Throw a visible error and pass an abort signal if the wait exceeds the `messaging.messageTimeoutSecs` timeout, which you set in your {@link PublicConfig} with {@link PublicConfigMessaging.messageTimeoutSecs | messageTimeoutSecs}.
 
 If you do not return a promise, the chat does not queue your messages, and it skips the loading indicator when no first chunk comes back.
 

--- a/packages/ai-chat/docs/CustomServer.md
+++ b/packages/ai-chat/docs/CustomServer.md
@@ -11,63 +11,63 @@ children:
 
 ## Overview
 
-You can connect the Carbon AI Chat to your own server. It supports both streaming and non-streaming results, or a mixture of both. There are two responsibilities you can implement:
+Connect the Carbon AI Chat to your own server. It supports streaming results, non-streaming results, or a mix of both. You can take on two responsibilities:
 
-1. **Exchanging messages** — receive a {@link MessageRequest} when a user sends a message, and deliver a {@link MessageResponse} back. This page covers wiring that up with {@link PublicConfigMessaging.customSendMessage}.
-2. **Persisting history** — restore previous conversations when the chat reopens. See [Conversation history](./CustomHistory.md).
+1. **Exchanging messages** — receive a {@link MessageRequest | message request} when a user sends a message, and deliver a {@link MessageResponse | message response} back. This page shows how to wire that up with {@link PublicConfigMessaging.customSendMessage | customSendMessage}.
+2. **Persisting history** — restore past conversations when the chat reopens. See [Conversation history](./CustomHistory.md).
 
-This page is the entry point. Depending on what you are building, continue to:
+This page is the entry point. Where you go next depends on what you build:
 
 - [Message format](./MessageFormat.md) — the shape of the requests you receive and responses you return (for server / API authors).
 - [Adding messages (legacy)](./AddMessageChunk.md) — the stable chunk-based streaming flow.
 - [Adding messages (experimental)](./UpsertMessage.md) — the preferred, experimental insert-or-update-by-ID flow.
 - [Structured data](./StructuredData.md) — send typed fields and uploaded files alongside the user's text.
-- [Conversation history](./CustomHistory.md) — loading and restoring previous conversations.
+- [Conversation history](./CustomHistory.md) — load and restore past conversations.
 - [Session state persistence](./StatePersistence.md) — own where the chat's session and UI state is stored.
 
 ## Connecting your server
 
-The Carbon AI Chat takes custom messaging server configuration as part of its {@link PublicConfig}. You must provide a {@link PublicConfigMessaging.customSendMessage} function that the Carbon AI Chat calls any time the user sends a message. It also gets called when you use {@link ChatInstance.send}.
+You pass your custom messaging configuration as part of the {@link PublicConfig | config}. You must provide a {@link PublicConfigMessaging.customSendMessage | customSendMessage} function, which the chat calls whenever the user sends a message. It also runs when you call {@link ChatInstance.send | send}.
 
 For more information, see [the examples page](https://github.com/carbon-design-system/carbon-ai-chat/tree/main/examples/react/basic-float/src/customSendMessage.ts).
 
-In this function, the Carbon AI Chat passes three parameters:
+The chat passes this function three parameters:
 
-1. {@link MessageRequest}: The message being sent.
-2. {@link CustomSendMessageOptions}: Options about that message. This includes an abort signal to cancel the request.
-3. {@link ChatInstance}: The Carbon AI Chat `instance` object.
+1. {@link MessageRequest}: the message being sent.
+2. {@link CustomSendMessageOptions}: options for that message, including an abort signal to cancel the request.
+3. {@link ChatInstance}: the Carbon AI Chat `instance` object.
 
-This function can return nothing or it can return a promise object. If you return a promise object, the Carbon AI Chat does the following:
+The function can return nothing, or it can return a promise. If you return a promise, the chat does this:
 
-1. Set up a message queue and only pass the next message to your function when the message completes.
-2. Show a loading indicator if the message is taking a while to return (or return its first chunk if streaming).
-3. Throw a visible error and pass an abort signal if waiting for the message exceeds the `messaging.messageTimeoutSecs` timeout identified in your {@link PublicConfig} with {@link PublicConfigMessaging.messageTimeoutSecs}.
+1. Sets up a message queue, passing the next message to your function only after the current one completes.
+2. Shows a loading indicator if the message takes a while to return (or to return its first chunk if streaming).
+3. Throws a visible error and passes an abort signal if the wait exceeds the `messaging.messageTimeoutSecs` timeout, which you set in your {@link PublicConfig} with {@link PublicConfigMessaging.messageTimeoutSecs | messageTimeoutSecs}.
 
-If you do not return a promise object, the Carbon AI Chat does not queue messages for you or show any loading indicator if no first chunk is returned.
+If you do not return a promise, the chat does not queue your messages, and it skips the loading indicator when no first chunk comes back.
 
 ## Delivering responses
 
-Once you have a response (or part of one), you push it onto the screen through {@link ChatInstanceMessaging}. There are two flows, and your assistant can return responses in either format and switch between them:
+When you have a response, or part of one, push it to the screen through {@link ChatInstanceMessaging | messaging}. You have two flows, and your assistant can return either format and switch between them:
 
-- **Stable flow** — {@link ChatInstanceMessaging.addMessage} for one-shot, non-streaming inserts, and {@link ChatInstanceMessaging.addMessageChunk} for chunked streaming. Fully supported with no deprecation. See [Adding messages (legacy)](./AddMessageChunk.md).
-- **Preferred flow (experimental)** — {@link ChatInstanceMessaging.upsertMessage} inserts or updates a message by ID via an updater function, covering streaming, regenerate, post-stream corrections, and optimistic updates with one method. It is the recommended direction for new code, but experimental — its semantics and updater signature may still evolve. See [Adding messages (experimental)](./UpsertMessage.md).
+- **Stable flow** — use {@link ChatInstanceMessaging.addMessage | addMessage} for one-shot, non-streaming inserts, and {@link ChatInstanceMessaging.addMessageChunk | addMessageChunk} for chunked streaming. Both are fully supported, with no deprecation. See [Adding messages (legacy)](./AddMessageChunk.md).
+- **Preferred flow (experimental)** — {@link ChatInstanceMessaging.upsertMessage | upsertMessage} inserts or updates a message by ID through an updater function, covering streaming, regenerate, post-stream fixes, and optimistic updates with one method. It is the recommended path for new code, but experimental: its semantics and updater signature may still change. See [Adding messages (experimental)](./UpsertMessage.md).
 
-For the shape of the data you return in either flow, see [Message format](./MessageFormat.md).
+For the data shape in either flow, see [Message format](./MessageFormat.md).
 
 ## Cancelling request (stop streaming)
 
-When streaming content, users can request to stop the stream in two ways:
+While content streams, users can stop the stream in two ways:
 
 1. Clicking the "stop streaming" button in the input field
 2. Restarting or clearing the conversation
 
-Both actions trigger request cancellation. The cancellation mechanism is identical across delivery flows — the same abort signal works whether you deliver responses with {@link ChatInstanceMessaging.addMessageChunk} or {@link ChatInstanceMessaging.upsertMessage}. Only the way you deliver the final state differs.
+Both actions cancel the request. Cancellation works the same across flows: the same abort signal works whether you deliver responses with {@link ChatInstanceMessaging.addMessageChunk | addMessageChunk} or {@link ChatInstanceMessaging.upsertMessage | upsertMessage}. Only the way you deliver the final state differs.
 
 ### 1. Mark your stream as cancellable
 
-Set `cancellable: true` in the {@link ItemStreamingMetadata} of the items you are streaming. The "stop streaming" button appears whenever a streaming item has `cancellable: true`.
+Set `cancellable: true` in the {@link ItemStreamingMetadata | streaming metadata} of the items you stream. The "stop streaming" button appears whenever a streaming item has `cancellable: true`.
 
-With {@link ChatInstanceMessaging.addMessageChunk}, set it on the partial item chunk as a {@link StreamChunk}:
+With {@link ChatInstanceMessaging.addMessageChunk | addMessageChunk}, set it on the partial item chunk as a {@link StreamChunk | stream chunk}:
 
 ```typescript
 const chunk: StreamChunk = {
@@ -85,17 +85,17 @@ const chunk: StreamChunk = {
 };
 ```
 
-With {@link ChatInstanceMessaging.upsertMessage}, set it on the item in the message your updater returns while the message is in {@link MessageState.STREAMING}.
+With {@link ChatInstanceMessaging.upsertMessage | upsertMessage}, set it on the item in the message your updater returns while the message is in the {@link MessageState.STREAMING | streaming} state.
 
 ### 2. Listen for cancellation
 
-The {@link CustomSendMessageOptions.signal} abort signal is triggered when a message request is cancelled. When aborted, the signal's `reason` property contains one of the values from the {@link CancellationReason} enum:
+The {@link CustomSendMessageOptions.signal | abort signal} fires when a message request is cancelled. On abort, the signal's `reason` holds one value from the {@link CancellationReason} enum:
 
-- {@link CancellationReason.STOP_STREAMING} (`"Stop streaming"`) - User clicked the stop streaming button
-- {@link CancellationReason.CONVERSATION_RESTARTED} (`"Conversation restarted"`) - User restarted or cleared the conversation
-- {@link CancellationReason.TIMEOUT} (`"Request timeout"`) - Request exceeded the configured timeout duration
+- {@link CancellationReason.STOP_STREAMING} (`"Stop streaming"`) - the user clicked the stop streaming button
+- {@link CancellationReason.CONVERSATION_RESTARTED} (`"Conversation restarted"`) - the user restarted or cleared the conversation
+- {@link CancellationReason.TIMEOUT} (`"Request timeout"`) - the request exceeded the configured timeout
 
-You can check if the request was cancelled using `signal.aborted` or by listening to the "abort" event, and access the specific reason via `signal.reason`. The abort signal provides unified handling for all cancellation scenarios.
+Check whether the request was cancelled with `signal.aborted`, or by listening for the "abort" event, and read the reason from `signal.reason`. The abort signal handles every cancellation the same way.
 
 ```typescript
 import { CancellationReason } from "@carbon/ai-chat";
@@ -138,11 +138,11 @@ async function customSendMessage(
 
 ### 3. Deliver the final state
 
-When cancellation is detected, exit your streaming loop and transition the message out of the streaming state. How you deliver that final state depends on which flow you are using.
+When you detect cancellation, exit your streaming loop and move the message out of the streaming state. How you deliver that final state depends on your flow.
 
 #### With addMessageChunk
 
-Send a {@link FinalResponseChunk}. Optionally send a {@link CompleteItemChunk} with `stream_stopped: true` first to trigger the appropriate a11y states:
+Send a {@link FinalResponseChunk | final response chunk}. Optionally send a {@link CompleteItemChunk | complete item chunk} with `stream_stopped: true` first, to trigger the right a11y states:
 
 ```typescript
 // Optional: mark the item as stopped for a11y messaging.
@@ -178,7 +178,7 @@ await instance.messaging.addMessageChunk({
 
 #### With upsertMessage
 
-Call {@link ChatInstanceMessaging.upsertMessage} with {@link MessageState.COMPLETE}. This transitions the message out of streaming and hides the "stop streaming" button. Set `streaming_metadata.stream_stopped: true` on the items to trigger the "Response stopped" a11y announcement:
+Call {@link ChatInstanceMessaging.upsertMessage | upsertMessage} with {@link MessageState.COMPLETE | the complete state}, which moves the message out of streaming and hides the "stop streaming" button. Set `streaming_metadata.stream_stopped: true` on the items to trigger the "Response stopped" a11y announcement:
 
 ```typescript
 await instance.messaging.upsertMessage(
@@ -203,21 +203,21 @@ await instance.messaging.upsertMessage(
 ### Important notes
 
 - The "stop streaming" button appears when a streaming item has `cancellable: true`.
-- Clicking the button triggers the abort signal (with reason {@link CancellationReason.STOP_STREAMING}), but does not automatically stop your streaming.
-- You must listen to the abort signal, stop your streaming logic, and deliver the final state.
-- The abort signal is also triggered for conversation restarts/clears ({@link CancellationReason.CONVERSATION_RESTARTED}) and timeouts ({@link CancellationReason.TIMEOUT}).
-- With {@link ChatInstanceMessaging.addMessageChunk}, the button remains visible (disabled) until a {@link FinalResponseChunk} is received; with {@link ChatInstanceMessaging.upsertMessage}, it hides when the message transitions to {@link MessageState.COMPLETE} (or {@link MessageState.ERROR}). Always deliver the final state, even when cancelled, to properly clean up UI state.
-- If the message was cancelled because of a {@link CancellationReason.TIMEOUT}, the UI marks the message as errored.
+- Clicking the button fires the abort signal (with reason {@link CancellationReason.STOP_STREAMING}), but it does not stop your streaming on its own.
+- You must listen for the abort signal, stop your streaming logic, and deliver the final state.
+- The abort signal also fires on conversation restarts and clears ({@link CancellationReason.CONVERSATION_RESTARTED}) and on timeouts ({@link CancellationReason.TIMEOUT}).
+- With {@link ChatInstanceMessaging.addMessageChunk | addMessageChunk}, the button stays visible but disabled until a {@link FinalResponseChunk | final response chunk} arrives. With {@link ChatInstanceMessaging.upsertMessage | upsertMessage}, it hides when the message reaches {@link MessageState.COMPLETE | complete} (or {@link MessageState.ERROR | error}). Always deliver the final state, even when cancelled, to clean up UI state.
+- If a {@link CancellationReason.TIMEOUT | timeout} cancels the message, the UI marks it as errored.
 
 ## Welcome messages
 
-By default, if the homescreen is disabled, the Carbon AI Chat sends a {@link MessageRequest} with `input.text` set to a blank string and `history.is_welcome_request` set to true when a user first opens the chat. This lets you inject a hard-coded greeting. To skip it, set {@link PublicConfigMessaging.skipWelcome} to `true`.
+By default, if the homescreen is disabled, the chat sends a {@link MessageRequest | message request} the first time a user opens it, with `input.text` set to a blank string and `history.is_welcome_request` set to true. This lets you inject a hard-coded greeting. To skip it, set {@link PublicConfigMessaging.skipWelcome | skipWelcome} to `true`.
 
-If you want to send your own "welcome" message (e.g. you send different text depending on the user and respond in kind) you can set {@link PublicConfigMessaging.skipWelcome} to `true` and deliver the greeting yourself — call {@link ChatInstanceMessaging.addMessage} for a one-shot greeting, or {@link ChatInstanceMessaging.upsertMessage} if you want to update that greeting later.
+To send your own welcome message, set {@link PublicConfigMessaging.skipWelcome | skipWelcome} to `true` and deliver the greeting yourself. For example, you might vary the text by user and respond in kind. Call {@link ChatInstanceMessaging.addMessage | addMessage} for a one-shot greeting, or {@link ChatInstanceMessaging.upsertMessage | upsertMessage} if you want to update that greeting later.
 
 ## Message loading indicators
 
-By default, the chat shows a loading indicator if it does not get back a chunk or message before {@link PublicConfigMessaging.messageLoadingIndicatorTimeoutSecs} expires. You can turn off this auto-showing of a loading indicator in this case by setting {@link PublicConfigMessaging.messageLoadingIndicatorTimeoutSecs} to 0. If your message is taking a long time to stream or has many thinking steps or long running API calls, toggle the loading indicator on manually using {@link ChatInstance.updateIsChatLoadingCounter}.
+By default, the chat shows a loading indicator if no chunk or message arrives before your {@link PublicConfigMessaging.messageLoadingIndicatorTimeoutSecs | loading-indicator timeout} expires. To turn off this auto-show, set {@link PublicConfigMessaging.messageLoadingIndicatorTimeoutSecs | that timeout} to 0. If your message streams slowly, has many thinking steps, or makes long-running API calls, turn the loading indicator on yourself with {@link ChatInstance.updateIsChatLoadingCounter | updateIsChatLoadingCounter}.
 
 ## Related
 
@@ -225,4 +225,4 @@ By default, the chat shows a loading indicator if it does not get back a chunk o
 - [Adding messages (legacy)](./AddMessageChunk.md) — the chunk-based streaming flow.
 - [Adding messages (experimental)](./UpsertMessage.md) — insert or update a message by ID.
 - [Structured data](./StructuredData.md) — send typed fields and uploaded files alongside the user's text.
-- [Conversation history](./CustomHistory.md) — loading and restoring previous conversations.
+- [Conversation history](./CustomHistory.md) — load and restore past conversations.


### PR DESCRIPTION
Closes #

Tone pass on `CustomServer.md` (Server communication) per `references/tone.md`. Prose only — code blocks and page structure unchanged.

#### Changelog

**Changed**

- Reword `CustomServer.md` for voice and reading level.

#### Testing / Reviewing

- Flesch-Kincaid grade: 8.4 (target 8–11). Measured with `npm run reading-level`, which ships in #1740.
- Confirm the reword kept every fact, default, and qualifier.
