### PR TITLE
feat: split PublicConfig into ChatCoreConfig and ChatShellConfig

### DIFF
--- a/packages/ai-chat/src/aiChatEntry.tsx
+++ b/packages/ai-chat/src/aiChatEntry.tsx
@@ -142,6 +142,8 @@ export {
 } from './types/config/MessagingConfig';
 
 export {
+  ChatCoreConfig,
+  ChatShellConfig,
   PublicConfig,
   PublicConfigFeatureFlags,
 } from './types/config/PublicConfig';
@@ -166,7 +168,11 @@ export type {
 export { enLanguagePack, LanguagePack } from './types/config/LanguagePack';
 export { LayoutConfig } from './types/config/LayoutConfig';
 export { OnErrorData, OnErrorType } from './types/config/ErrorConfig';
-export { PublicConfigMessaging } from './types/config/PublicConfigMessaging';
+export {
+  ChatCoreConfigMessaging,
+  ChatShellConfigMessaging,
+  PublicConfigMessaging,
+} from './types/config/PublicConfigMessaging';
 export { UploadConfig } from './types/config/UploadConfig';
 
 export {

--- a/packages/ai-chat/src/serverEntry.ts
+++ b/packages/ai-chat/src/serverEntry.ts
@@ -136,6 +136,8 @@ export {
 } from './types/config/MessagingConfig';
 
 export {
+  ChatCoreConfig,
+  ChatShellConfig,
   PublicConfig,
   PublicConfigFeatureFlags,
 } from './types/config/PublicConfig';
@@ -159,7 +161,11 @@ export type {
 export { enLanguagePack, LanguagePack } from './types/config/LanguagePack';
 export { LayoutConfig } from './types/config/LayoutConfig';
 export { OnErrorData, OnErrorType } from './types/config/ErrorConfig';
-export { PublicConfigMessaging } from './types/config/PublicConfigMessaging';
+export {
+  ChatCoreConfigMessaging,
+  ChatShellConfigMessaging,
+  PublicConfigMessaging,
+} from './types/config/PublicConfigMessaging';
 export { UploadConfig } from './types/config/UploadConfig';
 
 export {

--- a/packages/ai-chat/src/types/config/PublicConfig.ts
+++ b/packages/ai-chat/src/types/config/PublicConfig.ts
@@ -26,7 +26,11 @@ import { InputConfig } from './InputConfig';
 import { LanguagePack } from './LanguagePack';
 import { LayoutConfig } from './LayoutConfig';
 import { OnErrorData } from './ErrorConfig';
-import { PublicConfigMessaging } from './PublicConfigMessaging';
+import {
+  ChatCoreConfigMessaging,
+  ChatShellConfigMessaging,
+  PublicConfigMessaging,
+} from './PublicConfigMessaging';
 import { UploadConfig } from './UploadConfig';
 
 /**
@@ -63,17 +67,88 @@ export interface PublicConfigFeatureFlags {
 }
 
 /**
- * Configuration interface for Carbon AI Chat.
+ * The half of {@link PublicConfig} that configures the conversation itself: the transport, the
+ * identity a conversation is scoped to, lifecycle flags, and error and debug plumbing.
+ *
+ * Every field here applies whether or not the shipped UI is rendered, so this is the config a
+ * consumer composing their own interface supplies. The shipped React and web-component surfaces
+ * accept it as part of {@link PublicConfig} — they take this half and add
+ * {@link ChatShellConfig} on top.
  *
  * @category Config
  */
-export interface PublicConfig {
+export interface ChatCoreConfig {
   /**
    * This is a one-off listener for catastrophic errors. This is used instead of a normal event bus handler because this function can be
    * defined and called before the event bus has been created.
    */
   onError?: (data: OnErrorData) => void;
 
+  /**
+   * Add a bunch of noisy console.log messages!
+   */
+  debug?: boolean;
+
+  /**
+   * Expose internal serviceManager on ChatInstance for testing purposes.
+   * This should only be used in test environments.
+   *
+   * @internal
+   */
+  exposeServiceManagerForTesting?: boolean;
+
+  /**
+   * An optional namespace that can be added to the Carbon AI Chat that must be 30 characters or under. This value is
+   * intended to enable multiple instances of the Carbon AI Chat to be used on the same page. The namespace for this web
+   * chat. This value is used to generate a value to append to anything unique (id, session keys, etc) to allow
+   * multiple Carbon AI Chats on the same page.
+   *
+   * Note: this value is used in the aria region label for the Carbon AI Chat. This means this value will be read out loud
+   * by users using a screen reader.
+   */
+  namespace?: string;
+
+  /**
+   * Opt into behaviors slated to become the default in the next major release, following the
+   * feature-flag convention used across `@carbon/react`. See {@link PublicConfigFeatureFlags}.
+   * Enabling a flag here adopts a breaking change early to prepare for the upgrade.
+   */
+  featureFlags?: PublicConfigFeatureFlags;
+
+  /**
+   * Hands session-state persistence to the host page. By default the chat persists session state to
+   * the browser's `sessionStorage`; set this to boot from your own
+   * {@link PersistedStateConfig.initialState} and receive changes via
+   * {@link PersistedStateConfig.onStateChange} instead. See {@link PersistedStateConfig}.
+   */
+  persistedState?: PersistedStateConfig;
+
+  /**
+   * Config options for controlling messaging.
+   */
+  messaging?: ChatCoreConfigMessaging;
+
+  /**
+   * The locale to use for the widget. This controls regional formatting, such as how times and numbers are written
+   * and which plural rules apply to translated text. Example values include: 'en', 'en-us', 'fr', 'es'.
+   *
+   * This does not translate the interface. To render the chat in another language, supply the translated text
+   * through {@link PublicConfig.strings}.
+   */
+  locale?: string;
+}
+
+/**
+ * The half of {@link PublicConfig} that configures the shipped UI: the launcher, panels, header,
+ * composer, theming, and the copy rendered inside them.
+ *
+ * A consumer composing their own interface from `@carbon/ai-chat-components` renders none of these
+ * surfaces, so none of these fields apply to them. The shipped React and web-component surfaces
+ * layer this on top of {@link ChatCoreConfig}.
+ *
+ * @category Config
+ */
+export interface ChatShellConfig {
   /**
    * By default, the chat window will be rendered in a "closed" state.
    */
@@ -92,19 +167,6 @@ export interface PublicConfig {
    * value can be used to disable those enhancements while using a custom element.
    */
   disableCustomElementMobileEnhancements?: boolean;
-
-  /**
-   * Add a bunch of noisy console.log messages!
-   */
-  debug?: boolean;
-
-  /**
-   * Expose internal serviceManager on ChatInstance for testing purposes.
-   * This should only be used in test environments.
-   *
-   * @internal
-   */
-  exposeServiceManagerForTesting?: boolean;
 
   /**
    * Which Carbon theme tokens to inject. If unset (falsy), the chat inherits tokens from the host page.
@@ -144,24 +206,6 @@ export interface PublicConfig {
   shouldTakeFocusIfOpensAutomatically?: boolean;
 
   /**
-   * An optional namespace that can be added to the Carbon AI Chat that must be 30 characters or under. This value is
-   * intended to enable multiple instances of the Carbon AI Chat to be used on the same page. The namespace for this web
-   * chat. This value is used to generate a value to append to anything unique (id, session keys, etc) to allow
-   * multiple Carbon AI Chats on the same page.
-   *
-   * Note: this value is used in the aria region label for the Carbon AI Chat. This means this value will be read out loud
-   * by users using a screen reader.
-   */
-  namespace?: string;
-
-  /**
-   * Opt into behaviors slated to become the default in the next major release, following the
-   * feature-flag convention used across `@carbon/react`. See {@link PublicConfigFeatureFlags}.
-   * Enabling a flag here adopts a breaking change early to prepare for the upgrade.
-   */
-  featureFlags?: PublicConfigFeatureFlags;
-
-  /**
    * Indicates if Carbon AI Chat should sanitize HTML from the assistant.
    */
   shouldSanitizeHTML?: boolean;
@@ -177,14 +221,6 @@ export interface PublicConfig {
   history?: HistoryConfig;
 
   /**
-   * Hands session-state persistence to the host page. By default the chat persists session state to
-   * the browser's `sessionStorage`; set this to boot from your own
-   * {@link PersistedStateConfig.initialState} and receive changes via
-   * {@link PersistedStateConfig.onStateChange} instead. See {@link PersistedStateConfig}.
-   */
-  persistedState?: PersistedStateConfig;
-
-  /**
    * The config object for changing Carbon AI Chat's layout.
    */
   layout?: LayoutConfig;
@@ -192,7 +228,7 @@ export interface PublicConfig {
   /**
    * Config options for controlling messaging.
    */
-  messaging?: PublicConfigMessaging;
+  messaging?: ChatShellConfigMessaging;
 
   /**
    * Sets the chat into a read only mode for displaying old conversations.
@@ -218,15 +254,6 @@ export interface PublicConfig {
    * Sets the URL pointing to a custom avatar for the response author. This image should be a square. If not provided, the default Watsonx icon will be used.
    */
   assistantAvatarUrl?: string;
-
-  /**
-   * The locale to use for the widget. This controls regional formatting, such as how times and numbers are written
-   * and which plural rules apply to translated text. Example values include: 'en', 'en-us', 'fr', 'es'.
-   *
-   * This does not translate the interface. To render the chat in another language, supply the translated text
-   * through {@link PublicConfig.strings}.
-   */
-  locale?: string;
 
   /**
    * Configuration for the homescreen.
@@ -276,6 +303,27 @@ export interface PublicConfig {
    * @experimental
    */
   markdown?: PublicConfigMarkdown;
+}
+
+/**
+ * Configuration interface for Carbon AI Chat.
+ *
+ * Both halves of the config surface — {@link ChatCoreConfig} for the conversation and
+ * {@link ChatShellConfig} for the shipped UI — under the name the React `ChatContainer` and the
+ * `cds-aichat-*` web components accept. This type gains and loses nothing by being expressed as
+ * the union of the two.
+ *
+ * @category Config
+ */
+export interface PublicConfig extends ChatCoreConfig, ChatShellConfig {
+  /**
+   * Config options for controlling messaging.
+   *
+   * The `messaging` object is the one place the core/shell boundary runs through a nested config
+   * rather than between top-level fields, so it is restated here as the full
+   * {@link PublicConfigMessaging} that both halves compose to.
+   */
+  messaging?: PublicConfigMessaging;
 }
 
 /**

--- a/packages/ai-chat/src/types/config/PublicConfigMessaging.ts
+++ b/packages/ai-chat/src/types/config/PublicConfigMessaging.ts
@@ -13,11 +13,14 @@ import { MessageRequest } from '../messaging/Messages';
 import { HistoryItem } from '../messaging/History';
 
 /**
- * Config options for controlling messaging.
+ * The messaging options a headless consumer needs, surfaced on
+ * {@link ChatCoreConfig.messaging}. These configure the conversation itself — the transport
+ * callbacks, whether a conversation opens with a welcome request, and how long a request may run
+ * before the chat aborts it — so they apply whether or not the shipped UI is rendered.
  *
  * @category Config
  */
-export interface PublicConfigMessaging {
+export interface ChatCoreConfigMessaging {
   /**
    * Indicates if Carbon AI Chat should make a request for the welcome message when a new conversation begins. If this is
    * true, then Carbon AI Chat will start with an empty conversation.
@@ -35,14 +38,6 @@ export interface PublicConfigMessaging {
    * are called with in the window defined here, the chat will timeout (unless the value is set to 0).
    */
   messageTimeoutSecs?: number;
-
-  /**
-   * Controls how long AI chat should wait before showing the loading indicator. If set to 0, the chat will never show
-   * the loading indicator on its own. This is tied to either {@link ChatInstanceMessaging.addMessage} or
-   * {@link ChatInstanceMessaging.addMessageChunk} being called after this message was sent. If neither of those methods
-   * are called with in the window defined here, the loading indicator will be shown.
-   */
-  messageLoadingIndicatorTimeoutSecs?: number;
 
   /**
    * A callback for Carbon AI Chat to use to send messages to your assistant.
@@ -66,6 +61,24 @@ export interface PublicConfigMessaging {
    * If this function is mutated after it was initially called, the chat does not re-call it.
    */
   customLoadHistory?: (instance: ChatInstance) => Promise<HistoryItem[]>;
+}
+
+/**
+ * The messaging options that tune the shipped UI, surfaced on
+ * {@link ChatShellConfig.messaging}. Both control chrome a consumer who renders their own
+ * interface never draws — the built-in loading indicator and the built-in stop button — so
+ * neither has any effect without the shipped shell.
+ *
+ * @category Config
+ */
+export interface ChatShellConfigMessaging {
+  /**
+   * Controls how long AI chat should wait before showing the loading indicator. If set to 0, the chat will never show
+   * the loading indicator on its own. This is tied to either {@link ChatInstanceMessaging.addMessage} or
+   * {@link ChatInstanceMessaging.addMessageChunk} being called after this message was sent. If neither of those methods
+   * are called with in the window defined here, the loading indicator will be shown.
+   */
+  messageLoadingIndicatorTimeoutSecs?: number;
 
   /**
    * Controls when the stop streaming button becomes visible during message streaming.
@@ -86,3 +99,15 @@ export interface PublicConfigMessaging {
    */
   showStopButtonImmediately?: boolean;
 }
+
+/**
+ * Config options for controlling messaging.
+ *
+ * Both halves of the messaging surface, under the name the shipped React and web-component
+ * surfaces already accept. See {@link ChatCoreConfigMessaging} for the conversation options and
+ * {@link ChatShellConfigMessaging} for the ones that tune the shipped UI.
+ *
+ * @category Config
+ */
+export interface PublicConfigMessaging
+  extends ChatCoreConfigMessaging, ChatShellConfigMessaging {}

--- a/packages/ai-chat/tests/config/spec/configCoreShellSplit_spec.ts
+++ b/packages/ai-chat/tests/config/spec/configCoreShellSplit_spec.ts
@@ -1,0 +1,107 @@
+/*
+ *  Copyright IBM Corp. 2026
+ *
+ *  This source code is licensed under the Apache-2.0 license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ *  @license
+ */
+
+// This spec is intentionally focused on compile-time checks.
+// If any of the type assertions fail, ts-jest will surface a
+// compilation error and fail the test suite.
+//
+// `PublicConfig` is split into a core half a headless consumer supplies and a
+// shell half that configures the shipped UI. The split has to stay a pure
+// reorganization: `PublicConfig` keeps every field it had, at the type it had,
+// so existing consumers compile untouched.
+//
+// `_AssertTableCoversPublicConfig` in `src/web-components/shared/flattenedPublicConfig.ts`
+// already pins `keyof PublicConfig` against the flattened-prop table, so a field
+// dropped from or added to the top level breaks the build there. What it cannot
+// see is the nested `messaging` object — the one place the boundary runs through
+// a child config rather than between top-level fields — or whether the halves
+// stay projectable. Those are what this spec holds.
+
+import type {
+  ChatCoreConfig,
+  ChatShellConfig,
+  PublicConfig,
+} from '../../../src/types/config/PublicConfig';
+import type {
+  ChatCoreConfigMessaging,
+  ChatShellConfigMessaging,
+  PublicConfigMessaging,
+} from '../../../src/types/config/PublicConfigMessaging';
+
+// Utility types for compile-time assertions, matching `exports_compat_spec.ts`.
+type Equals<A, B> =
+  (<T>() => T extends A ? 1 : 2) extends <T>() => T extends B ? 1 : 2
+    ? true
+    : false;
+type AssertTrue<T extends true> = T;
+
+// 1) Every top-level field lands in exactly one half — no field is dropped, and
+//    none is declared on both. `messaging` is the sole deliberate exception: it
+//    is the nested config the boundary runs through, so both halves carry it.
+type SharedTopLevelKeys = Extract<keyof ChatCoreConfig, keyof ChatShellConfig>;
+type _OnlyMessagingIsShared = AssertTrue<
+  Equals<SharedTopLevelKeys, 'messaging'>
+>;
+
+type _HalvesCoverPublicConfig = AssertTrue<
+  Equals<keyof ChatCoreConfig | keyof ChatShellConfig, keyof PublicConfig>
+>;
+
+// 2) The same holds one level down, for the messaging halves.
+type _MessagingHalvesAreDisjoint = AssertTrue<
+  Equals<
+    Extract<keyof ChatCoreConfigMessaging, keyof ChatShellConfigMessaging>,
+    never
+  >
+>;
+
+type _MessagingHalvesRecompose = AssertTrue<
+  Equals<
+    keyof ChatCoreConfigMessaging | keyof ChatShellConfigMessaging,
+    keyof PublicConfigMessaging
+  >
+>;
+
+// 3) `PublicConfig.messaging` is still the full messaging type, not a half. This
+//    is what the `extends` clause alone would get wrong: without the explicit
+//    redeclaration on `PublicConfig`, TypeScript rejects the two halves as
+//    conflicting declarations of the same property (TS2320).
+type _PublicMessagingIsWhole = AssertTrue<
+  Equals<PublicConfig['messaging'], PublicConfigMessaging | undefined>
+>;
+
+// 4) A `PublicConfig` is usable as either half — the projection the shells will
+//    need to route the core subset down to `acquireChatSDK` while keeping the
+//    shell half for themselves (issue #1834). Kept type-level rather than an
+//    annotated value, so nothing here emits runtime code.
+type _CoreIsProjectable = AssertTrue<
+  PublicConfig extends ChatCoreConfig ? true : false
+>;
+type _ShellIsProjectable = AssertTrue<
+  PublicConfig extends ChatShellConfig ? true : false
+>;
+
+// Keep a minimal runtime test so Jest reports a passing spec when compilation succeeds.
+describe('PublicConfig core/shell split', () => {
+  it('compiles with the two halves recomposing to the original type', () => {
+    // A config literal mixing both halves — including a `messaging` object whose
+    // fields straddle the boundary — is what every existing consumer passes today.
+    const config: PublicConfig = {
+      namespace: 'core-side',
+      launcher: { isOn: true },
+      messaging: {
+        customSendMessage: () => Promise.resolve(),
+        showStopButtonImmediately: true,
+      },
+    };
+
+    expect(config.namespace).toBe('core-side');
+    expect(config.messaging?.showStopButtonImmediately).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #1830

Most of `PublicConfig` configures the shipped shell and does nothing for a consumer rendering their own interface. Split it in two. `PublicConfig` extends both halves, so every existing consumer compiles untouched.

Types only. `mergePublicConfig`, `createAppConfig`, and the dynamic-update path are unchanged.

Worth a careful read:

- [`src/types/config/PublicConfig.ts`](packages/ai-chat/src/types/config/PublicConfig.ts) — the split, plus the `messaging` redeclaration on `PublicConfig`. Without that line TypeScript rejects the two halves as conflicting declarations of the same property (TS2320). Both variants were tested.
- [`tests/config/spec/configCoreShellSplit_spec.ts`](packages/ai-chat/tests/config/spec/configCoreShellSplit_spec.ts) — compile-time only. Covers what the existing key-set guard cannot see.

#### Two classifications flipped

Both were tagged "confirm at PR" in the issue. Both came back the other way, and #1830 now records the evidence.

`history` is the history **panel** config, not conversation data. Its own doc says so, and all three fields are panel UI. Conversation-history loading is `messaging.customLoadHistory`, which stays core.

`isReadonly` does not gate `send()`. Nothing in `OutboundMessageCoordinator`, `MessageService`, or `ChatActionsImpl` reads it. It is the composer input baseline, and every reader is a view component.

The timer fields needed homes the issue had waived. All three are read from fenced core services, so "who reads it" does not separate them — the question is whether a headless consumer must configure it. `messageTimeoutSecs` fires the AbortSignal handed to the host's own `customSendMessage`, so it is core. `messageLoadingIndicatorTimeoutSecs` and `showStopButtonImmediately` time chrome a headless consumer never draws, so they are shell.

#### Changelog

**New**

- `ChatCoreConfig` — transport, identity, lifecycle flags, error and debug plumbing. 8 fields.
- `ChatShellConfig` — launcher, panels, header, composer, theming, copy. 25 fields.
- `ChatCoreConfigMessaging` and `ChatShellConfigMessaging`. `messaging` is the one place the boundary runs through a nested config, so both halves declare it.
- A compile-time spec pinning the messaging halves and the projection to each half.

**Changed**

- `PublicConfig` is now `ChatCoreConfig & ChatShellConfig` under its existing name. No field gained or lost.
- `PublicConfigMessaging` composes from the two messaging halves. Same six fields.

#### Testing / Reviewing

Nothing runtime changed, so there is nothing to click in the demo. The gates are the verification.

```bash
npm run build --workspace=@carbon/ai-chat
npm run test --workspace=@carbon/ai-chat
```

Two guards do most of the work:

`_AssertTableCoversPublicConfig` in `flattenedPublicConfig.ts` holds `keyof PublicConfig` against the flattened-prop table. It already existed. A clean typecheck proves this split drops and adds nothing.

The new spec covers what that one cannot reach — the messaging halves being disjoint, recomposing to `PublicConfigMessaging`, and `PublicConfig` projecting to each half. To confirm it bites, add `launcher?: LauncherConfig;` to `ChatCoreConfig` and rerun. Expect TS2344 on `_OnlyMessagingIsShared`.

Then confirm a consumer still builds, since this is the most-imported public type:

```bash
npm run build --workspace=@carbon/ai-chat-examples-demo
```

Full suite: 114 suites / 1176 tests green. Build is 0 errors and 3 pre-existing warnings. TypeDoc renders all four new types under Config; `PublicConfig` still shows 31 of 32 fields, the absent one being `@internal` and stripped by design.
