### PR TITLE
feat: graduate audio, video, history, carousel and feedback components

### DIFF
--- a/packages/ai-chat-components/src/components/audio-player/__stories__/audio-player-react.stories.jsx
+++ b/packages/ai-chat-components/src/components/audio-player/__stories__/audio-player-react.stories.jsx
@@ -18,7 +18,7 @@ const WITH_TRANSCRIPT_SOURCE_CHROMATIC_DATA_URI =
   'data:audio/wav;base64,UklGRiUAAABXQVZFZm10IBAAAAABAAEAQB8AAEAfAAABAAgAZGF0YQEAAACA';
 
 export default {
-  title: 'Preview/Audio player',
+  title: 'Components/Audio player',
   component: AudioPlayer,
   args: {
     source:

--- a/packages/ai-chat-components/src/components/audio-player/__stories__/audio-player.stories.js
+++ b/packages/ai-chat-components/src/components/audio-player/__stories__/audio-player.stories.js
@@ -16,7 +16,7 @@ const WITH_TRANSCRIPT_SOURCE_CHROMATIC_DATA_URI =
   'data:audio/wav;base64,UklGRiUAAABXQVZFZm10IBAAAAABAAEAQB8AAEAfAAABAAgAZGF0YQEAAACA';
 
 export default {
-  title: 'Preview/Audio player',
+  title: 'Components/Audio player',
   args: {
     source:
       'https://soundcloud.com/ibmthinkleaders/leveraging-ai-to-tackle-large-problems-being-an-optimistic-futurist-feat-kate-oneill',

--- a/packages/ai-chat-components/src/components/audio-player/__stories__/transcript-react.stories.jsx
+++ b/packages/ai-chat-components/src/components/audio-player/__stories__/transcript-react.stories.jsx
@@ -18,7 +18,7 @@ const WITH_TRANSCRIPT_SOURCE_CHROMATIC_DATA_URI =
   'data:audio/wav;base64,UklGRiUAAABXQVZFZm10IBAAAAABAAEAQB8AAEAfAAABAAgAZGF0YQEAAACA';
 
 export default {
-  title: 'Preview/Audio player/Transcript',
+  title: 'Components/Audio player/Transcript',
   component: Transcript,
   args: {
     text: 'My text input is, you know, I am a teapot and then my image input is a picture of David Hasselhoff.',

--- a/packages/ai-chat-components/src/components/audio-player/__stories__/transcript.stories.js
+++ b/packages/ai-chat-components/src/components/audio-player/__stories__/transcript.stories.js
@@ -15,7 +15,7 @@ const WITH_TRANSCRIPT_SOURCE_CHROMATIC_DATA_URI =
   'data:audio/wav;base64,UklGRiUAAABXQVZFZm10IBAAAAABAAEAQB8AAEAfAAABAAgAZGF0YQEAAACA';
 
 export default {
-  title: 'Preview/Audio player/Transcript',
+  title: 'Components/Audio player/Transcript',
   args: {
     text: 'My text input is, you know, I am a teapot and then my image input is a picture of David Hasselhoff.',
     label: 'English Transcript',

--- a/packages/ai-chat-components/src/components/carousel/__stories__/carousel-react.stories.jsx
+++ b/packages/ai-chat-components/src/components/carousel/__stories__/carousel-react.stories.jsx
@@ -8,10 +8,10 @@
  */
 
 /* eslint-disable */
-import React from "react";
-import { Carousel } from "../../../react/carousel";
-import { Card } from "../../../react/card";
-import "./story-styles.scss";
+import React from 'react';
+import { Carousel } from '../../../react/carousel';
+import { Card } from '../../../react/card';
+import './story-styles.scss';
 
 const cards = Array(8)
   .fill(null)
@@ -19,15 +19,15 @@ const cards = Array(8)
 
 const argTypes = {
   nextBtnText: {
-    control: "text",
-    description: "Text for the next button",
+    control: 'text',
+    description: 'Text for the next button',
   },
   previousBtnText: {
-    control: "text",
-    description: "Text for the previous button",
+    control: 'text',
+    description: 'Text for the previous button',
   },
   onChange: {
-    action: "cds-aichat-carousel-onchange",
+    action: 'cds-aichat-carousel-onchange',
     table: {
       disable: true,
     },
@@ -35,7 +35,7 @@ const argTypes = {
 };
 
 export default {
-  title: "Preview/Carousel",
+  title: 'Components/Carousel',
   argTypes,
   render: (args) => (
     <Carousel {...args}>
@@ -54,7 +54,7 @@ export default {
 
 export const Default = {
   args: {
-    nextBtnText: "Next",
-    previousBtnText: "Previous",
+    nextBtnText: 'Next',
+    previousBtnText: 'Previous',
   },
 };

--- a/packages/ai-chat-components/src/components/carousel/__stories__/carousel.stories.js
+++ b/packages/ai-chat-components/src/components/carousel/__stories__/carousel.stories.js
@@ -35,7 +35,7 @@ const argTypes = {
 };
 
 export default {
-  title: 'Preview/Carousel',
+  title: 'Components/Carousel',
   argTypes,
   decorators: [
     (story) => html`

--- a/packages/ai-chat-components/src/components/chat-history/__stories__/chat-history-react.stories.jsx
+++ b/packages/ai-chat-components/src/components/chat-history/__stories__/chat-history-react.stories.jsx
@@ -35,7 +35,7 @@ import { focusElementAfterRepaint } from '../../../globals/utils/focus-utils';
 import { PinFilled, Search, Time } from '@carbon/icons-react';
 
 export default {
-  title: 'Preview/Chat History',
+  title: 'Components/Chat history',
   component: HistoryShell,
   decorators: [
     (Story) => (

--- a/packages/ai-chat-components/src/components/chat-history/__stories__/chat-history.stories.js
+++ b/packages/ai-chat-components/src/components/chat-history/__stories__/chat-history.stories.js
@@ -521,7 +521,7 @@ if (!customElements.get('cds-aichat-history-demo')) {
 }
 
 export default {
-  title: 'Preview/Chat History',
+  title: 'Components/Chat history',
   component: 'cds-aichat-history-shell',
   decorators: [
     (story) => html`

--- a/packages/ai-chat-components/src/components/feedback/__stories__/feedback-buttons-react.stories.jsx
+++ b/packages/ai-chat-components/src/components/feedback/__stories__/feedback-buttons-react.stories.jsx
@@ -14,7 +14,7 @@ import Feedback from '../../../react/feedback';
 import FeedbackButtons from '../../../react/feedback-buttons';
 
 export default {
-  title: 'Preview/Feedback/Buttons',
+  title: 'Components/Feedback/Buttons',
   argTypes: {
     isPositiveSelected: {
       control: 'boolean',

--- a/packages/ai-chat-components/src/components/feedback/__stories__/feedback-buttons.stories.js
+++ b/packages/ai-chat-components/src/components/feedback/__stories__/feedback-buttons.stories.js
@@ -259,7 +259,7 @@ if (
 }
 
 export default {
-  title: 'Preview/Feedback/Buttons',
+  title: 'Components/Feedback/Buttons',
   component: 'cds-aichat-feedback-buttons',
   argTypes: {
     isPositiveSelected: {

--- a/packages/ai-chat-components/src/components/feedback/__stories__/feedback-react.stories.jsx
+++ b/packages/ai-chat-components/src/components/feedback/__stories__/feedback-react.stories.jsx
@@ -30,7 +30,7 @@ const positiveCategories = [
 ];
 
 export default {
-  title: 'Preview/Feedback',
+  title: 'Components/Feedback',
   argTypes: {
     isOpen: {
       control: 'boolean',

--- a/packages/ai-chat-components/src/components/feedback/__stories__/feedback.stories.js
+++ b/packages/ai-chat-components/src/components/feedback/__stories__/feedback.stories.js
@@ -28,7 +28,7 @@ const positiveCategories = [
 ];
 
 export default {
-  title: 'Preview/Feedback',
+  title: 'Components/Feedback',
   component: 'cds-aichat-feedback',
   argTypes: {
     isOpen: {

--- a/packages/ai-chat-components/src/components/video-player/__stories__/video-player-react.stories.jsx
+++ b/packages/ai-chat-components/src/components/video-player/__stories__/video-player-react.stories.jsx
@@ -13,7 +13,7 @@ import Card from '../../../react/card';
 import './video-player-react.stories.css';
 
 export default {
-  title: 'Preview/Video player',
+  title: 'Components/Video player',
   component: VideoPlayer,
   args: {
     source: 'https://www.youtube.com/watch?v=eZ1NizUx9U4',

--- a/packages/ai-chat-components/src/components/video-player/__stories__/video-player.stories.js
+++ b/packages/ai-chat-components/src/components/video-player/__stories__/video-player.stories.js
@@ -12,7 +12,7 @@ import '../../card/index.js';
 import { html } from 'lit';
 
 export default {
-  title: 'Preview/Video player',
+  title: 'Components/Video player',
   args: {
     source: 'https://www.youtube.com/watch?v=eZ1NizUx9U4',
     title: 'Sample Video Title',


### PR DESCRIPTION
Just updating the storybooks for audio, video, history, carousel and feedback to be in Components instead of Preview. Chat Shell and Prompt line remain in Preview. 