### PR TITLE
style(carousel): changes control type

### DIFF
--- a/packages/ai-chat-components/src/components/carousel/src/carousel.scss
+++ b/packages/ai-chat-components/src/components/carousel/src/carousel.scss
@@ -17,7 +17,7 @@ $blockClass: #{$prefix}-carousel;
 
 .#{$blockClass} {
   &__controls {
-    @include type.type-style("label-02");
+    @include type.type-style("body-compact-01");
 
     display: flex;
     align-items: center;


### PR DESCRIPTION
Closes #1507 

This PR fixes some type styles in the Carousel component controls (bottom part where the pagination lives)

#### Changelog



**Changed**

- Changes carousel pagination from` label-02` to `body-compact-01`



#### Testing / Reviewing

- Open storybook and inspect the new type styles for carousel pagination
