### PR TITLE
docs: apply tone guide to Homescreen.md

### DIFF
--- a/packages/ai-chat/docs/Homescreen.md
+++ b/packages/ai-chat/docs/Homescreen.md
@@ -4,7 +4,7 @@ title: Home screen
 
 ## Overview
 
-The home screen is an optional landing view that appears before the first message, and while many use it to offer sample prompts, it is also room to introduce your assistant. Configure the home screen through {@link PublicConfig.homescreen | homescreen} with a {@link HomeScreenConfig | home screen config} object, and enable it by setting {@link HomeScreenConfig.isOn | isOn}.
+The home screen is an optional landing view that appears before the first message, and while many use it to offer sample prompts, it is also room to introduce your assistant. Configure the home screen through {@link PublicConfig.homescreen | homescreen} with a {@link HomeScreenConfig | home screen config} object. Enable it by setting {@link HomeScreenConfig.isOn | isOn}.
 
 ```ts
 import type { PublicConfig } from "@carbon/ai-chat";

--- a/packages/ai-chat/docs/Homescreen.md
+++ b/packages/ai-chat/docs/Homescreen.md
@@ -4,7 +4,7 @@ title: Home screen
 
 ## Overview
 
-The home screen is an optional landing view shown before the first message. Many use it to offer sample prompts, but it is also room to introduce your assistant. Configure it through {@link PublicConfig.homescreen} with a {@link HomeScreenConfig}, and enable it with {@link HomeScreenConfig.isOn}.
+The home screen is an optional landing view that appears before the first message, and while many use it to offer sample prompts, it is also room to introduce your assistant. Configure the home screen through {@link PublicConfig.homescreen | homescreen} with a {@link HomeScreenConfig | home screen config} object, and enable it by setting {@link HomeScreenConfig.isOn | isOn}.
 
 ```ts
 import type { PublicConfig } from "@carbon/ai-chat";
@@ -23,15 +23,15 @@ const config: PublicConfig = {
 
 ## Greeting and starters
 
-Set a welcome message with {@link HomeScreenConfig.greeting}. Add conversation-starter buttons with {@link HomeScreenConfig.starters} (a {@link HomeScreenStarterButtons} object). Each {@link HomeScreenStarterButton} has a {@link HomeScreenStarterButton.label} that is also sent as the user's message when clicked, and an optional {@link HomeScreenStarterButton.isSelected} to render it as already chosen.
+Set a welcome message with {@link HomeScreenConfig.greeting | greeting}, and add conversation-starter buttons with {@link HomeScreenConfig.starters | starters}, a {@link HomeScreenStarterButtons} object. Each {@link HomeScreenStarterButton | button} has a {@link HomeScreenStarterButton.label | label} that is also sent as the user's message when the button is clicked, and an optional {@link HomeScreenStarterButton.isSelected | isSelected} renders it as already chosen.
 
 ## Custom content
 
-To hide the default greeting and starters and supply your own markup instead, set {@link HomeScreenConfig.customContentOnly} to `true` and render into the home-screen slots ({@link WriteableElementName.HOME_SCREEN_HEADER_BOTTOM_ELEMENT}, {@link WriteableElementName.HOME_SCREEN_AFTER_STARTERS_ELEMENT}, {@link WriteableElementName.HOME_SCREEN_BEFORE_INPUT_ELEMENT}) — see [Slots](./WriteableElements.md).
+To hide the default greeting and starters and supply your own markup instead, set {@link HomeScreenConfig.customContentOnly | customContentOnly} to `true`, then render your content into the home-screen slots: {@link WriteableElementName.HOME_SCREEN_HEADER_BOTTOM_ELEMENT | header bottom}, {@link WriteableElementName.HOME_SCREEN_AFTER_STARTERS_ELEMENT | after starters}, and {@link WriteableElementName.HOME_SCREEN_BEFORE_INPUT_ELEMENT | before input}, which are described in [Slots](./WriteableElements.md).
 
 ## Returning to the home screen
 
-By default users can navigate back to the home screen after sending a message. Set {@link HomeScreenConfig.disableReturn} to `true` to keep them in the conversation once it starts.
+By default, users can navigate back to the home screen after sending a message, but setting {@link HomeScreenConfig.disableReturn | disableReturn} to `true` keeps them in the conversation once it starts.
 
 ## Related
 


### PR DESCRIPTION
Closes #

Tone pass on `Homescreen.md` (Home screen) per `references/tone.md`. Prose only — code blocks and page structure unchanged.

#### Changelog

**Changed**

- Reword `Homescreen.md` for voice and reading level.

#### Testing / Reviewing

- Flesch-Kincaid grade: 8.4 (target 8–11). Measured with `npm run reading-level`, which ships in #1740.
- Confirm the reword kept every fact, default, and qualifier.
