### PR TITLE
chore: remove remaining 'Made with Bob' watermark comments

### DIFF
--- a/examples/react/workspace-sidebar/src/OutstandingOrdersCard.css
+++ b/examples/react/workspace-sidebar/src/OutstandingOrdersCard.css
@@ -50,5 +50,3 @@
   font-size: 0.875rem;
   font-style: italic;
 }
-
-/* Made with Bob */

--- a/examples/react/workspace-sidebar/src/OutstandingOrdersExample.css
+++ b/examples/react/workspace-sidebar/src/OutstandingOrdersExample.css
@@ -21,5 +21,3 @@
   color: #525252;
   margin-block-end: 1rem;
 }
-
-/* Made with Bob */

--- a/examples/react/workspace/src/OutstandingOrdersCard.css
+++ b/examples/react/workspace/src/OutstandingOrdersCard.css
@@ -50,5 +50,3 @@
   font-size: 0.875rem;
   font-style: italic;
 }
-
-/* Made with Bob */

--- a/examples/react/workspace/src/OutstandingOrdersExample.css
+++ b/examples/react/workspace/src/OutstandingOrdersExample.css
@@ -21,5 +21,3 @@
   color: #525252;
   margin-block-end: 1rem;
 }
-
-/* Made with Bob */

--- a/packages/ai-chat-components/src/components/audio-player/__stories__/audio-player-react.stories.css
+++ b/packages/ai-chat-components/src/components/audio-player/__stories__/audio-player-react.stories.css
@@ -24,5 +24,3 @@
   margin: 0 0 1rem 0;
   color: var(--cds-text-secondary);
 }
-
-/* Made with Bob */

--- a/packages/ai-chat-components/src/components/audio-player/__stories__/transcript-react.stories.css
+++ b/packages/ai-chat-components/src/components/audio-player/__stories__/transcript-react.stories.css
@@ -25,5 +25,3 @@
   flex-direction: column;
   gap: 1rem;
 }
-
-/* Made with Bob */

--- a/packages/ai-chat-components/src/components/video-player/__stories__/video-player-react.stories.css
+++ b/packages/ai-chat-components/src/components/video-player/__stories__/video-player-react.stories.css
@@ -19,5 +19,3 @@
   margin: 0;
   color: var(--cds-text-secondary);
 }
-
-/* Made with Bob */


### PR DESCRIPTION
## Summary

closes #1596 

Removes the last 7 `/* Made with Bob */` watermark comments left in source CSS files. The other 144 occurrences listed in the originating issue were already cleaned up in prior commits.

## Files changed

- `examples/react/workspace/src/OutstandingOrdersCard.css`
- `examples/react/workspace/src/OutstandingOrdersExample.css`
- `examples/react/workspace-sidebar/src/OutstandingOrdersCard.css`
- `examples/react/workspace-sidebar/src/OutstandingOrdersExample.css`
- `packages/ai-chat-components/src/components/audio-player/__stories__/audio-player-react.stories.css`
- `packages/ai-chat-components/src/components/audio-player/__stories__/transcript-react.stories.css`
- `packages/ai-chat-components/src/components/video-player/__stories__/video-player-react.stories.css`

## Acceptance criteria

- [x] `grep -rn "Made with Bob"` over the source tree returns zero matches
- [x] No blank-line / formatting drift (prettier run on all 7 files)
- [x] `npm run lint` and `npm run lint:styles` pass

## Stack

**PR 1 of 2** — PR 2 adds ESLint + Stylelint guards to prevent reintroduction and is stacked on top of this branch.