### PR TITLE
feat(prompt-line): simple history mechanism example

### DIFF
--- a/examples/react/README.md
+++ b/examples/react/README.md
@@ -615,6 +615,33 @@ The chat sits in a docked sidebar while the page body holds a grid of clickable 
 
 </details>
 
+### [Prompt line / History mechanism](./prompt-line-history-mechanism/README.md)
+
+A keyboard-only Tiptap extension intercepts `ArrowUp` / `ArrowDown` in the chat input to cycle through previously sent messages — shell-style — and writes recalled text back into the editor via `instance.input.updateContent`. Your in-progress draft is saved on the first `ArrowUp` press and restored when you navigate back past the most-recent entry.
+
+**Start command:** `npm run start --workspace=@carbon/ai-chat-examples-react-prompt-line-history-mechanism`
+
+<details>
+<summary>APIs and props demonstrated</summary>
+
+| Symbol                         | Package / kind              | Role in this example                                                                          |
+| ------------------------------ | --------------------------- | --------------------------------------------------------------------------------------------- |
+| `ChatCustomElement`            | `@carbon/ai-chat` component | Mounts the chat UI as a fullscreen surface.                                                   |
+| `PublicConfig`                 | `@carbon/ai-chat` type      | Types the config object passed to `ChatCustomElement`.                                        |
+| `ChatInstance`                 | `@carbon/ai-chat` type      | Provides `instance.input.updateContent` to write text into the editor.                        |
+| `Extension.create`             | `@tiptap/core` API          | Authors the keyboard-only history extension registered on the chat input.                     |
+| `addKeyboardShortcuts`         | `@tiptap/core` API          | Hook where `ArrowUp` / `ArrowDown` handlers are declared.                                     |
+| `instance.input.updateContent` | `@carbon/ai-chat` API       | Writes recalled history entries (or the saved draft) back into the editor.                    |
+| `textToDoc`                    | `@carbon/ai-chat` utility   | Converts a plain-text string into a `JSONContent` doc suitable for `updateContent`.           |
+| `getRawText`                   | `@carbon/ai-chat` utility   | Extracts the plain-text string from the editor's `JSONContent` to save the draft.             |
+| `onBeforeRender`               | component prop              | Callback that fires once with the `ChatInstance` so `historyState.instance` can be populated. |
+| `input.tiptap.extensions`      | config prop                 | Registers the host-authored history `Extension` on the chat input.                            |
+| `layout.showFrame`             | config prop                 | Hides the default frame so the chat fills the viewport.                                       |
+| `openChatByDefault`            | config prop                 | Mounts straight into the conversation, no launcher.                                           |
+| `messaging.customSendMessage`  | config prop                 | Captures sent text into `state.entries` and provides the mock response.                       |
+
+</details>
+
 ### [Prompt line / Mentions & commands](./prompt-line-mentions-and-commands/README.md)
 
 `ChatCustomElement` configured with `input.mention` for `@`-picking team members anywhere in the message and `input.command` for `/`-commands constrained to the start of the line.

--- a/examples/react/README.md
+++ b/examples/react/README.md
@@ -624,21 +624,21 @@ A keyboard-only Tiptap extension intercepts `ArrowUp` / `ArrowDown` in the chat 
 <details>
 <summary>APIs and props demonstrated</summary>
 
-| Symbol                         | Package / kind              | Role in this example                                                                          |
-| ------------------------------ | --------------------------- | --------------------------------------------------------------------------------------------- |
-| `ChatCustomElement`            | `@carbon/ai-chat` component | Mounts the chat UI as a fullscreen surface.                                                   |
-| `PublicConfig`                 | `@carbon/ai-chat` type      | Types the config object passed to `ChatCustomElement`.                                        |
-| `ChatInstance`                 | `@carbon/ai-chat` type      | Provides `instance.input.updateContent` to write text into the editor.                        |
-| `Extension.create`             | `@tiptap/core` API          | Authors the keyboard-only history extension registered on the chat input.                     |
-| `addKeyboardShortcuts`         | `@tiptap/core` API          | Hook where `ArrowUp` / `ArrowDown` handlers are declared.                                     |
-| `instance.input.updateContent` | `@carbon/ai-chat` API       | Writes recalled history entries (or the saved draft) back into the editor.                    |
-| `textToDoc`                    | `@carbon/ai-chat` utility   | Converts a plain-text string into a `JSONContent` doc suitable for `updateContent`.           |
-| `getRawText`                   | `@carbon/ai-chat` utility   | Extracts the plain-text string from the editor's `JSONContent` to save the draft.             |
-| `onBeforeRender`               | component prop              | Callback that fires once with the `ChatInstance` so `historyState.instance` can be populated. |
-| `input.tiptap.extensions`      | config prop                 | Registers the host-authored history `Extension` on the chat input.                            |
-| `layout.showFrame`             | config prop                 | Hides the default frame so the chat fills the viewport.                                       |
-| `openChatByDefault`            | config prop                 | Mounts straight into the conversation, no launcher.                                           |
-| `messaging.customSendMessage`  | config prop                 | Captures sent text into `state.entries` and provides the mock response.                       |
+| Symbol | Package / kind | Role in this example |
+| --- | --- | --- |
+| `ChatCustomElement` | `@carbon/ai-chat` component | Mounts the chat UI as a fullscreen surface. |
+| `PublicConfig` | `@carbon/ai-chat` type | Types the config object passed to `ChatCustomElement`. |
+| `ChatInstance` | `@carbon/ai-chat` type | Provides `instance.input.updateContent` to write text into the editor. |
+| `Extension.create` | `@tiptap/core` API | Authors the keyboard-only history extension registered on the chat input. |
+| `addKeyboardShortcuts` | `@tiptap/core` API | Hook where `ArrowUp` / `ArrowDown` handlers are declared. |
+| `instance.input.updateContent` | `@carbon/ai-chat` API | Writes recalled history entries (or the saved draft) back into the editor. |
+| `textToDoc` | `@carbon/ai-chat` utility | Converts a plain-text string into a `JSONContent` doc suitable for `updateContent`. |
+| `getRawText` | `@carbon/ai-chat` utility | Extracts the plain-text string from the editor's `JSONContent` to save the draft. |
+| `onBeforeRender` | component prop | Callback that fires once with the `ChatInstance` so `historyState.instance` can be populated. |
+| `input.tiptap.extensions` | config prop | Registers the host-authored history `Extension` on the chat input. |
+| `layout.showFrame` | config prop | Hides the default frame so the chat fills the viewport. |
+| `openChatByDefault` | config prop | Mounts straight into the conversation, no launcher. |
+| `messaging.customSendMessage` | config prop | Captures sent text into `state.entries` and provides the mock response. |
 
 </details>
 

--- a/examples/react/prompt-line-history-mechanism/README.md
+++ b/examples/react/prompt-line-history-mechanism/README.md
@@ -1,0 +1,53 @@
+# Prompt line / History mechanism
+
+A keyboard-only Tiptap extension intercepts `ArrowUp` / `ArrowDown` in the chat input to cycle through previously sent messages — shell-style — and writes recalled text back into the editor via `instance.input.updateContent`. Your in-progress draft is saved on the first `ArrowUp` press and restored when you navigate back past the most-recent entry.
+
+## What this example shows
+
+- Registering a keyboard-only Tiptap extension on the chat input via `PublicConfig.input.tiptap.extensions` — no custom node, no node view, no `renderInLightDom`.
+- Using `Extension.create` + `addKeyboardShortcuts` to intercept `ArrowUp` / `ArrowDown` with ProseMirror position checks: only fire when the cursor is at position 1 (start of the single paragraph) or at the last position of the doc, and only when the doc has a single block so normal cursor movement in multi-paragraph text is never interrupted.
+- Writing recalled text into the editor via `instance.input.updateContent((prev) => textToDoc(text))`.
+- Saving the in-progress draft with `getRawText(editor.getJSON())` on the first `ArrowUp` and restoring it when `ArrowDown` moves past entry 0.
+- Capturing history inside `customSendMessage` (via `state.entries.push(text)`) — simpler and more direct than subscribing to a bus event, because `customSendMessage` already has the text in hand.
+- Sharing state between the keyboard extension and the send handler through a plain mutable `HistoryState` object created once at module scope — no React state, no event bus.
+- Capturing `ChatInstance` via `onBeforeRender` and storing it on `historyState.instance` so the keyboard extension can call `instance.input.updateContent` without an event bus subscription.
+
+## When to use this pattern
+
+- Your users re-send variants of previous prompts and a shell-like `↑` / `↓` shortcut would save them time — power-user UX with no visible UI cost.
+- You need to write text into the editor from outside React (e.g. from a Tiptap extension callback) and `instance.input.updateContent` + `textToDoc` is the right tool for plain-text content.
+- You want to attach behaviour to the prompt-line keyboard without building a full custom node.
+
+## APIs and props demonstrated
+
+| Symbol                         | Package / kind              | Role in this example                                                                          |
+| ------------------------------ | --------------------------- | --------------------------------------------------------------------------------------------- |
+| `ChatCustomElement`            | `@carbon/ai-chat` component | Mounts the chat UI as a fullscreen surface.                                                   |
+| `PublicConfig`                 | `@carbon/ai-chat` type      | Types the config object passed to `ChatCustomElement`.                                        |
+| `ChatInstance`                 | `@carbon/ai-chat` type      | Provides `instance.input.updateContent` to write text into the editor.                        |
+| `Extension.create`             | `@tiptap/core` API          | Authors the keyboard-only history extension registered on the chat input.                     |
+| `addKeyboardShortcuts`         | `@tiptap/core` API          | Hook where `ArrowUp` / `ArrowDown` handlers are declared.                                     |
+| `instance.input.updateContent` | `@carbon/ai-chat` API       | Writes recalled history entries (or the saved draft) back into the editor.                    |
+| `textToDoc`                    | `@carbon/ai-chat` utility   | Converts a plain-text string into a `JSONContent` doc suitable for `updateContent`.           |
+| `getRawText`                   | `@carbon/ai-chat` utility   | Extracts the plain-text string from the editor's `JSONContent` to save the draft.             |
+| `onBeforeRender`               | component prop              | Callback that fires once with the `ChatInstance` so `historyState.instance` can be populated. |
+| `input.tiptap.extensions`      | config prop                 | Registers the host-authored history `Extension` on the chat input.                            |
+| `layout.showFrame`             | config prop                 | Hides the default frame so the chat fills the viewport.                                       |
+| `openChatByDefault`            | config prop                 | Mounts straight into the conversation, no launcher.                                           |
+| `messaging.customSendMessage`  | config prop                 | Captures sent text into `state.entries` and provides the mock response.                       |
+
+## Run it
+
+**Prerequisite — build the core packages first.** Examples consume the built output of `@carbon/ai-chat-components` and `@carbon/ai-chat`; without this step the dev server will fail with missing-module errors. Rebuild whenever you change anything under `packages/`.
+
+From the repository root:
+
+```bash
+npm install
+npm run build --workspace=@carbon/ai-chat-components
+npm run build --workspace=@carbon/ai-chat
+
+npm run start --workspace=@carbon/ai-chat-examples-react-prompt-line-history-mechanism
+```
+
+See [../README.md](../README.md) for the full setup walkthrough.

--- a/examples/react/prompt-line-history-mechanism/README.md
+++ b/examples/react/prompt-line-history-mechanism/README.md
@@ -20,21 +20,21 @@ A keyboard-only Tiptap extension intercepts `ArrowUp` / `ArrowDown` in the chat 
 
 ## APIs and props demonstrated
 
