### PR TITLE
feat: add alpha release workflow

### DIFF
--- a/.github/workflows/release-alpha.yml
+++ b/.github/workflows/release-alpha.yml
@@ -1,0 +1,176 @@
+# Publish a manual alpha release of @carbon/ai-chat and
+# @carbon/ai-chat-components from a feature integration branch (e.g.
+# feat/prompt-line).
+#
+# Alpha releases are rare, off-cadence previews handed to teams validating
+# in-progress features. Unlike the RC / stable release pipeline, this workflow:
+#   - publishes both packages to npm under the `alpha` dist-tag (never moves
+#     `latest` or `next`), each with its own independent alpha version
+#   - publishes the demo, docs, both Storybooks and the components bundle to
+#     chat.carbondesignsystem.com/tag/alpha (and components/.../tag/alpha)
+#   - creates NO git tag, GitHub release, changelog, versions.js update or PR
+#
+# It never commits or pushes: the version bumps happen only in the throwaway
+# runner checkout, so the branch it runs from is left untouched.
+#
+# Run it from the branch you want to publish: Actions -> Release alpha ->
+# "Run workflow" -> pick the feature branch. A workflow_dispatch run uses (and
+# checks out) the selected ref, so the alpha is built from that branch's code.
+name: Release alpha
+run-name: "Release alpha (${{ inputs.bump }}) dry-run:${{ inputs.dry-run }} from ${{ github.ref_name }}"
+
+concurrency:
+  group: release-alpha
+  cancel-in-progress: false
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: "Base bump off the current stable version (the alpha previews the next minor or patch)."
+        type: choice
+        options:
+          - minor
+          - patch
+        default: minor
+      dry-run:
+        description: "Dry run? Computes versions and builds everything, but publishes nothing to npm or the CDN."
+        type: boolean
+        default: true
+
+# id-token: write enables npm provenance (both packages set
+# publishConfig.provenance). Nothing is pushed, so contents: read is enough —
+# no PAT / contents: write, unlike the RC / stable release workflow.
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  release-alpha:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: "0"
+
+      - name: Use Node.js version from .nvmrc
+        uses: actions/setup-node@v6.4.0
+        with:
+          node-version-file: ".nvmrc"
+          registry-url: https://registry.npmjs.org
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci --prefer-offline
+
+      # Independently compute the next alpha version for each package from what
+      # is already on npm, and expose them as $AI_CHAT_ALPHA / $COMPONENTS_ALPHA.
+      - name: Compute alpha versions
+        env:
+          BUMP: ${{ inputs.bump }}
+        run: node scripts/compute-alpha-versions.js
+
+      # Apply the versions in the runner checkout only (no commit, no tag). Pin
+      # @carbon/ai-chat to the exact components alpha so installing
+      # @carbon/ai-chat@alpha pulls the matching components alpha, not stable.
+      - name: Apply alpha versions
+        run: |
+          npm pkg set version="$COMPONENTS_ALPHA" --workspace @carbon/ai-chat-components
+          npm pkg set version="$AI_CHAT_ALPHA" --workspace @carbon/ai-chat
+          npm pkg set "dependencies.@carbon/ai-chat-components=$COMPONENTS_ALPHA" --workspace @carbon/ai-chat
+
+      - name: Build packages, demo and docs
+        run: npm run build
+
+      - name: Build Storybooks
+        run: |
+          cd packages/ai-chat-components
+          npm run storybook:build
+          npm run storybook:react:build
+
+      - name: Set npm auth token
+        run: echo "//registry.npmjs.org/:_authToken=${{ secrets.CARBON_BOT_NPM_TOKEN }}" >> .npmrc
+
+      # Publish both public packages to the `alpha` dist-tag. `npm publish`
+      # (unlike `lerna publish`) needs no clean git working tree, so the edited
+      # package.json files are published as-is with no local commit. Components
+      # first so @carbon/ai-chat's dependency resolves for early installers.
+      - name: Publish to npm (alpha dist-tag)
+        if: ${{ !inputs.dry-run }}
+        run: |
+          npm publish --workspace @carbon/ai-chat-components --tag alpha
+          npm publish --workspace @carbon/ai-chat --tag alpha
+
+      # ---- Publish the sites / Storybooks to chat.carbondesignsystem.com/tag/alpha ----
+      # Mirrors publish-chat-cdn.yml / publish-components-cdn.yml, but only the
+      # single rolling `alpha` pointer (no version/<v> copies). Real runs only.
+      - name: Upload demo to COS under the `alpha` folder
+        if: ${{ !inputs.dry-run }}
+        uses: jakejarvis/s3-sync-action@master
+        with:
+          args: --acl public-read --follow-symlinks --delete
+        env:
+          AWS_S3_BUCKET: ${{ secrets.COMMON_COS_BUCKET }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.COMMON_COS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.COMMON_COS_SECRET_ACCESS_KEY }}
+          AWS_REGION: ${{ secrets.COMMON_COS_REGION }}
+          AWS_S3_ENDPOINT: https://${{ secrets.COMMON_COS_ENDPOINT }}
+          SOURCE_DIR: "demo/dist"
+          DEST_DIR: "tag/alpha/demo"
+
+      - name: Upload typedoc to COS under the `alpha` folder
+        if: ${{ !inputs.dry-run }}
+        uses: jakejarvis/s3-sync-action@master
+        with:
+          args: --acl public-read --follow-symlinks --delete
+        env:
+          AWS_S3_BUCKET: ${{ secrets.COMMON_COS_BUCKET }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.COMMON_COS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.COMMON_COS_SECRET_ACCESS_KEY }}
+          AWS_REGION: ${{ secrets.COMMON_COS_REGION }}
+          AWS_S3_ENDPOINT: https://${{ secrets.COMMON_COS_ENDPOINT }}
+          SOURCE_DIR: "packages/ai-chat/dist/docs/carbon-tsdocs"
+          DEST_DIR: "tag/alpha/docs"
+
+      - name: Upload components to COS under the `alpha` folder
+        if: ${{ !inputs.dry-run }}
+        uses: jakejarvis/s3-sync-action@master
+        with:
+          args: --acl public-read --follow-symlinks --delete
+        env:
+          AWS_S3_BUCKET: ${{ secrets.COMMON_COS_BUCKET }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.COMMON_COS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.COMMON_COS_SECRET_ACCESS_KEY }}
+          AWS_REGION: ${{ secrets.COMMON_COS_REGION }}
+          AWS_S3_ENDPOINT: https://${{ secrets.COMMON_COS_ENDPOINT }}
+          SOURCE_DIR: "packages/ai-chat-components/dist"
+          DEST_DIR: "components/tag/alpha"
+
+      - name: Upload ai-chat-components Storybook to COS under the `alpha` folder
+        if: ${{ !inputs.dry-run }}
+        uses: jakejarvis/s3-sync-action@master
+        with:
+          args: --acl public-read --follow-symlinks --delete
+        env:
+          AWS_S3_BUCKET: ${{ secrets.COMMON_COS_BUCKET }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.COMMON_COS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.COMMON_COS_SECRET_ACCESS_KEY }}
+          AWS_REGION: ${{ secrets.COMMON_COS_REGION }}
+          AWS_S3_ENDPOINT: https://${{ secrets.COMMON_COS_ENDPOINT }}
+          SOURCE_DIR: "packages/ai-chat-components/storybook-static"
+          DEST_DIR: "components/storybook/tag/alpha"
+
+      - name: Upload ai-chat-components React Storybook to COS under the `alpha` folder
+        if: ${{ !inputs.dry-run }}
+        uses: jakejarvis/s3-sync-action@master
+        with:
+          args: --acl public-read --follow-symlinks --delete
+        env:
+          AWS_S3_BUCKET: ${{ secrets.COMMON_COS_BUCKET }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.COMMON_COS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.COMMON_COS_SECRET_ACCESS_KEY }}
+          AWS_REGION: ${{ secrets.COMMON_COS_REGION }}
+          AWS_S3_ENDPOINT: https://${{ secrets.COMMON_COS_ENDPOINT }}
+          SOURCE_DIR: "packages/ai-chat-components/storybook-react-static"
+          DEST_DIR: "components/storybook/react/tag/alpha"

