### PR TITLE
feat(prompt-line): add overflow gradients

### DIFF
--- a/packages/ai-chat-components/src/components/file-uploads/src/file-uploads.scss
+++ b/packages/ai-chat-components/src/components/file-uploads/src/file-uploads.scss
@@ -6,6 +6,16 @@
  */
 
 @use "@carbon/layout";
+@use "@carbon/styles/scss/theme";
+
+// Mixin for directional gradients
+@mixin gradient-bg($direction, $color) {
+  background: linear-gradient(
+    $direction,
+    rgba(255, 255, 255, 0) 0%,
+    $color 100%
+  );
+}
 
 :host {
   display: block;
@@ -24,6 +34,30 @@
   clip: rect(0, 0, 0, 0);
   inline-size: 1px;
   white-space: nowrap;
+}
+
+.cds-aichat--file-uploads-gradient-wrapper {
+  position: relative;
+  z-index: 0;
+}
+
+.cds-aichat--file-uploads-gradient-wrapper--overflow::after {
+  position: absolute;
+  display: block;
+  content: "";
+  inline-size: layout.$spacing-05;
+  inset-block-end: 1px;
+  inset-block-start: 0;
+  inset-inline-end: 0;
+  pointer-events: none;
+}
+
+.cds-aichat--file-uploads-gradient-wrapper--overflow:dir(ltr)::after {
+  @include gradient-bg(90deg, theme.$background);
+}
+
+.cds-aichat--file-uploads-gradient-wrapper--overflow:dir(rtl)::after {
+  @include gradient-bg(270deg, theme.$background);
 }
 
 .cds-aichat--file-uploads-container {

--- a/packages/ai-chat-components/src/components/file-uploads/src/file-uploads.ts
+++ b/packages/ai-chat-components/src/components/file-uploads/src/file-uploads.ts
@@ -15,7 +15,7 @@ import {
   type PropertyValues,
   unsafeCSS,
 } from "lit";
-import { property } from "lit/decorators.js";
+import { property, state } from "lit/decorators.js";
 
 import { AriaAnnouncerManager } from "../../../globals/utils/aria-announcer-manager.js";
 import { carbonElement } from "../../../globals/decorators/carbon-element.js";
@@ -97,10 +97,25 @@ class FileUploadsElement extends LitElement {
   getFilesUploadingText: (args: { count: number }) => string = ({ count }) =>
     count === 1 ? "Uploading file." : `Uploading ${count} files.`;
 
+  /** Whether scrolling is required to view the entire width of all file upload items. */
+  @state() private _hasOverflow = false;
+
   private _announcer = new AriaAnnouncerManager();
 
   /** Previous-frame snapshot keyed by upload id, used to detect transitions. */
   private _snapshots = new Map<string, UploadSnapshot>();
+
+  private _resizeObserver = new ResizeObserver(() => {
+    this._checkOverflow();
+  });
+
+  private _checkOverflow() {
+    const container = this.renderRoot.querySelector<HTMLElement>(
+      `.${prefix}--file-uploads-container`,
+    );
+    this._hasOverflow =
+      !!container && container.scrollWidth > container.clientWidth;
+  }
 
   protected firstUpdated() {
     const regions = this.renderRoot.querySelectorAll<HTMLDivElement>(
@@ -113,6 +128,7 @@ class FileUploadsElement extends LitElement {
   }
 
   disconnectedCallback() {
+    this._resizeObserver.disconnect();
     this._announcer.disconnect();
     super.disconnectedCallback();
   }
@@ -121,6 +137,17 @@ class FileUploadsElement extends LitElement {
     if (changedProperties.has("uploads")) {
       this.toggleAttribute("has-uploads", this.uploads.length > 0);
       this._announceTransitions();
+
+      this._resizeObserver.disconnect();
+      const container = this.renderRoot.querySelector<HTMLElement>(
+        `.${prefix}--file-uploads-container`,
+      );
+      if (container) {
+        this._resizeObserver.observe(container);
+        this._checkOverflow();
+      } else {
+        this._hasOverflow = false;
+      }
     }
   }
 
@@ -213,17 +240,21 @@ class FileUploadsElement extends LitElement {
       ${
         this.uploads && this.uploads.length > 0
           ? html`
-              <div class="${prefix}--file-uploads-container">
-                ${this.uploads.map(
-                  (upload) => html`
-                    <cds-aichat-file-upload-item
-                      .upload="${upload}"
-                      remove-file-label="${this.removeFileLabel}"
-                      uploading-file-label="${this.uploadingFileLabel}"
-                      @cds-aichat-file-remove="${this._handleFileRemove}"
-                    ></cds-aichat-file-upload-item>
-                  `,
-                )}
+              <div
+                class="${prefix}--file-uploads-gradient-wrapper${this._hasOverflow ? ` ${prefix}--file-uploads-gradient-wrapper--overflow` : ""}"
+              >
+                <div class="${prefix}--file-uploads-container">
+                  ${this.uploads.map(
+                    (upload) => html`
+                      <cds-aichat-file-upload-item
+                        .upload="${upload}"
+                        remove-file-label="${this.removeFileLabel}"
+                        uploading-file-label="${this.uploadingFileLabel}"
+                        @cds-aichat-file-remove="${this._handleFileRemove}"
+                      ></cds-aichat-file-upload-item>
+                    `,
+                  )}
+                </div>
               </div>
             `
           : nothing

--- a/packages/ai-chat-components/src/components/prompt-line/src/error-message.scss
+++ b/packages/ai-chat-components/src/components/prompt-line/src/error-message.scss
@@ -12,6 +12,15 @@
 
 $block-class: #{$prefix}-error-message;
 
+// Mixin for directional gradients
+@mixin gradient-bg($direction, $color) {
+  background: linear-gradient(
+    $direction,
+    rgba(255, 255, 255, 0) 0%,
+    $color 100%
+  );
+}
+
 .#{$block-class} {
   position: relative;
   display: flex;
@@ -19,40 +28,43 @@ $block-class: #{$prefix}-error-message;
   align-items: flex-start;
   gap: layout.$spacing-03;
   inline-size: 100%;
+  padding-inline-start: layout.$spacing-03;
 
   &::after {
     position: absolute;
-    z-index: -1;
+    z-index: 0;
     display: block;
     background: theme.$border-subtle-00;
     block-size: 1px;
     content: "";
-    inline-size: calc(100% + #{layout.$spacing-05} + #{layout.$spacing-03});
+    inline-size: calc(100% + #{layout.$spacing-03} + #{layout.$spacing-03});
     inset-block-end: 0;
-    inset-inline-start: calc(-1 * #{layout.$spacing-05});
-  }
-}
-
-// In expanded mode or when the prompt line has message actions, the
-// container's inline start padding is $spacing-03 (not $spacing-05), so
-// the error message padding and separator line must be adjusted to match.
-:host([actions-layout]) {
-  .#{$block-class} {
-    padding-inline-start: layout.$spacing-03;
-
-    &::after {
-      inline-size: calc(100% + #{layout.$spacing-03} + #{layout.$spacing-03});
-      inset-inline-start: calc(-1 * #{layout.$spacing-03});
-    }
+    inset-inline-start: calc(-1 * #{layout.$spacing-03});
   }
 }
 
 .#{$block-class}__warning-icon-and-text {
+  position: relative;
+  z-index: 0;
   display: flex;
   flex: 1;
   align-items: flex-start;
   gap: layout.$spacing-05;
   margin-block-start: layout.$spacing-04;
+}
+
+.#{$block-class}__text-overflow-gradient::after {
+  @include gradient-bg(180deg, theme.$background);
+
+  position: absolute;
+  z-index: 1;
+  display: block;
+  block-size: layout.$spacing-04;
+  content: "";
+  inline-size: 100%;
+  inset-block-end: 0;
+  inset-inline-start: 0;
+  pointer-events: none;
 }
 
 .#{$block-class}__warning-icon-and-text--no-chevron {

--- a/packages/ai-chat-components/src/components/prompt-line/src/error-message.ts
+++ b/packages/ai-chat-components/src/components/prompt-line/src/error-message.ts
@@ -60,12 +60,6 @@ class ErrorMessage extends LitElement {
   collapsible = false;
 
   /**
-   * Whether the prompt line has alternate layout for expanded mode and/or message actions.
-   */
-  @property({ type: Boolean, reflect: true, attribute: "actions-layout" })
-  actionsLayout = false;
-
-  /**
    * Whether the error message is in fullscreen layout.
    */
   @property({ type: Boolean, attribute: "fullscreen" })
@@ -123,7 +117,7 @@ class ErrorMessage extends LitElement {
             !hasChevron
               ? ` ${blockClass}__warning-icon-and-text--no-chevron`
               : ""
-          }"
+          }${this._isExpanded ? ` ${blockClass}__text-overflow-gradient` : ""}"
         >
           ${this.fullscreen ? null : warningIcon}
           <div

--- a/packages/ai-chat/src/chat/components/input/Input.tsx
+++ b/packages/ai-chat/src/chat/components/input/Input.tsx
@@ -544,9 +544,6 @@ function Input(props: InputProps, ref: Ref<InputFunctions>) {
    * Renders the error message component if an error is provided.
    */
   const renderErrorMessage = () => {
-    // Whether the prompt line has alternate layout for expanded mode and/or message actions
-    const actionsLayout = expanded || showUploadButton || effectiveActions;
-
     if (overMaxLength) {
       const errorText = intl.formatMessage(
         { id: "input_maxCharCountExceeded" },
@@ -559,7 +556,6 @@ function Input(props: InputProps, ref: Ref<InputFunctions>) {
           >
             <ErrorMessage
               fullscreen={chatWidthBreakpoint === ChatWidthBreakpoint.WIDE}
-              actionsLayout={actionsLayout}
               title="Error: Max character count exceeded"
               description={errorText}
               collapsible={true}
@@ -582,7 +578,6 @@ function Input(props: InputProps, ref: Ref<InputFunctions>) {
         <AnnounceOnMountComponent announceOnce={announcement}>
           <ErrorMessage
             fullscreen={chatWidthBreakpoint === ChatWidthBreakpoint.WIDE}
-            actionsLayout={actionsLayout}
             title={error.title}
             description={error?.description}
             collapsible={error?.collapsible}


### PR DESCRIPTION
Closes #1917

Adds gradient styling for scrollable overflow content in the error state message and file upload chips.

#### Changelog

**New**

- Adds `_hasOverflow` to `file-uploads` to track whether there is currently scrollable content. Uses a ResizeObserver to update.
- Adds `cds-aichat--file-uploads-gradient-wrapper` div around `cds-aichat--file-uploads-container` in order to apply the gradient element.
- Adds the horizontal gradient as an `after` css psuedo-element to `cds-aichat--file-uploads-gradient-wrapper`. Similarly adds the vertical gradient to `cds-aichat-error-message__warning-icon-and-text`.

**Changed**

- Fixes style regression with error message padding when using the non-expanded prompt line. The message container styles applied previously when in "actions layout" should be the default.

**Removed**

- Removes unused `actionsLayout` prop from `<ErrorMessage>`

#### Testing / Reviewing

- Go to demo deploy preview
- Switch to Float layout
- Chat config -> Input -> Show prompt line error
- Verify the error state renders properly and the overflow gradient appears when the message is expanded
- Chat config -> Input -> Enable file uploads
- Add and remove multiple files, checking the overflow gradient on the uploads container looks right