-| Symbol                         | Package / kind              | Role in this example                                                                          |
-| ------------------------------ | --------------------------- | --------------------------------------------------------------------------------------------- |
-| `ChatCustomElement`            | `@carbon/ai-chat` component | Mounts the chat UI as a fullscreen surface.                                                   |
-| `PublicConfig`                 | `@carbon/ai-chat` type      | Types the config object passed to `ChatCustomElement`.                                        |
-| `ChatInstance`                 | `@carbon/ai-chat` type      | Provides `instance.input.updateContent` to write text into the editor.                        |
-| `Extension.create`             | `@tiptap/core` API          | Authors the keyboard-only history extension registered on the chat input.                     |
-| `addKeyboardShortcuts`         | `@tiptap/core` API          | Hook where `ArrowUp` / `ArrowDown` handlers are declared.                                     |
-| `instance.input.updateContent` | `@carbon/ai-chat` API       | Writes recalled history entries (or the saved draft) back into the editor.                    |
-| `textToDoc`                    | `@carbon/ai-chat` utility   | Converts a plain-text string into a `JSONContent` doc suitable for `updateContent`.           |
-| `getRawText`                   | `@carbon/ai-chat` utility   | Extracts the plain-text string from the editor's `JSONContent` to save the draft.             |
-| `onBeforeRender`               | component prop              | Callback that fires once with the `ChatInstance` so `historyState.instance` can be populated. |
-| `input.tiptap.extensions`      | config prop                 | Registers the host-authored history `Extension` on the chat input.                            |
-| `layout.showFrame`             | config prop                 | Hides the default frame so the chat fills the viewport.                                       |
-| `openChatByDefault`            | config prop                 | Mounts straight into the conversation, no launcher.                                           |
-| `messaging.customSendMessage`  | config prop                 | Captures sent text into `state.entries` and provides the mock response.                       |
+| Symbol | Package / kind | Role in this example |
+| --- | --- | --- |
+| `ChatCustomElement` | `@carbon/ai-chat` component | Mounts the chat UI as a fullscreen surface. |
+| `PublicConfig` | `@carbon/ai-chat` type | Types the config object passed to `ChatCustomElement`. |
+| `ChatInstance` | `@carbon/ai-chat` type | Provides `instance.input.updateContent` to write text into the editor. |
+| `Extension.create` | `@tiptap/core` API | Authors the keyboard-only history extension registered on the chat input. |
+| `addKeyboardShortcuts` | `@tiptap/core` API | Hook where `ArrowUp` / `ArrowDown` handlers are declared. |
+| `instance.input.updateContent` | `@carbon/ai-chat` API | Writes recalled history entries (or the saved draft) back into the editor. |
+| `textToDoc` | `@carbon/ai-chat` utility | Converts a plain-text string into a `JSONContent` doc suitable for `updateContent`. |
+| `getRawText` | `@carbon/ai-chat` utility | Extracts the plain-text string from the editor's `JSONContent` to save the draft. |
+| `onBeforeRender` | component prop | Callback that fires once with the `ChatInstance` so `historyState.instance` can be populated. |
+| `input.tiptap.extensions` | config prop | Registers the host-authored history `Extension` on the chat input. |
+| `layout.showFrame` | config prop | Hides the default frame so the chat fills the viewport. |
+| `openChatByDefault` | config prop | Mounts straight into the conversation, no launcher. |
+| `messaging.customSendMessage` | config prop | Captures sent text into `state.entries` and provides the mock response. |
 
 ## Run it
 

--- a/examples/react/prompt-line-history-mechanism/index.html
+++ b/examples/react/prompt-line-history-mechanism/index.html
@@ -1,0 +1,29 @@
+<!--
+  Copyright IBM Corp. 2026
+
+  This source code is licensed under the Apache-2.0 license found in the
+  LICENSE file in the root directory of this source tree.
+ -->
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>@carbon/ai-chat - react - Prompt line / History mechanism</title>
+    <style>
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+      }
+      .chat-custom-element {
+        height: 100vh;
+        width: 100vw;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>

--- a/examples/react/prompt-line-history-mechanism/package.json
+++ b/examples/react/prompt-line-history-mechanism/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@carbon/ai-chat-examples-react-prompt-line-history-mechanism",
+  "private": true,
+  "version": "1.18.0-rc.0",
+  "type": "module",
+  "description": "An example demonstrating ArrowUp/ArrowDown shell-style history navigation in the chat prompt line using a Tiptap keyboard extension.",
+  "scripts": {
+    "start": "cross-env ENVIRONMENT=development webpack serve --config ./webpack.config.js",
+    "build": "webpack --config ./webpack.config.js"
+  },
+  "author": "IBM Corp",
+  "license": "Apache-2.0",
+  "browserslist": "> 0.5%, last 2 versions, not dead",
+  "dependencies": {
+    "@carbon/ai-chat": "^1.18.0-rc.0",
+    "@carbon/web-components": "^2.58.1",
+    "@tiptap/core": "^3.22.5",
+    "lit": "^3.1.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.26.0",
+    "@babel/preset-env": "^7.26.0",
+    "@babel/preset-react": "^7.25.9",
+    "@babel/preset-typescript": "^7.26.0",
+    "babel-loader": "^9.2.1",
+    "cross-env": "^7.0.3",
+    "css-loader": "^7.1.2",
+    "html-webpack-plugin": "^5.6.3",
+    "style-loader": "^4.0.0",
+    "ts-loader": "^9.5.1",
+    "typescript": "^5.6.3",
+    "webpack": "^5.95.0",
+    "webpack-cli": "^5.1.4",
+    "webpack-dev-server": "^5.1.0"
+  }
+}

--- a/examples/react/prompt-line-history-mechanism/src/App.tsx
+++ b/examples/react/prompt-line-history-mechanism/src/App.tsx
@@ -1,0 +1,84 @@
+/*
+ *  Copyright IBM Corp. 2026
+ *
+ *  This source code is licensed under the Apache-2.0 license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ *  @license
+ */
+
+/**
+ * Example: Carbon AI Chat — Prompt line history mechanism
+ *
+ * Demonstrates: registering a keyboard-only Tiptap extension on the chat input
+ * that intercepts ArrowUp / ArrowDown to cycle through previously sent messages
+ * — shell-style — using `instance.input.updateContent` + `textToDoc` to write
+ * recalled entries back into the editor. A shared `HistoryState` object ties
+ * the keyboard extension to the `customSendMessage` handler so no React state
+ * or event bus subscription is needed.
+ *
+ * APIs exercised:
+ *   - `ChatCustomElement` + `onBeforeRender`
+ *   - `PublicConfig.input.tiptap.extensions` (the history keyboard extension)
+ *   - `PublicConfig.layout.showFrame` / `openChatByDefault`
+ *   - `instance.input.updateContent` + `textToDoc` / `getRawText`
+ *
+ * Start reading at: the module-scope constants, then `App()`.
+ */
+
+import "@carbon/styles/css/styles.css";
+import { ChatCustomElement, ChatInstance, PublicConfig } from "@carbon/ai-chat";
+import React, { useCallback, useMemo } from "react";
+import { createRoot } from "react-dom/client";
+
+import { createCustomSendMessage } from "./customSendMessage";
+import { createHistoryExtension, createHistoryState } from "./historyExtension";
+
+// These three constants are created at module scope — outside the component —
+// so their references are stable across re-renders. Recreating `historyState`
+// on each render would reset history; recreating `historyExtension` would cause
+// Tiptap to rebuild the editor on every render.
+const historyState = createHistoryState();
+const historyExtension = createHistoryExtension(historyState);
+const sendMessage = createCustomSendMessage(historyState);
+
+function App() {
+  // Capture the `ChatInstance` as soon as the chat is ready so the keyboard
+  // extension can call `instance.input.updateContent`. `useCallback` keeps the
+  // callback reference stable so it isn't re-registered on every render.
+  const onBeforeRender = useCallback((instance: ChatInstance) => {
+    historyState.instance = instance;
+  }, []);
+
+  const config: PublicConfig = useMemo(
+    () => ({
+      messaging: { customSendMessage: sendMessage },
+      layout: {
+        // Hide the default chat frame so the custom element fills its host
+        // container — required for the canonical fullscreen surface.
+        showFrame: false,
+      },
+      // Auto-open so the conversation shows from first paint.
+      openChatByDefault: true,
+      input: {
+        // Register the history keyboard extension. A non-empty `extensions`
+        // array causes `resolvePromptLineMode` to switch the input to Tiptap
+        // rich mode automatically — no extra config needed.
+        tiptap: { extensions: [historyExtension] },
+      },
+    }),
+    [],
+  );
+
+  return (
+    <ChatCustomElement
+      className="chat-custom-element"
+      {...config}
+      onBeforeRender={onBeforeRender}
+    />
+  );
+}
+
+const root = createRoot(document.querySelector("#root") as Element);
+
+root.render(<App />);

--- a/examples/react/prompt-line-history-mechanism/src/App.tsx
+++ b/examples/react/prompt-line-history-mechanism/src/App.tsx
@@ -26,13 +26,13 @@
  * Start reading at: the module-scope constants, then `App()`.
  */
 
-import "@carbon/styles/css/styles.css";
-import { ChatCustomElement, ChatInstance, PublicConfig } from "@carbon/ai-chat";
-import React, { useCallback, useMemo } from "react";
-import { createRoot } from "react-dom/client";
+import '@carbon/styles/css/styles.css';
+import { ChatCustomElement, ChatInstance, PublicConfig } from '@carbon/ai-chat';
+import React, { useCallback, useMemo } from 'react';
+import { createRoot } from 'react-dom/client';
 
-import { createCustomSendMessage } from "./customSendMessage";
-import { createHistoryExtension, createHistoryState } from "./historyExtension";
+import { createCustomSendMessage } from './customSendMessage';
+import { createHistoryExtension, createHistoryState } from './historyExtension';
 
 // These three constants are created at module scope — outside the component —
 // so their references are stable across re-renders. Recreating `historyState`
@@ -67,7 +67,7 @@ function App() {
         tiptap: { extensions: [historyExtension] },
       },
     }),
-    [],
+    []
   );
 
   return (
@@ -79,6 +79,6 @@ function App() {
   );
 }
 
-const root = createRoot(document.querySelector("#root") as Element);
+const root = createRoot(document.querySelector('#root') as Element);
 
 root.render(<App />);

--- a/examples/react/prompt-line-history-mechanism/src/customSendMessage.ts
+++ b/examples/react/prompt-line-history-mechanism/src/customSendMessage.ts
@@ -29,9 +29,9 @@ import {
   CustomSendMessageOptions,
   MessageRequest,
   MessageResponseTypes,
-} from "@carbon/ai-chat";
+} from '@carbon/ai-chat';
 
