### PR TITLE
fix: remove needsAnnouncement prop from Image component

### DIFF
--- a/packages/ai-chat/src/chat/components-legacy/MessageTypeComponent.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/MessageTypeComponent.tsx
@@ -457,7 +457,6 @@ function MessageTypeComponent(props: MessageTypeComponentProps) {
         title={message.item.title}
         description={message.item.description}
         altText={message.item.alt_text}
-        needsAnnouncement={message.ui_state.needsAnnouncement}
         useAITheme={aiEnabled}
       />
     );

--- a/packages/ai-chat/src/chat/components-legacy/responseTypes/image/Image.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/responseTypes/image/Image.tsx
@@ -14,13 +14,12 @@ import SkeletonPlaceholder from '../../../components/carbon/SkeletonPlaceholder'
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 
 import { HasClassName } from '../../../../types/utilities/HasClassName';
-import { HasNeedsAnnouncement } from '../../../../types/utilities/HasNeedsAnnouncement';
 import { getURLHostName } from '../../../utils/browserUtils';
 import { RESPONSE_TYPE_TIMEOUT_MS } from '../../../utils/constants';
 import InlineError from '../../../components/util/InlineError';
 import { TextBlock } from '../../../components/util/TextBlock/TextBlock';
 
-interface ImageProps extends HasNeedsAnnouncement, HasClassName {
+interface ImageProps extends HasClassName {
   source: string;
   title?: string;
   description?: string;


### PR DESCRIPTION
Closes #1912 

Passed inside of `MessageTypeComponent.tsx` but never read inside `Image` or `ImageOnly`. Removes the prop from the interface and the call site. `HasNeedsAnnouncement`, `ui_state.needsAnnouncement`, and all other readers are untouched.

#### Changelog

**Removed**

- `needsAnnouncement` prop from the `Image` component — it was never consumed.

#### Testing / Reviewing

1. Passes all ci checks and tests
2. Nothing else breaks from this change
3. Start the demo and send an image-type message; announcements on new messages still fire normally.