### PR TITLE
refactor(types): simplify StructuredFieldType and widen field value

### DIFF
--- a/packages/ai-chat/docs/StructuredData.md
+++ b/packages/ai-chat/docs/StructuredData.md
@@ -20,12 +20,16 @@ A {@link StructuredData} payload has two parts: `fields`, an array of typed {@li
 ```typescript
 const data: StructuredData = {
   fields: [
-    { id: "rating", type: "number", value: 4 },
-    { id: "topics", type: "multi_select", value: ["billing", "shipping"] },
+    { id: "rating", value: 4 },
+    { id: "topics", value: ["billing", "shipping"] },
   ],
   user_defined: { source_widget: "checkout-page" },
 };
 ```
+
+Each field's `value` is carried as `unknown` — the chat never inspects it, so put whatever your backend needs there and narrow it yourself in {@link PublicConfigMessaging.customSendMessage}.
+
+`type` is optional, and only three values mean anything to the chat: `file` (see [File uploads](#file-uploads) below), and `mention` / `command` (produced by the {@link InputConfig.mention} and {@link InputConfig.command} input nodes). You may set `type` to any other string to tag a field for your own code, but the chat treats it as an opaque pass-through hint.
 
 ## Setting structured data from the host
 
@@ -35,7 +39,7 @@ Call {@link ChatInstanceInput.updateStructuredData} with an updater that receive
 // Add a field, preserving anything already pending.
 instance.input.updateStructuredData((prev) => ({
   ...prev,
-  fields: [...(prev?.fields ?? []), { id: "rating", type: "number", value: 4 }],
+  fields: [...(prev?.fields ?? []), { id: "rating", value: 4 }],
 }));
 ```
 

--- a/packages/ai-chat/references/code-examples.md
+++ b/packages/ai-chat/references/code-examples.md
@@ -10,7 +10,7 @@ Each rule below comes with its _why_ — the why changes how you apply it.
 
 - **Self-contained & runnable as written.** Put the imports and an entry point inside the block; call only the public surface; import only from `@carbon/ai-chat` (never `@carbon/ai-chat/src/...`). Mark a deliberate omission with a real language comment (`// … your render logic`), never a bare `...`. _An agent retrieves the block with no neighbors, and a human pastes it — anything off-screen is lost._
 - **Minimal.** Roughly 5–25 lines. Show only the API being documented; drop unrelated config, providers, and deps. _Noise hides the one call the reader came for._
-- **Realistic, well-typed values — never `foo` / `bar`.** Arguments are the de-facto schema docs; concrete, correctly-typed values (`{ id: "rating", type: "number", value: 4 }`) tell the reader the shape. _Placeholder junk forces agents to guess the schema and guess wrong._
+- **Realistic, well-typed values — never `foo` / `bar`.** Arguments are the de-facto schema docs; concrete, correctly-typed values (`{ id: "rating", value: 4 }`) tell the reader the shape. _Placeholder junk forces agents to guess the schema and guess wrong._
 - **One _titled_ `@example` per distinct case.** Give each mode, overload, or scenario its own `@example` with a title line (TSDoc renders the first line as the caption). Don't cram add/replace/clear into one fence separated by `//` comments. _Search and the MCP index surface blocks individually; a titled block stands alone._
 - **Show what comes back.** For a method that returns or resolves a value, show the caller using it, with the result annotated inline (`// => …`). _The return shape is half the contract; a call that drops the result documents only half._
 - **Model the correct pattern, not the shortest.** Examples are copied verbatim into production, so make the example production-safe: `await` promises, clean up listeners, memoize where the API demands it, and call out footguns inline. Never reach for a deprecated API for brevity. _The shortest snippet teaches the wrong habit at scale._
@@ -25,14 +25,14 @@ The first line after `@example` is the title; the fenced code follows. One block
  * ```ts
  * instance.input.updateStructuredData((prev) => ({
  *   ...prev,
- *   fields: [...(prev?.fields ?? []), { id: "rating", type: "number", value: 4 }],
+ *   fields: [...(prev?.fields ?? []), { id: "rating", value: 4 }],
  * }));
  * ```
  *
  * @example Replace all pending structured data
  * ```ts
  * instance.input.updateStructuredData(() => ({
- *   fields: [{ id: "selection", type: "multi_select", value: ["a", "b"] }],
+ *   fields: [{ id: "selection", value: ["billing", "shipping"] }],
  * }));
  * ```
  *

--- a/packages/ai-chat/src/aiChatEntry.tsx
+++ b/packages/ai-chat/src/aiChatEntry.tsx
@@ -301,7 +301,6 @@ export {
   StructuredData,
   StructuredField,
   StructuredFieldType,
-  StructuredFieldValue,
   InlineFile,
   ExternalFileReference,
   FileFieldValue,

--- a/packages/ai-chat/src/serverEntry.ts
+++ b/packages/ai-chat/src/serverEntry.ts
@@ -286,7 +286,6 @@ export {
   StructuredData,
   StructuredField,
   StructuredFieldType,
-  StructuredFieldValue,
   InlineFile,
   ExternalFileReference,
   FileFieldValue,

--- a/packages/ai-chat/src/types/instance/ChatInstanceInput.ts
+++ b/packages/ai-chat/src/types/instance/ChatInstanceInput.ts
@@ -91,7 +91,7 @@ export interface ChatInstanceInput {
    *   ...prev,
    *   fields: [
    *     ...(prev?.fields ?? []),
-   *     { id: "rating", type: "number", value: 4 },
+   *     { id: "rating", value: 4 },
    *   ],
    * }));
    * ```
@@ -99,7 +99,7 @@ export interface ChatInstanceInput {
    * @example Replace all pending structured data
    * ```ts
    * instance.input.updateStructuredData(() => ({
-   *   fields: [{ id: "selection", type: "multi_select", value: ["a", "b"] }],
+   *   fields: [{ id: "selection", value: ["billing", "shipping"] }],
    * }));
    * ```
    *

--- a/packages/ai-chat/src/types/messaging/Messages.ts
+++ b/packages/ai-chat/src/types/messaging/Messages.ts
@@ -166,22 +166,29 @@ interface EventInputData<TNameType extends string = string> {
 /**
  * The type of a structured field.
  *
+ * Only three values carry meaning to the chat itself:
+ *
+ * - `"file"` — drives the upload merge logic and in-flight upload tracking.
+ * - `"mention"` — produced by the mention input node.
+ * - `"command"` — produced by the command input node.
+ *
+ * Any other string is accepted and passed through untouched — a free-form hint
+ * for your own {@link PublicConfigMessaging.customSendMessage}, which the chat
+ * never inspects. The three named members exist only so they keep
+ * autocompleting; describe every other backend widget type however your
+ * backend already names it.
+ *
  * @experimental
  * @category Messaging
  */
 type StructuredFieldType =
-  | "text"
-  | "textarea"
-  | "number"
-  | "boolean"
-  | "select"
-  | "multi_select"
-  | "date"
-  | "datetime"
   | "file"
   | "mention"
   | "command"
-  | "unknown";
+  // `string & {}` widens to any string while keeping the three literals in
+  // autocomplete — a plain `| string` would collapse the whole union to `string`.
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  | (string & {});
 
 /**
  * Represents an inline file — the actual File object to be uploaded.
@@ -270,31 +277,15 @@ interface ExternalFileReference {
 type FileFieldValue = InlineFile | ExternalFileReference;
 
 /**
- * The value of a structured field. The actual type depends on the field's
- * {@link StructuredFieldType}.
- *
- * @experimental
- * @category Messaging
- */
-type StructuredFieldValue =
-  | string // text, textarea, select, date, datetime
-  | number // number
-  | boolean // boolean
-  | string[] // multi_select
-  | FileFieldValue // file (single)
-  | FileFieldValue[] // file (multiple)
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  | any; // unknown / user_defined escape hatch
-
-/**
- * A single typed field within a {@link StructuredData} payload.
+ * A single field within a {@link StructuredData} payload.
  *
  * @experimental
  * @category Messaging
  */
 interface StructuredField {
   /**
-   * Unique identifier for this field.
+   * Unique identifier for this field. Read it back in
+   * {@link PublicConfigMessaging.customSendMessage} to find the field you sent.
    */
   id: string;
 
@@ -304,27 +295,33 @@ interface StructuredField {
   label?: string;
 
   /**
-   * The type of field.
+   * The type of field. Only `"file"`, `"mention"`, and `"command"` mean
+   * anything to the chat (see {@link StructuredFieldType}); any other value is
+   * carried through untouched for your own
+   * {@link PublicConfigMessaging.customSendMessage} to interpret.
    */
   type?: StructuredFieldType;
 
   /**
-   * The value of the field.
+   * The value of the field, carried untyped. For a `"file"` field it is a
+   * {@link FileFieldValue}; for every other field it is whatever your backend
+   * needs — narrow it yourself in
+   * {@link PublicConfigMessaging.customSendMessage}.
    */
-  value: StructuredFieldValue;
+  value: unknown;
 }
 
 /**
  * Structured data that can be sent alongside or instead of plain text input.
- * Supports typed fields for common input patterns (text, select, multi-select,
- * file, etc.) as well as an escape hatch for arbitrary user-defined data.
+ * Carries an array of {@link StructuredField} entries plus `user_defined`, an
+ * escape hatch for arbitrary host-defined data.
  *
  * @experimental
  * @category Messaging
  */
 interface StructuredData {
   /**
-   * Typed fields with known structures (recommended for most use cases).
+   * The structured fields carried with the message.
    */
   fields?: StructuredField[];
 
@@ -354,8 +351,8 @@ interface MessageInput extends BaseMessageInput {
 
   /**
    * Structured data that can be sent alongside or instead of plain text input.
-   * Supports typed fields (text, select, multi-select, file, etc.) and an
-   * escape hatch for arbitrary user-defined data.
+   * Carries an array of structured fields and an escape hatch for arbitrary
+   * user-defined data.
    *
    * @experimental
    */
@@ -2440,7 +2437,6 @@ export {
   StructuredData,
   StructuredField,
   StructuredFieldType,
-  StructuredFieldValue,
   InlineFile,
   ExternalFileReference,
   FileFieldValue,

--- a/packages/ai-chat/tests/instance/spec/structuredData_spec.ts
+++ b/packages/ai-chat/tests/instance/spec/structuredData_spec.ts
@@ -33,7 +33,7 @@ describe("ChatInstance.input.updateStructuredData", () => {
     const { instance, store } = await renderChatAndGetInstanceWithStore(config);
 
     const structuredData: StructuredData = {
-      fields: [{ id: "rating", type: "number", value: 4 }],
+      fields: [{ id: "rating", value: 4 }],
     };
 
     instance.input.updateStructuredData(() => structuredData);
@@ -50,31 +50,28 @@ describe("ChatInstance.input.updateStructuredData", () => {
 
     // Set initial value
     instance.input.updateStructuredData(() => ({
-      fields: [{ id: "field1", type: "text", value: "hello" }],
+      fields: [{ id: "field1", value: "hello" }],
     }));
 
     // Update by appending a field
     const updater = jest.fn(
       (prev: StructuredData | undefined): StructuredData => ({
         ...prev,
-        fields: [
-          ...(prev?.fields ?? []),
-          { id: "field2", type: "number" as const, value: 42 },
-        ],
+        fields: [...(prev?.fields ?? []), { id: "field2", value: 42 }],
       }),
     );
 
     instance.input.updateStructuredData(updater);
 
     expect(updater).toHaveBeenCalledWith({
-      fields: [{ id: "field1", type: "text", value: "hello" }],
+      fields: [{ id: "field1", value: "hello" }],
     });
 
     const state = store.getState();
     expect(state.assistantInputState.pendingStructuredData).toEqual({
       fields: [
-        { id: "field1", type: "text", value: "hello" },
-        { id: "field2", type: "number", value: 42 },
+        { id: "field1", value: "hello" },
+        { id: "field2", value: 42 },
       ],
     });
   });
@@ -85,7 +82,7 @@ describe("ChatInstance.input.updateStructuredData", () => {
 
     // Set initial value
     instance.input.updateStructuredData(() => ({
-      fields: [{ id: "field1", type: "text", value: "hello" }],
+      fields: [{ id: "field1", value: "hello" }],
     }));
 
     expect(
@@ -100,28 +97,31 @@ describe("ChatInstance.input.updateStructuredData", () => {
     ).toBeUndefined();
   });
 
-  it("supports multi_select field type", async () => {
+  it("carries arbitrary field values as unknown and passes type hints through untouched", async () => {
     const config = createBaseConfig();
     const { instance, store } = await renderChatAndGetInstanceWithStore(config);
 
     instance.input.updateStructuredData(() => ({
       fields: [
         {
-          id: "features",
-          type: "multi_select",
-          value: ["feature-a", "feature-b"],
+          id: "priority",
+          // A free-form host hint the chat never inspects.
+          type: "radio",
+          value: { level: "high", weight: 3 },
         },
+        { id: "topics", value: ["billing", "shipping"] },
       ],
     }));
 
     const state = store.getState();
-    expect(
-      state.assistantInputState.pendingStructuredData?.fields?.[0],
-    ).toEqual({
-      id: "features",
-      type: "multi_select",
-      value: ["feature-a", "feature-b"],
-    });
+    expect(state.assistantInputState.pendingStructuredData?.fields).toEqual([
+      {
+        id: "priority",
+        type: "radio",
+        value: { level: "high", weight: 3 },
+      },
+      { id: "topics", value: ["billing", "shipping"] },
+    ]);
   });
 
   it("supports file field with ExternalFileReference", async () => {
@@ -190,7 +190,7 @@ describe("getState().input.structuredData", () => {
     const { instance } = await renderChatAndGetInstanceWithStore(config);
 
     const structuredData: StructuredData = {
-      fields: [{ id: "rating", type: "number", value: 5 }],
+      fields: [{ id: "rating", value: 5 }],
     };
 
     instance.input.updateStructuredData(() => structuredData);
@@ -204,7 +204,7 @@ describe("getState().input.structuredData", () => {
     const { instance } = await renderChatAndGetInstanceWithStore(config);
 
     instance.input.updateStructuredData(() => ({
-      fields: [{ id: "field1", type: "text", value: "hello" }],
+      fields: [{ id: "field1", value: "hello" }],
     }));
 
     const snapshot = instance.getState().input.structuredData;
@@ -225,7 +225,7 @@ describe("structured_data merge on send", () => {
     const { instance } = await renderChatAndGetInstanceWithStore(config);
 
     const structuredData: StructuredData = {
-      fields: [{ id: "rating", type: "number", value: 4 }],
+      fields: [{ id: "rating", value: 4 }],
     };
 
     instance.input.updateStructuredData(() => structuredData);
@@ -246,7 +246,7 @@ describe("structured_data merge on send", () => {
     const { instance, store } = await renderChatAndGetInstanceWithStore(config);
 
     instance.input.updateStructuredData(() => ({
-      fields: [{ id: "rating", type: "number", value: 4 }],
+      fields: [{ id: "rating", value: 4 }],
     }));
 
     expect(
@@ -266,12 +266,12 @@ describe("structured_data merge on send", () => {
 
     // Set pending structured data in the store
     instance.input.updateStructuredData(() => ({
-      fields: [{ id: "store_field", type: "text", value: "from store" }],
+      fields: [{ id: "store_field", value: "from store" }],
     }));
 
     // Send a MessageRequest that already has structured_data
     const explicitStructuredData: StructuredData = {
-      fields: [{ id: "explicit_field", type: "text", value: "explicit" }],
+      fields: [{ id: "explicit_field", value: "explicit" }],
     };
 
     const sendHandler = jest.fn();
@@ -298,8 +298,8 @@ describe("structured_data merge on send", () => {
 
     const structuredData: StructuredData = {
       fields: [
-        { id: "name", type: "text", value: "John Doe" },
-        { id: "score", type: "number", value: 10 },
+        { id: "name", value: "John Doe" },
+        { id: "score", value: 10 },
       ],
     };
 
@@ -333,7 +333,7 @@ describe("structured_data merge on send", () => {
     instance.on([{ type: BusEventType.SEND, handler: sendHandler }]);
 
     const structuredData: StructuredData = {
-      fields: [{ id: "selection", type: "multi_select", value: ["a", "b"] }],
+      fields: [{ id: "selection", value: ["a", "b"] }],
     };
 
     await instance.send({

--- a/packages/ai-chat/tests/instance/spec/uploadApi_spec.ts
+++ b/packages/ai-chat/tests/instance/spec/uploadApi_spec.ts
@@ -265,7 +265,7 @@ describe("upload API – Redux store lifecycle", () => {
 
     // Set manual structured data (host-page fields).
     instance.input.updateStructuredData(() => ({
-      fields: [{ id: "user_id", type: "text", value: "user-123" }],
+      fields: [{ id: "user_id", value: "user-123" }],
     }));
 
     // Add a completed upload with its own contribution.
@@ -290,7 +290,7 @@ describe("upload API – Redux store lifecycle", () => {
 
     const state = store.getState();
     expect(state.assistantInputState.pendingStructuredData?.fields).toEqual([
-      { id: "user_id", type: "text", value: "user-123" },
+      { id: "user_id", value: "user-123" },
       {
         id: "attachment",
         type: "file",
@@ -304,7 +304,7 @@ describe("upload API – Redux store lifecycle", () => {
       await renderChatAndGetInstanceWithStore(createBaseConfig());
 
     instance.input.updateStructuredData(() => ({
-      fields: [{ id: "user_id", type: "text", value: "user-123" }],
+      fields: [{ id: "user_id", value: "user-123" }],
     }));
 
     const contributedData: StructuredData = {
@@ -332,7 +332,7 @@ describe("upload API – Redux store lifecycle", () => {
     const state = store.getState();
     // Only the manual data remains.
     expect(state.assistantInputState.pendingStructuredData?.fields).toEqual([
-      { id: "user_id", type: "text", value: "user-123" },
+      { id: "user_id", value: "user-123" },
     ]);
   });
 
@@ -397,7 +397,7 @@ describe("upload API – Redux store lifecycle", () => {
       await renderChatAndGetInstanceWithStore(createBaseConfig());
 
     instance.input.updateStructuredData(() => ({
-      fields: [{ id: "x", type: "text", value: "y" }],
+      fields: [{ id: "x", value: "y" }],
     }));
     store.dispatch(
       actions.addPendingUpload(


### PR DESCRIPTION
Closes #1784

Simplify the `@experimental` `StructuredFieldType` to the three values the chat actually acts on — `file`, `mention`, `command` — while keeping the union open via `string & {}` so hosts can still tag a field with any backend widget type as a free-form hint. Widen `StructuredField.value` to `unknown` and drop the `StructuredFieldValue` alias; the chat never reads field values, so hosts narrow them in `customSendMessage`.

Type + docs + tests only. No runtime behaviour change.

- [`Messages.ts`](packages/ai-chat/src/types/messaging/Messages.ts) — the type surface; note the `string & {}` autocomplete trick and its `ban-types` disable.

Docs edits stay off the lines [#1763](https://github.com/carbon-design-system/carbon-ai-chat/pull/1763) touches — merge in either order is conflict-free.

#### Changelog

**Changed**

- `StructuredFieldType`: `file` / `mention` / `command` stay named for autocomplete; any other string is accepted as an opaque host hint.
- `StructuredField.value` widened to `unknown`.

**Removed**

- `StructuredFieldValue` type alias. Breaking (experimental API): narrow the value yourself when reading it; use `FileFieldValue` for `type: "file"` fields.

#### Testing / Reviewing

- No runtime surface — type-layer change, not exercisable from the demo.
- `npx jest tests/instance/spec/structuredData_spec.ts tests/instance/spec/uploadApi_spec.ts tests/instance/spec/uploadUI_spec.ts` (in `packages/ai-chat`) — 45 pass.
- `npm run build --workspace=@carbon/ai-chat` — rollup + TypeDoc clean (validates the `{@link}` refs).
