### PR TITLE
docs: apply tone guide to Theming.md

### DIFF
--- a/packages/ai-chat/docs/Theming.md
+++ b/packages/ai-chat/docs/Theming.md
@@ -4,7 +4,7 @@ title: Theming
 
 ## Overview
 
-Customize the Carbon theme of the chat. By default, it inherits a Carbon theme from the host page. If your site doesn't use Carbon and you don't set `injectCarbonTheme`, the chat renders the white theme: it reads your page background and switches to a dark theme only when your page is dark. To take control, pick one of four built-in themes, or inject your own and override specific colors.
+Customize the Carbon theme of the chat. By default, it inherits a Carbon theme from the host page. If your site doesn't use Carbon and you don't set `injectCarbonTheme`, the chat renders the white theme - it reads your page background and switches to a dark theme only when your page is dark. To take control, pick one of four built-in themes, or inject your own and override specific colors.
 
 ## Pick a built-in theme
 

--- a/packages/ai-chat/docs/Theming.md
+++ b/packages/ai-chat/docs/Theming.md
@@ -4,11 +4,11 @@ title: Theming
 
 ## Overview
 
-Customize the Carbon theme of the chat. By default, it inherits a Carbon theme from the host page. If your site doesn't use Carbon and you don't set `injectCarbonTheme`, the chat renders the white theme — it reads your page background and switches to a dark theme only if your page is dark. To take control, pick one of four built-in themes or inject your own and override specific colors.
+Customize the Carbon theme of the chat. By default, it inherits a Carbon theme from the host page. If your site doesn't use Carbon and you don't set `injectCarbonTheme`, the chat renders the white theme: it reads your page background and switches to a dark theme only when your page is dark. To take control, pick one of four built-in themes, or inject your own and override specific colors.
 
 ## Pick a built-in theme
 
-If your site doesn't use Carbon, set {@link PublicConfig.injectCarbonTheme} to one of four themes:
+If your site doesn't use Carbon, set {@link PublicConfig.injectCarbonTheme | injectCarbonTheme} to one of four themes:
 
 - {@link CarbonTheme.WHITE}
 - {@link CarbonTheme.G10} (Gray 10)
@@ -43,7 +43,7 @@ The chat exposes two layers of CSS custom properties:
 
 ### Override with your own CSS
 
-The simplest way to recolor (or resize) the chat is to set these custom properties on a host element. They inherit through the chat's shadow boundary, so the chat picks them up:
+The simplest way to recolor or resize the chat is to set these custom properties on a host element. They inherit through the chat's shadow boundary, so the chat picks them up:
 
 ```css
 .my-host {
@@ -55,11 +55,11 @@ The simplest way to recolor (or resize) the chat is to set these custom properti
 }
 ```
 
-The `--cds-aichat-*` shell tokens are overridable this way in every theme mode. The Carbon `--cds-*` tokens are overridable this way whenever the chat inherits its theme — the default, or when your site uses Carbon.
+You can override the `--cds-aichat-*` shell tokens this way in every theme mode. You can override the Carbon `--cds-*` tokens this way whenever the chat inherits its theme — the default, or when your site uses Carbon.
 
 ### Override under a forced theme
 
-If you force a theme with {@link PublicConfig.injectCarbonTheme}, the chat supplies its own Carbon `--cds-*` tokens, so page-level `--cds-*` overrides no longer reach the Carbon components. Set them through {@link LayoutConfig.customProperties} instead — the chat injects these inside its own DOM, so they win over the forced theme. A bare key sets a `--cds-aichat-*` shell token; a key prefixed with `$` sets a Carbon `--cds-*` token (`$`-prefixed values must be hexadecimal colors):
+If you force a theme with {@link PublicConfig.injectCarbonTheme}, the chat supplies its own Carbon `--cds-*` tokens, so page-level `--cds-*` overrides no longer reach the Carbon components. Set them through {@link LayoutConfig.customProperties | customProperties} instead: the chat injects these inside its own DOM, so they win over the forced theme. A bare key sets a `--cds-aichat-*` shell token; a key prefixed with `$` sets a Carbon `--cds-*` token, and `$`-prefixed values must be hexadecimal colors:
 
 ```tsx
 import { ChatContainer, CarbonTheme } from "@carbon/ai-chat";


### PR DESCRIPTION
Closes #

Tone pass on `Theming.md` (Theming) per `references/tone.md`. Prose only — code blocks and page structure unchanged.

#### Changelog

**Changed**

- Reword `Theming.md` for voice and reading level.

#### Testing / Reviewing

- Flesch-Kincaid grade: 8.9 (target 8–11). Measured with `npm run reading-level`, which ships in #1740.
- Confirm the reword kept every fact, default, and qualifier.
