### PR TITLE
docs: apply tone guide to MessageFormat.md

### DIFF
--- a/packages/ai-chat/docs/MessageFormat.md
+++ b/packages/ai-chat/docs/MessageFormat.md
@@ -4,26 +4,26 @@ title: Message format
 
 ## Overview
 
-Build the payloads your server exchanges with Carbon AI Chat: the request the chat sends you and the response it expects back. This page is aimed at the author of the server, assistant, or API that produces those payloads. If you are wiring the chat up to that server in your host application, start with [Server communication](./CustomServer.md) and the delivery guides it links to.
+Build the two payloads your server trades with Carbon AI Chat: the chat sends you a request, and your server returns a response. This page is for whoever writes the server, assistant, or API that builds those payloads. To wire the chat to that server in your host app, start with [Server communication](./CustomServer.md) and the delivery guides it links to.
 
-When someone sends a message, the chat hands your {@link PublicConfigMessaging.customSendMessage} function a {@link MessageRequest}. Your code is responsible for producing a {@link MessageResponse} and delivering it back to the chat. You can navigate the full field-level reference for every type from the linked symbols below.
+When someone sends a message, the chat hands a {@link MessageRequest | request} to your {@link PublicConfigMessaging.customSendMessage | customSendMessage} function. Your code builds a {@link MessageResponse | response} and sends it back. Follow the links below to reach each type's full field reference.
 
 ## Requests
 
-A {@link MessageRequest} represents an outgoing user message. The fields you most commonly read:
+A {@link MessageRequest | request} is an outgoing user message. The fields you read most often:
 
-- `input` ({@link MessageInput}) — the user input. `input.text` holds the typed (or posted-back) text. `input.structured_data` carries typed fields and uploaded files when present — see [Structured data](./StructuredData.md).
-- `history` ({@link MessageRequestHistory}) — request metadata. `history.is_welcome_request` is `true` for the synthetic request the chat sends when a user first opens the chat (see [Welcome messages](./CustomServer.md#welcome-messages)).
+- `input` ({@link MessageInput}) — the user input. `input.text` holds the typed or posted-back text. `input.structured_data` carries typed fields and uploaded files when present — see [Structured data](./StructuredData.md).
+- `history` ({@link MessageRequestHistory}) — request metadata. `history.is_welcome_request` is `true` on the synthetic request the chat sends when a user first opens the chat (see [Welcome messages](./CustomServer.md#welcome-messages)).
 - `context` — an opaque pass-through you can use to carry your own per-request data.
 
 ## Responses
 
-A {@link MessageResponse} is what your server returns. Its core shape:
+A {@link MessageResponse | response} is what your server returns. Its core shape:
 
-- `id` — a unique identifier for the response. When you stream, this must match the `response_id` carried on your chunks (see [Streaming](#streaming)). When you update a message later, it is the key you pass to {@link ChatInstanceMessaging.upsertMessage}.
-- `output` ({@link MessageOutput}) — `output.generic` is an ordered array of response items. Each item is a {@link GenericItem}; navigate that type to see every supported `response_type` ({@link MessageResponseTypes}) — text, image, button, card, user_defined, conversational search, and more — and its properties.
+- `id` — a unique identifier for the response. When you stream, it must match the `response_id` on your chunks (see [Streaming](#streaming)). To update the message later, this is the key you pass to {@link ChatInstanceMessaging.upsertMessage | upsertMessage}.
+- `output` ({@link MessageOutput}) — `output.generic` is an ordered array of response items, and each item is a {@link GenericItem | generic item}. Open that type to see its properties and every `response_type` it supports; those types ({@link MessageResponseTypes}) include text, image, button, card, user_defined, conversational search, and more.
 - `message_options` ({@link MessageResponseOptions}) — message-level options such as `response_user_profile` and `reasoning`.
-- `history` ({@link MessageResponseHistory}) — response metadata (timestamps, labels, error states, feedback) that you persist and replay through [Conversation history](./CustomHistory.md).
+- `history` ({@link MessageResponseHistory}) — response metadata (timestamps, labels, error states, and feedback) that you persist and replay through [Conversation history](./CustomHistory.md).
 
 A minimal response looks like this:
 
@@ -43,17 +43,17 @@ const response: MessageResponse = {
 
 ## Streaming
 
-The shapes above describe a complete message. When you produce a response incrementally, you wrap items in chunk envelopes and apply them one at a time. There are two delivery mechanisms:
+The shapes above describe a complete message. To build a response piece by piece, wrap items in chunk envelopes and apply them one at a time. You can deliver a response two ways:
 
-- [Adding messages (legacy)](./AddMessageChunk.md) — the current flow. Documents the full chunk reference: {@link StreamChunk}, {@link PartialItemChunk}, {@link CompleteItemChunk}, and {@link FinalResponseChunk}.
-- [Adding messages (experimental)](./UpsertMessage.md) — the forward-thinking flow. You accumulate state in app code and apply each update with a single call, sidestepping the chunk-shape contract.
+- [Adding messages (legacy)](./AddMessageChunk.md) — the current flow. It documents the full chunk reference: {@link StreamChunk}, {@link PartialItemChunk}, {@link CompleteItemChunk}, and {@link FinalResponseChunk}.
+- [Adding messages (experimental)](./UpsertMessage.md) — the forward-thinking flow. You accumulate state in your app code and apply each update with one call, which sidesteps the chunk-shape contract.
 
-Both ultimately render the same {@link MessageResponse} shape described above.
+Both render the same {@link MessageResponse | response} shape shown above.
 
 ## Related
 
 - [Server communication](./CustomServer.md) — wire the chat to your server.
 - [Structured data](./StructuredData.md) — send typed fields and uploaded files on the request.
-- [Adding messages (legacy)](./AddMessageChunk.md) — deliver a response incrementally.
+- [Adding messages (legacy)](./AddMessageChunk.md) — deliver a response piece by piece.
 - [Adding messages (experimental)](./UpsertMessage.md) — accumulate state and apply each update with one call.
 - [Conversation history](./CustomHistory.md) — persist and replay responses.


### PR DESCRIPTION
Closes #

Tone pass on `MessageFormat.md` (Message format) per `references/tone.md`. Prose only — code blocks and page structure unchanged.

#### Changelog

**Changed**

- Reword `MessageFormat.md` for voice and reading level.

#### Testing / Reviewing

- Flesch-Kincaid grade: 9.3 (target 8–11). Measured with `npm run reading-level`, which ships in #1740.
- Confirm the reword kept every fact, default, and qualifier.
