### PR TITLE
fix(prompt-line): visual regressions

### DIFF
--- a/packages/ai-chat-components/src/components/prompt-line/src/prompt-line-shell.scss
+++ b/packages/ai-chat-components/src/components/prompt-line/src/prompt-line-shell.scss
@@ -207,12 +207,18 @@
 // -----------------------------------------------------------
 // Autocomplete slot (light DOM, positioned above input)
 // -----------------------------------------------------------
+// The autocomplete lives inside `.--input-uploads-and-autocomplete`, which is
+// itself inset by the container's `padding-inline: layout.$spacing-03` on each
+// side, plus a `margin-inline-end: layout.$spacing-03` applied by the
+// adjacent-child rule below. Stretch back to the full container width by
+// offsetting inline-start by the start padding and widening by start padding +
+// end padding + end margin (3x $spacing-03).
 ::slotted([slot="autocomplete-content"]) {
   position: absolute;
   z-index: 10;
-  inline-size: 100%;
+  inline-size: calc(100% + #{layout.$spacing-03} * 3);
   inset-block-end: 100%;
-  inset-inline-start: 0;
+  inset-inline-start: calc(-1 * #{layout.$spacing-03});
 }
 
 // Add gap when autocomplete is not attached (fullscreen layout)

--- a/packages/ai-chat/src/chat/utils/carbonIcon.ts
+++ b/packages/ai-chat/src/chat/utils/carbonIcon.ts
@@ -75,7 +75,9 @@ export function carbonIconToReact(
         width: icon.attrs.width || 16,
         height: icon.attrs.height || 16,
         fill: icon.attrs.fill || "currentColor",
+        focusable: "false",
         tabIndex: -1,
+        style: { pointerEvents: "none" },
         ...transformedProps,
       },
       icon.content.map((child, i) =>


### PR DESCRIPTION
Fixes visual regression where the width of the autocomplete list is compressed. Also fixes bug where the `<svg>` within an icon button receives focus on click.

#### Changelog

**Changed**

- `autocomplete-content` slot styles: `inline-size` and `inset-inline-start` set to account for padding and margin now applied to `.--input-uploads-and-autocomplete`
- `carbonIconToReact` util function:
  - Adds attributes `focusable: "false"` and `style: { pointerEvents: "none" }` to prevent focus on click events

#### Testing / Reviewing

- Go to demo deploy preview Chat config -> Input -> Enable autocomplete suggestions, expanded layout, and dummy menu options
- Verify the autocomplete list aligns with the width of the input (matches the designs)
- Click on the menu action buttons and make sure the svg cannot be focused by either clicking or pressing Tab between buttons
- Test in Fullscreen, Float, and Sidebar chat layouts

