### PR TITLE
fix: publish alphas through the trusted release workflow

### DIFF
--- a/.github/workflows/release-alpha.yml
+++ b/.github/workflows/release-alpha.yml
@@ -13,25 +13,29 @@
 # It never commits or pushes: the version bumps happen only in the throwaway
 # runner checkout, so the branch it runs from is left untouched.
 #
-# Run it from the branch you want to publish: Actions -> Release alpha ->
-# "Run workflow" -> pick the feature branch. A workflow_dispatch run uses (and
-# checks out) the selected ref, so the alpha is built from that branch's code.
+# This workflow is NOT dispatched directly — it is called by `release-start.yml`
+# with `type: alpha`. npm trusted publishing authenticates the publish via OIDC,
+# and npm validates the *calling* workflow's filename rather than the one that
+# runs `npm publish`; a package can only have one trusted publisher configured.
+# Routing the alpha through `release-start.yml` (the same caller the RC / stable
+# releases use) is therefore what makes the npm publish authorized at all.
+# Dispatching this file on its own would fail with a 404 on the publish step.
+#
+# Run it from the branch you want to publish: Actions -> Release start ->
+# "Run workflow" -> pick the feature branch, choose `type: alpha`. The run uses
+# (and checks out) the selected ref, so the alpha is built from that branch.
 name: Release alpha
-run-name: "Release alpha (${{ inputs.bump }}) dry-run:${{ inputs.dry-run }} from ${{ github.ref_name }}"
 
 concurrency:
   group: release-alpha
   cancel-in-progress: false
 
 on:
-  workflow_dispatch:
+  workflow_call:
     inputs:
       bump:
         description: "Base bump off the current stable version (the alpha previews the next minor or patch). Ignored for a package with an explicit base below."
-        type: choice
-        options:
-          - minor
-          - patch
+        type: string
         default: minor
       ai-chat-base:
         description: "Exact base version for @carbon/ai-chat, e.g. 1.19.0 when the branch lands a release later than the next one. Leave both base inputs blank to derive from `bump`; setting one requires the other."

--- a/.github/workflows/release-start.yml
+++ b/.github/workflows/release-start.yml
@@ -1,12 +1,19 @@
-# Publish minor or patch releases, both rc (release candidates) and full releases
-name: Release start - minor / patch
+# Publish minor or patch releases, both rc (release candidates) and full
+# releases, plus off-cadence `alpha` previews cut from a feature branch.
+#
+# Every npm publish in this repo has to be dispatched from this file: npm
+# trusted publishing validates the *calling* workflow's filename over OIDC, and
+# a package can only have one trusted publisher configured. `release-base.yml`
+# and `release-alpha.yml` are both reusable workflows called from here so they
+# share that single trusted identity.
+name: Release start - minor / patch / alpha
 run-name: ${{ inputs.type }} - dry-run:${{ inputs.dry-run }}
 
 on:
   workflow_dispatch:
     inputs:
       semver-type:
-        description: 'Specify the type of semver release'
+        description: "Specify the type of semver release. For `alpha`, this is the bump the alpha previews off the current version."
         required: true
         type: choice
         default: minor
@@ -21,10 +28,13 @@ on:
         # Full release (ie. v1.0.0 -> v1.1.0)
         # First RC (ie. v1.0.0 -> v1.1.0-rc.0)
         # Subsequent RC (ie v1.1.0-rc.0 -> v1.1.0-rc.1)
+        # Alpha (ie. v1.0.0 -> v1.1.0-alpha.0, published under the `alpha`
+        # dist-tag from a feature branch — see release-alpha.yml)
         options:
           - full release
           - first rc
           - subsequent rc
+          - alpha
       dry-run:
         # Check dry run to test run lerna and confirm package version bumps
         required: true
@@ -33,17 +43,40 @@ on:
         default: true
       force-publish:
         # May need to force publish at times when lerna doesn't detect changes
-        description: "Force publish?"
+        description: "Force publish? Ignored for `alpha`."
         type: boolean
         default: false
+      ai-chat-base:
+        # Alpha only. See release-alpha.yml / scripts/compute-alpha-versions.js.
+        description: "Alpha only: exact base version for @carbon/ai-chat, e.g. 1.19.0 when the branch lands a release later than the next one. Blank derives it from `semver-type`; setting one base requires the other."
+        type: string
+        default: ""
+      components-base:
+        description: "Alpha only: exact base version for @carbon/ai-chat-components, e.g. 1.9.0. The two packages version independently, so this must be set whenever `ai-chat-base` is."
+        type: string
+        default: ""
 
 jobs:
   Release:
     # trigger the input data to the `release-base` workflow and trigger it
+    if: ${{ inputs.type != 'alpha' }}
     uses: ./.github/workflows/release-base.yml
     with:
       semver-type: ${{ inputs.semver-type }}
       type: ${{ inputs.type }}
       dry-run: ${{ inputs.dry-run }}
       force-publish: ${{ inputs.force-publish}}
