### PR TITLE
docs: apply tone guide to Header.md

### DIFF
--- a/packages/ai-chat/docs/Header.md
+++ b/packages/ai-chat/docs/Header.md
@@ -4,7 +4,7 @@ title: Header
 
 ## Overview
 
-The header is the bar across the top of the chat. It is displayed by default and can be configured through {@link PublicConfig.header} with a {@link HeaderConfig}. To remove the header entirely, set {@link HeaderConfig.isOn} to `false`. This is useful for a fullscreen or embedded chat that reuses your application's own header.
+The header is the bar across the top of the chat; it is displayed by default, and you configure it by setting {@link PublicConfig.header | header} to a {@link HeaderConfig}. To remove the header entirely, set {@link HeaderConfig.isOn | isOn} to `false`, which is useful when a fullscreen or embedded chat reuses your application's own header.
 
 ```ts
 import type { PublicConfig } from "@carbon/ai-chat";
@@ -19,26 +19,26 @@ const config: PublicConfig = {
 
 ## Title and name
 
-Set {@link HeaderConfig.title} for the header title and {@link HeaderConfig.name} for the **bolded** name shown directly after it.
+Set {@link HeaderConfig.title | title} for the header title and {@link HeaderConfig.name | name} for the **bolded** name shown directly after it.
 
 ## Built-in buttons
 
 The header renders a minimize button and an optional restart button:
 
-- {@link HeaderConfig.minimizeButtonIconType} picks the minimize icon from {@link MinimizeButtonIconType} (close, minimize, or a side-panel direction), and {@link HeaderConfig.hideMinimizeButton} removes it.
-- {@link HeaderConfig.showRestartButton} adds a button that restarts the conversation, on both the home screen and the main chat.
+- {@link HeaderConfig.minimizeButtonIconType | minimizeButtonIconType} picks the minimize icon from {@link MinimizeButtonIconType} — close, minimize, or a side-panel direction — and {@link HeaderConfig.hideMinimizeButton | hideMinimizeButton} removes it.
+- {@link HeaderConfig.showRestartButton | showRestartButton} adds a button that restarts the conversation, on both the home screen and the main chat.
 
 ## Custom menu and actions
 
-Add your own entries to the header overflow menu with {@link HeaderConfig.menuOptions} — an array of {@link CustomMenuOption}. For richer toolbar controls, {@link HeaderConfig.actions} renders custom buttons that overflow into a menu when space is tight; the built-in restart and close buttons are appended after them.
+Add your own entries to the header overflow menu with {@link HeaderConfig.menuOptions | menuOptions}, an array of {@link CustomMenuOption}. For richer toolbar controls, {@link HeaderConfig.actions | actions} renders custom buttons that overflow into a menu when space is tight, and the built-in restart and close buttons are appended after them.
 
 ## AI label
 
-The header shows the AI label by default. Toggle it with {@link HeaderConfig.showAiLabel}. To replace its default popover content with your own, set {@link HeaderConfig.hideDefaultAiLabelContent} to `true` and render into the {@link WriteableElementName.EXPLAINABILITY_POPOVER_CONTENT} and {@link WriteableElementName.EXPLAINABILITY_POPOVER_ACTIONS} slots — see [Slots](./WriteableElements.md).
+The header shows the AI label by default, and you toggle it with {@link HeaderConfig.showAiLabel | showAiLabel}. To replace the default popover content with your own, set {@link HeaderConfig.hideDefaultAiLabelContent | hideDefaultAiLabelContent} to `true` and render into the {@link WriteableElementName.EXPLAINABILITY_POPOVER_CONTENT | popover content} and {@link WriteableElementName.EXPLAINABILITY_POPOVER_ACTIONS | popover actions} slots — see [Slots](./WriteableElements.md).
 
 ## Width
 
-By default the header spans the full width of the chat. Set {@link HeaderConfig.hasContentMaxWidth} to `true` to constrain it to the message content width (`--cds-aichat-messages-max-width`) instead — see [Layout](./Layout.md#layout-css-custom-properties).
+By default, the header spans the full width of the chat, but you can set {@link HeaderConfig.hasContentMaxWidth | hasContentMaxWidth} to `true` to constrain it to the message content width (`--cds-aichat-messages-max-width`) instead — see [Layout](./Layout.md#layout-css-custom-properties).
 
 ## Related
 


### PR DESCRIPTION
Closes #

Tone pass on `Header.md` (Header) per `references/tone.md`. Prose only — code blocks and page structure unchanged.

#### Changelog

**Changed**

- Reword `Header.md` for voice and reading level.

#### Testing / Reviewing

- Flesch-Kincaid grade: 9.1 (target 8–11). Measured with `npm run reading-level`, which ships in #1740.
- Confirm the reword kept every fact, default, and qualifier.
