### PR TITLE
fix: pagination tooltip position

### DIFF
--- a/packages/ai-chat-components/src/components/table/src/table-pagination.template.ts
+++ b/packages/ai-chat-components/src/components/table/src/table-pagination.template.ts
@@ -13,6 +13,7 @@ import "@carbon/web-components/es/components/select/index.js";
 import { html } from "lit";
 import { ifDefined } from "lit/directives/if-defined.js";
 import { TableRowContent } from "./table.js";
+import { isDirectionRTL } from "../../../globals/utils/rtl-utils.js";
 
 // Import only the constants, not the class
 const POSSIBLE_PAGE_SIZES = [5, 10, 15, 20, 50];
@@ -81,7 +82,7 @@ function tablePaginationTemplate(props: TablePaginationProps) {
     .formatStatusWithDeterminateTotal=${ifDefined(getPaginationStatusText)}
     @cds-pagination-changed-current=${handlePageChangeEvent}
     @cds-page-sizes-select-changed=${handlePageSizeChangeEvent}
-    forward-text-tooltip-position="left"
+    forward-text-tooltip-position=${isDirectionRTL() ? "right" : "left"}
   >
     ${supportedPageSizes.map(
       (pageSize) =>

--- a/packages/ai-chat-components/src/components/table/src/table-pagination.template.ts
+++ b/packages/ai-chat-components/src/components/table/src/table-pagination.template.ts
@@ -1,5 +1,5 @@
 /*
- *  Copyright IBM Corp. 2025
+ *  Copyright IBM Corp. 2025, 2026
  *
  *  This source code is licensed under the Apache-2.0 license found in the
  *  LICENSE file in the root directory of this source tree.
@@ -81,6 +81,7 @@ function tablePaginationTemplate(props: TablePaginationProps) {
     .formatStatusWithDeterminateTotal=${ifDefined(getPaginationStatusText)}
     @cds-pagination-changed-current=${handlePageChangeEvent}
     @cds-page-sizes-select-changed=${handlePageSizeChangeEvent}
+    forward-text-tooltip-position="left"
   >
     ${supportedPageSizes.map(
       (pageSize) =>


### PR DESCRIPTION
Closes #1152 

address small UI bug where the carbon table pagination tooltip was getting cut off in the float view by utilizing an updated pagination API from https://github.com/carbon-design-system/carbon/issues/22106

<img width="599" height="672" alt="Screenshot 2026-07-22 at 2 37 34 PM" src="https://github.com/user-attachments/assets/f7aed8c3-af43-4a77-84a9-3415eb06958e" />


#### Changelog

**Changed**

- `packages/ai-chat-components/src/components/table/src/table-pagination.template.ts` adds `forward-text-tooltip-position="left"` to the `cds-pagination` component to avoid the tooltip being cutoff by the floating variant

#### Testing / Reviewing

go to the demo, enable float mode, enter `table` in the prompt line, scroll down to the pagination part of the table, and hover over the pagination icon button to verify that it's showing up appropriately on the left and not being cut off.