-import type { HistoryState } from "./historyExtension";
+import type { HistoryState } from './historyExtension';
 
 const WELCOME_TEXT = `Welcome! This example demonstrates shell-style message history in the chat input.
 
@@ -49,7 +49,7 @@ function createCustomSendMessage(state: HistoryState) {
   return async function customSendMessage(
     request: MessageRequest,
     _requestOptions: CustomSendMessageOptions,
-    instance: ChatInstance,
+    instance: ChatInstance
   ) {
     const text = request.input.text?.trim();
 

--- a/examples/react/prompt-line-history-mechanism/src/customSendMessage.ts
+++ b/examples/react/prompt-line-history-mechanism/src/customSendMessage.ts
@@ -72,9 +72,9 @@ function createCustomSendMessage(state: HistoryState) {
     // Append to history before the response so ArrowUp works on the very next
     // keypress after the bot replies.
     state.entries.push(text);
-    // Reset navigation cursor so the next ArrowUp starts from the most-recent
+    // Reset historyIndex so the next ArrowUp starts from the most-recent
     // entry, even if the user was mid-navigation when they sent.
-    state.cursor = -1;
+    state.historyIndex = -1;
 
     instance.messaging.addMessage({
       output: {

--- a/examples/react/prompt-line-history-mechanism/src/customSendMessage.ts
+++ b/examples/react/prompt-line-history-mechanism/src/customSendMessage.ts
@@ -1,0 +1,92 @@
+/*
+ *  Copyright IBM Corp. 2026
+ *
+ *  This source code is licensed under the Apache-2.0 license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ *  @license
+ */
+
+/**
+ * Mock backend for the prompt-line-history-mechanism example.
+ *
+ * Demonstrates: capturing `request.input.text` into the shared `HistoryState`
+ * before the mock response, so the keyboard extension can recall earlier sends
+ * via ArrowUp / ArrowDown. History is captured here rather than via a bus
+ * listener because `customSendMessage` already has the text in hand — no extra
+ * wiring required.
+ *
+ * APIs exercised:
+ *   - `customSendMessage` (signature `(request, options, instance)`)
+ *   - `ChatInstance.messaging.addMessage`
+ *   - `MessageResponseTypes.TEXT`
+ *
+ * Start reading at: `createCustomSendMessage`.
+ */
+
+import {
+  ChatInstance,
+  CustomSendMessageOptions,
+  MessageRequest,
+  MessageResponseTypes,
+} from "@carbon/ai-chat";
+
+import type { HistoryState } from "./historyExtension";
+
+const WELCOME_TEXT = `Welcome! This example demonstrates shell-style message history in the chat input.
+
+Send a message, then press **↑** in the input to navigate your message history. Press **↓** to move forward through history. Your in-progress text is saved when you start navigating and restored when you return.`;
+
+/**
+ * Returns a `customSendMessage` handler that captures each sent message into
+ * `state.entries` before generating the mock response.
+ *
+ * Wrapping in a factory (instead of exporting a bare function) lets the handler
+ * close over the same `state` object used by `createHistoryExtension` without
+ * any module-level mutable singleton — the caller owns the state.
+ */
+function createCustomSendMessage(state: HistoryState) {
+  return async function customSendMessage(
+    request: MessageRequest,
+    _requestOptions: CustomSendMessageOptions,
+    instance: ChatInstance,
+  ) {
+    const text = request.input.text?.trim();
+
+    if (!text) {
+      // The framework sends an empty hydration request on first render — use it
+      // to surface onboarding instructions instead of echoing nothing back.
+      instance.messaging.addMessage({
+        output: {
+          generic: [
+            {
+              response_type: MessageResponseTypes.TEXT,
+              text: WELCOME_TEXT,
+            },
+          ],
+        },
+      });
+      return;
+    }
+
+    // Append to history before the response so ArrowUp works on the very next
+    // keypress after the bot replies.
+    state.entries.push(text);
+    // Reset navigation cursor so the next ArrowUp starts from the most-recent
+    // entry, even if the user was mid-navigation when they sent.
+    state.cursor = -1;
+
+    instance.messaging.addMessage({
+      output: {
+        generic: [
+          {
+            response_type: MessageResponseTypes.TEXT,
+            text: `Got it: "${text}"\n\nPress **↑** to recall this message.`,
+          },
+        ],
+      },
+    });
+  };
+}
+
+export { createCustomSendMessage };

--- a/examples/react/prompt-line-history-mechanism/src/historyExtension.ts
+++ b/examples/react/prompt-line-history-mechanism/src/historyExtension.ts
@@ -23,8 +23,8 @@
  * Start reading at: `HistoryState`, then `createHistoryExtension`.
  */
 
-import { getRawText, textToDoc, type ChatInstance } from "@carbon/ai-chat";
-import { Extension } from "@tiptap/core";
+import { getRawText, textToDoc, type ChatInstance } from '@carbon/ai-chat';
+import { Extension } from '@tiptap/core';
 
 /**
  * Shared mutable state that flows between the keyboard extension and the
@@ -46,7 +46,7 @@ interface HistoryState {
 }
 
 function createHistoryState(): HistoryState {
-  return { entries: [], cursor: -1, draft: "", instance: null };
+  return { entries: [], cursor: -1, draft: '', instance: null };
 }
 
 /**
@@ -71,7 +71,7 @@ function createHistoryState(): HistoryState {
  */
 function createHistoryExtension(state: HistoryState): Extension {
   return Extension.create({
-    name: "historyNavigation",
+    name: 'historyNavigation',
 
     addKeyboardShortcuts() {
       return {
@@ -106,7 +106,7 @@ function createHistoryExtension(state: HistoryState): Extension {
           state.cursor = Math.min(state.cursor + 1, state.entries.length - 1);
 
           state.instance?.input.updateContent(() =>
-            textToDoc(state.entries[state.entries.length - 1 - state.cursor]),
+            textToDoc(state.entries[state.entries.length - 1 - state.cursor])
           );
 
           return true;
@@ -137,7 +137,7 @@ function createHistoryExtension(state: HistoryState): Extension {
             state.instance?.input.updateContent(() => textToDoc(state.draft));
           } else {
             state.instance?.input.updateContent(() =>
-              textToDoc(state.entries[state.entries.length - 1 - state.cursor]),
+              textToDoc(state.entries[state.entries.length - 1 - state.cursor])
             );
           }
 

--- a/examples/react/prompt-line-history-mechanism/src/historyExtension.ts
+++ b/examples/react/prompt-line-history-mechanism/src/historyExtension.ts
@@ -32,7 +32,7 @@ import { Extension } from '@tiptap/core';
  * `createHistoryState` so that the reference is stable across re-renders.
  *
  * `entries`  — sent messages, oldest-first; grows on every send.
- * `cursor`   — -1 when not navigating; 0 = most-recent entry (entries.length - 1).
+ * `historyIndex` — -1 when not navigating; 0 = most-recent entry (entries.length - 1).
  * `draft`    — the in-progress text saved on the first ArrowUp press so it can
  *              be restored when the user navigates back past entry 0.
  * `instance` — set by `onBeforeRender` so the keyboard handler can call
@@ -40,13 +40,13 @@ import { Extension } from '@tiptap/core';
  */
 interface HistoryState {
   entries: string[];
-  cursor: number;
+  historyIndex: number;
   draft: string;
   instance: ChatInstance | null;
 }
 
 function createHistoryState(): HistoryState {
-  return { entries: [], cursor: -1, draft: '', instance: null };
+  return { entries: [], historyIndex: -1, draft: '', instance: null };
 }
 
 /**
@@ -64,9 +64,9 @@ function createHistoryState(): HistoryState {
  *   - `ArrowUp`: cursor must be at position 1 (the very start of the single
  *     paragraph) and there must be entries above the current position.
  *   - `ArrowDown`: cursor must be at the last position of the doc and the
- *     extension must currently be navigating (`state.cursor >= 0`).
+ *     extension must currently be navigating (`state.historyIndex >= 0`).
  *
- * Cursor index mapping: `state.cursor` 0 = most-recent entry
+ * History index mapping: `state.historyIndex` 0 = most-recent entry
  * (`entries[entries.length - 1]`); each increment goes one step further back.
  */
 function createHistoryExtension(state: HistoryState): Extension {
@@ -92,21 +92,26 @@ function createHistoryExtension(state: HistoryState): Extension {
           }
 
           // Already at the oldest entry
-          if (state.cursor >= state.entries.length - 1) {
-            return true; // consume the event so the cursor doesn't jump out
+          if (state.historyIndex >= state.entries.length - 1) {
+            return true; // consume the event so the editor cursor doesn't jump out
           }
 
           // Save the in-progress draft on the first ArrowUp of a navigation
           // session so we can restore it when the user presses ArrowDown past
           // entry 0.
-          if (state.cursor === -1) {
+          if (state.historyIndex === -1) {
             state.draft = getRawText(editor.getJSON());
           }
 
-          state.cursor = Math.min(state.cursor + 1, state.entries.length - 1);
+          state.historyIndex = Math.min(
+            state.historyIndex + 1,
+            state.entries.length - 1
+          );
 
           state.instance?.input.updateContent(() =>
-            textToDoc(state.entries[state.entries.length - 1 - state.cursor])
+            textToDoc(
+              state.entries[state.entries.length - 1 - state.historyIndex]
+            )
           );
 
           return true;
@@ -114,7 +119,7 @@ function createHistoryExtension(state: HistoryState): Extension {
 
         ArrowDown: ({ editor }) => {
           // Not currently navigating — let ProseMirror handle it.
-          if (state.cursor === -1) {
+          if (state.historyIndex === -1) {
             return false;
           }
 
@@ -130,14 +135,16 @@ function createHistoryExtension(state: HistoryState): Extension {
             return false;
           }
 
-          state.cursor -= 1;
+          state.historyIndex -= 1;
 
-          if (state.cursor === -1) {
+          if (state.historyIndex === -1) {
             // Navigated back past the most-recent entry
             state.instance?.input.updateContent(() => textToDoc(state.draft));
           } else {
             state.instance?.input.updateContent(() =>
-              textToDoc(state.entries[state.entries.length - 1 - state.cursor])
+              textToDoc(
+                state.entries[state.entries.length - 1 - state.historyIndex]
+              )
             );
           }
 

--- a/examples/react/prompt-line-history-mechanism/src/historyExtension.ts
+++ b/examples/react/prompt-line-history-mechanism/src/historyExtension.ts
@@ -76,7 +76,6 @@ function createHistoryExtension(state: HistoryState): Extension {
     addKeyboardShortcuts() {
       return {
         ArrowUp: ({ editor }) => {
-          // Nothing to navigate yet.
           if (state.entries.length === 0) {
             return false;
           }
@@ -88,13 +87,11 @@ function createHistoryExtension(state: HistoryState): Extension {
           }
 
           // Only intercept when the cursor is at the very start of the doc.
-          // In a single-paragraph doc, position 1 is "inside the only paragraph
-          // at the start" — the first character position.
           if (editor.state.selection.$from.pos !== 1) {
             return false;
           }
 
-          // Already at the oldest entry — nowhere further to go.
+          // Already at the oldest entry
           if (state.cursor >= state.entries.length - 1) {
             return true; // consume the event so the cursor doesn't jump out
           }
@@ -106,11 +103,8 @@ function createHistoryExtension(state: HistoryState): Extension {
             state.draft = getRawText(editor.getJSON());
           }
 
-          // Advance toward the oldest entry (0 = most-recent, length-1 = oldest).
           state.cursor = Math.min(state.cursor + 1, state.entries.length - 1);
 
-          // Write the recalled entry into the editor. The updater signature
-          // matches `updateContent((prev: JSONContent) => JSONContent)`.
           state.instance?.input.updateContent(() =>
             textToDoc(state.entries[state.entries.length - 1 - state.cursor]),
           );
@@ -124,15 +118,11 @@ function createHistoryExtension(state: HistoryState): Extension {
             return false;
           }
 
-          // Single-block guard: if the user somehow typed multi-paragraph
-          // content while navigating (shouldn't happen, but guard anyway).
           if (editor.state.doc.childCount !== 1) {
             return false;
           }
 
           // Only intercept when the cursor is at the very end of the doc.
-          // `doc.content.size - 1` is the last valid cursor position inside
-          // the paragraph (one step before the closing paragraph boundary).
           if (
             editor.state.selection.$from.pos !==
             editor.state.doc.content.size - 1
@@ -143,7 +133,7 @@ function createHistoryExtension(state: HistoryState): Extension {
           state.cursor -= 1;
 
           if (state.cursor === -1) {
-            // Navigated back past the most-recent entry — restore the draft.
+            // Navigated back past the most-recent entry
             state.instance?.input.updateContent(() => textToDoc(state.draft));
           } else {
             state.instance?.input.updateContent(() =>

--- a/examples/react/prompt-line-history-mechanism/src/historyExtension.ts
+++ b/examples/react/prompt-line-history-mechanism/src/historyExtension.ts
@@ -1,0 +1,162 @@
+/*
+ *  Copyright IBM Corp. 2026
+ *
+ *  This source code is licensed under the Apache-2.0 license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ *  @license
+ */
+
+/**
+ * History extension for the prompt-line-history-mechanism example.
+ *
+ * Demonstrates: a keyboard-only Tiptap extension that hooks `ArrowUp` /
+ * `ArrowDown` to navigate through previously sent messages — shell-style — and
+ * writes the recalled text back into the prompt-line editor via
+ * `instance.input.updateContent`.
+ *
+ * APIs exercised:
+ *   - `Extension.create` + `addKeyboardShortcuts` from `@tiptap/core`
+ *   - `getRawText` / `textToDoc` from `@carbon/ai-chat`
+ *   - `ChatInstance.input.updateContent` from `@carbon/ai-chat`
+ *
+ * Start reading at: `HistoryState`, then `createHistoryExtension`.
+ */
+
+import { getRawText, textToDoc, type ChatInstance } from "@carbon/ai-chat";
+import { Extension } from "@tiptap/core";
+
+/**
+ * Shared mutable state that flows between the keyboard extension and the
+ * `customSendMessage` handler. Created once at module scope (outside React) via
+ * `createHistoryState` so that the reference is stable across re-renders.
+ *
+ * `entries`  — sent messages, oldest-first; grows on every send.
+ * `cursor`   — -1 when not navigating; 0 = most-recent entry (entries.length - 1).
+ * `draft`    — the in-progress text saved on the first ArrowUp press so it can
+ *              be restored when the user navigates back past entry 0.
+ * `instance` — set by `onBeforeRender` so the keyboard handler can call
+ *              `instance.input.updateContent`.
+ */
+interface HistoryState {
+  entries: string[];
+  cursor: number;
+  draft: string;
+  instance: ChatInstance | null;
+}
+
+function createHistoryState(): HistoryState {
+  return { entries: [], cursor: -1, draft: "", instance: null };
+}
+
+/**
+ * Returns a Tiptap `Extension` that handles `ArrowUp` / `ArrowDown` in the
+ * chat prompt-line editor, cycling through `state.entries`.
+ *
+ * The extension is created by a factory so the `state` reference is captured
+ * in the closure; call it once at module scope and pass the same `state` object
+ * to `createCustomSendMessage` and the `onBeforeRender` callback.
+ *
+ * Trigger conditions (both keys share a single-block guard):
+ *   - The doc must have exactly one block (`editor.state.doc.childCount === 1`).
+ *     If the user has written a multi-paragraph message, arrow keys move the
+ *     cursor normally.
+ *   - `ArrowUp`: cursor must be at position 1 (the very start of the single
+ *     paragraph) and there must be entries above the current position.
+ *   - `ArrowDown`: cursor must be at the last position of the doc and the
+ *     extension must currently be navigating (`state.cursor >= 0`).
+ *
+ * Cursor index mapping: `state.cursor` 0 = most-recent entry
+ * (`entries[entries.length - 1]`); each increment goes one step further back.
+ */
+function createHistoryExtension(state: HistoryState): Extension {
+  return Extension.create({
+    name: "historyNavigation",
+
+    addKeyboardShortcuts() {
+      return {
+        ArrowUp: ({ editor }) => {
+          // Nothing to navigate yet.
+          if (state.entries.length === 0) {
+            return false;
+          }
+
+          // Only intercept when the doc is a single block (no multi-paragraph
+          // text). Multi-block content: let ProseMirror move the cursor normally.
+          if (editor.state.doc.childCount !== 1) {
+            return false;
+          }
+
+          // Only intercept when the cursor is at the very start of the doc.
+          // In a single-paragraph doc, position 1 is "inside the only paragraph
+          // at the start" — the first character position.
+          if (editor.state.selection.$from.pos !== 1) {
+            return false;
+          }
+
+          // Already at the oldest entry — nowhere further to go.
+          if (state.cursor >= state.entries.length - 1) {
+            return true; // consume the event so the cursor doesn't jump out
+          }
+
+          // Save the in-progress draft on the first ArrowUp of a navigation
+          // session so we can restore it when the user presses ArrowDown past
+          // entry 0.
+          if (state.cursor === -1) {
+            state.draft = getRawText(editor.getJSON());
+          }
+
+          // Advance toward the oldest entry (0 = most-recent, length-1 = oldest).
+          state.cursor = Math.min(state.cursor + 1, state.entries.length - 1);
+
+          // Write the recalled entry into the editor. The updater signature
+          // matches `updateContent((prev: JSONContent) => JSONContent)`.
+          state.instance?.input.updateContent(() =>
+            textToDoc(state.entries[state.entries.length - 1 - state.cursor]),
+          );
+
+          return true;
+        },
+
+        ArrowDown: ({ editor }) => {
+          // Not currently navigating — let ProseMirror handle it.
+          if (state.cursor === -1) {
+            return false;
+          }
+
+          // Single-block guard: if the user somehow typed multi-paragraph
+          // content while navigating (shouldn't happen, but guard anyway).
+          if (editor.state.doc.childCount !== 1) {
+            return false;
+          }
+
+          // Only intercept when the cursor is at the very end of the doc.
+          // `doc.content.size - 1` is the last valid cursor position inside
+          // the paragraph (one step before the closing paragraph boundary).
+          if (
+            editor.state.selection.$from.pos !==
+            editor.state.doc.content.size - 1
+          ) {
+            return false;
+          }
+
+          state.cursor -= 1;
+
+          if (state.cursor === -1) {
+            // Navigated back past the most-recent entry — restore the draft.
+            state.instance?.input.updateContent(() => textToDoc(state.draft));
+          } else {
+            state.instance?.input.updateContent(() =>
+              textToDoc(state.entries[state.entries.length - 1 - state.cursor]),
+            );
+          }
+
+          return true;
+        },
+      };
+    },
+  });
+}
+
+export type { HistoryState };
+export { createHistoryState, createHistoryExtension };

--- a/examples/react/prompt-line-history-mechanism/tsconfig.json
+++ b/examples/react/prompt-line-history-mechanism/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "module": "esnext",
+    "jsx": "react",
+    "strict": true,
+    "esModuleInterop": true,
+    "declaration": false,
+    "sourceMap": true,
+    "experimentalDecorators": true,
+    "useDefineForClassFields": true,
+    "moduleResolution": "node"
+  },
+  "include": ["src/**/*"]
+}

--- a/examples/react/prompt-line-history-mechanism/webpack.config.js
+++ b/examples/react/prompt-line-history-mechanism/webpack.config.js
@@ -1,0 +1,76 @@
+/*
+ *  Copyright IBM Corp. 2026
+ *
+ *  This source code is licensed under the Apache-2.0 license found in the
+ *  LICENSE file in the root directory of this source tree.
+ */
+
+import HtmlWebpackPlugin from "html-webpack-plugin";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const environment = process.env.ENVIRONMENT
+  ? process.env.ENVIRONMENT
+  : "production";
+
+export default () => {
+  const port = process.env.PORT || 3000;
+
+  return {
+    mode: environment,
+    entry: "./src/App.tsx",
+    output: {
+      path: path.resolve(__dirname, "dist"),
+      filename: "bundle.js",
+      clean: true,
+    },
+    resolve: {
+      extensions: [".ts", ".tsx", ".js", ".jsx", ".css"],
+    },
+    module: {
+      rules: [
+        {
+          test: /\.(ts|tsx|js|jsx)$/,
+          exclude: /node_modules/,
+          use: {
+            loader: "babel-loader",
+            options: {
+              presets: [
+                "@babel/preset-env",
+                "@babel/preset-react",
+                "@babel/preset-typescript",
+              ],
+            },
+          },
+        },
+        {
+          test: /\.css$/,
+          use: ["style-loader", "css-loader"],
+        },
+      ],
+    },
+    plugins: [
+      new HtmlWebpackPlugin({
+        template: "./index.html",
+        inject: "body",
+      }),
+    ],
+    devtool: "source-map",
+    snapshot: {
+      managedPaths: [], // don't treat node_modules as immutable
+    },
+    watchOptions: {
+      ignored: /node_modules\/(?!@carbon\/ai-chat)/, // watch only our packages @carbon/ai-chat and @carbon/ai-chat-components
+    },
+    devServer: {
+      static: path.join(__dirname, "dist"),
+      compress: true,
+      port,
+      open: true,
+      hot: true,
+    },
+  };
+};

--- a/examples/react/prompt-line-history-mechanism/webpack.config.js
+++ b/examples/react/prompt-line-history-mechanism/webpack.config.js
@@ -5,30 +5,30 @@
  *  LICENSE file in the root directory of this source tree.
  */
 
-import HtmlWebpackPlugin from "html-webpack-plugin";
-import path from "path";
-import { fileURLToPath } from "url";
+import HtmlWebpackPlugin from 'html-webpack-plugin';
+import path from 'path';
+import { fileURLToPath } from 'url';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 const environment = process.env.ENVIRONMENT
   ? process.env.ENVIRONMENT
-  : "production";
+  : 'production';
 
 export default () => {
   const port = process.env.PORT || 3000;
 
   return {
     mode: environment,
-    entry: "./src/App.tsx",
+    entry: './src/App.tsx',
     output: {
-      path: path.resolve(__dirname, "dist"),
-      filename: "bundle.js",
+      path: path.resolve(__dirname, 'dist'),
+      filename: 'bundle.js',
       clean: true,
     },
     resolve: {
-      extensions: [".ts", ".tsx", ".js", ".jsx", ".css"],
+      extensions: ['.ts', '.tsx', '.js', '.jsx', '.css'],
     },
     module: {
       rules: [
@@ -36,29 +36,29 @@ export default () => {
           test: /\.(ts|tsx|js|jsx)$/,
           exclude: /node_modules/,
           use: {
-            loader: "babel-loader",
+            loader: 'babel-loader',
             options: {
               presets: [
-                "@babel/preset-env",
-                "@babel/preset-react",
-                "@babel/preset-typescript",
+                '@babel/preset-env',
+                '@babel/preset-react',
+                '@babel/preset-typescript',
               ],
             },
           },
         },
         {
           test: /\.css$/,
-          use: ["style-loader", "css-loader"],
+          use: ['style-loader', 'css-loader'],
         },
       ],
     },
     plugins: [
       new HtmlWebpackPlugin({
-        template: "./index.html",
-        inject: "body",
+        template: './index.html',
+        inject: 'body',
       }),
     ],
-    devtool: "source-map",
+    devtool: 'source-map',
     snapshot: {
       managedPaths: [], // don't treat node_modules as immutable
     },
@@ -66,7 +66,7 @@ export default () => {
       ignored: /node_modules\/(?!@carbon\/ai-chat)/, // watch only our packages @carbon/ai-chat and @carbon/ai-chat-components
     },
     devServer: {
-      static: path.join(__dirname, "dist"),
+      static: path.join(__dirname, 'dist'),
       compress: true,
       port,
       open: true,

--- a/examples/web-components/README.md
+++ b/examples/web-components/README.md
@@ -516,6 +516,33 @@ Enables file attachments on `<cds-aichat-custom-element>` with a mock `onFileUpl
 
 </details>
 