+    secrets: inherit
+
+  # Alphas skip lerna, the git tag, the changelog and the release PR entirely;
+  # `release-alpha.yml` only bumps versions inside the runner checkout, publishes
+  # to the `alpha` dist-tag and uploads the sites under `tag/alpha`.
+  Alpha:
+    if: ${{ inputs.type == 'alpha' }}
+    uses: ./.github/workflows/release-alpha.yml
+    with:
+      bump: ${{ inputs.semver-type }}
+      ai-chat-base: ${{ inputs.ai-chat-base }}
+      components-base: ${{ inputs.components-base }}
+      dry-run: ${{ inputs.dry-run }}
     secrets: inherit

--- a/docs/publishing-releases.md
+++ b/docs/publishing-releases.md
@@ -13,6 +13,7 @@
   - [Post release](#post-release)
   - [Patch release](#patch-release)
   - [Alpha release](#alpha-release)
+    - [Why alphas run from the release workflow](#why-alphas-run-from-the-release-workflow)
 - [Troubleshooting](#troubleshooting)
   - [Force publish](#force-publish)
   - [Tag already exists](#tag-already-exists)
@@ -316,11 +317,12 @@ An alpha release publishes `@carbon/ai-chat` and `@carbon/ai-chat-components` to
 
 To publish an alpha:
 
-- [ ] Go to the [Release alpha workflow](https://github.com/carbon-design-system/carbon-ai-chat/actions/workflows/release-alpha.yml) and choose "Run workflow".
+- [ ] Go to the [release workflow](https://github.com/carbon-design-system/carbon-ai-chat/actions/workflows/release-start.yml) and choose "Run workflow" — the same workflow used for RCs and stable releases, not a separate one. See [Why alphas run from the release workflow](#why-alphas-run-from-the-release-workflow) below.
 - [ ] **Select the feature branch** you want to publish from (e.g. `feat/prompt-line`) — the alpha is built from whatever branch you select.
+- [ ] Set `type` to `alpha`. The `force publish` option does not apply and is ignored.
 - [ ] Leave `dry run` checked for the first run. The workflow computes the alpha versions and builds everything, but publishes nothing. Check the log to confirm the planned versions (e.g. `@carbon/ai-chat -> 1.18.0-alpha.0` and `@carbon/ai-chat-components -> 1.8.0-alpha.0`).
-- [ ] Leave `bump` as `minor` unless the alpha previews a patch release, in which case select `patch`.
-- [ ] If the branch will not land in the next release — say the alpha runs while `1.18.0` is already in flight but the feature ships in `1.19.0` — set the base explicitly instead of relying on `bump`. The two packages version independently, so fill in **both** `ai-chat-base` (e.g. `1.19.0`) and `components-base` (e.g. `1.9.0`): filling in only one fails the run, so that an alpha never pairs one package's release with another's. A base that is not ahead of the package's current version also fails.
+- [ ] Leave `semver-type` as `minor` unless the alpha previews a patch release, in which case select `patch`.
+- [ ] If the branch will not land in the next release — say the alpha runs while `1.18.0` is already in flight but the feature ships in `1.19.0` — set the base explicitly instead of relying on `semver-type`. The two packages version independently, so fill in **both** `ai-chat-base` (e.g. `1.19.0`) and `components-base` (e.g. `1.9.0`): filling in only one fails the run, so that an alpha never pairs one package's release with another's. A base that is not ahead of the package's current version also fails.
 - [ ] If the versions look right, run the workflow again with `dry run` unchecked to publish to npm and the CDN.
 - [ ] Confirm the publish:
   - [ ] `npm view @carbon/ai-chat dist-tags` and `npm view @carbon/ai-chat-components dist-tags` show the new `alpha` version, and `latest` / `next` are unchanged.
@@ -331,6 +333,19 @@ A few things to know:
 - Alpha versions auto-increment per package from what is already published on npm — the first alpha of a base version is `alpha.0`, and re-running produces `alpha.1`, `alpha.2`, and so on. There is no git tag or committed bump to keep in sync.
 - `@carbon/ai-chat@alpha` pins the exact `@carbon/ai-chat-components` alpha built in the same run, so installers get a self-consistent alpha stack rather than the stable components.
 - Alpha is unlisted in the version-selector dropdowns on the stable `latest` / `next` sites by design; the "Alpha" entry only appears when viewing the alpha site itself.
+
+#### Why alphas run from the release workflow
+
+Alphas are dispatched from `release-start.yml` — the same entry point as RCs and stable releases — rather than from their own workflow, and that is load-bearing rather than cosmetic.
+
+We publish to npm with [trusted publishing](https://docs.npmjs.com/trusted-publishers): the runner authenticates over OIDC as GitHub Actions instead of using a long-lived npm token. npm ties that trust to a specific workflow **filename**, and two of its rules constrain the layout:
+
+- A package can only have **one** trusted publisher configured at a time, so `release-alpha.yml` cannot simply be registered alongside the release workflow.
+- When a workflow uses `workflow_call`, npm validates the **calling** workflow's filename, not the one that actually runs `npm publish`.
+
+So `release-base.yml` (RC / stable) and `release-alpha.yml` (alpha) are both reusable workflows invoked from `release-start.yml`, letting them share that single trusted identity. Dispatching `release-alpha.yml` directly would build everything and then fail on the publish step with `npm error 404 ... PUT .../@carbon%2fai-chat-components` — npm's way of saying the identity is not authorized to write that package.
+
+The corollary: **if the trusted publisher is ever re-pointed at a different workflow filename, the alpha breaks with it.** Keep the npm setting and this entry point in sync.
 
 ## Troubleshooting
 


### PR DESCRIPTION
Closes #

The first real (non-dry-run) alpha release [failed on the publish step](https://github.com/carbon-design-system/carbon-ai-chat/actions/runs/29761336305/job/88417983816) with `npm error 404 Not Found - PUT .../@carbon%2fai-chat-components`, after building for 37 minutes. The cause is npm trusted publishing: our stable and RC releases authenticate over OIDC as GitHub Actions rather than with `CARBON_BOT_NPM_TOKEN`, and npm ties that trust to a single workflow **filename** — validating the *calling* workflow, not the one that runs `npm publish`. Because `release-alpha.yml` was dispatched on its own, it did not match, fell back to the bot token, and the registry refused the write (npm answers 404 rather than 403 to avoid confirming the package exists). This makes `release-alpha.yml` a reusable workflow invoked from `release-start.yml` behind a new `alpha` release type, so alphas publish under the same trusted identity as everything else.

- [`.github/workflows/release-alpha.yml`](.github/workflows/release-alpha.yml) — the trigger flips from `workflow_dispatch` to `workflow_call`, which forces `bump` from `type: choice` to `type: string` (reusable workflows do not support `choice`) and drops `run-name` (the caller's wins). The publish steps are untouched; the header comment now records why the file must not be dispatched directly, since doing so reintroduces exactly this bug.
- [`.github/workflows/release-start.yml`](.github/workflows/release-start.yml) — gains a second `uses:` job guarded by `if: inputs.type == 'alpha'`, with the existing `Release` job now guarded by the inverse. `semver-type` does double duty as the alpha's `bump`, so no redundant input was added.

#### Changelog

**New**

- `alpha` option on the `type` input of the release workflow, publishing an alpha from the selected feature branch.
- `ai-chat-base` / `components-base` inputs surfaced on the release workflow and passed through to the alpha (alpha-only; blank derives the base from `semver-type`).
- A "Why alphas run from the release workflow" section in [`docs/publishing-releases.md`](docs/publishing-releases.md) explaining the npm trusted-publishing constraints, so the structure is not "simplified" back into a standalone workflow later.

**Changed**

- `release-alpha.yml` is now a reusable `workflow_call` workflow and no longer appears as its own entry in the Actions sidebar. The alpha checklist in the release docs points at the release workflow instead.
- `release-start.yml` renamed to "Release start - minor / patch / alpha"; `force publish` is documented as ignored for alphas.

**Removed**

- Nothing.

#### Testing / Reviewing

Not reachable from the demo site — this is release tooling. Version computation itself is unchanged by this PR ([`scripts/compute-alpha-versions.js`](scripts/compute-alpha-versions.js) is untouched), and the failed run already proved it works: it logged `@carbon/ai-chat -> 1.19.0-alpha.0` and `@carbon/ai-chat-components -> 1.9.0-alpha.0` before dying at publish.

**Precondition to confirm before merging.** This design assumes the npm trusted publisher for both packages is registered against `release-start.yml`. That is a strong inference — every stable and RC version on the registry carries `_npmUser.trustedPublisher` with `npm-oidc-no-reply@github.com`, and `release-start.yml` is the caller for all of them — but it is worth an npm admin confirming it in Package → Settings → Trusted Publisher, because if it is registered against some other filename the alpha will fail the same way:

```sh
# Every one of these should report the OIDC publisher, not carbon-bot.
curl -s https://registry.npmjs.org/@carbon/ai-chat/1.17.0 | jq '._npmUser'
curl -s https://registry.npmjs.org/@carbon/ai-chat-components/1.7.0 | jq '._npmUser'
```

Verifying the change itself:

- [ ] **Alpha dry run.** Actions → Release start → "Run workflow" on `feat/prompt-line`, `type: alpha`, `ai-chat-base: 1.19.0`, `components-base: 1.9.0`, dry run checked. Confirm only the `Alpha` job runs (`Release` is skipped), and the compute step logs `1.19.0-alpha.0` / `1.9.0-alpha.0`.
- [ ] **Alpha real run.** Same inputs, dry run unchecked. Confirm the publish step succeeds, then `npm view @carbon/ai-chat dist-tags` shows the new `alpha` while `latest` / `next` are unchanged. `curl -s https://registry.npmjs.org/@carbon/ai-chat/1.19.0-alpha.0 | jq '._npmUser'` should show the OIDC publisher — that is the actual proof the fix worked.
- [ ] **No regression to the stable path.** Run the release workflow with `type: first rc` and dry run checked; confirm `Release` runs, `Alpha` is skipped, and lerna reports the same version bumps as before.
- [ ] Confirm `release-alpha.yml` no longer appears as a dispatchable workflow in the Actions sidebar.
