### PR TITLE
feat: allow saying an explicit version for the alpha

### DIFF
--- a/.github/workflows/release-alpha.yml
+++ b/.github/workflows/release-alpha.yml
@@ -27,12 +27,20 @@ on:
   workflow_dispatch:
     inputs:
       bump:
-        description: "Base bump off the current stable version (the alpha previews the next minor or patch)."
+        description: "Base bump off the current stable version (the alpha previews the next minor or patch). Ignored for a package with an explicit base below."
         type: choice
         options:
           - minor
           - patch
         default: minor
+      ai-chat-base:
+        description: "Exact base version for @carbon/ai-chat, e.g. 1.19.0 when the branch lands a release later than the next one. Leave both base inputs blank to derive from `bump`; setting one requires the other."
+        type: string
+        default: ""
+      components-base:
+        description: "Exact base version for @carbon/ai-chat-components, e.g. 1.9.0. The two packages version independently, so this must be set whenever `ai-chat-base` is."
+        type: string
+        default: ""
       dry-run:
         description: "Dry run? Computes versions and builds everything, but publishes nothing to npm or the CDN."
         type: boolean
@@ -69,6 +77,8 @@ jobs:
       - name: Compute alpha versions
         env:
           BUMP: ${{ inputs.bump }}
+          AI_CHAT_BASE: ${{ inputs.ai-chat-base }}
+          COMPONENTS_BASE: ${{ inputs.components-base }}
         run: node scripts/compute-alpha-versions.js
 
       # Apply the versions in the runner checkout only (no commit, no tag). Pin

--- a/docs/publishing-releases.md
+++ b/docs/publishing-releases.md
@@ -320,6 +320,7 @@ To publish an alpha:
 - [ ] **Select the feature branch** you want to publish from (e.g. `feat/prompt-line`) — the alpha is built from whatever branch you select.
 - [ ] Leave `dry run` checked for the first run. The workflow computes the alpha versions and builds everything, but publishes nothing. Check the log to confirm the planned versions (e.g. `@carbon/ai-chat -> 1.18.0-alpha.0` and `@carbon/ai-chat-components -> 1.8.0-alpha.0`).
 - [ ] Leave `bump` as `minor` unless the alpha previews a patch release, in which case select `patch`.
+- [ ] If the branch will not land in the next release — say the alpha runs while `1.18.0` is already in flight but the feature ships in `1.19.0` — set the base explicitly instead of relying on `bump`. The two packages version independently, so fill in **both** `ai-chat-base` (e.g. `1.19.0`) and `components-base` (e.g. `1.9.0`): filling in only one fails the run, so that an alpha never pairs one package's release with another's. A base that is not ahead of the package's current version also fails.
 - [ ] If the versions look right, run the workflow again with `dry run` unchecked to publish to npm and the CDN.
 - [ ] Confirm the publish:
   - [ ] `npm view @carbon/ai-chat dist-tags` and `npm view @carbon/ai-chat-components dist-tags` show the new `alpha` version, and `latest` / `next` are unchanged.

--- a/scripts/compute-alpha-versions.js
+++ b/scripts/compute-alpha-versions.js
@@ -23,11 +23,13 @@ const PACKAGES = [
     name: "@carbon/ai-chat-components",
     dir: "packages/ai-chat-components",
     envKey: "COMPONENTS_ALPHA",
+    baseEnvKey: "COMPONENTS_BASE",
   },
   {
     name: "@carbon/ai-chat",
     dir: "packages/ai-chat",
     envKey: "AI_CHAT_ALPHA",
+    baseEnvKey: "AI_CHAT_BASE",
   },
 ];
 
