### PR TITLE
fix(scripts): fix ci-check format failures

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "clean": "lerna run clean && lerna clean --yes && rimraf node_modules",
     "format": "prettier --check '**/*.{js,md,scss,ts,tsx}' '!**/*.snap.js' '!**/{build,es,lib,.storybook,ts,umd,storybook-static}/**'",
     "format:write": "prettier --cache --write '**/*.{js,md,scss,ts,tsx}' '!**/*.snap.js' '!**/{build,es,lib,.storybook,ts,umd,storybook-static}/**'",
-    "format:staged": "prettier --list-different '**/*.{js,md,scss,ts,tsx}' '!**/*.snap.js' '!**/{build,es,lib,storybook,ts,umd}/**'",
+    "format:staged": "prettier --list-different '**/*.{js,md,scss,ts,tsx}' '!**/*.snap.js' '!**/{build,es,lib,.storybook,ts,umd,storybook-static}/**'",
     "lint": "eslint packages --ext .js,.ts,.tsx",
     "lint:license": "tools/check-license.js -a",
     "lint:license:staged": "tools/check-license.js -w",

--- a/scripts/verify-example-readmes.mjs
+++ b/scripts/verify-example-readmes.mjs
@@ -6,7 +6,7 @@
  *  LICENSE file in the root directory of this source tree.
  */
 
-import { parseArgs } from "node:util";
+import { parseArgs } from 'node:util';
 
 import {
   loadTree,
@@ -17,15 +17,15 @@ import {
   sortExamples,
   AGGREGATOR_INDEX_START,
   AGGREGATOR_INDEX_END,
-} from "./_example-readme-lib.mjs";
+} from './_example-readme-lib.mjs';
 
-const TREES = ["react", "web-components"];
+const TREES = ['react', 'web-components'];
 
 const { values } = parseArgs({
   options: {
-    tree: { type: "string" },
-    "examples-only": { type: "boolean", default: false },
-    "aggregator-only": { type: "boolean", default: false },
+    tree: { type: 'string' },
+    'examples-only': { type: 'boolean', default: false },
+    'aggregator-only': { type: 'boolean', default: false },
   },
 });
 
