### PR TITLE
docs: apply tone guide to UpsertMessage.md

### DIFF
--- a/packages/ai-chat/docs/UpsertMessage.md
+++ b/packages/ai-chat/docs/UpsertMessage.md
@@ -4,68 +4,68 @@ title: Adding messages (experimental)
 
 ## Overview
 
-{@link ChatInstanceMessaging.upsertMessage} inserts or updates a single message identified by a stable `messageID`. One method covers inserting, streaming, correcting, and regenerating a message. The updater you pass receives the message's current value and returns what replaces it.
+{@link ChatInstanceMessaging.upsertMessage | upsertMessage} inserts or updates one message. A stable `messageID` names it. One method covers inserting, streaming, correcting, and regenerating a message. You pass an updater. It gets the message's current value and returns what replaces it.
 
-This is the preferred flow for new code, but experimental — its semantics and the updater signature may still evolve. If you want a settled API, the stable {@link ChatInstanceMessaging.addMessageChunk} flow remains fully supported; see [Adding messages (legacy)](./AddMessageChunk.md).
+Prefer this flow for new code, but note it's experimental. Its behavior and the updater signature may still change. For a settled API, the stable {@link ChatInstanceMessaging.addMessageChunk | addMessageChunk} flow is still fully supported. See [Adding messages (legacy)](./AddMessageChunk.md).
 
-The examples below call `instance.messaging`, so you need a {@link ChatInstance} first — get one from the `onBeforeRender` prop.
+The examples below call `instance.messaging`. So you need a {@link ChatInstance} first. Get one from the `onBeforeRender` prop.
 
-Reach for `upsertMessage` over {@link ChatInstanceMessaging.addMessage} / {@link ChatInstanceMessaging.addMessageChunk} when you want to:
+Reach for `upsertMessage` over {@link ChatInstanceMessaging.addMessage | addMessage} or {@link ChatInstanceMessaging.addMessageChunk | addMessageChunk} when you want to:
 
-- **Stream from any source** — drive a streaming UI from SSE, WebSocket, polling, or whole-message snapshots. Accumulate state in your app and apply it with one call per update. You skip the chunk-shape contract of {@link ChatInstanceMessaging.addMessageChunk}.
-- **Regenerate** — replace a prior response to the same user input with a fresh one.
-- **Correct after the fact** — fix a message after it has already been delivered.
-- **Update optimistically** — show a placeholder, then mutate it in place once a backend call returns.
+- **Stream from any source** — drive a streaming UI from SSE, WebSocket, polling, or whole-message snapshots. Build up the state in your app. Apply it with one call per update. You skip the chunk-shape contract of {@link ChatInstanceMessaging.addMessageChunk | addMessageChunk}.
+- **Regenerate** — replace an earlier response to the same user input with a fresh one.
+- **Correct after the fact** — fix a message after the chat delivers it.
+- **Update optimistically** — show a placeholder, then change it in place once a backend call returns.
 
-The {@link MessageResponse} shape you return is the same one described in [Message format](./MessageFormat.md).
+You return a {@link MessageResponse | MessageResponse} shape. [Message format](./MessageFormat.md) describes it.
 
 ## The updater contract
 
-See {@link ChatInstanceMessaging.upsertMessage} for the exact signature and {@link UpsertMessageUpdater} for the updater type.
+See {@link ChatInstanceMessaging.upsertMessage | upsertMessage} for the full signature. See {@link UpsertMessageUpdater | the updater type} for its shape.
 
-The updater receives the {@link MessageResponse} currently stored under `messageID`, or `undefined` when no message with that ID exists yet, and returns the message that replaces it. The updater may be synchronous or return a Promise; the Promise {@link ChatInstanceMessaging.upsertMessage} returns does not resolve until the updater resolves **and** the chat applies the resulting state.
+The updater gets the {@link MessageResponse | MessageResponse} now stored under `messageID`. It gets `undefined` when no message with that ID exists yet. It returns the message that replaces the stored one. The updater can be synchronous or return a Promise. {@link ChatInstanceMessaging.upsertMessage | upsertMessage} also returns a Promise. That Promise waits until the updater resolves **and** the chat applies the new state.
 
 ID rules:
 
 - If the returned message has no `id`, the chat assigns `messageID`.
 - A returned message whose `id` differs from `messageID` throws a `TypeError`.
