### PR TITLE
fix: chat history toolbar autofocus

### DIFF
--- a/packages/ai-chat-components/src/components/chat-history/__stories__/chat-history-react.stories.jsx
+++ b/packages/ai-chat-components/src/components/chat-history/__stories__/chat-history-react.stories.jsx
@@ -73,6 +73,10 @@ export const Default = {
       description:
         "true if search should be turned off in chat history toolbar.",
     },
+    autofocus: {
+      control: "boolean",
+      description: "Toggles the native autofocus attribute on the text input",
+    },
     searchAttributes: {
       control: "object",
       description:
@@ -94,6 +98,7 @@ export const Default = {
   args: {
     HeaderTitle: "Chats",
     searchOff: false,
+    autofocus: false,
     searchAttributes: {
       "label-text": "Search",
       placeholder: "Search",
@@ -387,6 +392,7 @@ export const Default = {
         />
         <HistoryToolbar
           searchOff={args.searchOff}
+          autofocus={args.autofocus}
           searchAttributes={args.searchAttributes}
           onSearchInput={handleSearchInput}
         />

--- a/packages/ai-chat-components/src/components/chat-history/__stories__/chat-history.stories.js
+++ b/packages/ai-chat-components/src/components/chat-history/__stories__/chat-history.stories.js
@@ -56,6 +56,7 @@ class ChatHistoryDemo extends LitElement {
     searchTotalCount: { type: Number },
     searchValue: { type: String },
     searchOff: { type: Boolean, attribute: "search-off" },
+    autofocus: { type: Boolean },
     searchAttributes: { type: Object },
     overflowMenuLabel: { type: String, attribute: "overflow-menu-label" },
     selectedId: { type: String },
@@ -78,6 +79,7 @@ class ChatHistoryDemo extends LitElement {
     super();
     this.headerTitle = "Chats";
     this.searchOff = false;
+    this.autofocus = false;
     this.searchAttributes = {
       "label-text": "Search",
       placeholder: "Search",
@@ -386,6 +388,7 @@ class ChatHistoryDemo extends LitElement {
         ></cds-aichat-history-header>
         <cds-aichat-history-toolbar
           ?search-off=${this.searchOff}
+          ?autofocus=${this.autofocus}
           .searchAttributes=${this.searchAttributes}
         >
         </cds-aichat-history-toolbar>
@@ -553,6 +556,10 @@ export const Default = {
       description:
         "true if search should be turned off in chat history toolbar.",
     },
+    autofocus: {
+      control: "boolean",
+      description: "Toggles the native autofocus attribute on the text input",
+    },
     searchAttributes: {
       control: "object",
       description:
@@ -574,6 +581,7 @@ export const Default = {
   args: {
     HeaderTitle: "Chats",
     searchOff: false,
+    autofocus: false,
     searchAttributes: {
       "label-text": "Search",
       placeholder: "Search",
@@ -587,6 +595,7 @@ export const Default = {
     <cds-aichat-history-demo
       header-title="${args.HeaderTitle}"
       ?search-off=${args.searchOff}
+      ?autofocus=${args.autofocus}
       .searchAttributes=${args.searchAttributes}
       overflow-menu-label="${args.overflowMenuLabel}"
       ?show-close-action=${args.showCloseAction}

--- a/packages/ai-chat-components/src/components/chat-history/src/history-toolbar.ts
+++ b/packages/ai-chat-components/src/components/chat-history/src/history-toolbar.ts
@@ -69,6 +69,12 @@ class CDSAIChatHistoryToolbar extends LitElement {
   closeButtonLabelText = "Clear search";
 
   /**
+   * Toggles the native autofocus attribute on the text input
+   */
+  @property({ type: Boolean, reflect: true })
+  autofocus;
+
+  /**
    * Optional attributes to pass to the cds-search component.
    * Allows customization of search behavior and appearance.
    *
@@ -135,6 +141,7 @@ class CDSAIChatHistoryToolbar extends LitElement {
           ? html`<cds-search
               close-button-label-text=${effectiveCloseButtonLabel}
               ${searchAttributes ? spread(searchAttributes as any) : nothing}
+              autofocus=${this.autofocus}
             ></cds-search>`
           : nothing
       }


### PR DESCRIPTION
Closes #1386 

adds the `autofocus` attribute to the `chat-history-toolbar` component for added accessibility support.
#### Changelog

**Changed**

- `packages/ai-chat-components/src/components/chat-history/src/history-toolbar.ts` adds the `autofocus` prop for the underlying `cds-search` component

#### Testing / Reviewing

navigate to the chat history part of storybook, toggle the `autofocus` attribute, and review the expected results.