+### [Prompt line / History mechanism](./prompt-line-history-mechanism/README.md)
+
+A keyboard-only Tiptap extension intercepts `ArrowUp` / `ArrowDown` in the chat input to cycle through previously sent messages — shell-style — and writes recalled text back into the editor via `instance.input.updateContent`. Your in-progress draft is saved on the first `ArrowUp` press and restored when you navigate back past the most-recent entry.
+
+**Start command:** `npm run start --workspace=@carbon/ai-chat-examples-web-components-prompt-line-history-mechanism`
+
+<details>
+<summary>APIs and props demonstrated</summary>
+
+| Symbol                         | Kind               | Role in this example                                                                          |
+| ------------------------------ | ------------------ | --------------------------------------------------------------------------------------------- |
+| `<cds-aichat-custom-element>`  | custom element     | Mounts the chat UI as a fullscreen surface.                                                   |
+| `PublicConfig`                 | type               | Types the config object bound to the element's properties.                                    |
+| `ChatInstance`                 | type               | Provides `instance.input.updateContent` to write text into the editor.                        |
+| `Extension.create`             | `@tiptap/core` API | Authors the keyboard-only history extension registered on the chat input.                     |
+| `addKeyboardShortcuts`         | `@tiptap/core` API | Hook where `ArrowUp` / `ArrowDown` handlers are declared.                                     |
+| `instance.input.updateContent` | API                | Writes recalled history entries (or the saved draft) back into the editor.                    |
+| `textToDoc`                    | utility            | Converts a plain-text string into a `JSONContent` doc suitable for `updateContent`.           |
+| `getRawText`                   | utility            | Extracts the plain-text string from the editor's `JSONContent` to save the draft.             |
+| `.onBeforeRender`              | property           | Callback that fires once with the `ChatInstance` so `historyState.instance` can be populated. |
+| `.input` (`tiptap.extensions`) | property           | Registers the host-authored history `Extension` on the chat input.                            |
+| `.layout` (`showFrame`)        | property           | Hides the default frame so the chat fills the viewport.                                       |
+| `.openChatByDefault`           | property           | Mounts straight into the conversation, no launcher.                                           |
+| `.messaging.customSendMessage` | property           | Captures sent text into `state.entries` and provides the mock response.                       |
+
+</details>
+
 ### [Prompt line / Mentions & commands](./prompt-line-mentions-and-commands/README.md)
 
 `<cds-aichat-custom-element>` configured with `input.mention` for `@`-picking team members anywhere in the message and `input.command` for `/`-commands constrained to the start of the line.

--- a/examples/web-components/README.md
+++ b/examples/web-components/README.md
@@ -525,21 +525,21 @@ A keyboard-only Tiptap extension intercepts `ArrowUp` / `ArrowDown` in the chat 
 <details>
 <summary>APIs and props demonstrated</summary>
 