-- Returning `null`/`undefined`, or a non-assistant message (a request or a human-agent message), throws a `TypeError`.
+- Returning `null` or `undefined` throws a `TypeError`. So does returning a non-assistant message — a request or a human-agent message.
 
 ## The state argument
 
-The second argument is a {@link MessageState} describing the lifecycle the chat records for this message after it applies the upsert:
+The second argument is a {@link MessageState | MessageState}. It sets the lifecycle the chat records for this message after the upsert applies:
 
-- {@link MessageState.STREAMING} — still producing; the UI may render a streaming indicator.
-- {@link MessageState.COMPLETE} — finished producing for now; may still be updated later.
-- {@link MessageState.ERROR} — failed to produce; the UI surfaces an error treatment. Treat `ERROR` as terminal.
+- {@link MessageState.STREAMING | STREAMING} — still producing. The UI may show a streaming indicator.
+- {@link MessageState.COMPLETE | COMPLETE} — done producing for now. You can still update it later.
+- {@link MessageState.ERROR | ERROR} — failed to produce. The UI shows an error treatment. Treat `ERROR` as terminal.
 
-Required on every call; the chat does not preserve state across calls and applies it uniformly to every item in the returned message. There are no locked-terminal states for `STREAMING`/`COMPLETE`: "complete" means "complete as of now," so you can call `upsertMessage(id, MessageState.STREAMING, ...)` on an already-complete message to start re-streaming it (for example, a regenerate-with-streaming flow).
+The state is required on every call. The chat does not keep state across calls. It applies your state to every item in the returned message. `STREAMING` and `COMPLETE` are not locked-terminal states. The chat treats "complete" as "complete as of now." So you can call `upsertMessage(id, MessageState.STREAMING, ...)` on an already-complete message to start re-streaming it. One example is a regenerate-with-streaming flow.
 
 ## Per-messageID serialization
 
-Calls targeting the same `messageID` are serialized — each call awaits the previous call for that ID before running. Calls targeting different `messageID`s run independently and in parallel. This lets several messages stream or update concurrently while each individual message stays internally consistent.
+Calls to the same `messageID` are serialized. Each call waits for the previous call to that ID before it runs. Calls to different `messageID`s run on their own, in parallel. So several messages can stream or update at once. Each message still stays internally consistent.
 
 ## When receive fires
 
-`upsertMessage` fires {@link BusEventType.PRE_RECEIVE} and {@link BusEventType.RECEIVE} exactly when a call transitions the message into `MessageState.COMPLETE` from any other state — including the case where the message did not previously exist. `STREAMING`-to-`STREAMING` and `COMPLETE`-to-`COMPLETE` upserts do **not** fire these events.
+`upsertMessage` fires {@link BusEventType.PRE_RECEIVE | PRE_RECEIVE} and {@link BusEventType.RECEIVE | RECEIVE} on one exact transition. That transition moves the message into `MessageState.COMPLETE` from any other state. This includes the case where the message did not exist before. `STREAMING`-to-`STREAMING` and `COMPLETE`-to-`COMPLETE` upserts do **not** fire these events.
 
-This is the same rule the other delivery methods follow:
+The other delivery methods follow the same rule:
 
-- {@link ChatInstanceMessaging.addMessage} records `COMPLETE` and fires {@link BusEventType.RECEIVE} (a one-shot complete insert is a transition to complete).
-- {@link ChatInstanceMessaging.addMessageChunk} records `STREAMING` for partial/complete-item chunks and `COMPLETE` on the {@link FinalResponseChunk} — the transition-to-complete fires {@link BusEventType.RECEIVE}.
+- {@link ChatInstanceMessaging.addMessage | addMessage} records `COMPLETE` and fires {@link BusEventType.RECEIVE | RECEIVE}. A one-shot complete insert is a transition to complete.
+- {@link ChatInstanceMessaging.addMessageChunk | addMessageChunk} records `STREAMING` for partial and complete-item chunks. It records `COMPLETE` on the {@link FinalResponseChunk | FinalResponseChunk}. That transition to complete fires {@link BusEventType.RECEIVE | RECEIVE}.
 
-So regenerating a message that is already `COMPLETE` does not fire {@link BusEventType.RECEIVE} (it is not a new turn landing), while inserting a brand-new `COMPLETE` message does.
+So regenerating a message that is already `COMPLETE` does not fire {@link BusEventType.RECEIVE | RECEIVE}. It is not a new turn landing. But inserting a brand-new `COMPLETE` message does fire it.
 
 ## User-defined responses
 