--- a/demo/src/framework/demo-chat-version-switcher.ts
+++ b/demo/src/framework/demo-chat-version-switcher.ts
@@ -1,5 +1,5 @@
 /*
- *  Copyright IBM Corp. 2025
+ *  Copyright IBM Corp. 2025, 2026
  *
  *  This source code is licensed under the Apache-2.0 license found in the
  *  LICENSE file in the root directory of this source tree.
@@ -50,8 +50,8 @@ export class VersionDropdown extends LitElement {
   private getCurrentVersionInfo(): VersionInfo {
     const path = window.location.pathname;
 
-    // Check if we're on a tag (latest/next)
-    const tagMatch = path.match(/\/tag\/(latest|next)\//);
+    // Check if we're on a tag (latest/next/alpha)
+    const tagMatch = path.match(/\/tag\/(latest|next|alpha)\//);
     if (tagMatch) {
       return { type: "tag", value: tagMatch[1] };
     }

--- a/docs/publishing-releases.md
+++ b/docs/publishing-releases.md
@@ -12,6 +12,7 @@
   - [Stable release](#stable-release)
   - [Post release](#post-release)
   - [Patch release](#patch-release)
+  - [Alpha release](#alpha-release)
 - [Troubleshooting](#troubleshooting)
   - [Force publish](#force-publish)
   - [Tag already exists](#tag-already-exists)
@@ -306,6 +307,29 @@ patch release:
       [subsequent prerelease](#subsequent-prerelease), and
       [stable release](#stable-release) publishes, except instead of selecting `minor` in the type of semver release, select `patch`
       ![Screenshot of release workflow with patch](https://github.com/user-attachments/assets/1fa292ba-8b7b-4609-9ec1-dac278b98388)
+
+### Alpha release
+
+Alpha releases are rare, off-cadence previews of an in-progress feature, cut straight from a feature integration branch (e.g. `feat/prompt-line`) and handed to specific teams for validation. They are independent of the biweekly `next` / `latest` cadence.
+
+An alpha release publishes `@carbon/ai-chat` and `@carbon/ai-chat-components` to npm under the **`alpha`** dist-tag, and publishes the demo, documentation, both Storybooks, and the components bundle under `chat.carbondesignsystem.com/tag/alpha`. It deliberately does **not** create a git tag, GitHub release, changelog, `versions.js` update, or release PR, and it never commits or pushes — the version bumps happen only in the throwaway workflow runner, so the branch it runs from is left untouched.
+
+To publish an alpha:
+
+- [ ] Go to the [Release alpha workflow](https://github.com/carbon-design-system/carbon-ai-chat/actions/workflows/release-alpha.yml) and choose "Run workflow".
+- [ ] **Select the feature branch** you want to publish from (e.g. `feat/prompt-line`) — the alpha is built from whatever branch you select.
+- [ ] Leave `dry run` checked for the first run. The workflow computes the alpha versions and builds everything, but publishes nothing. Check the log to confirm the planned versions (e.g. `@carbon/ai-chat -> 1.18.0-alpha.0` and `@carbon/ai-chat-components -> 1.8.0-alpha.0`).
+- [ ] Leave `bump` as `minor` unless the alpha previews a patch release, in which case select `patch`.
+- [ ] If the versions look right, run the workflow again with `dry run` unchecked to publish to npm and the CDN.
+- [ ] Confirm the publish:
+  - [ ] `npm view @carbon/ai-chat dist-tags` and `npm view @carbon/ai-chat-components dist-tags` show the new `alpha` version, and `latest` / `next` are unchanged.
+  - [ ] The sites are live: [demo](https://chat.carbondesignsystem.com/tag/alpha/demo/index.html), [documentation](https://chat.carbondesignsystem.com/tag/alpha/docs/documents/Overview.html), [Web Components Storybook](https://chat.carbondesignsystem.com/components/storybook/tag/alpha/index.html), and [React Storybook](https://chat.carbondesignsystem.com/components/storybook/react/tag/alpha/index.html).
+
+A few things to know:
+
+- Alpha versions auto-increment per package from what is already published on npm — the first alpha of a base version is `alpha.0`, and re-running produces `alpha.1`, `alpha.2`, and so on. There is no git tag or committed bump to keep in sync.
+- `@carbon/ai-chat@alpha` pins the exact `@carbon/ai-chat-components` alpha built in the same run, so installers get a self-consistent alpha stack rather than the stable components.
+- Alpha is unlisted in the version-selector dropdowns on the stable `latest` / `next` sites by design; the "Alpha" entry only appears when viewing the alpha site itself.
 
 ## Troubleshooting
 

--- a/packages/typedoc-theme/theme/assets/versionDropdown.js
+++ b/packages/typedoc-theme/theme/assets/versionDropdown.js
@@ -1,5 +1,5 @@
 /*
- *  Copyright IBM Corp. 2025
+ *  Copyright IBM Corp. 2025, 2026
  *
  *  This source code is licensed under the Apache-2.0 license found in the
  *  LICENSE file in the root directory of this source tree.
@@ -12,8 +12,8 @@
   function getCurrentVersionInfo() {
     const path = window.location.pathname;
 
-    // Check if we're on a tag (latest/next)
-    const tagMatch = path.match(/\/tag\/(latest|next)\//);
+    // Check if we're on a tag (latest/next/alpha)
+    const tagMatch = path.match(/\/tag\/(latest|next|alpha)\//);
     if (tagMatch) {
       return { type: "tag", value: tagMatch[1] };
     }
@@ -117,6 +117,17 @@
         href: `https://chat.carbondesignsystem.com${getVersionPath({ type: "tag", value: "next" })}`,
         selected: currentInfo.type === "tag" && currentInfo.value === "next",
       });
+
+      // Add an "Alpha" option only when viewing an alpha site, so alpha stays
+      // unlisted on the stable latest/next docs.
+      if (currentInfo.type === "tag" && currentInfo.value === "alpha") {
+        options.push({
+          label: "Alpha",
+          value: "tag:alpha",
+          href: `https://chat.carbondesignsystem.com${getVersionPath({ type: "tag", value: "alpha" })}`,
+          selected: true,
+        });
+      }
 
       // Add all version options from the array
       // If current version is "latest" tag, select the first version in the array

--- a/scripts/compute-alpha-versions.js
+++ b/scripts/compute-alpha-versions.js
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+
+/**
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+"use strict";
+
+const fs = require("fs");
+const { execSync } = require("child_process");
+
+/**
+ * Public packages published under the `alpha` dist-tag. Each is versioned
+ * independently: its alpha number is derived from what is already on npm, so
+ * repeated alpha runs increment (alpha.0 -> alpha.1) without relying on any git
+ * tag or committed version bump.
+ */
+const PACKAGES = [
+  {
+    name: "@carbon/ai-chat-components",
+    dir: "packages/ai-chat-components",
+    envKey: "COMPONENTS_ALPHA",
+  },
+  {
+    name: "@carbon/ai-chat",
+    dir: "packages/ai-chat",
+    envKey: "AI_CHAT_ALPHA",
+  },
+];
+
+const bump = process.env.BUMP === "patch" ? "patch" : "minor";
+
+/**
+ * Returns the base release version the alpha is a preview of: the next minor
+ * (or patch) after the package's current stable version. e.g. 1.17.0 -> 1.18.0.
+ *
+ * @param {string} version The current package.json version.
+ * @returns {string} The base version for the alpha prerelease.
+ */
+function nextBase(version) {
+  const [major, minor, patch] = version.split("-")[0].split(".").map(Number);
+  return bump === "patch"
+    ? `${major}.${minor}.${patch + 1}`
+    : `${major}.${minor + 1}.0`;
+}
+
+/**
+ * Returns every version currently published for the given package, or an empty
+ * array if the package has never been published.
+ *
+ * @param {string} name The npm package name.
+ * @returns {string[]} The published versions.
+ */
+function publishedVersions(name) {
+  try {
+    const output = execSync(`npm view ${name} versions --json`, {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    const parsed = JSON.parse(output);
+    return Array.isArray(parsed) ? parsed : [parsed];
+  } catch (error) {
+    // Package or its versions are not on the registry yet: start fresh.
+    return [];
+  }
+}
+
+/**
+ * Computes the next alpha version for a package: `<base>-alpha.<n>`, where `n`
+ * is one greater than the highest alpha already published for that base.
+ *
+ * @param {{ name: string, dir: string }} pkg The package descriptor.
+ * @returns {string} The next alpha version to publish.
+ */
+function computeAlpha(pkg) {
+  const { version } = JSON.parse(
+    fs.readFileSync(`${pkg.dir}/package.json`, "utf8"),
+  );
+  const base = nextBase(version);
+  const alphaPattern = new RegExp(
+    `^${base.replace(/\./g, "\\.")}-alpha\\.(\\d+)$`,
+  );
+  let highest = -1;
+  for (const published of publishedVersions(pkg.name)) {
+    const match = alphaPattern.exec(published);
+    if (match) {
+      highest = Math.max(highest, Number(match[1]));
+    }
+  }
+  return `${base}-alpha.${highest + 1}`;
+}
+
+const envLines = [];
+for (const pkg of PACKAGES) {
+  const alpha = computeAlpha(pkg);
+  envLines.push(`${pkg.envKey}=${alpha}`);
+  console.log(`${pkg.name} -> ${alpha}`);
+}
+
+// Expose the computed versions to later GitHub Actions steps.
+if (process.env.GITHUB_ENV) {
+  fs.appendFileSync(process.env.GITHUB_ENV, `${envLines.join("\n")}\n`);
+}


### PR DESCRIPTION
Closes #1774

Adds a manual, off-cadence flow for cutting **alpha** releases of `@carbon/ai-chat` and `@carbon/ai-chat-components` straight from a feature integration branch (e.g. `feat/prompt-line`), so preview builds can be handed to teams validating in-progress features. Both packages publish to the npm `alpha` dist-tag with independent, auto-incrementing alpha versions, and the demo/docs/Storybooks publish under `chat.carbondesignsystem.com/tag/alpha`. The flow intentionally creates no git tag, GitHub release, changelog, `versions.js` update, or PR, and it never commits or pushes — the version bumps happen only in the throwaway runner checkout, so the branch it runs from is left untouched.

Files worth a closer look:

- [`.github/workflows/release-alpha.yml`](.github/workflows/release-alpha.yml) — the whole flow. The npm publish and all five CDN-upload steps are gated on `!inputs.dry-run`, and publishing uses `npm publish --workspace … --tag alpha` (not `lerna publish`) so no clean working tree / local commit is needed after the in-place version bump.
- [`scripts/compute-alpha-versions.js`](scripts/compute-alpha-versions.js) — derives each package's next `-alpha.N` from what is already on npm (no git state), and the workflow pins `@carbon/ai-chat` to the exact components alpha built in the same run so the published alpha stack is self-consistent.

#### Changelog

**New**

- `Release alpha` GitHub Actions workflow (`workflow_dispatch`, run from a selected feature branch) that publishes `@carbon/ai-chat` + `@carbon/ai-chat-components` to the npm `alpha` dist-tag and the demo/docs/both Storybooks to `chat.carbondesignsystem.com/tag/alpha`, with a `dry run` default that computes versions and builds but publishes nothing.
- `scripts/compute-alpha-versions.js`, which computes independent per-package next-alpha versions from the npm registry.
- "Alpha release" section (and TOC entry) in [`docs/publishing-releases.md`](docs/publishing-releases.md).

**Changed**

- The demo and TypeDoc version-selector switchers now recognize `/tag/alpha/` and surface an "Alpha" entry, shown only when viewing the alpha site so alpha stays unlisted on the stable `latest` / `next` sites.

**Removed**

- N/A

#### Testing / Reviewing

This is release automation, not reachable from the demo toggles, so verification is manual:

- **Version compute (local, no side effects):** `node scripts/compute-alpha-versions.js` prints the next alpha per package (e.g. `@carbon/ai-chat -> 1.18.0-alpha.0`, `@carbon/ai-chat-components -> 1.8.0-alpha.0`); `BUMP=patch node scripts/compute-alpha-versions.js` previews a patch-based alpha.
- **Dry run (safe):** after this lands on `main`, Actions → **Release alpha** → Run workflow → pick a feature branch, leave `dry run` checked. Confirm the log prints the planned versions and that the build + Storybook steps succeed while no publish/upload steps run.
- **Real run:** re-run with `dry run` unchecked, then confirm `npm view @carbon/ai-chat dist-tags` / `npm view @carbon/ai-chat-components dist-tags` show the new `alpha` version with `latest` / `next` unchanged, the `tag/alpha` demo/docs/Storybook URLs return 200, and no new git tag or commit appears on the source branch.
- **Switchers:** the `/tag/(latest|next|alpha)/` detection and conditional "Alpha" option are covered by review; "Alpha" appears only on `/tag/alpha/` paths.

Reviewer note: the workflow YAML has no repo CI gate (prettier excludes `.yml`, eslint is `packages/`-scoped), so please eyeball it — running `actionlint` is recommended.
