### PR TITLE
chore: add ESLint and Stylelint guards against watermark comments

### DIFF
--- a/examples/react/workspace-sidebar/src/OutstandingOrdersCard.css
+++ b/examples/react/workspace-sidebar/src/OutstandingOrdersCard.css
@@ -50,5 +50,3 @@
   font-size: 0.875rem;
   font-style: italic;
 }
-
-/* Made with Bob */

--- a/examples/react/workspace-sidebar/src/OutstandingOrdersExample.css
+++ b/examples/react/workspace-sidebar/src/OutstandingOrdersExample.css
@@ -21,5 +21,3 @@
   color: #525252;
   margin-block-end: 1rem;
 }
-
-/* Made with Bob */

--- a/examples/react/workspace/src/OutstandingOrdersCard.css
+++ b/examples/react/workspace/src/OutstandingOrdersCard.css
@@ -50,5 +50,3 @@
   font-size: 0.875rem;
   font-style: italic;
 }
-
-/* Made with Bob */

--- a/examples/react/workspace/src/OutstandingOrdersExample.css
+++ b/examples/react/workspace/src/OutstandingOrdersExample.css
@@ -21,5 +21,3 @@
   color: #525252;
   margin-block-end: 1rem;
 }
-
-/* Made with Bob */

--- a/package.json
+++ b/package.json
@@ -154,6 +154,15 @@
       }
     ],
     "rules": {
+      "no-warning-comments": [
+        "error",
+        {
+          "terms": [
+            "Made with Bob"
+          ],
+          "location": "anywhere"
+        }
+      ],
       "jsdoc/check-tag-names": [
         "error",
         {
@@ -232,6 +241,15 @@
           "ignoreTypes": [
             "/^cds-/"
           ]
+        }
+      ],
+      "comment-word-disallowed-list": [
+        [
+          "Made with Bob"
+        ],
+        {
+          "message": "Remove tool-generated watermark comments ('Made with Bob')",
+          "severity": "error"
         }
       ]
     }

--- a/packages/ai-chat-components/src/components/audio-player/__stories__/audio-player-react.stories.css
+++ b/packages/ai-chat-components/src/components/audio-player/__stories__/audio-player-react.stories.css
@@ -24,5 +24,3 @@
   margin: 0 0 1rem 0;
   color: var(--cds-text-secondary);
 }
-
-/* Made with Bob */

--- a/packages/ai-chat-components/src/components/audio-player/__stories__/transcript-react.stories.css
+++ b/packages/ai-chat-components/src/components/audio-player/__stories__/transcript-react.stories.css
@@ -25,5 +25,3 @@
   flex-direction: column;
   gap: 1rem;
 }
-
-/* Made with Bob */

--- a/packages/ai-chat-components/src/components/video-player/__stories__/video-player-react.stories.css
+++ b/packages/ai-chat-components/src/components/video-player/__stories__/video-player-react.stories.css
@@ -19,5 +19,3 @@
   margin: 0;
   color: var(--cds-text-secondary);
 }
-
-/* Made with Bob */


### PR DESCRIPTION
## Summary

Adds linter rules to prevent `Made with Bob` watermark comments from being reintroduced.

## Changes

**ESLint** (`eslintConfig.rules` in `package.json`)
- `no-warning-comments` → `error` for the term `"Made with Bob"` (location: anywhere)
- Covers all `.ts`, `.tsx`, `.js` files under `npm run lint`

**Stylelint** (`stylelint.rules` in `package.json`)
- `comment-word-disallowed-list` → `error` for `"Made with Bob"`
- Covers all `.scss` files under `npm run lint:styles`

## Acceptance criteria

- [x] `npm run lint` passes (0 errors)
- [x] `npm run lint:styles` passes (0 errors)
- [x] Any future reintroduction of the watermark fails CI

