### PR TITLE
docs: apply tone guide to React.md

### DIFF
--- a/packages/ai-chat/docs/React.md
+++ b/packages/ai-chat/docs/React.md
@@ -6,11 +6,11 @@ title: Using with React
 
 Carbon AI Chat exports two React components.
 
-{@link ChatCustomElement} renders the chat into an element you size and place — a sidebar, full screen, or nested in your UI — and is the most common choice. {@link ChatContainer} is a convenience component that renders the classic floating widget (a corner launcher and a window that opens on click) by applying the [float layout classes](./Layout.md#floating-layout) for you.
+{@link ChatCustomElement} renders the chat into an element you size and place — a sidebar, full screen, or nested in your UI — and is the most common choice. {@link ChatContainer} is a convenience component that renders the classic floating widget — a corner launcher and a window that opens on click — by applying the [float layout classes](./Layout.md#floating-layout) for you.
 
-You don't need {@link ChatContainer} for a float layout. Those classes are exported, so you can apply them to {@link ChatCustomElement} yourself and get the same floating widget — see [Float layout](#float-layout). Reach for {@link ChatContainer} only when you'd rather skip that wiring.
+You don't need {@link ChatContainer} for a float layout. The classes are exported, so you can apply them to {@link ChatCustomElement} yourself and get the same floating widget — see [Float layout](#float-layout). Reach for {@link ChatContainer} only when you'd rather skip that wiring.
 
-> **Note**: This page covers only what's specific to React. For theming, layout, slotting your own content, and the rest of the configuration shared across every framework, see [UI customization](./Customization.md).
+> **Note**: This page covers only what's specific to React. For theming, layout, slots, and the rest of the configuration shared across every framework, see [UI customization](./Customization.md).
 
 For more information, see [the examples page](https://github.com/carbon-design-system/carbon-ai-chat/tree/main/examples/react).
 
@@ -34,7 +34,7 @@ yarn add @carbon/ai-chat
 
 ### Basic example
 
-Render this component in your application and provide the configuration options for the Carbon AI Chat as individual props. Give it a `className` that sizes it.
+Render this component in your application and pass the Carbon AI Chat configuration as individual props. Give it a `className` that sizes it.
 
 ```tsx
 import React from "react";
@@ -61,11 +61,11 @@ function App() {
 
 ## Using ChatCustomElement
 
-Use {@link ChatCustomElement} to render the Carbon AI Chat inside a custom element, controlling where the chat renders. This component renders an element in your React app and uses it as the custom element for the chat. See {@link ChatCustomElementProps} for the accepted props.
+Use {@link ChatCustomElement} to render the chat inside a custom element, so you control where it renders. This component renders an element in your React app and uses it as the custom element for the chat. See {@link ChatCustomElementProps} for the accepted props.
 
-This component requires a `className` prop that defines the size and positioning of the chat when open. The default behavior sets the element's dimensions to 0x0, so it doesn't take up space while keeping any fixed-positioned launcher visible.
+This component requires a `className` prop that sets the size and position of the chat when open. By default, the element's dimensions are 0x0, so it takes up no space while keeping any fixed-position launcher visible.
 
-If you want different open/close behavior — say, to animate the chat in and out — provide the {@link ChatCustomElementProps.onViewPreChange} and {@link ChatCustomElementProps.onViewChange} props. {@link ChatCustomElementProps.onViewPreChange} runs before the view changes and is awaited, so you can update your `className` and let an animation finish before the chat shell is hidden. {@link ChatCustomElementProps.onViewChange} runs once the change completes; provide it to replace the default 0x0 sizing.
+To change the open/close behavior — say, to animate the chat in and out — provide the {@link ChatCustomElementProps.onViewPreChange | onViewPreChange} and {@link ChatCustomElementProps.onViewChange | onViewChange} props. `onViewPreChange` runs before the view changes and the chat awaits it, so you can update your `className` and let an animation finish before the chat shell hides. `onViewChange` runs once the change completes; provide it to replace the default 0x0 sizing.
 
 ```tsx
 import React from "react";
@@ -102,7 +102,7 @@ function App() {
 
 ### Float layout
 
-The float layout pins the chat to the corner of the page as a launcher button that opens a floating window — the widget {@link ChatContainer} renders for you. To get that same layout on your own {@link ChatCustomElement} instead, import `@carbon/ai-chat/css/chat-float-layout.css` and apply the `cds-aichat-float--*` classes through `className`, driven by the chat's view-change events. See [Float layout classes](./Layout.md#floating-layout) for the class list, and the [custom-element-as-float example](https://github.com/carbon-design-system/carbon-ai-chat/tree/main/examples/react/custom-element-as-float) for the full pattern. To skip this wiring, use {@link ChatContainer}.
+The float layout pins the chat to a corner of the page as a launcher button that opens a floating window — the same widget {@link ChatContainer} renders for you. To get that layout on your own {@link ChatCustomElement}, import `@carbon/ai-chat/css/chat-float-layout.css` and apply the `cds-aichat-float--*` classes through `className`, driven by the chat's view-change events. See [Float layout classes](./Layout.md#floating-layout) for the class list, and the [custom-element-as-float example](https://github.com/carbon-design-system/carbon-ai-chat/tree/main/examples/react/custom-element-as-float) for the full pattern. To skip this wiring, use {@link ChatContainer}.
 
 ## Using ChatContainer
 
@@ -112,13 +112,13 @@ See {@link ChatContainerProps} for the accepted props.
 
 ## Accessing instance methods
 
-Capture the {@link ChatInstance} from {@link ChatContainerProps.onBeforeRender} (or {@link ChatContainerProps.onAfterRender}) when you need to call instance methods later. See those props for an example.
+To call instance methods later, capture the {@link ChatInstance} from {@link ChatContainerProps.onBeforeRender | onBeforeRender} or {@link ChatContainerProps.onAfterRender | onAfterRender}. See those props for an example.
 
 ## User-defined responses
 
-This component can also manage `user_defined` responses. (See {@link UserDefinedItem}). For what `user_defined` responses are and how they're styled, see [Customizing responses](./Responses.md). You must pass a {@link ChatContainerProps.renderUserDefinedResponse} function as a render prop. This function returns a React component that renders content for the specific message that relates to that response.
+This component can also manage `user_defined` responses (see {@link UserDefinedItem}). To learn what they are and how they're styled, see [Customizing responses](./Responses.md). You must pass a {@link ChatContainerProps.renderUserDefinedResponse | renderUserDefinedResponse} function as a render prop, which returns a React component that renders content for the message tied to that response.
 
-Treat the {@link ChatContainerProps.renderUserDefinedResponse} prop like any typical React render prop. It is called every time the App rerenders and every time a new `user_defined` message is received. This means you don't want to be calling functions from inside {@link ChatContainerProps.renderUserDefinedResponse} that you don't want called on every render. Consider putting those function calls inside the React component you render with a `useEffect`.
+Treat `renderUserDefinedResponse` like any typical React render prop. It runs on every app rerender and on every new `user_defined` message, so don't call functions inside it that you don't want run on every render. Put those calls inside the React component you render, with a `useEffect`.
 
 ```tsx
 import React from "react";
@@ -185,13 +185,13 @@ function renderUserDefinedResponse(
 }
 ```
 
-You may also want the renderer to read your app's state, or to stream. Wrap the prop in `useCallback` so it only changes when your state does, and read {@link RenderUserDefinedState.partialItems} for streaming — see [the streaming model](./Responses.md#streaming-and-updates) for how `partialItems` and chunk correlation work. For runnable versions, see the [basic](https://github.com/carbon-design-system/carbon-ai-chat/tree/main/examples/react/basic) and [streaming](https://github.com/carbon-design-system/carbon-ai-chat/tree/main/examples/react/reasoning-with-streaming-generic-items) examples.
+The renderer can also read your app's state or stream. Wrap the prop in `useCallback` so it changes only when your state does, and read {@link RenderUserDefinedState.partialItems | partialItems} for streaming — see [the streaming model](./Responses.md#streaming-and-updates) for how `partialItems` and chunk correlation work. For runnable versions, see the [basic](https://github.com/carbon-design-system/carbon-ai-chat/tree/main/examples/react/basic) and [streaming](https://github.com/carbon-design-system/carbon-ai-chat/tree/main/examples/react/reasoning-with-streaming-generic-items) examples.
 
 ## Slots
 
-This component also has several elements inside the chat that you can add extra content to with a slot. The {@link ChatContainerProps.renderWriteableElements} prop is an object with the key as the area you want to render a component to and the value being the component to render there. See [Slots](./WriteableElements.md) for the available slots and the corner-alignment attributes (`data-rounded`/`data-stacked`).
+The chat has several elements you can add content to with a slot. The {@link ChatContainerProps.renderWriteableElements | renderWriteableElements} prop is an object whose key is the area to render into and whose value is the component to render there. See [Slots](./WriteableElements.md) for the available slots and the corner-alignment attributes (`data-rounded`/`data-stacked`).
 
-Similarly to the {@link ChatContainerProps.renderUserDefinedResponse} prop, if you define your {@link ChatContainerProps.renderWriteableElements} object inside your component, it will be re-created every time your component renders. To avoid this, consider wrapping `renderWriteableElements` in `useMemo` or defining it outside your component. When wrapping with `useMemo` you can also pass values from your component into the slots.
+Like `renderUserDefinedResponse`, this object is re-created on every render if you define it inside your component. To avoid that, wrap `renderWriteableElements` in `useMemo` or define it outside your component. With `useMemo`, you can also pass values from your component into the slots.
 
 ```tsx
 import React, { useMemo, useState } from "react";
@@ -225,13 +225,13 @@ For a runnable version, see the [workspace example](https://github.com/carbon-de
 
 ## Testing with Jest
 
-Carbon AI Chat exports as an ES module and does not include a CJS build. Please refer to the [Jest documentation](https://jestjs.io/docs/code-transformation) for information about transforming ESM to CJS for Jest using `babel-jest` or `ts-jest`.
+Carbon AI Chat ships as an ES module, with no CJS build. See the [Jest documentation](https://jestjs.io/docs/code-transformation) for how to transform ESM to CJS with `babel-jest` or `ts-jest`.
 
 See [jsdom examples](https://github.com/carbon-design-system/carbon-ai-chat/tree/main/examples/react/tests-jest-jsdom) and [happydom examples](https://github.com/carbon-design-system/carbon-ai-chat/tree/main/examples/react/tests-jest-happydom).
 
 ## Custom message footer
 
-Insert a `custom_footer_slot` in assistant messages to render your own content beneath them — copy and share actions, ratings, or links. See [Custom message footer](./CustomMessageFooter.md) for the concept. In React, pass a {@link ChatContainerProps.renderCustomMessageFooter} render prop that returns the footer component:
+Insert a `custom_footer_slot` in assistant messages to render your own content beneath them — copy and share actions, ratings, or links. See [Custom message footer](./CustomMessageFooter.md) for the concept. In React, pass a {@link ChatContainerProps.renderCustomMessageFooter | renderCustomMessageFooter} render prop that returns the footer component:
 
 ```tsx
 <ChatContainer
@@ -251,7 +251,7 @@ Insert a `custom_footer_slot` in assistant messages to render your own content b
 />
 ```
 
-Like {@link ChatContainerProps.renderUserDefinedResponse}, it runs on every render, so keep per-render work out of it. For the full footer component and the mock backend that attaches the slot, see the [custom message footer example](https://github.com/carbon-design-system/carbon-ai-chat/tree/main/examples/react/messages-custom-footer).
+Like `renderUserDefinedResponse`, it runs on every render, so keep per-render work out of it. For the full footer component and the mock backend that attaches the slot, see the [custom message footer example](https://github.com/carbon-design-system/carbon-ai-chat/tree/main/examples/react/messages-custom-footer).
 
 ## Related
 

--- a/packages/ai-chat/docs/React.md
+++ b/packages/ai-chat/docs/React.md
@@ -61,7 +61,7 @@ function App() {
 
 ## Using ChatCustomElement
 
-Use {@link ChatCustomElement} to render the chat inside a custom element, so you control where it renders. This component renders an element in your React app and uses it as the custom element for the chat. See {@link ChatCustomElementProps} for the accepted props.
+Use {@link ChatCustomElement} to render Carbon AI Chat inside a custom element you size and place. This component renders an element in your React app and uses it as the custom element for the chat. See {@link ChatCustomElementProps} for the accepted props.
 
 This component requires a `className` prop that sets the size and position of the chat when open. By default, the element's dimensions are 0x0, so it takes up no space while keeping any fixed-position launcher visible.
 
@@ -185,7 +185,7 @@ function renderUserDefinedResponse(
 }
 ```
 
-The renderer can also read your app's state or stream. Wrap the prop in `useCallback` so it changes only when your state does, and read {@link RenderUserDefinedState.partialItems | partialItems} for streaming — see [the streaming model](./Responses.md#streaming-and-updates) for how `partialItems` and chunk correlation work. For runnable versions, see the [basic](https://github.com/carbon-design-system/carbon-ai-chat/tree/main/examples/react/basic) and [streaming](https://github.com/carbon-design-system/carbon-ai-chat/tree/main/examples/react/reasoning-with-streaming-generic-items) examples.
+The renderer can also read your app's state, or drive streaming. Wrap the prop in `useCallback` so it changes only when your state does, and read {@link RenderUserDefinedState.partialItems | partialItems} for streaming — see [the streaming model](./Responses.md#streaming-and-updates) for how `partialItems` and chunk correlation work. For runnable versions, see the [basic](https://github.com/carbon-design-system/carbon-ai-chat/tree/main/examples/react/basic) and [streaming](https://github.com/carbon-design-system/carbon-ai-chat/tree/main/examples/react/reasoning-with-streaming-generic-items) examples.
 
 ## Slots
 


### PR DESCRIPTION
Closes #

Tone pass on `React.md` (Using with React) per `references/tone.md`. Prose only — code blocks and page structure unchanged.

#### Changelog

**Changed**

- Reword `React.md` for voice and reading level.

#### Testing / Reviewing

- Flesch-Kincaid grade: 9.2 (target 8–11). Measured with `npm run reading-level`, which ships in #1740.
- Confirm the reword kept every fact, default, and qualifier.