-| Symbol                         | Kind               | Role in this example                                                                          |
-| ------------------------------ | ------------------ | --------------------------------------------------------------------------------------------- |
-| `<cds-aichat-custom-element>`  | custom element     | Mounts the chat UI as a fullscreen surface.                                                   |
-| `PublicConfig`                 | type               | Types the config object bound to the element's properties.                                    |
-| `ChatInstance`                 | type               | Provides `instance.input.updateContent` to write text into the editor.                        |
-| `Extension.create`             | `@tiptap/core` API | Authors the keyboard-only history extension registered on the chat input.                     |
-| `addKeyboardShortcuts`         | `@tiptap/core` API | Hook where `ArrowUp` / `ArrowDown` handlers are declared.                                     |
-| `instance.input.updateContent` | API                | Writes recalled history entries (or the saved draft) back into the editor.                    |
-| `textToDoc`                    | utility            | Converts a plain-text string into a `JSONContent` doc suitable for `updateContent`.           |
-| `getRawText`                   | utility            | Extracts the plain-text string from the editor's `JSONContent` to save the draft.             |
-| `.onBeforeRender`              | property           | Callback that fires once with the `ChatInstance` so `historyState.instance` can be populated. |
-| `.input` (`tiptap.extensions`) | property           | Registers the host-authored history `Extension` on the chat input.                            |
-| `.layout` (`showFrame`)        | property           | Hides the default frame so the chat fills the viewport.                                       |
-| `.openChatByDefault`           | property           | Mounts straight into the conversation, no launcher.                                           |
-| `.messaging.customSendMessage` | property           | Captures sent text into `state.entries` and provides the mock response.                       |
+| Symbol | Kind | Role in this example |
+| --- | --- | --- |
+| `<cds-aichat-custom-element>` | custom element | Mounts the chat UI as a fullscreen surface. |
+| `PublicConfig` | type | Types the config object bound to the element's properties. |
+| `ChatInstance` | type | Provides `instance.input.updateContent` to write text into the editor. |
+| `Extension.create` | `@tiptap/core` API | Authors the keyboard-only history extension registered on the chat input. |
+| `addKeyboardShortcuts` | `@tiptap/core` API | Hook where `ArrowUp` / `ArrowDown` handlers are declared. |
+| `instance.input.updateContent` | API | Writes recalled history entries (or the saved draft) back into the editor. |
+| `textToDoc` | utility | Converts a plain-text string into a `JSONContent` doc suitable for `updateContent`. |
+| `getRawText` | utility | Extracts the plain-text string from the editor's `JSONContent` to save the draft. |
+| `.onBeforeRender` | property | Callback that fires once with the `ChatInstance` so `historyState.instance` can be populated. |
+| `.input` (`tiptap.extensions`) | property | Registers the host-authored history `Extension` on the chat input. |
+| `.layout` (`showFrame`) | property | Hides the default frame so the chat fills the viewport. |
+| `.openChatByDefault` | property | Mounts straight into the conversation, no launcher. |
+| `.messaging.customSendMessage` | property | Captures sent text into `state.entries` and provides the mock response. |
 
 </details>
 

--- a/examples/web-components/prompt-line-history-mechanism/README.md
+++ b/examples/web-components/prompt-line-history-mechanism/README.md
@@ -1,0 +1,53 @@
+# Prompt line / History mechanism
+
+A keyboard-only Tiptap extension intercepts `ArrowUp` / `ArrowDown` in the chat input to cycle through previously sent messages — shell-style — and writes recalled text back into the editor via `instance.input.updateContent`. Your in-progress draft is saved on the first `ArrowUp` press and restored when you navigate back past the most-recent entry.
+
+## What this example shows
+
+- Registering a keyboard-only Tiptap extension on the chat input via `PublicConfig.input.tiptap.extensions` — no custom node, no node view, no `renderInLightDom`.
+- Using `Extension.create` + `addKeyboardShortcuts` to intercept `ArrowUp` / `ArrowDown` with ProseMirror position checks: only fire when the cursor is at position 1 (start of the single paragraph) or at the last position of the doc, and only when the doc has a single block so normal cursor movement in multi-paragraph text is never interrupted.
+- Writing recalled text into the editor via `instance.input.updateContent((prev) => textToDoc(text))`.
+- Saving the in-progress draft with `getRawText(editor.getJSON())` on the first `ArrowUp` and restoring it when `ArrowDown` moves past entry 0.
+- Capturing history inside `customSendMessage` (via `state.entries.push(text)`) — simpler and more direct than subscribing to a bus event, because `customSendMessage` already has the text in hand.
+- Sharing state between the keyboard extension and the send handler through a plain mutable `HistoryState` object created once at module scope — no framework state, no event bus.
+- Capturing `ChatInstance` via `.onBeforeRender` and storing it on `historyState.instance` so the keyboard extension can call `instance.input.updateContent` without an event bus subscription.
+
+## When to use this pattern
+
+- Your users re-send variants of previous prompts and a shell-like `↑` / `↓` shortcut would save them time — power-user UX with no visible UI cost.
+- You need to write text into the editor from outside your component tree (e.g. from a Tiptap extension callback) and `instance.input.updateContent` + `textToDoc` is the right tool for plain-text content.
+- You want to attach behaviour to the prompt-line keyboard without building a full custom node.
+
+## APIs and props demonstrated
+
+| Symbol                         | Kind               | Role in this example                                                                          |
+| ------------------------------ | ------------------ | --------------------------------------------------------------------------------------------- |
+| `<cds-aichat-custom-element>`  | custom element     | Mounts the chat UI as a fullscreen surface.                                                   |
+| `PublicConfig`                 | type               | Types the config object bound to the element's properties.                                    |
+| `ChatInstance`                 | type               | Provides `instance.input.updateContent` to write text into the editor.                        |
+| `Extension.create`             | `@tiptap/core` API | Authors the keyboard-only history extension registered on the chat input.                     |
+| `addKeyboardShortcuts`         | `@tiptap/core` API | Hook where `ArrowUp` / `ArrowDown` handlers are declared.                                     |
+| `instance.input.updateContent` | API                | Writes recalled history entries (or the saved draft) back into the editor.                    |
+| `textToDoc`                    | utility            | Converts a plain-text string into a `JSONContent` doc suitable for `updateContent`.           |
+| `getRawText`                   | utility            | Extracts the plain-text string from the editor's `JSONContent` to save the draft.             |
+| `.onBeforeRender`              | property           | Callback that fires once with the `ChatInstance` so `historyState.instance` can be populated. |
+| `.input` (`tiptap.extensions`) | property           | Registers the host-authored history `Extension` on the chat input.                            |
+| `.layout` (`showFrame`)        | property           | Hides the default frame so the chat fills the viewport.                                       |
+| `.openChatByDefault`           | property           | Mounts straight into the conversation, no launcher.                                           |
+| `.messaging.customSendMessage` | property           | Captures sent text into `state.entries` and provides the mock response.                       |
+
+## Run it
+
+**Prerequisite — build the core packages first.** Examples consume the built output of `@carbon/ai-chat-components` and `@carbon/ai-chat`; without this step the dev server will fail with missing-module errors. Rebuild whenever you change anything under `packages/`.
+
+From the repository root:
+
+```bash
+npm install
+npm run build --workspace=@carbon/ai-chat-components
+npm run build --workspace=@carbon/ai-chat
+
+npm run start --workspace=@carbon/ai-chat-examples-web-components-prompt-line-history-mechanism
+```
+
+See [../README.md](../README.md) for the full setup walkthrough.

--- a/examples/web-components/prompt-line-history-mechanism/README.md
+++ b/examples/web-components/prompt-line-history-mechanism/README.md
@@ -20,21 +20,21 @@ A keyboard-only Tiptap extension intercepts `ArrowUp` / `ArrowDown` in the chat 
 
 ## APIs and props demonstrated
 
-| Symbol                         | Kind               | Role in this example                                                                          |
-| ------------------------------ | ------------------ | --------------------------------------------------------------------------------------------- |
-| `<cds-aichat-custom-element>`  | custom element     | Mounts the chat UI as a fullscreen surface.                                                   |
-| `PublicConfig`                 | type               | Types the config object bound to the element's properties.                                    |
-| `ChatInstance`                 | type               | Provides `instance.input.updateContent` to write text into the editor.                        |
-| `Extension.create`             | `@tiptap/core` API | Authors the keyboard-only history extension registered on the chat input.                     |
-| `addKeyboardShortcuts`         | `@tiptap/core` API | Hook where `ArrowUp` / `ArrowDown` handlers are declared.                                     |
-| `instance.input.updateContent` | API                | Writes recalled history entries (or the saved draft) back into the editor.                    |
-| `textToDoc`                    | utility            | Converts a plain-text string into a `JSONContent` doc suitable for `updateContent`.           |
-| `getRawText`                   | utility            | Extracts the plain-text string from the editor's `JSONContent` to save the draft.             |
-| `.onBeforeRender`              | property           | Callback that fires once with the `ChatInstance` so `historyState.instance` can be populated. |
-| `.input` (`tiptap.extensions`) | property           | Registers the host-authored history `Extension` on the chat input.                            |
-| `.layout` (`showFrame`)        | property           | Hides the default frame so the chat fills the viewport.                                       |
-| `.openChatByDefault`           | property           | Mounts straight into the conversation, no launcher.                                           |
-| `.messaging.customSendMessage` | property           | Captures sent text into `state.entries` and provides the mock response.                       |
+| Symbol | Kind | Role in this example |
+| --- | --- | --- |
+| `<cds-aichat-custom-element>` | custom element | Mounts the chat UI as a fullscreen surface. |
+| `PublicConfig` | type | Types the config object bound to the element's properties. |
+| `ChatInstance` | type | Provides `instance.input.updateContent` to write text into the editor. |
+| `Extension.create` | `@tiptap/core` API | Authors the keyboard-only history extension registered on the chat input. |
+| `addKeyboardShortcuts` | `@tiptap/core` API | Hook where `ArrowUp` / `ArrowDown` handlers are declared. |
+| `instance.input.updateContent` | API | Writes recalled history entries (or the saved draft) back into the editor. |
+| `textToDoc` | utility | Converts a plain-text string into a `JSONContent` doc suitable for `updateContent`. |
+| `getRawText` | utility | Extracts the plain-text string from the editor's `JSONContent` to save the draft. |
+| `.onBeforeRender` | property | Callback that fires once with the `ChatInstance` so `historyState.instance` can be populated. |
+| `.input` (`tiptap.extensions`) | property | Registers the host-authored history `Extension` on the chat input. |
+| `.layout` (`showFrame`) | property | Hides the default frame so the chat fills the viewport. |
+| `.openChatByDefault` | property | Mounts straight into the conversation, no launcher. |
+| `.messaging.customSendMessage` | property | Captures sent text into `state.entries` and provides the mock response. |
 
 ## Run it
 

--- a/examples/web-components/prompt-line-history-mechanism/index.html
+++ b/examples/web-components/prompt-line-history-mechanism/index.html
@@ -1,0 +1,31 @@
+<!--
+  Copyright IBM Corp. 2026
+
+  This source code is licensed under the Apache-2.0 license found in the
+  LICENSE file in the root directory of this source tree.
+ -->
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>
+      @carbon/ai-chat - web components - Prompt line / History mechanism
+    </title>
+    <style>
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+      }
+    </style>
+    <link
+      rel="stylesheet"
+      href="https://1.www.s81c.com/common/carbon/plex/sans.css"
+    />
+  </head>
+  <body>
+    <my-app></my-app>
+  </body>
+</html>

--- a/examples/web-components/prompt-line-history-mechanism/package.json
+++ b/examples/web-components/prompt-line-history-mechanism/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@carbon/ai-chat-examples-web-components-prompt-line-history-mechanism",
+  "version": "1.18.0-rc.0",
+  "private": true,
+  "type": "module",
+  "description": "An example demonstrating ArrowUp/ArrowDown shell-style history navigation in the chat prompt line using a Tiptap keyboard extension, using @carbon/ai-chat as a web component.",
+  "scripts": {
+    "start": "cross-env ENVIRONMENT=development webpack serve --config ./webpack.config.js",
+    "build": "webpack --config ./webpack.config.js"
+  },
+  "author": "IBM Corp",
+  "license": "Apache-2.0",
+  "browserslist": "> 0.5%, last 2 versions, not dead",
+  "dependencies": {
+    "@carbon/ai-chat": "^1.18.0-rc.0",
+    "@carbon/ai-chat-components": "^1.8.0-rc.0",
+    "@carbon/web-components": "^2.58.1",
+    "@tiptap/core": "^3.22.5",
+    "lit": "^3.1.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.26.0",
+    "@babel/plugin-proposal-class-properties": "^7.18.6",
+    "@babel/plugin-proposal-decorators": "^7.25.9",
+    "@babel/plugin-transform-class-properties": "^7.25.9",
+    "@babel/plugin-transform-class-static-block": "^7.27.1",
+    "@babel/plugin-transform-private-methods": "^7.25.9",
+    "@babel/plugin-transform-runtime": "^7.25.9",
+    "@babel/preset-env": "^7.26.0",
+    "@babel/preset-typescript": "^7.26.0",
+    "babel-loader": "^9.2.1",
+    "cross-env": "^7.0.3",
+    "css-loader": "^7.1.2",
+    "html-webpack-plugin": "^5.6.3",
+    "style-loader": "^4.0.0",
+    "ts-lit-plugin": "^2.0.2",
+    "ts-loader": "^9.5.1",
+    "typescript": "^5.6.3",
+    "webpack": "^5.95.0",
+    "webpack-cli": "^5.1.4",
+    "webpack-dev-server": "^5.1.0"
+  }
+}

