### PR TITLE
fix: responseTypes import into legacy

### DIFF
--- a/packages/ai-chat/src/chat/components-legacy/responseTypes/_imports.scss
+++ b/packages/ai-chat/src/chat/components-legacy/responseTypes/_imports.scss
@@ -12,3 +12,4 @@
 @use "grid/imports" as responseType-grid;
 @use "iframe/imports" as responseType-iframe;
 @use "image/imports" as responseType-image;
+@use "util/imports" as responseType-util;


### PR DESCRIPTION
Closes #1859 

This PR solves the rogue button `user agent stylesheet` default css styles being applied to image cards. The regression was introduced inside of #1726 where the util stylesheet was removed from the legacy main imports.

**Before:**
<img width="654" height="409" alt="Image" src="https://github.com/user-attachments/assets/90bac381-0354-48f7-ab9d-092d46ddf075" />

<img width="1193" height="912" alt="Image" src="https://github.com/user-attachments/assets/aec20a8e-da77-4286-9715-5f46926f0731" />


**After:**
<img width="846" height="1269" alt="Screenshot 2026-07-23 at 10 33 11 AM" src="https://github.com/user-attachments/assets/32327ac1-f1d2-4345-8788-959c607d65e7" />


#### Changelog

**New**

- Re-added `@use "util/imports" as responseType-util;` inside of `packages/ai-chat/src/chat/components-legacy/responseTypes/_imports.scss`

#### Testing / Reviewing

1. Open up deploy preview for demo
2. type image or look for image in the dropdown
3. Verify the button styles are gone
