### PR TITLE
fix(markdown): render the newest tree when leaving table loading mode

### DIFF
--- a/packages/ai-chat-components/src/components/markdown/__tests__/markdown.test.ts
+++ b/packages/ai-chat-components/src/components/markdown/__tests__/markdown.test.ts
@@ -1964,3 +1964,68 @@ describe('cds-aichat-markdown thematic break (hr) rendering', () => {
     ).to.equal('contents');
   });
 });
+
+describe('streaming table loading mode', () => {
+  const TABLE = `| h1 | h2 |\n| --- | --- |\n| a | b |`;
+
+  it('renders the newest content on the tick that leaves loading mode', async () => {
+    // While a trailing table is streaming the element stages each tree instead of
+    // rendering it. On the tick that leaves loading mode it must render the tree it
+    // just parsed — rendering the staged one instead dropped the final chunk, which
+    // stuck permanently when that tick was the last.
+    const el = await fixture<MarkdownElementInstance>(
+      html`<cds-aichat-markdown
+        streaming
+        .markdown=${TABLE}></cds-aichat-markdown>`
+    );
+    await el.updateComplete;
+
+    el.markdown = `${TABLE}\n| c | d |`;
+    await el.updateComplete;
+
+    el.markdown = `${TABLE}\n| c | d |\n\nAfter the table.`;
+    await el.updateComplete;
+
+    // Table cell text lives in the table element's own shadow root, so assert on the
+    // trailing paragraph — it only exists in the tree parsed on this tick.
+    expect(el.shadowRoot?.textContent ?? '').to.contain('After the table.');
+    expect(el.shadowRoot?.querySelector('cds-aichat-table')).to.not.equal(null);
+  });
+
+  it('renders the staged tree when streaming stops without a reparse', async () => {
+    // Leaving loading mode by dropping `streaming` does not reparse, so this tick
+    // renders whatever `previousTreeForDiff` seeds from — the staged tree. It is the
+    // only path that reads `stagedStreamingTokenTree`, so it is what stops that field
+    // from looking like dead state, and it is where a dropped final row would show up.
+    const calls: Array<{ isLoading: boolean; rowCount: number }> = [];
+    const el = await fixture<MarkdownElementInstance>(
+      html`<cds-aichat-markdown
+        streaming
+        .customRenderers=${{
+          table: ({
+            isLoading,
+            rows,
+          }: {
+            isLoading: boolean;
+            rows: unknown[][];
+          }) => {
+            calls.push({ isLoading, rowCount: rows.length });
+            return document.createElement('div');
+          },
+        }}
+        .markdown=${TABLE}></cds-aichat-markdown>`
+    );
+    await el.updateComplete;
+    expect(calls.at(-1)?.isLoading).to.equal(true);
+
+    // Staged, not rendered — the element is holding the table in its loading frame.
+    el.markdown = `${TABLE}\n| c | d |`;
+    await el.updateComplete;
+
+    el.streaming = false;
+    await el.updateComplete;
+
+    expect(calls.at(-1)?.isLoading).to.equal(false);
+    expect(calls.at(-1)?.rowCount).to.equal(2);
+  });
+});

