### PR TITLE
fix: resolve postcss dep cve

### DIFF
--- a/examples/react/frameworks-next/package.json
+++ b/examples/react/frameworks-next/package.json
@@ -16,7 +16,7 @@
     "@carbon/ai-chat": "^1.18.0-rc.0",
     "@carbon/web-components": "^2.58.1",
     "lit": "^3.1.0",
-    "next": "^16.2.11",
+    "next": "^16.2.12",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -631,7 +631,7 @@
         "@carbon/ai-chat": "^1.18.0-rc.0",
         "@carbon/web-components": "^2.58.1",
         "lit": "^3.1.0",
-        "next": "^16.2.11",
+        "next": "^16.2.12",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
       },
@@ -23436,20 +23436,7 @@
         "node": ">=14"
       }
     },
-    "node_modules/conventional-changelog-writer/node_modules/semver": {
-      "version": "7.8.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
-      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/conventional-commits-filter": {
+    "node_modules/conventional-changelog-writer/node_modules/conventional-commits-filter": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-3.0.0.tgz",
       "integrity": "sha512-1ymej8b5LouPx9Ox0Dw/qAO2dVdfpRFq28e5Y0jJEU8ZrLdy0vOSkkIInwmxErFGhg6SALro60ZrwYFVTUDo4Q==",
@@ -23461,6 +23448,19 @@
       },
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/conventional-changelog-writer/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/conventional-commits-parser": {
@@ -23497,6 +23497,20 @@
       },
       "bin": {
         "conventional-recommended-bump": "cli.js"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/conventional-recommended-bump/node_modules/conventional-commits-filter": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-3.0.0.tgz",
+      "integrity": "sha512-1ymej8b5LouPx9Ox0Dw/qAO2dVdfpRFq28e5Y0jJEU8ZrLdy0vOSkkIInwmxErFGhg6SALro60ZrwYFVTUDo4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash.ismatch": "^4.4.0",
+        "modify-values": "^1.0.1"
       },
       "engines": {
         "node": ">=14"
@@ -35154,7 +35168,7 @@
         "@swc/helpers": "0.5.15",
         "baseline-browser-mapping": "^2.9.19",
         "caniuse-lite": "^1.0.30001579",
-        "postcss": "8.4.31",
+        "postcss": "8.5.23",
         "styled-jsx": "5.1.6"
       },
       "bin": {
@@ -35204,6 +35218,34 @@
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/next/node_modules/postcss": {
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.16",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/no-case": {
@@ -37464,6 +37506,7 @@
       "version": "8.5.23",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
       "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -47234,7 +47277,7 @@
         "jest": "^30.0.0",
         "jest-environment-jsdom": "^30.0.0",
         "lit": "^3.1.0",
-        "postcss": "^8.5.10",
+        "postcss": "^8.5.23",
         "postcss-discard-comments": "^8.0.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",

--- a/packages/ai-chat/package.json
+++ b/packages/ai-chat/package.json
@@ -109,7 +109,7 @@
     "jest": "^30.0.0",
     "jest-environment-jsdom": "^30.0.0",
     "lit": "^3.1.0",
-    "postcss": "^8.5.10",
+    "postcss": "^8.5.23",
     "postcss-discard-comments": "^8.0.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",


### PR DESCRIPTION
resolves cve-2026-45623 by updating `next` and `postcss`

[ref](https://ibm.service-now.com/now/nav/ui/classic/params/target/sn_vul_product_records.do%3Fsys_id%3D7964129a2b1acb907622f198f291bf10%26sysparm_view%3D%26sysparm_view_forced%3Dtrue)