--- a/examples/web-components/prompt-line-history-mechanism/src/customSendMessage.ts
+++ b/examples/web-components/prompt-line-history-mechanism/src/customSendMessage.ts
@@ -29,9 +29,9 @@ import {
   CustomSendMessageOptions,
   MessageRequest,
   MessageResponseTypes,
-} from "@carbon/ai-chat";
+} from '@carbon/ai-chat';
 
-import type { HistoryState } from "./historyExtension";
+import type { HistoryState } from './historyExtension';
 
 const WELCOME_TEXT = `Welcome! This example demonstrates shell-style message history in the chat input.
 
@@ -49,7 +49,7 @@ function createCustomSendMessage(state: HistoryState) {
   return async function customSendMessage(
     request: MessageRequest,
     _requestOptions: CustomSendMessageOptions,
-    instance: ChatInstance,
+    instance: ChatInstance
   ) {
     const text = request.input.text?.trim();
 

--- a/examples/web-components/prompt-line-history-mechanism/src/customSendMessage.ts
+++ b/examples/web-components/prompt-line-history-mechanism/src/customSendMessage.ts
@@ -72,9 +72,9 @@ function createCustomSendMessage(state: HistoryState) {
     // Append to history before the response so ArrowUp works on the very next
     // keypress after the bot replies.
     state.entries.push(text);
-    // Reset navigation cursor so the next ArrowUp starts from the most-recent
+    // Reset historyIndex so the next ArrowUp starts from the most-recent
     // entry, even if the user was mid-navigation when they sent.
-    state.cursor = -1;
+    state.historyIndex = -1;
 
     instance.messaging.addMessage({
       output: {

--- a/examples/web-components/prompt-line-history-mechanism/src/customSendMessage.ts
+++ b/examples/web-components/prompt-line-history-mechanism/src/customSendMessage.ts
@@ -1,0 +1,92 @@
+/*
+ *  Copyright IBM Corp. 2026
+ *
+ *  This source code is licensed under the Apache-2.0 license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ *  @license
+ */
+
+/**
+ * Mock backend for the prompt-line-history-mechanism example.
+ *
+ * Demonstrates: capturing `request.input.text` into the shared `HistoryState`
+ * before the mock response, so the keyboard extension can recall earlier sends
+ * via ArrowUp / ArrowDown. History is captured here rather than via a bus
+ * listener because `customSendMessage` already has the text in hand — no extra
+ * wiring required.
+ *
+ * APIs exercised:
+ *   - `customSendMessage` (signature `(request, options, instance)`)
+ *   - `ChatInstance.messaging.addMessage`
+ *   - `MessageResponseTypes.TEXT`
+ *
+ * Start reading at: `createCustomSendMessage`.
+ */
+
+import {
+  ChatInstance,
+  CustomSendMessageOptions,
+  MessageRequest,
+  MessageResponseTypes,
+} from "@carbon/ai-chat";
+
+import type { HistoryState } from "./historyExtension";
+
+const WELCOME_TEXT = `Welcome! This example demonstrates shell-style message history in the chat input.
+
+Send a message, then press **↑** in the input to navigate your message history. Press **↓** to move forward through history. Your in-progress text is saved when you start navigating and restored when you return.`;
+
+/**
+ * Returns a `customSendMessage` handler that captures each sent message into
+ * `state.entries` before generating the mock response.
+ *
+ * Wrapping in a factory (instead of exporting a bare function) lets the handler
+ * close over the same `state` object used by `createHistoryExtension` without
+ * any module-level mutable singleton — the caller owns the state.
+ */
+function createCustomSendMessage(state: HistoryState) {
+  return async function customSendMessage(
+    request: MessageRequest,
+    _requestOptions: CustomSendMessageOptions,
+    instance: ChatInstance,
+  ) {
+    const text = request.input.text?.trim();
+
+    if (!text) {
+      // The framework sends an empty hydration request on first render — use it
+      // to surface onboarding instructions instead of echoing nothing back.
+      instance.messaging.addMessage({
+        output: {
+          generic: [
+            {
+              response_type: MessageResponseTypes.TEXT,
+              text: WELCOME_TEXT,
+            },
+          ],
+        },
+      });
+      return;
+    }
+
+    // Append to history before the response so ArrowUp works on the very next
+    // keypress after the bot replies.
+    state.entries.push(text);
+    // Reset navigation cursor so the next ArrowUp starts from the most-recent
+    // entry, even if the user was mid-navigation when they sent.
+    state.cursor = -1;
+
+    instance.messaging.addMessage({
+      output: {
+        generic: [
+          {
+            response_type: MessageResponseTypes.TEXT,
+            text: `Got it: "${text}"\n\nPress **↑** to recall this message.`,
+          },
+        ],
+      },
+    });
+  };
+}
+
+export { createCustomSendMessage };

--- a/examples/web-components/prompt-line-history-mechanism/src/historyExtension.ts
+++ b/examples/web-components/prompt-line-history-mechanism/src/historyExtension.ts
@@ -23,8 +23,8 @@
  * Start reading at: `HistoryState`, then `createHistoryExtension`.
  */
 
-import { getRawText, textToDoc, type ChatInstance } from "@carbon/ai-chat";
-import { Extension } from "@tiptap/core";
+import { getRawText, textToDoc, type ChatInstance } from '@carbon/ai-chat';
+import { Extension } from '@tiptap/core';
 
 /**
  * Shared mutable state that flows between the keyboard extension and the
@@ -46,7 +46,7 @@ interface HistoryState {
 }
 
 function createHistoryState(): HistoryState {
-  return { entries: [], cursor: -1, draft: "", instance: null };
+  return { entries: [], cursor: -1, draft: '', instance: null };
 }
 
 /**
@@ -71,7 +71,7 @@ function createHistoryState(): HistoryState {
  */
 function createHistoryExtension(state: HistoryState): Extension {
   return Extension.create({
-    name: "historyNavigation",
+    name: 'historyNavigation',
 
     addKeyboardShortcuts() {
       return {
@@ -106,7 +106,7 @@ function createHistoryExtension(state: HistoryState): Extension {
           state.cursor = Math.min(state.cursor + 1, state.entries.length - 1);
 
           state.instance?.input.updateContent(() =>
-            textToDoc(state.entries[state.entries.length - 1 - state.cursor]),
+            textToDoc(state.entries[state.entries.length - 1 - state.cursor])
           );
 
           return true;
@@ -137,7 +137,7 @@ function createHistoryExtension(state: HistoryState): Extension {
             state.instance?.input.updateContent(() => textToDoc(state.draft));
           } else {
             state.instance?.input.updateContent(() =>
-              textToDoc(state.entries[state.entries.length - 1 - state.cursor]),
+              textToDoc(state.entries[state.entries.length - 1 - state.cursor])
             );
           }
 

--- a/examples/web-components/prompt-line-history-mechanism/src/historyExtension.ts
+++ b/examples/web-components/prompt-line-history-mechanism/src/historyExtension.ts
@@ -32,7 +32,7 @@ import { Extension } from '@tiptap/core';
  * `createHistoryState` so that the reference is stable across re-renders.
  *
  * `entries`  — sent messages, oldest-first; grows on every send.
- * `cursor`   — -1 when not navigating; 0 = most-recent entry (entries.length - 1).
+ * `historyIndex` — -1 when not navigating; 0 = most-recent entry (entries.length - 1).
  * `draft`    — the in-progress text saved on the first ArrowUp press so it can
  *              be restored when the user navigates back past entry 0.
  * `instance` — set by `onBeforeRender` so the keyboard handler can call
@@ -40,13 +40,13 @@ import { Extension } from '@tiptap/core';
  */
 interface HistoryState {
   entries: string[];
-  cursor: number;
+  historyIndex: number;
   draft: string;
   instance: ChatInstance | null;
 }
 
 function createHistoryState(): HistoryState {
-  return { entries: [], cursor: -1, draft: '', instance: null };
+  return { entries: [], historyIndex: -1, draft: '', instance: null };
 }
 
 /**
@@ -64,9 +64,9 @@ function createHistoryState(): HistoryState {
  *   - `ArrowUp`: cursor must be at position 1 (the very start of the single
  *     paragraph) and there must be entries above the current position.
  *   - `ArrowDown`: cursor must be at the last position of the doc and the
- *     extension must currently be navigating (`state.cursor >= 0`).
+ *     extension must currently be navigating (`state.historyIndex >= 0`).
  *
- * Cursor index mapping: `state.cursor` 0 = most-recent entry
+ * History index mapping: `state.historyIndex` 0 = most-recent entry
  * (`entries[entries.length - 1]`); each increment goes one step further back.
  */
 function createHistoryExtension(state: HistoryState): Extension {
@@ -92,21 +92,26 @@ function createHistoryExtension(state: HistoryState): Extension {
           }
 
           // Already at the oldest entry
-          if (state.cursor >= state.entries.length - 1) {
-            return true; // consume the event so the cursor doesn't jump out
+          if (state.historyIndex >= state.entries.length - 1) {
+            return true; // consume the event so the editor cursor doesn't jump out
           }
 
           // Save the in-progress draft on the first ArrowUp of a navigation
           // session so we can restore it when the user presses ArrowDown past
           // entry 0.
-          if (state.cursor === -1) {
+          if (state.historyIndex === -1) {
             state.draft = getRawText(editor.getJSON());
           }
 
-          state.cursor = Math.min(state.cursor + 1, state.entries.length - 1);
+          state.historyIndex = Math.min(
+            state.historyIndex + 1,
+            state.entries.length - 1
+          );
 
           state.instance?.input.updateContent(() =>
-            textToDoc(state.entries[state.entries.length - 1 - state.cursor])
+            textToDoc(
+              state.entries[state.entries.length - 1 - state.historyIndex]
+            )
           );
 
           return true;
@@ -114,7 +119,7 @@ function createHistoryExtension(state: HistoryState): Extension {
 
         ArrowDown: ({ editor }) => {
           // Not currently navigating — let ProseMirror handle it.
-          if (state.cursor === -1) {
+          if (state.historyIndex === -1) {
             return false;
           }
 
@@ -130,14 +135,16 @@ function createHistoryExtension(state: HistoryState): Extension {
             return false;
           }
 
-          state.cursor -= 1;
+          state.historyIndex -= 1;
 
-          if (state.cursor === -1) {
+          if (state.historyIndex === -1) {
             // Navigated back past the most-recent entry
             state.instance?.input.updateContent(() => textToDoc(state.draft));
           } else {
             state.instance?.input.updateContent(() =>
-              textToDoc(state.entries[state.entries.length - 1 - state.cursor])
+              textToDoc(
+                state.entries[state.entries.length - 1 - state.historyIndex]
+              )
             );
           }
 

--- a/examples/web-components/prompt-line-history-mechanism/src/historyExtension.ts
+++ b/examples/web-components/prompt-line-history-mechanism/src/historyExtension.ts
@@ -76,7 +76,6 @@ function createHistoryExtension(state: HistoryState): Extension {
     addKeyboardShortcuts() {
       return {
         ArrowUp: ({ editor }) => {
-          // Nothing to navigate yet.
           if (state.entries.length === 0) {
             return false;
           }
@@ -88,13 +87,11 @@ function createHistoryExtension(state: HistoryState): Extension {
           }
 
           // Only intercept when the cursor is at the very start of the doc.
-          // In a single-paragraph doc, position 1 is "inside the only paragraph
-          // at the start" — the first character position.
           if (editor.state.selection.$from.pos !== 1) {
             return false;
           }
 
-          // Already at the oldest entry — nowhere further to go.
+          // Already at the oldest entry
           if (state.cursor >= state.entries.length - 1) {
             return true; // consume the event so the cursor doesn't jump out
           }
@@ -106,11 +103,8 @@ function createHistoryExtension(state: HistoryState): Extension {
             state.draft = getRawText(editor.getJSON());
           }
 
-          // Advance toward the oldest entry (0 = most-recent, length-1 = oldest).
           state.cursor = Math.min(state.cursor + 1, state.entries.length - 1);
 
-          // Write the recalled entry into the editor. The updater signature
-          // matches `updateContent((prev: JSONContent) => JSONContent)`.
           state.instance?.input.updateContent(() =>
             textToDoc(state.entries[state.entries.length - 1 - state.cursor]),
           );
@@ -124,15 +118,11 @@ function createHistoryExtension(state: HistoryState): Extension {
             return false;
           }
 
-          // Single-block guard: if the user somehow typed multi-paragraph
-          // content while navigating (shouldn't happen, but guard anyway).
           if (editor.state.doc.childCount !== 1) {
             return false;
           }
 
           // Only intercept when the cursor is at the very end of the doc.
-          // `doc.content.size - 1` is the last valid cursor position inside
-          // the paragraph (one step before the closing paragraph boundary).
           if (
             editor.state.selection.$from.pos !==
             editor.state.doc.content.size - 1
@@ -143,7 +133,7 @@ function createHistoryExtension(state: HistoryState): Extension {
           state.cursor -= 1;
 
           if (state.cursor === -1) {
-            // Navigated back past the most-recent entry — restore the draft.
+            // Navigated back past the most-recent entry
             state.instance?.input.updateContent(() => textToDoc(state.draft));
           } else {
             state.instance?.input.updateContent(() =>

--- a/examples/web-components/prompt-line-history-mechanism/src/historyExtension.ts
+++ b/examples/web-components/prompt-line-history-mechanism/src/historyExtension.ts
@@ -1,0 +1,162 @@
+/*
+ *  Copyright IBM Corp. 2026
+ *
+ *  This source code is licensed under the Apache-2.0 license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ *  @license
+ */
+
+/**
+ * History extension for the prompt-line-history-mechanism example.
+ *
+ * Demonstrates: a keyboard-only Tiptap extension that hooks `ArrowUp` /
+ * `ArrowDown` to navigate through previously sent messages — shell-style — and
+ * writes the recalled text back into the prompt-line editor via
+ * `instance.input.updateContent`.
+ *
+ * APIs exercised:
+ *   - `Extension.create` + `addKeyboardShortcuts` from `@tiptap/core`
+ *   - `getRawText` / `textToDoc` from `@carbon/ai-chat`
+ *   - `ChatInstance.input.updateContent` from `@carbon/ai-chat`
+ *
+ * Start reading at: `HistoryState`, then `createHistoryExtension`.
+ */
+
+import { getRawText, textToDoc, type ChatInstance } from "@carbon/ai-chat";
+import { Extension } from "@tiptap/core";
+
+/**
+ * Shared mutable state that flows between the keyboard extension and the
+ * `customSendMessage` handler. Created once at module scope via
+ * `createHistoryState` so that the reference is stable across re-renders.
+ *
+ * `entries`  — sent messages, oldest-first; grows on every send.
+ * `cursor`   — -1 when not navigating; 0 = most-recent entry (entries.length - 1).
+ * `draft`    — the in-progress text saved on the first ArrowUp press so it can
+ *              be restored when the user navigates back past entry 0.
+ * `instance` — set by `onBeforeRender` so the keyboard handler can call
+ *              `instance.input.updateContent`.
+ */
+interface HistoryState {
+  entries: string[];
+  cursor: number;
+  draft: string;
+  instance: ChatInstance | null;
+}
+
+function createHistoryState(): HistoryState {
+  return { entries: [], cursor: -1, draft: "", instance: null };
+}
+
+/**
+ * Returns a Tiptap `Extension` that handles `ArrowUp` / `ArrowDown` in the
+ * chat prompt-line editor, cycling through `state.entries`.
+ *
+ * The extension is created by a factory so the `state` reference is captured
+ * in the closure; call it once at module scope and pass the same `state` object
+ * to `createCustomSendMessage` and the `onBeforeRender` callback.
+ *
+ * Trigger conditions (both keys share a single-block guard):
+ *   - The doc must have exactly one block (`editor.state.doc.childCount === 1`).
+ *     If the user has written a multi-paragraph message, arrow keys move the
+ *     cursor normally.
+ *   - `ArrowUp`: cursor must be at position 1 (the very start of the single
+ *     paragraph) and there must be entries above the current position.
+ *   - `ArrowDown`: cursor must be at the last position of the doc and the
+ *     extension must currently be navigating (`state.cursor >= 0`).
+ *
+ * Cursor index mapping: `state.cursor` 0 = most-recent entry
+ * (`entries[entries.length - 1]`); each increment goes one step further back.
+ */
+function createHistoryExtension(state: HistoryState): Extension {
+  return Extension.create({
+    name: "historyNavigation",
+
+    addKeyboardShortcuts() {
+      return {
+        ArrowUp: ({ editor }) => {
+          // Nothing to navigate yet.
+          if (state.entries.length === 0) {
+            return false;
+          }
+
+          // Only intercept when the doc is a single block (no multi-paragraph
+          // text). Multi-block content: let ProseMirror move the cursor normally.
+          if (editor.state.doc.childCount !== 1) {
+            return false;
+          }
+
+          // Only intercept when the cursor is at the very start of the doc.
+          // In a single-paragraph doc, position 1 is "inside the only paragraph
+          // at the start" — the first character position.
+          if (editor.state.selection.$from.pos !== 1) {
+            return false;
+          }
+
+          // Already at the oldest entry — nowhere further to go.
+          if (state.cursor >= state.entries.length - 1) {
+            return true; // consume the event so the cursor doesn't jump out
+          }
+
+          // Save the in-progress draft on the first ArrowUp of a navigation
+          // session so we can restore it when the user presses ArrowDown past
+          // entry 0.
+          if (state.cursor === -1) {
+            state.draft = getRawText(editor.getJSON());
+          }
+
+          // Advance toward the oldest entry (0 = most-recent, length-1 = oldest).
+          state.cursor = Math.min(state.cursor + 1, state.entries.length - 1);
+
+          // Write the recalled entry into the editor. The updater signature
+          // matches `updateContent((prev: JSONContent) => JSONContent)`.
+          state.instance?.input.updateContent(() =>
+            textToDoc(state.entries[state.entries.length - 1 - state.cursor]),
+          );
+
+          return true;
+        },
+
+        ArrowDown: ({ editor }) => {
+          // Not currently navigating — let ProseMirror handle it.
+          if (state.cursor === -1) {
+            return false;
+          }
+
+          // Single-block guard: if the user somehow typed multi-paragraph
+          // content while navigating (shouldn't happen, but guard anyway).
+          if (editor.state.doc.childCount !== 1) {
+            return false;
+          }
+
+          // Only intercept when the cursor is at the very end of the doc.
+          // `doc.content.size - 1` is the last valid cursor position inside
+          // the paragraph (one step before the closing paragraph boundary).
+          if (
+            editor.state.selection.$from.pos !==
+            editor.state.doc.content.size - 1
+          ) {
+            return false;
+          }
+
+          state.cursor -= 1;
+
+          if (state.cursor === -1) {
+            // Navigated back past the most-recent entry — restore the draft.
+            state.instance?.input.updateContent(() => textToDoc(state.draft));
+          } else {
+            state.instance?.input.updateContent(() =>
+              textToDoc(state.entries[state.entries.length - 1 - state.cursor]),
+            );
+          }
+
+          return true;
+        },
+      };
+    },
+  });
+}
+
+export type { HistoryState };
+export { createHistoryState, createHistoryExtension };

--- a/examples/web-components/prompt-line-history-mechanism/src/main.ts
+++ b/examples/web-components/prompt-line-history-mechanism/src/main.ts
@@ -1,0 +1,94 @@
+/*
+ *  Copyright IBM Corp. 2026
+ *
+ *  This source code is licensed under the Apache-2.0 license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ *  @license
+ */
+
+/**
+ * Example: Carbon AI Chat — Prompt line history mechanism (Web Components)
+ *
+ * Demonstrates: registering a keyboard-only Tiptap extension on the chat input
+ * that intercepts ArrowUp / ArrowDown to cycle through previously sent messages
+ * — shell-style — using `instance.input.updateContent` + `textToDoc` to write
+ * recalled entries back into the editor. A shared `HistoryState` object ties
+ * the keyboard extension to the `customSendMessage` handler so no framework
+ * state or event bus subscription is needed.
+ *
+ * APIs exercised:
+ *   - `<cds-aichat-custom-element>` + `.onBeforeRender` property
+ *   - `PublicConfig.input.tiptap.extensions` (the history keyboard extension)
+ *   - `PublicConfig.layout.showFrame` / `openChatByDefault`
+ *   - `instance.input.updateContent` + `textToDoc` / `getRawText`
+ *
+ * Start reading at: the module-scope constants, then the `Demo` class.
+ */
+
+import "@carbon/ai-chat/dist/es/web-components/cds-aichat-custom-element/index.js";
+import "@carbon/styles/css/styles.css";
+import { type ChatInstance, type PublicConfig } from "@carbon/ai-chat";
+import { css, html, LitElement } from "lit";
+import { customElement } from "lit/decorators.js";
+
+import { createCustomSendMessage } from "./customSendMessage";
+import { createHistoryExtension, createHistoryState } from "./historyExtension";
+
+// These three constants are created at module scope — outside the component —
+// so their references are stable across re-renders. Recreating `historyState`
+// would reset history; recreating `historyExtension` would cause Tiptap to
+// rebuild the editor on every render.
+const historyState = createHistoryState();
+const historyExtension = createHistoryExtension(historyState);
+const sendMessage = createCustomSendMessage(historyState);
+
+// Module-scope so the reference is stable across renders — a fresh `input`
+// object (or `tiptap.extensions` array) would make the editor recreate.
+const config: PublicConfig = {
+  messaging: { customSendMessage: sendMessage },
+  layout: {
+    // Hide the default chat frame so the custom element fills its host
+    // container — required for the canonical fullscreen surface.
+    showFrame: false,
+  },
+  // Auto-open so the conversation shows from first paint.
+  openChatByDefault: true,
+  input: {
+    // Register the history keyboard extension. A non-empty `extensions`
+    // array causes `resolvePromptLineMode` to switch the input to Tiptap
+    // rich mode automatically — no extra config needed.
+    tiptap: { extensions: [historyExtension] },
+  },
+};
+
+@customElement("my-app")
+export class Demo extends LitElement {
+  static styles = css`
+    .chat-custom-element {
+      height: 100vh;
+      width: 100vw;
+    }
+  `;
+
+  // Capture the `ChatInstance` as soon as the chat is ready so the keyboard
+  // extension can call `instance.input.updateContent`. The arrow-function
+  // class field keeps `this` bound without needing `.bind(this)` in the
+  // template — matching the pattern used in upsert-message-user-defined.
+  private onBeforeRender = (instance: ChatInstance) => {
+    historyState.instance = instance;
+  };
+
+  render() {
+    return html`
+      <cds-aichat-custom-element
+        class="chat-custom-element"
+        .messaging=${config.messaging}
+        .input=${config.input}
+        .layout=${config.layout}
+        .openChatByDefault=${config.openChatByDefault}
+        .onBeforeRender=${this.onBeforeRender}
+      ></cds-aichat-custom-element>
+    `;
+  }
+}

--- a/examples/web-components/prompt-line-history-mechanism/src/main.ts
+++ b/examples/web-components/prompt-line-history-mechanism/src/main.ts
@@ -26,14 +26,14 @@
  * Start reading at: the module-scope constants, then the `Demo` class.
  */
 
-import "@carbon/ai-chat/dist/es/web-components/cds-aichat-custom-element/index.js";
-import "@carbon/styles/css/styles.css";
-import { type ChatInstance, type PublicConfig } from "@carbon/ai-chat";
-import { css, html, LitElement } from "lit";
-import { customElement } from "lit/decorators.js";
+import '@carbon/ai-chat/dist/es/web-components/cds-aichat-custom-element/index.js';
+import '@carbon/styles/css/styles.css';
+import { type ChatInstance, type PublicConfig } from '@carbon/ai-chat';
+import { css, html, LitElement } from 'lit';
+import { customElement } from 'lit/decorators.js';
 
-import { createCustomSendMessage } from "./customSendMessage";
-import { createHistoryExtension, createHistoryState } from "./historyExtension";
+import { createCustomSendMessage } from './customSendMessage';
+import { createHistoryExtension, createHistoryState } from './historyExtension';
 
 // These three constants are created at module scope — outside the component —
 // so their references are stable across re-renders. Recreating `historyState`
@@ -59,7 +59,7 @@ const config: PublicConfig = {
   },
 };
 
-@customElement("my-app")
+@customElement('my-app')
 export class Demo extends LitElement {
   static styles = css`
     .chat-custom-element {
@@ -80,8 +80,7 @@ export class Demo extends LitElement {
         .input=${config.input}
         .layout=${config.layout}
         .openChatByDefault=${config.openChatByDefault}
-        .onBeforeRender=${this.onBeforeRender}
-      ></cds-aichat-custom-element>
+        .onBeforeRender=${this.onBeforeRender}></cds-aichat-custom-element>
     `;
   }
 }

--- a/examples/web-components/prompt-line-history-mechanism/src/main.ts
+++ b/examples/web-components/prompt-line-history-mechanism/src/main.ts
@@ -48,11 +48,8 @@ const sendMessage = createCustomSendMessage(historyState);
 const config: PublicConfig = {
   messaging: { customSendMessage: sendMessage },
   layout: {
-    // Hide the default chat frame so the custom element fills its host
-    // container — required for the canonical fullscreen surface.
     showFrame: false,
   },
-  // Auto-open so the conversation shows from first paint.
   openChatByDefault: true,
   input: {
     // Register the history keyboard extension. A non-empty `extensions`
@@ -71,10 +68,6 @@ export class Demo extends LitElement {
     }
   `;
 
-  // Capture the `ChatInstance` as soon as the chat is ready so the keyboard
-  // extension can call `instance.input.updateContent`. The arrow-function
-  // class field keeps `this` bound without needing `.bind(this)` in the
-  // template — matching the pattern used in upsert-message-user-defined.
   private onBeforeRender = (instance: ChatInstance) => {
     historyState.instance = instance;
   };

--- a/examples/web-components/prompt-line-history-mechanism/tsconfig.json
+++ b/examples/web-components/prompt-line-history-mechanism/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "module": "esnext",
+    "strict": true,
+    "esModuleInterop": true,
+    "declaration": false,
+    "sourceMap": true,
+    "experimentalDecorators": true,
+    "useDefineForClassFields": true,
+    "moduleResolution": "node",
+    "plugins": [
+      {
+        "name": "ts-lit-plugin"
+      }
+    ]
+  },
+  "include": ["src/**/*"]
+}