-`upsertMessage` reuses the existing {@link BusEventType.USER_DEFINED_RESPONSE} event for `user_defined` items; it fires once per user-defined item per call, for both inserts and updates. The payload's optional `state` field ({@link BusEventUserDefinedResponse}) carries the current {@link MessageState} whenever the chat has a recorded lifecycle for the message — including messages produced through `upsertMessage`, {@link ChatInstanceMessaging.addMessage}, and the final-response transition of {@link ChatInstanceMessaging.addMessageChunk}. The field is additive, so existing consumers ignore it. In React, the same value is available on {@link RenderUserDefinedState} as `state`.
+For `user_defined` items, `upsertMessage` reuses the existing {@link BusEventType.USER_DEFINED_RESPONSE | USER_DEFINED_RESPONSE} event. It fires once per user-defined item per call. This holds for both inserts and updates. The payload has an optional `state` field on {@link BusEventUserDefinedResponse | BusEventUserDefinedResponse}. That field carries the current {@link MessageState | MessageState} whenever the chat has a recorded lifecycle for the message. This includes messages from `upsertMessage`, {@link ChatInstanceMessaging.addMessage | addMessage}, and the final-response transition of {@link ChatInstanceMessaging.addMessageChunk | addMessageChunk}. The field is additive, so existing consumers ignore it. In React, the same value sits on {@link RenderUserDefinedState | RenderUserDefinedState} as `state`.
 
-**Component identity is preserved across updates.** Successive `upsertMessage` calls for the same item resolve to the same slot, so:
+**The chat keeps component identity across updates.** Repeated `upsertMessage` calls for the same item resolve to the same slot. So:
 
-- **React consumers** — the slot name is the React `key`, so your component **re-renders with new props** rather than re-mounting. Local component state, animations, and side effects survive across updates.
-- **Web component consumers** — the slot wrapper persists across calls. If element-level identity matters, return the same `HTMLElement` reference from `renderUserDefinedResponse` and mutate its content imperatively (the established pattern from {@link ChatInstanceMessaging.addMessageChunk}).
+- **React consumers** — the slot name is the React `key`. So your component **re-renders with new props** instead of re-mounting. Local component state, animations, and side effects survive across updates.
+- **Web component consumers** — the slot wrapper persists across calls. If element-level identity matters, return the same `HTMLElement` reference from `renderUserDefinedResponse`. Change its content imperatively. This is the established pattern from {@link ChatInstanceMessaging.addMessageChunk | addMessageChunk}.
 
-Nested `user_defined` items inside {@link MessageResponseTypes.CARD} / {@link MessageResponseTypes.CAROUSEL} / {@link MessageResponseTypes.GRID} containers are supported — `upsertMessage` inherits the recursion logic from the existing event path.
+Nested `user_defined` items work inside {@link MessageResponseTypes.CARD | CARD}, {@link MessageResponseTypes.CAROUSEL | CAROUSEL}, and {@link MessageResponseTypes.GRID | GRID} containers. `upsertMessage` inherits the recursion logic from the existing event path.
 
 A React renderer can drive an in-widget streaming indicator straight from the lifecycle state:
 