--- a/packages/ai-chat-components/src/components/markdown/src/markdown.ts
+++ b/packages/ai-chat-components/src/components/markdown/src/markdown.ts
@@ -305,7 +305,15 @@ class CDSAIChatMarkdown extends LitElement {
    * @internal
    */
   private stagedStreamingTokenTree: TokenTree | null = null;
+
+  /**
+   * @internal
+   */
   private isStreamingTableLoadingMode = false;
+
+  /**
+   * @internal
+   */
   private hasConnected = false;
 
   /**

--- a/packages/ai-chat-components/src/components/markdown/src/markdown.ts
+++ b/packages/ai-chat-components/src/components/markdown/src/markdown.ts
@@ -298,6 +298,12 @@ class CDSAIChatMarkdown extends LitElement {
   private renderTask: Promise<void> | null = null;
 
   private hasRenderedStreamingTableLoadingFrame = false;
+  /**
+   * The most recent tree parsed while in streaming table loading mode, held back
+   * from rendering. It seeds `previousTreeForDiff`, so the tick that leaves loading
+   * mode without a reparse still renders the content staged during it.
+   * @internal
+   */
   private stagedStreamingTokenTree: TokenTree | null = null;
   private isStreamingTableLoadingMode = false;
   private hasConnected = false;
@@ -652,16 +658,18 @@ class CDSAIChatMarkdown extends LitElement {
         return;
       }
 
-      const renderTree = this.stagedStreamingTokenTree ?? nextTokenTree;
+      // Never prefer the staged tree here: when nothing was reparsed `nextTokenTree`
+      // *is* the staged tree (see `previousTreeForDiff` above), and when something
+      // was, it came from newer source.
       this.stagedStreamingTokenTree = null;
       this.hasRenderedStreamingTableLoadingFrame = false;
-      if (renderTree !== this.tokenTree) {
-        this.tokenTree = renderTree;
+      if (nextTokenTree !== this.tokenTree) {
+        this.tokenTree = nextTokenTree;
       }
 
       // Next we take that tree and transform it into Lit content to be rendered into the template.
       // this.renderedContent is what is rendered in the template directly.
-      renderAndDispatch(renderTree);
+      renderAndDispatch(nextTokenTree);
     } catch (error) {
       console.error(`${CONSOLE_PREFIX} Failed to parse markdown`, error);
     }

--- a/packages/ai-chat/src/types/utilities/inputUtils.ts
+++ b/packages/ai-chat/src/types/utilities/inputUtils.ts
@@ -52,6 +52,7 @@ import type {
  * `cds-aichat-trigger-change` dispatch. Pass distinct `name` values when
  * composing multiple instances.
  *
+ * @function
  * @category Utilities
  */
 export const carbonMention = _carbonMention;
@@ -62,6 +63,7 @@ export const carbonMention = _carbonMention;
  * (`"command"` vs `"mention"`), the dispatched trigger type, and the default
  * chip color.
  *
+ * @function
  * @category Utilities
  */
 export const carbonCommand = _carbonCommand;
@@ -72,6 +74,7 @@ export const carbonCommand = _carbonCommand;
  * rather than a schema node. Activates whenever the input has any non-empty
  * trailing word.
  *
+ * @function
  * @category Utilities
  */
 export const carbonAutocomplete = _carbonAutocomplete;
@@ -83,6 +86,7 @@ export const carbonAutocomplete = _carbonAutocomplete;
  * `extension.storage.items` so the host can swap the list without
  * recreating the editor.
  *
+ * @function
  * @category Utilities
  */
 export const carbonStarterTrigger = _carbonStarterTrigger;
@@ -93,6 +97,7 @@ export const carbonStarterTrigger = _carbonStarterTrigger;
  * contains exactly the extensions whose backing config was supplied. Use
  * directly when mounting `<cds-aichat-prompt-line>` outside the chat shell.
  *
+ * @function
  * @category Utilities
  */
 export const buildCarbonExtensions = _buildCarbonExtensions;
@@ -107,6 +112,7 @@ export const buildCarbonExtensions = _buildCarbonExtensions;
  * emission for the round-trip. Use when dispatching transactions via
  * `(await getEditor()).view.dispatch(tr)` to opt out of the change loop.
  *
+ * @function
  * @category Utilities
  */
 export const setHostOriginMeta = _setHostOriginMeta;
@@ -115,6 +121,7 @@ export const setHostOriginMeta = _setHostOriginMeta;
  * Return a new Tiptap `JSONContent` tree with every node whose `type` matches
  * one of `types` removed. Marks on text nodes are preserved.
  *
+ * @function
  * @category Utilities
  */
 export const removeNodesByType = _removeNodesByType;
@@ -125,6 +132,7 @@ export const removeNodesByType = _removeNodesByType;
  * replaces it. The walk is post-order — children are visited before their
  * parents.
  *
+ * @function
  * @category Utilities
  */
 export const mapNodes = _mapNodes;
@@ -133,6 +141,7 @@ export const mapNodes = _mapNodes;
  * Collect every node in a Tiptap `JSONContent` tree whose `type` matches
  * `type`. Returns a flat array in document order.
  *
+ * @function
  * @category Utilities
  */
 export const findNodesByType = _findNodesByType;
@@ -143,6 +152,7 @@ export const findNodesByType = _findNodesByType;
  * nodes contribute `attrs.value || attrs.label`, paragraph boundaries
  * become `"\n"`, and `hardBreak` nodes contribute `"\n"`.
  *
+ * @function
  * @category Utilities
  */
 export const getRawText = _getRawText;
@@ -155,6 +165,7 @@ export const getRawText = _getRawText;
  * {@link ChatInstanceInput.updateContent}:
  * `updateContent((prev) => textToDoc(updater(getRawText(prev))))`.
  *
+ * @function
  * @category Utilities
  */
 export const textToDoc = _textToDoc;
@@ -170,6 +181,7 @@ export const textToDoc = _textToDoc;
  * {@link renderInLightDom} when the renderer returns custom content. Shared
  * so editor chips and bubble chips render identically.
  *
+ * @function
  * @category Utilities
  */
 export const renderTokenChip = _renderTokenChip;
@@ -183,6 +195,7 @@ export const renderTokenChip = _renderTokenChip;
  * back into position via a `<slot>`. `renderTokenChip` is a token-specific
  * wrapper over this primitive.
  *
+ * @function
  * @category Utilities
  */
 export const renderInLightDom = _renderInLightDom;


### PR DESCRIPTION
Closes #2066

Streamed markdown tables could render a chunk behind. While a trailing table streams, each pass stashes the parsed tree instead of rendering it. The pass that left loading mode then preferred that stash. It ignored the tree it had just parsed. The next chunk usually repaired it. When the exiting pass was the last one, the element stayed stale, possibly leaving a table stuck in a streaming state.

- `packages/ai-chat-components/src/components/markdown/src/markdown.ts` — one line in `renderMarkdown`. Invariant worth checking: `nextTokenTree` is never staler than the staged tree. `previousTreeForDiff` seeds from the staged tree whenever nothing reparsed.

#### Changelog

**Changed**

- Markdown renders the newest parsed tree when a streaming table leaves loading mode.
- Input utility re-exports reflect as functions in TypeDoc, so `{@link}` references to them resolve instead of degrading to plain text.

#### Testing / Reviewing

Not reachable from the demo as shipped. `table (stream)` puts the table last. That exits loading mode via `streaming = false`, a path that was already correct. Hitting the bug needs content *after* the table.

Run the suite:

```bash
cd packages/ai-chat-components
npx web-test-runner "src/components/markdown/**/*.test.ts" --node-resolve
```

Each new test pins a different invariant. To confirm both are meaningful, break one at a time on this branch:

- Restore `const renderTree = this.stagedStreamingTokenTree ?? nextTokenTree` → "renders the newest content on the tick that leaves loading mode" fails.
- Drop `stagedStreamingTokenTree ??` from `previousTreeForDiff` → "renders the staged tree when streaming stops without a reparse" fails with `expected 1 to equal 2`, the dropped-row symptom.

Manual check in the demo. `MARKDOWN` in `demo/src/customSendMessage/constants.ts` has no table, so paste one into the middle of it — a table with prose after it is the shape that trips the bug. Then run the demo and send `text (stream)`.

```md
| h1 | h2 |
| --- | --- |
| a | b |
| c | d |
```

Watch the final row. On `main` the table settles one chunk behind and drops it. Revert the demo edit afterwards.

TypeDoc half is unverified end to end — the tag choice is confirmed against typedoc's `shouldAutomaticallyConvertAsFunction`, but nothing here renders the docs. CI covers it.