@@ -36,22 +36,22 @@ const errors = [];
 for (const tree of trees) {
   const loaded = sortExamples(await loadTree(tree));
 
-  if (!values["aggregator-only"]) {
+  if (!values['aggregator-only']) {
     for (const entry of loaded) {
       const sectionErrors = validateExampleReadmeShape(
         entry.parsed,
-        entry.descriptor,
+        entry.descriptor
       );
       errors.push(...sectionErrors);
     }
   }
 
-  if (!values["examples-only"]) {
+  if (!values['examples-only']) {
     const { aggregatorPath, raw } = await readAggregator(tree);
     const located = locateAggregatorMarkers(raw);
     if (!located) {
       errors.push(
-        `${aggregatorPath}: missing aggregator markers ${AGGREGATOR_INDEX_START} ... ${AGGREGATOR_INDEX_END}`,
+        `${aggregatorPath}: missing aggregator markers ${AGGREGATOR_INDEX_START} ... ${AGGREGATOR_INDEX_END}`
       );
       continue;
     }
@@ -59,12 +59,12 @@ for (const tree of trees) {
     const expected = renderAggregatorSections(loaded);
     const actualBlock = raw.slice(
       raw.indexOf(AGGREGATOR_INDEX_START),
-      raw.indexOf(AGGREGATOR_INDEX_END) + AGGREGATOR_INDEX_END.length,
+      raw.indexOf(AGGREGATOR_INDEX_END) + AGGREGATOR_INDEX_END.length
     );
     if (normalizeBlock(actualBlock) !== normalizeBlock(expected)) {
       errors.push(
         `${aggregatorPath}: aggregator section list is out of sync with per-example READMEs.\n` +
-          `Run \`npm run repair:example-readmes -- --from=examples\` to regenerate it.`,
+          `Run \`npm run repair:example-readmes -- --from=examples\` to regenerate it.`
       );
     }
   }
@@ -76,35 +76,63 @@ for (const tree of trees) {
  * paragraph rewraps) does not trip the verifier.
  */
 function normalizeBlock(block) {
-  return block
-    .split("\n")
+  // First pass: trim every line and drop blanks, then join consecutive prose
+  // lines so that prettier's line-wrap (e.g. splitting a long "**Start
+  // command:** `...`" across two lines) does not cause a false mismatch.
+  const lines = block
+    .split('\n')
     .map((line) => line.trim())
-    .filter((line) => line !== "")
+    .filter((line) => line !== '');
+
+  const merged = [];
+  for (const line of lines) {
+    const isStructural =
+      line.startsWith('|') ||
+      line.startsWith('#') ||
+      line.startsWith('<') ||
+      line.startsWith('```') ||
+      line.startsWith('<!--');
+    const prev = merged.length > 0 ? merged[merged.length - 1] : null;
+    const prevIsStructural =
+      prev !== null &&
+      (prev.startsWith('|') ||
+        prev.startsWith('#') ||
+        prev.startsWith('<') ||
+        prev.startsWith('```') ||
+        prev.startsWith('<!--'));
+    if (!isStructural && prev !== null && !prevIsStructural) {
+      // Merge this prose continuation into the previous prose line.
+      merged[merged.length - 1] = merged[merged.length - 1] + ' ' + line;
+    } else {
+      merged.push(line);
+    }
+  }
+
+  return merged
     .map((line) => {
-      if (!line.startsWith("|")) {
-        // Collapse internal whitespace runs in prose lines so prettier's
-        // line-wrap doesn't matter once lines are joined.
-        return line.replace(/\s+/g, " ");
+      if (!line.startsWith('|')) {
+        // Collapse internal whitespace runs in prose lines.
+        return line.replace(/\s+/g, ' ');
       }
       // Collapse the row to a canonical shape: every cell trimmed, separator
       // rows reduced to a single dash per cell so prettier's column-width
       // padding (which inserts both spaces and dashes) doesn't trip us.
       return line
-        .split("|")
+        .split('|')
         .map((cell) => {
           const trimmed = cell.trim();
           if (/^-+:?$/.test(trimmed) || /^:?-+:?$/.test(trimmed)) {
-            return "-";
+            return '-';
           }
-          return trimmed.replace(/\s+/g, " ");
+          return trimmed.replace(/\s+/g, ' ');
         })
-        .join("|");
+        .join('|');
     })
-    .join("\n");
+    .join('\n');
 }
 
 if (errors.length > 0) {
-  console.error("verify:example-readmes failed:\n");
+  console.error('verify:example-readmes failed:\n');
   for (const e of errors) {
     console.error(`  - ${e}`);
   }
@@ -112,5 +140,5 @@ if (errors.length > 0) {
 }
 
 console.log(
-  `verify:example-readmes: ${trees.join(", ")} OK (${TREES.length} tree(s) checked).`,
+  `verify:example-readmes: ${trees.join(', ')} OK (${TREES.length} tree(s) checked).`
 );


### PR DESCRIPTION


Two related fixes that prevent `npm run ci-check` from failing on format checks unrelated to the current change.

#### Changelog

**Changed**

- `scripts/verify-example-readmes.mjs`: `normalizeBlock` now merges consecutive prose lines before comparing, so Prettier line-wraps (e.g. splitting a long `**Start command:** \`...\`` onto two lines) no longer cause a false mismatch between the aggregator content and the rendered output.
- `package.json`: aligned `format:staged` ignore patterns with `format` and `format:write` — added missing `.storybook` and `storybook-static` exclusions so all three scripts treat the same files consistently.

**New**

- None

**Removed**

- None

#### Testing / Reviewing

1. Run `npm run ci-check` — `format:staged` and `verify:example-readmes` should both pass with no unrelated files reported.
2. Make a change to any staged `.md` file, run `git commit` — the pre-commit hook should pass `verify:example-readmes` without needing to run `repair:example-readmes` first.