@@ -45,6 +47,65 @@ function nextBase(version) {
   return bump === "patch"
     ? `${major}.${minor}.${patch + 1}`
     : `${major}.${minor + 1}.0`;
+}
+
+/**
+ * Compares two plain `x.y.z` versions.
+ *
+ * @param {string} a The first version.
+ * @param {string} b The second version.
+ * @returns {number} Negative if a < b, zero if equal, positive if a > b.
+ */
+function compare(a, b) {
+  const left = a.split(".").map(Number);
+  const right = b.split(".").map(Number);
+  for (let index = 0; index < 3; index++) {
+    if (left[index] !== right[index]) {
+      return left[index] - right[index];
+    }
+  }
+  return 0;
+}
+
+/**
+ * Returns the explicit base version requested for a package, if any. Feature
+ * branches often land a release or more after the next one (e.g. work on
+ * `feat/prompt-line` ships in 1.19.0 while 1.18.0 is already in flight), so the
+ * base cannot always be derived from the current stable version.
+ *
+ * @param {{ name: string, baseEnvKey: string }} pkg The package descriptor.
+ * @returns {string | undefined} The requested base version, if provided.
+ */
+function requestedBase(pkg) {
+  const value = (process.env[pkg.baseEnvKey] || "").trim();
+  if (!value) {
+    return undefined;
+  }
+  if (!/^\d+\.\d+\.\d+$/.test(value)) {
+    throw new Error(
+      `Invalid base version "${value}" for ${pkg.name}: expected a plain x.y.z release version with no prerelease suffix.`,
+    );
+  }
+  return value;
+}
+
+/**
+ * Fails unless the explicit base versions are given for every package or for
+ * none of them. Half an override silently derives the other package's base from
+ * `bump`, which pairs an alpha of one release with an alpha of another.
+ *
+ * @returns {void}
+ */
+function assertCompleteOverride() {
+  const overridden = PACKAGES.filter((pkg) => requestedBase(pkg));
+  if (overridden.length !== 0 && overridden.length !== PACKAGES.length) {
+    const missing = PACKAGES.filter((pkg) => !requestedBase(pkg));
+    throw new Error(
+      `Base versions must be set for every package or none. Missing: ${missing
+        .map((pkg) => `${pkg.baseEnvKey} (${pkg.name})`)
+        .join(", ")}.`,
+    );
+  }
 }
 
 /**
@@ -79,7 +140,13 @@ function computeAlpha(pkg) {
   const { version } = JSON.parse(
     fs.readFileSync(`${pkg.dir}/package.json`, "utf8"),
   );
-  const base = nextBase(version);
+  const override = requestedBase(pkg);
+  const base = override || nextBase(version);
+  if (override && compare(override, version.split("-")[0]) <= 0) {
+    throw new Error(
+      `Base version ${override} for ${pkg.name} is not ahead of its current version ${version}.`,
+    );
+  }
   const alphaPattern = new RegExp(
     `^${base.replace(/\./g, "\\.")}-alpha\\.(\\d+)$`,
   );
@@ -94,10 +161,17 @@ function computeAlpha(pkg) {
 }
 
 const envLines = [];
-for (const pkg of PACKAGES) {
-  const alpha = computeAlpha(pkg);
-  envLines.push(`${pkg.envKey}=${alpha}`);
-  console.log(`${pkg.name} -> ${alpha}`);
+try {
+  assertCompleteOverride();
+  for (const pkg of PACKAGES) {
+    const alpha = computeAlpha(pkg);
+    envLines.push(`${pkg.envKey}=${alpha}`);
+    console.log(`${pkg.name} -> ${alpha}`);
+  }
+} catch (error) {
+  // A bad base version is operator error, not a crash: keep the log readable.
+  console.error(error.message);
+  process.exit(1);
 }
 
 // Expose the computed versions to later GitHub Actions steps.


### PR DESCRIPTION
e.g. as is, if i publish an alpha for prompt line it comes out as 1.18.0-alpha.0... but I want to say 1.19.0-alpha.0

The alpha release workflow could only ever preview the *next* release: it derived the base version by bumping each package's current stable version, so an alpha cut from `feat/prompt-line` came out as `1.18.0-alpha.0` even though that work ships in `1.19.0`. This adds optional `ai-chat-base` / `components-base` workflow inputs that set the base version explicitly, leaving the existing `bump`-derived behavior as the default when both are blank.

- [`scripts/compute-alpha-versions.js`](scripts/compute-alpha-versions.js) — the base version is now either an explicit override or the previous `nextBase()` derivation, guarded by three validations worth reviewing together: the format check in `requestedBase()`, the "must be ahead of current" check in `computeAlpha()`, and `assertCompleteOverride()`, which rejects a half-filled override. The last one exists because the two packages version independently (`@carbon/ai-chat` is at 1.17.0, `@carbon/ai-chat-components` at 1.7.0) — overriding only one would silently pair an alpha of one release with an alpha of another. It runs before any `npm view` calls so a bad input fails in seconds.

#### Changelog

**New**

- `ai-chat-base` and `components-base` inputs on the Release alpha workflow, setting the exact base version each package's alpha previews (e.g. `1.19.0-alpha.0` instead of `1.18.0-alpha.0`).
- Validation of those inputs: they must be plain `x.y.z` versions, must be ahead of the package's current version, and must be set for both packages or neither. Failures exit 1 with a single-line message rather than a stack trace.

**Changed**

- `bump` is ignored for a package with an explicit base; its input description now says so. With both base inputs blank, version computation is unchanged.
- [`docs/publishing-releases.md`](docs/publishing-releases.md) gained an alpha-release checklist item covering when and how to set the bases.

**Removed**

- Nothing.

#### Testing / Reviewing

Not reachable from the demo site — this is release tooling, exercised through the script directly and through a workflow dry run.

Run the version computation locally from the repo root (it only reads `package.json` and queries npm; it publishes nothing):

```sh
# Default: unchanged behavior, derived from `bump`.
node scripts/compute-alpha-versions.js
# -> @carbon/ai-chat-components -> 1.8.0-alpha.0
# -> @carbon/ai-chat -> 1.18.0-alpha.0

# Explicit bases, the case this PR adds.
AI_CHAT_BASE=1.19.0 COMPONENTS_BASE=1.9.0 node scripts/compute-alpha-versions.js
# -> @carbon/ai-chat-components -> 1.9.0-alpha.0
# -> @carbon/ai-chat -> 1.19.0-alpha.0

# Patch bump still works.
BUMP=patch node scripts/compute-alpha-versions.js
```

Each of these should exit 1 with one line of output and no stack trace:

```sh
AI_CHAT_BASE=1.19.0 node scripts/compute-alpha-versions.js
# -> Base versions must be set for every package or none. Missing: COMPONENTS_BASE (@carbon/ai-chat-components).

AI_CHAT_BASE=1.19 COMPONENTS_BASE=1.9.0 node scripts/compute-alpha-versions.js
# -> Invalid base version "1.19" for @carbon/ai-chat: expected a plain x.y.z release version with no prerelease suffix.

AI_CHAT_BASE=1.16.0 COMPONENTS_BASE=1.9.0 node scripts/compute-alpha-versions.js
# -> Base version 1.16.0 for @carbon/ai-chat is not ahead of its current version 1.17.0.
```

