### PR TITLE
docs: apply tone guide to Responses.md

### DIFF
--- a/packages/ai-chat/docs/Responses.md
+++ b/packages/ai-chat/docs/Responses.md
@@ -13,7 +13,7 @@ Style `text` responses to match your theme. Use Markdown or HTML returned from y
 Extend how the chat parses and renders Markdown through the {@link PublicConfigMarkdown `markdown`} config. Use {@link PublicConfigMarkdown.markdownItPlugins `markdownItPlugins`} to register [markdown-it](https://github.com/markdown-it/markdown-it) plugins after the built-ins. These plugins add token types the renderer does not understand out of the box. Examples include math, diagrams, and custom embeds. Use {@link CustomMarkdownRenderers `customRenderers`} to change how specific elements draw. Overrides come in three kinds:
 
 - **Element replacements** — render `table` and `codeBlock` through your own component instead of the default Carbon one. Return a React node (or an `HTMLElement` for web components), or `null` to fall back to the default.
-- **Attribute transforms** — for `link` and `image`, you rewrite attributes while the framework renders the element and its children. It also keeps the link `target="_blank"` safety default. Edit a link's `href`, `target`, or `rel`. Add context-aware query params. Or resolve an image `src` to an authenticated CDN URL. Return the overrides, or `null` to keep the defaults.
+- **Attribute transforms** — `link` and `image` keep the framework rendering the element and its children (the link `target="_blank"` safety default is also preserved) while you rewrite attributes. Edit a link's `href`, `target`, or `rel`, add context-aware query params, or resolve an image `src` to an authenticated CDN URL. Return the overrides, or `null` to keep the defaults.
 - **Behavior hook** — `checklist` makes task-list checkboxes actionable. Provide an `onToggle` callback to persist and react to toggles. Add an optional `getChecked` source of truth so a persisted state survives streaming re-renders.
 
 For working setups, see the `markdown-plugin`, `markdown-override`, and `workspace-table-markdown-override` projects under [examples](https://github.com/carbon-design-system/carbon-ai-chat/tree/main/examples).
@@ -38,7 +38,7 @@ To show custom content, return this from your server (a user-defined card):
 }
 ```
 
-The `user_defined_type` field is a unique name for each UI component. Your renderer switches on it to decide what to draw. The `user_defined` response injects into a slot in the chat's shadow DOM. Style it from global CSS. It also inherits some styling from the chat, such as fonts. You can use Carbon components alongside your own components.
+The `user_defined_type` field is a unique name for each UI component. Your renderer switches on it to decide what to draw. The `user_defined` response injects into a slot within the chat's shadow DOM. You can style it from global CSS, and it inherits some styling from the chat, such as fonts. You can use Carbon components alongside your own custom components.
 
 Example render for the `promo-card` response:
 
@@ -62,7 +62,7 @@ Prefer {@link ChatInstanceMessaging.upsertMessage | upsertMessage} to insert, st
 
 {@link ChatInstanceMessaging.addMessageChunk | addMessageChunk} is the stable streaming path. It is fully supported with no deprecation, and the right choice if you prefer a settled API. If you stream with it, read [Adding messages (legacy)](./AddMessageChunk.md) first. The model is the same in every framework:
 
-- {@link RenderUserDefinedState.partialItems | `partialItems`} is an array of every chunk received, **not** concatenated for you. The streaming API sends string chunks, not partial JSON. So stringify your JSON. Then concatenate and parse the chunks in your renderer with `try`/`catch` or an optimistic parser.
+- {@link RenderUserDefinedState.partialItems | `partialItems`} is an array of every chunk received, **not** concatenated for you. The streaming API sends string chunks, not partial JSON. So stringify your JSON, then concatenate and parse the chunks in your renderer with `try`/`catch` or an optimistic parser.
 - Include `streaming_metadata.response_id` for the message and {@link ItemStreamingMetadata.id | `id`} for each item so chunks correlate correctly.
 
 ## Related

--- a/packages/ai-chat/docs/Responses.md
+++ b/packages/ai-chat/docs/Responses.md
@@ -4,25 +4,25 @@ title: Customizing responses
 
 ## Overview
 
-Customize what the chat renders for each response type. The chat supports many response types — rich text, buttons, carousels, cards, media, and your own components, among others. See the base {@link GenericItem} type for the full set and the properties of each.
+Customize what the chat renders for each response type. The chat supports many types: rich text, buttons, carousels, cards, media, your own components, and more. See {@link GenericItem | the base response type} for the full set and each type's properties.
 
 ## Rich text responses
 
-Style `text` responses to match your theme, using Markdown or HTML returned from your assistant. For supported Markdown syntax and HTML content handling, see {@link TextItem}.
+Style `text` responses to match your theme. Use Markdown or HTML returned from your assistant. For supported Markdown syntax and HTML handling, see {@link TextItem | the text item type}.
 
-You can extend how Markdown is parsed and rendered through the {@link PublicConfigMarkdown `markdown`} config. Use {@link PublicConfigMarkdown.markdownItPlugins `markdownItPlugins`} to register [markdown-it](https://github.com/markdown-it/markdown-it) plugins after the built-ins, adding token types the renderer does not understand out of the box — math, diagrams, custom embeds. Use {@link CustomMarkdownRenderers `customRenderers`} to customize how specific elements draw. There are three kinds of override:
+Extend how the chat parses and renders Markdown through the {@link PublicConfigMarkdown `markdown`} config. Use {@link PublicConfigMarkdown.markdownItPlugins `markdownItPlugins`} to register [markdown-it](https://github.com/markdown-it/markdown-it) plugins after the built-ins. These plugins add token types the renderer does not understand out of the box. Examples include math, diagrams, and custom embeds. Use {@link CustomMarkdownRenderers `customRenderers`} to change how specific elements draw. Overrides come in three kinds:
 
-- **Element replacements** — `table` and `codeBlock` render through your own component instead of the default Carbon one. Return your own React node (or `HTMLElement` for web components), or `null` to fall back to the default.
-- **Attribute transforms** — `link` and `image` keep the framework rendering the element and its children (and the link `target="_blank"` safety default) while you rewrite attributes. Edit a link's `href`, `target`, or `rel`, add context-aware query params, or resolve an image `src` to an authenticated CDN URL. Return the overrides, or `null` to keep the defaults.
-- **Behavior hook** — `checklist` makes task-list checkboxes actionable. Provide an `onToggle` callback to persist and react to toggles, and an optional `getChecked` source-of-truth so a persisted state survives streaming re-renders.
+- **Element replacements** — render `table` and `codeBlock` through your own component instead of the default Carbon one. Return a React node (or an `HTMLElement` for web components), or `null` to fall back to the default.
+- **Attribute transforms** — for `link` and `image`, you rewrite attributes while the framework renders the element and its children. It also keeps the link `target="_blank"` safety default. Edit a link's `href`, `target`, or `rel`. Add context-aware query params. Or resolve an image `src` to an authenticated CDN URL. Return the overrides, or `null` to keep the defaults.
+- **Behavior hook** — `checklist` makes task-list checkboxes actionable. Provide an `onToggle` callback to persist and react to toggles. Add an optional `getChecked` source of truth so a persisted state survives streaming re-renders.
 
 For working setups, see the `markdown-plugin`, `markdown-override`, and `workspace-table-markdown-override` projects under [examples](https://github.com/carbon-design-system/carbon-ai-chat/tree/main/examples).
 
 ## User-defined responses
 
-Render content from your own HTML, CSS, or JavaScript through a `user_defined` {@link UserDefinedItem}, so you can change responses without editing your assistant. In React, you can use portals to render content from your main application.
+Render content from your own HTML, CSS, or JavaScript through a `user_defined` {@link UserDefinedItem | response}. This lets you change responses without editing your assistant. In React, use portals to render content from your main app.
 
-User-defined content renders into a slot on the {@link ChatInstance}; see [React](./React.md) and [web components](./WebComponent.md) for how to reach the instance and wire up the handler.
+User-defined content renders into a slot on the {@link ChatInstance | chat instance}. See [React](./React.md) and [web components](./WebComponent.md) for how to reach the instance and wire up the handler.
 
 To show custom content, return this from your server (a user-defined card):
 
@@ -38,7 +38,7 @@ To show custom content, return this from your server (a user-defined card):
 }
 ```
 
-The `user_defined_type` field is a unique name for each UI component. Your renderer switches on it to decide what to draw. The `user_defined` response injects into a slot within the chat's shadow DOM. You can style it from global CSS, and it inherits some styling from the chat, such as fonts. You can use Carbon components alongside your own custom components.
+The `user_defined_type` field is a unique name for each UI component. Your renderer switches on it to decide what to draw. The `user_defined` response injects into a slot in the chat's shadow DOM. Style it from global CSS. It also inherits some styling from the chat, such as fonts. You can use Carbon components alongside your own components.
 
 Example render for the `promo-card` response:
 
@@ -54,16 +54,16 @@ Example render for the `promo-card` response:
 </cds-aichat-card>
 ```
 
-Your framework renderer receives the accumulated {@link RenderUserDefinedState} for each `user_defined` response: `messageItem` holds the complete {@link UserDefinedItem}, and `partialItems` holds streaming chunks. See [React](./React.md#user-defined-responses) and [web components](./WebComponent.md#user-defined-responses) for the wiring.
+For each `user_defined` response, your framework renderer receives the accumulated {@link RenderUserDefinedState | render state}. `messageItem` holds the complete {@link UserDefinedItem | item}, and `partialItems` holds streaming chunks. See [React](./React.md#user-defined-responses) and [web components](./WebComponent.md#user-defined-responses) for the wiring.
 
 ### Streaming and updates
 
-Prefer {@link ChatInstanceMessaging.upsertMessage} to insert, stream, correct, and regenerate `user_defined` responses — one method covers all four, drives a streaming UI from any source (SSE, WebSocket, polling, or whole-message snapshots), and preserves component identity across updates. You accumulate state in your app and apply it with one call per update, skipping the chunk-shape contract below. It is the recommended direction for new code, but experimental — its semantics and updater signature may still evolve. See [Adding messages (experimental)](./UpsertMessage.md). Nested `user_defined` items inside {@link MessageResponseTypes.CARD}, {@link MessageResponseTypes.CAROUSEL}, and {@link MessageResponseTypes.GRID} containers are supported.
+Prefer {@link ChatInstanceMessaging.upsertMessage | upsertMessage} to insert, stream, correct, and regenerate `user_defined` responses. One method covers all four. It drives a streaming UI from any source: SSE, WebSocket, polling, or whole-message snapshots. It also preserves component identity across updates. You accumulate state in your app and apply it with one call per update. This skips the chunk-shape contract below. It is the recommended direction for new code, but experimental. Its semantics and updater signature may still evolve. See [Adding messages (experimental)](./UpsertMessage.md). The chat supports nested `user_defined` items inside {@link MessageResponseTypes.CARD | card}, {@link MessageResponseTypes.CAROUSEL | carousel}, and {@link MessageResponseTypes.GRID | grid} containers.
 
-{@link ChatInstanceMessaging.addMessageChunk} is the stable streaming path — fully supported with no deprecation, and the right choice if you prefer a settled API. If you stream with it, read [Adding messages (legacy)](./AddMessageChunk.md) first; the model is the same in every framework:
+{@link ChatInstanceMessaging.addMessageChunk | addMessageChunk} is the stable streaming path. It is fully supported with no deprecation, and the right choice if you prefer a settled API. If you stream with it, read [Adding messages (legacy)](./AddMessageChunk.md) first. The model is the same in every framework:
 
-- {@link RenderUserDefinedState.partialItems} is an array of every chunk received — **not** concatenated for you. The streaming API sends string chunks, not partial JSON, so stringify your JSON, then concatenate and parse the chunks in your renderer with `try`/`catch` or an optimistic parser.
-- Include `streaming_metadata.response_id` for the message and {@link ItemStreamingMetadata.id} for each item so chunks correlate correctly.
+- {@link RenderUserDefinedState.partialItems | `partialItems`} is an array of every chunk received, **not** concatenated for you. The streaming API sends string chunks, not partial JSON. So stringify your JSON. Then concatenate and parse the chunks in your renderer with `try`/`catch` or an optimistic parser.
+- Include `streaming_metadata.response_id` for the message and {@link ItemStreamingMetadata.id | `id`} for each item so chunks correlate correctly.
 
 ## Related
 


### PR DESCRIPTION
Closes #

Tone pass on `Responses.md` (Customizing responses) per `references/tone.md`. Prose only — code blocks and page structure unchanged.

#### Changelog

**Changed**

- Reword `Responses.md` for voice and reading level.

#### Testing / Reviewing

- Flesch-Kincaid grade: 8.6 (target 8–11). Measured with `npm run reading-level`, which ships in #1740.
- Confirm the reword kept every fact, default, and qualifier.