--- a/examples/web-components/prompt-line-history-mechanism/webpack.config.js
+++ b/examples/web-components/prompt-line-history-mechanism/webpack.config.js
@@ -1,0 +1,78 @@
+/*
+ *  Copyright IBM Corp. 2026
+ *
+ *  This source code is licensed under the Apache-2.0 license found in the
+ *  LICENSE file in the root directory of this source tree.
+ */
+
+import HtmlWebpackPlugin from "html-webpack-plugin";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const environment = process.env.ENVIRONMENT
+  ? process.env.ENVIRONMENT
+  : "production";
+
+export default () => {
+  const port = process.env.PORT || 3000;
+
+  return {
+    mode: environment,
+    entry: "./src/main.ts",
+    output: {
+      path: path.resolve(__dirname, "dist"),
+      filename: "bundle.js",
+      clean: true,
+    },
+    resolve: {
+      extensions: [".ts", ".tsx", ".js", ".jsx", ".css"],
+    },
+    module: {
+      rules: [
+        {
+          test: /\.(ts|tsx|js|jsx)$/,
+          exclude: /node_modules/,
+          use: {
+            loader: "babel-loader",
+            options: {
+              presets: ["@babel/preset-env", "@babel/preset-typescript"],
+              plugins: [
+                ["@babel/plugin-proposal-decorators", { version: "2023-05" }],
+                "@babel/plugin-proposal-class-properties",
+                "@babel/plugin-transform-private-methods",
+                "@babel/plugin-transform-class-static-block",
+              ],
+            },
+          },
+        },
+        {
+          test: /\.css$/,
+          use: ["style-loader", "css-loader"],
+        },
+      ],
+    },
+    plugins: [
+      new HtmlWebpackPlugin({
+        template: "./index.html",
+        inject: "body",
+      }),
+    ],
+    devtool: "source-map",
+    snapshot: {
+      managedPaths: [], // don't treat node_modules as immutable
+    },
+    watchOptions: {
+      ignored: /node_modules\/(?!@carbon\/ai-chat)/, // watch only our packages @carbon/ai-chat and @carbon/ai-chat-components
+    },
+    devServer: {
+      static: path.join(__dirname, "dist"),
+      compress: true,
+      port,
+      open: true,
+      hot: true,
+    },
+  };
+};

