### PR TITLE
fix: toolbar decorator position

### DIFF
--- a/packages/ai-chat-components/src/components/toolbar/src/toolbar.ts
+++ b/packages/ai-chat-components/src/components/toolbar/src/toolbar.ts
@@ -91,7 +91,14 @@ class CDSAIChatToolbar extends LitElement {
   @query(`.${blockClass}__actions-container`)
   private actionsContainer!: HTMLElement;
 
-  @state() private containerWidth = 0;
+  @query(`.${blockClass}__decorator-container`)
+  private decoratorContainer!: HTMLElement;
+
+  @query(`.${blockClass}__fixed-actions`)
+  private fixedActions!: HTMLElement;
+
+  @state()
+  private containerWidth = 0;
 
   private resizeObserver?: ResizeObserver;
 
@@ -145,8 +152,23 @@ class CDSAIChatToolbar extends LitElement {
         hiddenActions: [],
       };
     }
+
+    const actionsContainerWidth =
+      this.actionsContainer.getBoundingClientRect().width;
+    const overflowMenuIconWidth = 40;
+    const fixedActionsWidth =
+      this.fixedActions.getBoundingClientRect().width || 0;
+    const decoratorContainerWidth =
+      this.decoratorContainer.getBoundingClientRect().width || 0;
+    /**
+     * to properly gauge the container width we need to account for some additional variables
+     * 1. the size of the overflow menu icon, which should always be a constant
+     * 2. the size of any optional fixed width items
+     * 3. the size of any optional decorator items
+     */
     const containerWidth =
-      this.actionsContainer.getBoundingClientRect().width - 40; // subtract 40 to account for size of overflow menu button
+      actionsContainerWidth -
+      (overflowMenuIconWidth + fixedActionsWidth + decoratorContainerWidth);
     const children = this.actionsContainer.children;
     let currentWidth = 0;
     const visibleChildren: Element[] = [];
@@ -320,6 +342,9 @@ class CDSAIChatToolbar extends LitElement {
           data-floating-menu-container
         >
           <div class="${blockClass}__actions-container">
+            <div class="${blockClass}__decorator-container">
+              <slot name="decorator"></slot>
+            </div>
             ${repeat(
               showInitialActions ? this.actions : visibleActions,
               (action) => action.text,
@@ -373,12 +398,9 @@ class CDSAIChatToolbar extends LitElement {
                   `
                 : nothing
             }
-          </div>
-          <div data-fixed class="${blockClass}__fixed-actions">
-            <slot name="fixed-actions"></slot>
-          </div>
-          <div class="${blockClass}__decorator-container">
-            <slot name="decorator"></slot>
+            <div data-fixed class="${blockClass}__fixed-actions">
+              <slot name="fixed-actions"></slot>
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Closes #1825 

fixes the position of the toolbar decorator to the correct spot at the left end of the actions and updates the overflow menu calculation to account for the new positioning

https://github.com/user-attachments/assets/a581d53c-ae87-40f7-8af4-f12ad7d200a4

in the video above you can see the overflow functionality is working with a decorator on the left and fixed actions on the right

#### Changelog

**Changed**

- `packages/ai-chat-components/src/components/toolbar/src/toolbar.ts` updates the html structure to move the decorator slot to the left by default and updates the overflow calculation to account for the new position of the decorator slot

#### Testing / Reviewing

go to the `toolbar` storybook, enable the `ailabel` decorator, and verify that it shows up on the left. same with the demo; enable the float mode and enable `add menu actions`