@@ -89,7 +89,7 @@ function renderUserDefinedResponse(state: RenderUserDefinedState) {
 
 ## Code patterns
 
-**Streaming a single message (SSE-style).** One call per delta. The first call creates the message; subsequent calls update it. {@link BusEventType.RECEIVE} fires once, on the final transition to `COMPLETE`. Each call returns a {@link MessageResponse}.
+**Streaming a single message (SSE-style).** One call per delta. The first call creates the message. Later calls update it. {@link BusEventType.RECEIVE | RECEIVE} fires once, on the final transition to `COMPLETE`. Each call returns a {@link MessageResponse | MessageResponse}.
 
 ```typescript
 const messageID = "msg-1";
@@ -122,7 +122,7 @@ await instance.messaging.upsertMessage(
 );
 ```
 
-**Regenerate (one-shot, non-streaming).** Fires {@link BusEventType.RECEIVE} if `prev` did not exist or was not `COMPLETE`; does not fire if `prev` was already `COMPLETE`. `request_id` is a field of {@link MessageResponse} that links the response to the user input it answers.
+**Regenerate (one-shot, non-streaming).** This fires {@link BusEventType.RECEIVE | RECEIVE} if `prev` did not exist or was not `COMPLETE`. It does not fire if `prev` was already `COMPLETE`. `request_id` is a field of {@link MessageResponse | MessageResponse}. It links the response to the user input it answers.
 
 ```typescript
 const userInputID = "req-42";
@@ -138,7 +138,7 @@ await instance.messaging.upsertMessage(
 );
 ```
 
-**Optimistic update.** Show a placeholder immediately, then replace it once the backend returns.
+**Optimistic update.** Show a placeholder right away. Then replace it once the backend returns.
 
 ```typescript
 await instance.messaging.upsertMessage(
@@ -168,11 +168,11 @@ await instance.messaging.upsertMessage(
 
 ## Cancellation
 
-Cancellation works the same way regardless of which delivery method you use. When the abort signal fires, stop your stream and call `upsertMessage` with `MessageState.COMPLETE` to transition the message out of streaming and hide the "stop streaming" button. See [Cancelling request (stop streaming)](./CustomServer.md#cancelling-request-stop-streaming) for the full pattern and an `upsertMessage` finalization example.
+Cancellation works the same way for every delivery method. When the abort signal fires, stop your stream. Then call `upsertMessage` with `MessageState.COMPLETE`. This moves the message out of streaming and hides the "stop streaming" button. See [Cancelling request (stop streaming)](./CustomServer.md#cancelling-request-stop-streaming) for the full pattern and an `upsertMessage` finalization example.
 
 ## Related
 
 - [Adding messages (legacy)](./AddMessageChunk.md) — the stable chunk-based streaming flow.
-- [Server communication](./CustomServer.md) — wiring up {@link PublicConfigMessaging.customSendMessage} and cancellation.
+- [Server communication](./CustomServer.md) — wiring up {@link PublicConfigMessaging.customSendMessage | customSendMessage} and cancellation.
 - React example: [examples/react/upsert-message-user-defined](https://github.com/carbon-design-system/carbon-ai-chat/tree/main/examples/react/upsert-message-user-defined) — a stateful steps-card widget updated in place over time.
 - Web component example: [examples/web-components/upsert-message-user-defined](https://github.com/carbon-design-system/carbon-ai-chat/tree/main/examples/web-components/upsert-message-user-defined) — the same flow with `cds-aichat-custom-element`.

--- a/packages/ai-chat/docs/UpsertMessage.md
+++ b/packages/ai-chat/docs/UpsertMessage.md
@@ -4,11 +4,11 @@ title: Adding messages (experimental)
 
 ## Overview
 
-{@link ChatInstanceMessaging.upsertMessage | upsertMessage} inserts or updates one message. A stable `messageID` names it. One method covers inserting, streaming, correcting, and regenerating a message. You pass an updater. It gets the message's current value and returns what replaces it.
+{@link ChatInstanceMessaging.upsertMessage | upsertMessage} inserts or updates one message by a stable `messageID`. One method covers inserting, streaming, correcting, and regenerating — you pass an updater that receives the current message and returns what replaces it.
 
 Prefer this flow for new code, but note it's experimental. Its behavior and the updater signature may still change. For a settled API, the stable {@link ChatInstanceMessaging.addMessageChunk | addMessageChunk} flow is still fully supported. See [Adding messages (legacy)](./AddMessageChunk.md).
 
-The examples below call `instance.messaging`. So you need a {@link ChatInstance} first. Get one from the `onBeforeRender` prop.
+The examples below call `instance.messaging`, so get a {@link ChatInstance | ChatInstance} from the `onBeforeRender` prop first.
 
 Reach for `upsertMessage` over {@link ChatInstanceMessaging.addMessage | addMessage} or {@link ChatInstanceMessaging.addMessageChunk | addMessageChunk} when you want to:
 


### PR DESCRIPTION
Closes #

Tone pass on `UpsertMessage.md` (Adding messages (experimental)) per `references/tone.md`. Prose only — code blocks and page structure unchanged.

#### Changelog

**Changed**

- Reword `UpsertMessage.md` for voice and reading level.

#### Testing / Reviewing

- Flesch-Kincaid grade: 8.0 (target 8–11). Measured with `npm run reading-level`, which ships in #1740.
- Confirm the reword kept every fact, default, and qualifier.
