### PR TITLE
docs: apply tone guide to StatePersistence.md

### DIFF
--- a/packages/ai-chat/docs/StatePersistence.md
+++ b/packages/ai-chat/docs/StatePersistence.md
@@ -4,19 +4,19 @@ title: Session state persistence
 
 ## Overview
 
-Carbon AI Chat keeps a small amount of session state — which views are open, whether the disclaimer has been accepted, in-progress human-agent connection state, and similar UI flags — so a page reload restores where the user left off. By default this state lives in the browser's `sessionStorage`.
+Carbon AI Chat keeps a small amount of session state, so a page reload restores where the user left off. This state covers which views are open, whether the user accepted the disclaimer, the in-progress human-agent connection, and similar UI flags. By default it lives in the browser's `sessionStorage`.
 
-Set {@link PublicConfig.persistedState} to take over that storage yourself: boot the chat from state you supply and receive every change to persist wherever you like (your own backend, `localStorage`, cross-device sync). This does not persist conversation messages — those load through [Conversation history](./CustomHistory.md) — only the session and UI state described by {@link PersistableState}.
+Set {@link PublicConfig.persistedState | persisted state} to take over that storage yourself. You boot the chat from state you supply, then receive every change so you can save it wherever you like: your own backend, `localStorage`, or cross-device sync. This saves only the session and UI state that {@link PersistableState} describes, not conversation messages, which load through [Conversation history](./CustomHistory.md) instead.
 
-> **Note**: When you do not set {@link PublicConfig.persistedState}, the chat continues to use `sessionStorage` exactly as before. This is an opt-in override with no change to the default behavior.
+> **Note**: When you don't set {@link PublicConfig.persistedState | persisted state}, the chat keeps using `sessionStorage` as before. The override is opt-in, so it doesn't change the default behavior.
 
 ## What is persisted
 
-{@link PersistableState} is the value handed to and from your storage. Treat it as an opaque blob: store the whole thing and hand it back unchanged. It carries session and UI state such as disclaimer acceptance, home-screen state, and the human-agent connection subset needed to reconnect after a reload. It never contains conversation message text.
+{@link PersistableState} is the value passed to and from your storage. Treat it as an opaque blob: store the whole thing and hand it back unchanged. It carries session and UI state such as disclaimer acceptance, home-screen state, and the part of the human-agent connection needed to reconnect after a reload. It never contains conversation message text.
 
 ## Providing your own storage
 
-Set {@link PersistedStateConfig.initialState} to boot from stored state, and {@link PersistedStateConfig.onStateChange} to receive changes to store.
+Set {@link PersistedStateConfig.initialState | initialState} to boot from stored state, and {@link PersistedStateConfig.onStateChange | onStateChange} to receive changes to store.
 
 ```ts
 import { PersistableState, PublicConfig } from "@carbon/ai-chat";
@@ -32,24 +32,24 @@ const config: PublicConfig = {
 };
 ```
 
-- {@link PersistedStateConfig.initialState} replaces the `sessionStorage` read at startup. It is synchronous — resolve any asynchronous load (for example from your backend) before you construct the chat and pass the resolved value. Omit it to start a fresh session.
-- {@link PersistedStateConfig.onStateChange} replaces the `sessionStorage` write. It is called with the complete {@link PersistableState} whenever that state changes — not on transient changes such as input text. Persist the value verbatim.
+- {@link PersistedStateConfig.initialState | initialState} replaces the `sessionStorage` read at startup. It's synchronous, so resolve any asynchronous load, such as a fetch from your backend, before you build the chat and pass the resolved value. Omit it to start a fresh session.
+- {@link PersistedStateConfig.onStateChange | onStateChange} replaces the `sessionStorage` write. The chat calls it with the complete {@link PersistableState} whenever that state changes, but skips transient changes such as input text. Store the value verbatim.
 
-Providing either field disables the internal `sessionStorage` entirely: the chat no longer reads, writes, or clears it.
+Setting either field turns off the internal `sessionStorage` completely, so the chat no longer reads, writes, or clears it.
 
-A restored session is treated as an existing session, so {@link PublicConfig.openChatByDefault} does not re-open the chat on reload.
+The chat treats a restored session as an existing one, so {@link PublicConfig.openChatByDefault | openChatByDefault} doesn't re-open the chat on reload.
 
 ## Do not drop fields
 
-Round-trip the whole {@link PersistableState}. If you store only part of it, reload regresses:
+Round-trip the whole {@link PersistableState}. If you store only part of it, the reload regresses:
 
-- Dropping `disclaimersAccepted` re-prompts the disclaimer on every reload and blocks messages until it is accepted again.
-- Dropping `humanAgentState` prevents an in-progress human-agent conversation from reconnecting.
+- Dropping `disclaimersAccepted` re-prompts the disclaimer on every reload and blocks messages until the user accepts again.
+- Dropping `humanAgentState` stops an in-progress human-agent conversation from reconnecting.
 - Dropping `hasSentNonWelcomeMessage` re-sends the welcome message.
 
-Storing the value verbatim avoids all of these.
+Store the value verbatim to avoid all of these.
 
 ## Related
 
-- [Conversation history](./CustomHistory.md) — persist and restore the conversation messages themselves, which are separate from session state.
+- [Conversation history](./CustomHistory.md) — save and restore the conversation messages, which are separate from session state.
 - [Server communication](./CustomServer.md) — connect the chat to your own backend.


### PR DESCRIPTION
Closes #

Tone pass on `StatePersistence.md` (Session state persistence) per `references/tone.md`. Prose only — code blocks and page structure unchanged.

#### Changelog

**Changed**

- Reword `StatePersistence.md` for voice and reading level.

#### Testing / Reviewing

- Flesch-Kincaid grade: 8.6 (target 8–11). Measured with `npm run reading-level`, which ships in #1740.
- Confirm the reword kept every fact, default, and qualifier.
