### PR TITLE
docs: apply tone guide to WriteableElements.md

### DIFF
--- a/packages/ai-chat/docs/WriteableElements.md
+++ b/packages/ai-chat/docs/WriteableElements.md
@@ -8,7 +8,7 @@ Render your own content in slots throughout the chat, including the chat footer,
 
 ## Writing to a slot
 
-Write to slots as portals from your application, using frameworks such as [React](./React.md), [Angular](./Angular.md), Vue, or [web components](./WebComponent.md), and access them through {@link ChatInstance.writeableElements}. For a list of the available slots, see {@link WriteableElementName | the slot list}.
+Write to slots as portals from your application, using frameworks such as [React](./React.md), [Angular](./Angular.md), Vue, or [web components](./WebComponent.md). For a list of the available slots, see {@link WriteableElementName | the slot list}. Access slots through {@link ChatInstance.writeableElements}.
 
 Some slots are layout-specific: {@link WriteableElementName.PROMPT_LINE_ACTIONS_END | the prompt-line actions slot} renders only when the input uses the expanded layout ({@link InputConfig.expanded}), and the default (compact) layout hides any content written to it.
 

--- a/packages/ai-chat/docs/WriteableElements.md
+++ b/packages/ai-chat/docs/WriteableElements.md
@@ -4,19 +4,17 @@ title: Slots
 
 ## Overview
 
-You may render custom content inside of various slots throughout the chat, such as the chat footer, above the prompt line, and panel content.
+Render your own content in slots throughout the chat, including the chat footer, the space above the prompt line, and panel content.
 
 ## Writing to a slot
 
-Write to slots as portals from your application with frameworks such as [React](./React.md), [Angular](./Angular.md), Vue, or [web components](./WebComponent.md). See {@link WriteableElementName} for a list of available slots.
+Write to slots as portals from your application, using frameworks such as [React](./React.md), [Angular](./Angular.md), Vue, or [web components](./WebComponent.md), and access them through {@link ChatInstance.writeableElements}. For a list of the available slots, see {@link WriteableElementName | the slot list}.
 
-Some slots are layout-specific. {@link WriteableElementName.PROMPT_LINE_ACTIONS_END} only renders when the input uses the expanded layout ({@link InputConfig.expanded}); content written to it is not shown in the default (compact) layout.
-
-Access slots via {@link ChatInstance.writeableElements}.
+Some slots are layout-specific: {@link WriteableElementName.PROMPT_LINE_ACTIONS_END | the prompt-line actions slot} renders only when the input uses the expanded layout ({@link InputConfig.expanded}), and the default (compact) layout hides any content written to it.
 
 ### Align rounded corners
 
-Slotted content can use `data-rounded` and `data-stacked` attributes to align with the chat's corner rounding. This is especially useful for footer actions, custom headers, or any content that integrates with the chat shell.
+Slotted content can use the `data-rounded` and `data-stacked` attributes to align with the chat's corner rounding, which is especially useful for footer actions, custom headers, or any content that integrates with the chat shell.
 
 Example (footer slot):
 
@@ -34,11 +32,11 @@ if (footer) {
 }
 ```
 
-`data-rounded="bottom"` inherits the bottom corner rounding; `data-stacked` arranges the buttons vertically. See [Rounded corners](./Layout.md#rounded-corners).
+`data-rounded="bottom"` inherits the bottom corner rounding, and `data-stacked` stacks the buttons vertically. See [Rounded corners](./Layout.md#rounded-corners).
 
 ## Related
 
-- [Custom panels](./CustomPanels.md) — render your own content in an overlay panel through {@link WriteableElementName.CUSTOM_PANEL_ELEMENT}.
+- [Custom panels](./CustomPanels.md) — render your own content in an overlay panel through {@link WriteableElementName.CUSTOM_PANEL_ELEMENT | the custom panel slot}.
 - [Layout](./Layout.md) — corner-rounding tokens used by `data-rounded`.
 - [Using with React](./React.md) — get the {@link ChatInstance} and render slots in a React app.
 - [Using as a Web component](./WebComponent.md) — get the {@link ChatInstance} and render slots with the web component.


### PR DESCRIPTION
Closes #

Tone pass on `WriteableElements.md` (Slots) per `references/tone.md`. Prose only — code blocks and page structure unchanged.

#### Changelog

**Changed**

- Reword `WriteableElements.md` for voice and reading level.

#### Testing / Reviewing

- Flesch-Kincaid grade: 9.9 (target 8–11). Measured with `npm run reading-level`, which ships in #1740.
- Confirm the reword kept every fact, default, and qualifier.