--- a/examples/web-components/prompt-line-history-mechanism/webpack.config.js
+++ b/examples/web-components/prompt-line-history-mechanism/webpack.config.js
@@ -5,30 +5,30 @@
  *  LICENSE file in the root directory of this source tree.
  */
 
-import HtmlWebpackPlugin from "html-webpack-plugin";
-import path from "path";
-import { fileURLToPath } from "url";
+import HtmlWebpackPlugin from 'html-webpack-plugin';
+import path from 'path';
+import { fileURLToPath } from 'url';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 const environment = process.env.ENVIRONMENT
   ? process.env.ENVIRONMENT
-  : "production";
+  : 'production';
 
 export default () => {
   const port = process.env.PORT || 3000;
 
   return {
     mode: environment,
-    entry: "./src/main.ts",
+    entry: './src/main.ts',
     output: {
-      path: path.resolve(__dirname, "dist"),
-      filename: "bundle.js",
+      path: path.resolve(__dirname, 'dist'),
+      filename: 'bundle.js',
       clean: true,
     },
     resolve: {
-      extensions: [".ts", ".tsx", ".js", ".jsx", ".css"],
+      extensions: ['.ts', '.tsx', '.js', '.jsx', '.css'],
     },
     module: {
       rules: [
@@ -36,31 +36,31 @@ export default () => {
           test: /\.(ts|tsx|js|jsx)$/,
           exclude: /node_modules/,
           use: {
-            loader: "babel-loader",
+            loader: 'babel-loader',
             options: {
-              presets: ["@babel/preset-env", "@babel/preset-typescript"],
+              presets: ['@babel/preset-env', '@babel/preset-typescript'],
               plugins: [
-                ["@babel/plugin-proposal-decorators", { version: "2023-05" }],
-                "@babel/plugin-proposal-class-properties",
-                "@babel/plugin-transform-private-methods",
-                "@babel/plugin-transform-class-static-block",
+                ['@babel/plugin-proposal-decorators', { version: '2023-05' }],
+                '@babel/plugin-proposal-class-properties',
+                '@babel/plugin-transform-private-methods',
+                '@babel/plugin-transform-class-static-block',
               ],
             },
           },
         },
         {
           test: /\.css$/,
-          use: ["style-loader", "css-loader"],
+          use: ['style-loader', 'css-loader'],
         },
       ],
     },
     plugins: [
       new HtmlWebpackPlugin({
-        template: "./index.html",
-        inject: "body",
+        template: './index.html',
+        inject: 'body',
       }),
     ],
-    devtool: "source-map",
+    devtool: 'source-map',
     snapshot: {
       managedPaths: [], // don't treat node_modules as immutable
     },
@@ -68,7 +68,7 @@ export default () => {
       ignored: /node_modules\/(?!@carbon\/ai-chat)/, // watch only our packages @carbon/ai-chat and @carbon/ai-chat-components
     },
     devServer: {
-      static: path.join(__dirname, "dist"),
+      static: path.join(__dirname, 'dist'),
       compress: true,
       port,
       open: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1336,6 +1336,54 @@
         "yarn": ">=1"
       }
     },
+    "examples/react/prompt-line-history-mechanism": {
+      "name": "@carbon/ai-chat-examples-react-prompt-line-history-mechanism",
+      "version": "1.18.0-rc.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@carbon/ai-chat": "^1.18.0-rc.0",
+        "@carbon/web-components": "^2.58.1",
+        "@tiptap/core": "^3.22.5",
+        "lit": "^3.1.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0"
+      },
+      "devDependencies": {
+        "@babel/core": "^7.26.0",
+        "@babel/preset-env": "^7.26.0",
+        "@babel/preset-react": "^7.25.9",
+        "@babel/preset-typescript": "^7.26.0",
+        "babel-loader": "^9.2.1",
+        "cross-env": "^7.0.3",
+        "css-loader": "^7.1.2",
+        "html-webpack-plugin": "^5.6.3",
+        "style-loader": "^4.0.0",
+        "ts-loader": "^9.5.1",
+        "typescript": "^5.6.3",
+        "webpack": "^5.95.0",
+        "webpack-cli": "^5.1.4",
+        "webpack-dev-server": "^5.1.0"
+      }
+    },
+    "examples/react/prompt-line-history-mechanism/node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
     "examples/react/prompt-line-mentions-and-commands": {
       "name": "@carbon/ai-chat-examples-react-prompt-line-mentions-and-commands",
       "version": "1.18.0-rc.0",
@@ -3409,6 +3457,61 @@
       }
     },
     "examples/web-components/prompt-line-file-upload/node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "examples/web-components/prompt-line-history-mechanism": {
+      "name": "@carbon/ai-chat-examples-web-components-prompt-line-history-mechanism",
+      "version": "1.18.0-rc.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@carbon/ai-chat": "^1.18.0-rc.0",
+        "@carbon/ai-chat-components": "^1.8.0-rc.0",
+        "@carbon/web-components": "^2.58.1",
+        "@tiptap/core": "^3.22.5",
+        "lit": "^3.1.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0"
+      },
+      "devDependencies": {
+        "@babel/core": "^7.26.0",
+        "@babel/plugin-proposal-class-properties": "^7.18.6",
+        "@babel/plugin-proposal-decorators": "^7.25.9",
+        "@babel/plugin-transform-class-properties": "^7.25.9",
+        "@babel/plugin-transform-class-static-block": "^7.27.1",
+        "@babel/plugin-transform-private-methods": "^7.25.9",
+        "@babel/plugin-transform-runtime": "^7.25.9",
+        "@babel/preset-env": "^7.26.0",
+        "@babel/preset-typescript": "^7.26.0",
+        "babel-loader": "^9.2.1",
+        "cross-env": "^7.0.3",
+        "css-loader": "^7.1.2",
+        "html-webpack-plugin": "^5.6.3",
+        "style-loader": "^4.0.0",
+        "ts-lit-plugin": "^2.0.2",
+        "ts-loader": "^9.5.1",
+        "typescript": "^5.6.3",
+        "webpack": "^5.95.0",
+        "webpack-cli": "^5.1.4",
+        "webpack-dev-server": "^5.1.0"
+      }
+    },
+    "examples/web-components/prompt-line-history-mechanism/node_modules/cross-env": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
       "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
@@ -6587,6 +6690,10 @@
       "resolved": "examples/react/prompt-line-file-upload",
       "link": true
     },
+    "node_modules/@carbon/ai-chat-examples-react-prompt-line-history-mechanism": {
+      "resolved": "examples/react/prompt-line-history-mechanism",
+      "link": true
+    },
     "node_modules/@carbon/ai-chat-examples-react-prompt-line-mentions-and-commands": {
       "resolved": "examples/react/prompt-line-mentions-and-commands",
       "link": true
@@ -6749,6 +6856,10 @@
     },
     "node_modules/@carbon/ai-chat-examples-web-components-prompt-line-file-upload": {
       "resolved": "examples/web-components/prompt-line-file-upload",
+      "link": true
+    },
+    "node_modules/@carbon/ai-chat-examples-web-components-prompt-line-history-mechanism": {
+      "resolved": "examples/web-components/prompt-line-history-mechanism",
       "link": true
     },
     "node_modules/@carbon/ai-chat-examples-web-components-prompt-line-mentions-and-commands": {


### PR DESCRIPTION
Closes #838 

Adds new example `prompt-line-history-mechanism` that uses a tiptap Extension via `PublicConfig.input.tiptap` to implement a shell-like message history scroll feature in the prompt line. 

#### Changelog

**New**

- `examples/react/prompt-line-history-mechanism/`: new example demonstrating shell-style ArrowUp/ArrowDown history navigation in the prompt line
- `examples/web-components/prompt-line-history-mechanism/`: mirrors the React example using web components
- `src/historyExtension.ts`
  - `createHistoryState`: creates a shared mutable state between the keyboard extension and `customSendMessage`. Tracks a message history array, the current history navigation index, current message draft, and the Chat instance.
  - `createHistoryExtension`: returns a Tiptap extension that handles ArrowUp/ArrowDown functionality. Saves draft of current message via `getRawText` so you can navigate back to it.
- `src/customSendMessage.ts`: captures `request.input.text` into `state.entries` on each send and resets `state.historyIndex` so next ↑ starts from most recently sent message.

#### Testing / Reviewing

Test the React & Web component example:
`npm run start --workspace=@carbon/ai-chat-examples-react-prompt-line-history-mechanism`
`npm run start --workspace=@carbon/ai-chat-examples-web-components-prompt-line-history-mechanism`