### PR TITLE
fix(prompt-line): autocomplete send event wired to input send

### DIFF
--- a/packages/ai-chat-components/src/react/hooks/useChatAutocomplete.tsx
+++ b/packages/ai-chat-components/src/react/hooks/useChatAutocomplete.tsx
@@ -45,6 +45,10 @@ export interface UseChatAutocompleteOptions {
   isSendDisabled?: boolean;
   /** Fired after a starter is selected and inserted (used to trigger send). */
   onStarterSelected?: (text: string) => void;
+  /**
+   * Fired when the send button inside an autocomplete suggestion item is clicked.
+   */
+  onSendItem?: (text: string) => void;
   /** Whether the autocomplete is attached to the input (affects corner rounding). */
   attached?: boolean;
   /** Maximum height for the autocomplete popover */
@@ -74,6 +78,7 @@ export function useChatAutocomplete(
     promptLineRef,
     isSendDisabled,
     onStarterSelected,
+    onSendItem,
     attached = true,
     maxHeight,
   } = options;
@@ -90,6 +95,8 @@ export function useChatAutocomplete(
   // but reading them out of refs avoids re-instantiation churn.
   const onStarterRef = React.useRef(onStarterSelected);
   onStarterRef.current = onStarterSelected;
+  const onSendItemRef = React.useRef(onSendItem);
+  onSendItemRef.current = onSendItem;
 
   if (!controllerRef.current) {
     controllerRef.current = new AutocompleteController({
@@ -138,6 +145,15 @@ export function useChatAutocomplete(
 
   const handleSelect = React.useCallback((item: SuggestionItem) => {
     controllerRef.current?.select(item);
+  }, []);
+
+  const handleSend = React.useCallback((e: CustomEvent<{ text: string }>) => {
+    const text = e.detail?.text;
+    if (!text) {
+      return;
+    }
+    controllerRef.current?.dismiss();
+    onSendItemRef.current?.(text);
   }, []);
 
   const dismiss = React.useCallback(() => {
@@ -197,10 +213,11 @@ export function useChatAutocomplete(
         onSelect={(e: CustomEvent<{ item: SuggestionItem }>) =>
           handleSelect(e.detail.item)
         }
+        onSend={handleSend}
         onDismiss={dismiss}
       />
     );
-  }, [state, handleSelect, dismiss, setListElement, attached]);
+  }, [state, handleSelect, handleSend, dismiss, setListElement, attached]);
 
   return { onTriggerChange, autocompleteContent };
 }

--- a/packages/ai-chat/src/chat/components/input/Input.tsx
+++ b/packages/ai-chat/src/chat/components/input/Input.tsx
@@ -505,6 +505,9 @@ function Input(props: InputProps, ref: Ref<InputFunctions>) {
       rawInputValueRef.current = text;
       sendCurrentValue();
     },
+    onSendItem: (text) => {
+      onSendInput(text);
+    },
   });
 
   useInputImperativeHandle({


### PR DESCRIPTION
Selecting the send button inside of an autocomplete item wasn't actually sending a message. Added `onSendItem` to `UseChatAutocompleteOptions` and wired it to `onSendInput` in `Input.tsx` to make it work.

#### Changelog

**New**

- Adds `onSendItem` to `UseChatAutocompleteOptions` and wires it to `onSendInput()` in `packages/ai-chat/src/chat/components/input/Input.tsx`
- Adds `onSendItemRef` so the callback is always current without being a dependency
- `onSend` event triggers `handleSend()` handler to extract text from the event detail, call `controller.dismiss()` to close the overlay, and call `onSendItemRef.current?.(text)`

#### Testing / Reviewing

- Go to demo deploy preview
- Chat config -> Input -> Enable autocomplete suggestions
- Verify that clicking the send button from the list item actually sends the message to the chat