### PR TITLE
feat(markdown): settle the markdown extensibility contract

### DIFF
--- a/packages/ai-chat-components/src/components/markdown/__tests__/markdown.test.ts
+++ b/packages/ai-chat-components/src/components/markdown/__tests__/markdown.test.ts
@@ -1320,6 +1320,68 @@ HTTP: http://example.com
       ).to.not.equal(null);
     });
 
+    it('does not pass the internal token tree to any callback', async () => {
+      // `node` was a `TokenTree` escape hatch on all five arg types. TokenTree is
+      // the streaming-diff structure and is not a consumer contract, so it must
+      // stay out of the payload — nothing else would catch it being re-added.
+      const source = [
+        '| h1 | h2 |',
+        '| --- | --- |',
+        '| a | b |',
+        '',
+        '```ts',
+        'const x = 1;',
+        '```',
+        '',
+        '[label](https://example.com "link title")',
+        '',
+        '![alt text](https://example.com/i.png "image title")',
+        '',
+        '- [ ] Task',
+      ].join('\n');
+      const keysByKind: Record<string, string[]> = {};
+      const capture =
+        (kind: string) =>
+        (args: Record<string, unknown>): null => {
+          keysByKind[kind] = Object.keys(args);
+          return null;
+        };
+
+      const el = await fixture<MarkdownElementInstance>(
+        html`<cds-aichat-markdown
+          .customRenderers=${{
+            table: capture('table'),
+            codeBlock: capture('codeBlock'),
+            link: capture('link'),
+            image: capture('image'),
+            checklist: {
+              onToggle: () => {},
+              getChecked: capture('checklistItem'),
+            },
+          }}
+          .markdown=${source}></cds-aichat-markdown>`
+      );
+      await el.updateComplete;
+
+      expect(Object.keys(keysByKind).sort()).to.deep.equal([
+        'checklistItem',
+        'codeBlock',
+        'image',
+        'link',
+        'table',
+      ]);
+      for (const [kind, keys] of Object.entries(keysByKind)) {
+        expect(
+          keys,
+          `${kind} args should not carry the token tree`
+        ).to.not.include('node');
+        expect(
+          keys,
+          `${kind} args should still carry the markdown-it token`
+        ).to.include('token');
+      }
+    });
+
     it('re-invokes the callback after each render', async () => {
       const calls: string[] = [];
       const el = await fixture<MarkdownElementInstance>(

--- a/packages/ai-chat-components/src/components/markdown/index.ts
+++ b/packages/ai-chat-components/src/components/markdown/index.ts
@@ -23,5 +23,5 @@ export type {
   MarkdownRendererTableArgs,
   MarkdownRendererTableData,
 } from './src/markdown-renderer-types.js';
-export type { MarkdownItPlugin, TokenTree } from './src/markdown-token-tree.js';
+export type { MarkdownItPlugin } from './src/markdown-token-tree.js';
 export { markdownToMarkdownItTokens } from './src/markdown-token-tree.js';

--- a/packages/ai-chat-components/src/components/markdown/src/markdown-renderer-types.ts
+++ b/packages/ai-chat-components/src/components/markdown/src/markdown-renderer-types.ts
@@ -66,8 +66,6 @@ export interface MarkdownRendererTableArgs extends MarkdownRendererTableData {
    * the `markdown-it` `Token` documentation for the field shape.
    */
   token: Readonly<Token>;
-  /** The full token-tree node, including descendants. */
-  node: Readonly<TokenTree>;
   /**
    * Stable slot identifier for this rendered element. The same name is
    * reused across renders while the underlying source line stays put — useful
@@ -87,8 +85,6 @@ export interface MarkdownRendererCodeBlockArgs extends MarkdownRendererCodeBlock
    * `markdown-it` `Token` documentation for the field shape.
    */
   token: Readonly<Token>;
-  /** The full token-tree node. */
-  node: Readonly<TokenTree>;
   /**
    * Stable slot identifier for this rendered element. The same name is
    * reused across renders while the underlying source line stays put — useful
@@ -120,8 +116,6 @@ export interface MarkdownRendererLinkArgs {
   attributes: Record<string, string>;
   /** The markdown-it `link_open` `Token`. */
   token: Readonly<Token>;
-  /** The full token-tree node, including descendants. */
-  node: Readonly<TokenTree>;
 }
 
 /**
@@ -170,8 +164,6 @@ export interface MarkdownRendererImageArgs {
   attributes: Record<string, string>;
   /** The markdown-it `image` `Token`. */
   token: Readonly<Token>;
-  /** The full token-tree node. */
-  node: Readonly<TokenTree>;
 }
 
 /**
@@ -210,16 +202,14 @@ export interface MarkdownRendererChecklistItemArgs {
   checked: boolean;
   /** The markdown-it checkbox `Token`. */
   token: Readonly<Token>;
-  /** The full token-tree node. */
-  node: Readonly<TokenTree>;
 }
 
 /**
  * Payload passed to {@link MarkdownRendererChecklist.onToggle} when a user
  * toggles a task-list checkbox. Carries the item identity and the new state.
- * The markdown-it token/node are intentionally omitted — they are not
- * available at DOM-event time; use {@link MarkdownRendererChecklistItemArgs}
- * (via `getChecked`) when you need them.
+ * The markdown-it token is intentionally omitted — it is not available at
+ * DOM-event time; use {@link MarkdownRendererChecklistItemArgs} (via
+ * `getChecked`) when you need it.
  *
  * @category Messaging
  */
@@ -306,21 +296,18 @@ export type MarkdownRendererSlotDescriptor =
       slotName: string;
       kind: 'table';
       token: Readonly<Token>;
-      node: Readonly<TokenTree>;
       data: MarkdownRendererTableData;
     }
   | {
       slotName: string;
       kind: 'codeBlock';
       token: Readonly<Token>;
-      node: Readonly<TokenTree>;
       data: MarkdownRendererCodeBlockData;
     }
   | {
       slotName: string;
       kind: 'pluginFallback';
       token: Readonly<Token>;
-      node: Readonly<TokenTree>;
       /**
        * Sanitized HTML produced by the user plugin's renderer rule. The
        * markdown element assigns this to a light-DOM slot host's `innerHTML`

--- a/packages/ai-chat-components/src/components/markdown/src/markdown-renderer.ts
+++ b/packages/ai-chat-components/src/components/markdown/src/markdown-renderer.ts
@@ -296,7 +296,6 @@ export function renderTokenTree(
         slotName,
         kind: 'codeBlock',
         token: token as Token,
-        node,
         data: {
           language,
           code: token.content ?? '',
@@ -486,7 +485,6 @@ function renderWithStaticTag(
           label: extractText(node),
           checked: isChecked,
           token,
-          node,
         });
         if (typeof override === 'boolean') {
           isChecked = override;
@@ -570,7 +568,6 @@ function renderWithStaticTag(
           text: extractText(node),
           attributes: { ...attrs },
           token,
-          node,
         });
 
         if (result) {
@@ -618,7 +615,6 @@ function renderWithStaticTag(
           title: attrs.title,
           attributes: { ...attrs },
           token,
-          node,
         });
         if (result) {
           imgAttrs = { ...attrs, ...(result.attributes ?? {}) };

--- a/packages/ai-chat-components/src/components/markdown/src/markdown-token-tree.ts
+++ b/packages/ai-chat-components/src/components/markdown/src/markdown-token-tree.ts
@@ -82,8 +82,6 @@ export const PLUGIN_DELEGABLE_TOKEN_TYPES: ReadonlySet<string> = new Set([
  * A markdown-it plugin reference. Either a bare plugin function or a
  * `[plugin, options]` / `[plugin, ...params]` tuple matching
  * `MarkdownIt.use(...)`.
- *
- * @experimental
  */
 export type MarkdownItPlugin =
   | MarkdownIt.PluginSimple

--- a/packages/ai-chat-components/src/components/markdown/src/markdown.ts
+++ b/packages/ai-chat-components/src/components/markdown/src/markdown.ts
@@ -852,7 +852,6 @@ class CDSAIChatMarkdown extends LitElement {
         )({
           ...descriptor.data,
           token: descriptor.token,
-          node: descriptor.node,
           slotName: descriptor.slotName,
         });
       } catch (error) {

--- a/packages/ai-chat-components/src/components/markdown/src/utils/plugin-fallback.ts
+++ b/packages/ai-chat-components/src/components/markdown/src/utils/plugin-fallback.ts
@@ -227,7 +227,6 @@ export function renderFallback(
     slotName,
     kind: 'pluginFallback',
     token,
-    node,
     html: safe,
     isInline: token.block === false,
   });

--- a/packages/ai-chat-components/src/components/markdown/src/utils/table-helpers.ts
+++ b/packages/ai-chat-components/src/components/markdown/src/utils/table-helpers.ts
@@ -270,7 +270,6 @@ export function renderTable(
       slotName,
       kind: 'table',
       token,
-      node,
       data: {
         headers: dataHeaders,
         rows: dataRows,

--- a/packages/ai-chat/src/aiChatEntry.tsx
+++ b/packages/ai-chat/src/aiChatEntry.tsx
@@ -345,7 +345,6 @@ export {
   RenderUserDefinedResponse,
   RenderUserDefinedState,
   RenderWriteableElementResponse,
-  TokenTree,
   WCCustomMarkdownRenderers,
   WCMarkdown,
   WCRenderCustomMessageFooter,

--- a/packages/ai-chat/src/serverEntry.ts
+++ b/packages/ai-chat/src/serverEntry.ts
@@ -318,7 +318,6 @@ export {
   RenderUserDefinedResponse,
   RenderUserDefinedState,
   RenderWriteableElementResponse,
-  TokenTree,
   WCCustomMarkdownRenderers,
   WCMarkdown,
   WCRenderCustomMessageFooter,

--- a/packages/ai-chat/src/types/AGENTS.md
+++ b/packages/ai-chat/src/types/AGENTS.md
@@ -42,6 +42,8 @@ Untagged symbols fall into the `*` bucket — a sign the author forgot.
 
 Public API that may still change. Pair with a short note on why it's unstable. Renders with a visible badge on the docs site. Use on a property, enum member, or whole type.
 
+The tag is also what makes a later removal legitimate: narrowing or removing a tagged symbol ships as a `feat`, not a breaking change — see [Definition of done](#definition-of-done). Take the tag off only when you are prepared to keep the symbol for good.
+
 ### `@internal`
 
 Symbols the build pipeline forces into the public types for mechanical reasons but that consumers must never rely on (example: [../chat/services/ChatActionsImpl.ts](../chat/services/ChatActionsImpl.ts)-adjacent plumbing reached via `ChatInstance.serviceManager`). `@internal` is stripped from TypeDoc output — if a reader should never see it, tag it.
@@ -243,7 +245,7 @@ When you change anything under [.](.) (or a type in `@carbon/ai-chat-components`
 1. `npm run build --workspace=@carbon/ai-chat` — rollup + TypeDoc. The build fails on `validation.invalidLink` errors.
 2. If you added a new public export, confirm it appears in both [../aiChatEntry.tsx](../aiChatEntry.tsx) and [../serverEntry.ts](../serverEntry.ts).
 3. If you added or changed a public instance method, confirm it carries at least one titled `@example` that meets [code-examples.md](../../references/code-examples.md) (review gate — not build-enforced).
-4. Semver: any change to a public type is a `feat` (additive) or a `fix!` / `BREAKING CHANGE` (non-additive). See [../../AGENTS.md](../../AGENTS.md) → _Authoring rules_ → _Public API changes_.
+4. Semver: any change to a public type is a `feat` (additive) or a `fix!` / `BREAKING CHANGE` (non-additive). **Symbols still tagged [`@experimental`](#experimental) are the exception** — narrowing or removing one ships as a `feat`, because the tag is the notice that it could happen. A `!` bumps the major, and the majors are planned windows; don't open one to retract something we said was unstable. See [../../AGENTS.md](../../AGENTS.md) → _Authoring rules_ → _Public API changes_.
 
 ## Related Guidance
 

--- a/packages/ai-chat/src/types/component/ChatContainer.ts
+++ b/packages/ai-chat/src/types/component/ChatContainer.ts
@@ -228,7 +228,6 @@ type RenderWriteableElementResponse = {
  * headers, rows, and streaming/loading flags.
  *
  * @category Messaging
- * @experimental
  */
 export type MarkdownRendererTableData = _MarkdownRendererTableData;
 
@@ -238,7 +237,6 @@ export type MarkdownRendererTableData = _MarkdownRendererTableData;
  * Carries the language, code text, and streaming flag.
  *
  * @category Messaging
- * @experimental
  */
 export type MarkdownRendererCodeBlockData = _MarkdownRendererCodeBlockData;
 
@@ -250,7 +248,6 @@ export type MarkdownRendererCodeBlockData = _MarkdownRendererCodeBlockData;
  * stable `slotName` suitable for use as a key.
  *
  * @category Messaging
- * @experimental
  */
 export type MarkdownRendererTableArgs = _MarkdownRendererTableArgs;
 
@@ -262,7 +259,6 @@ export type MarkdownRendererTableArgs = _MarkdownRendererTableArgs;
  * a stable `slotName` suitable for use as a key.
  *
  * @category Messaging
- * @experimental
  */
 export type MarkdownRendererCodeBlockArgs = _MarkdownRendererCodeBlockArgs;
 
@@ -272,7 +268,6 @@ export type MarkdownRendererCodeBlockArgs = _MarkdownRendererCodeBlockArgs;
  * (href, title, text, attributes) plus the source markdown-it token.
  *
  * @category Messaging
- * @experimental
  */
 export type MarkdownRendererLinkArgs = _MarkdownRendererLinkArgs;
 
@@ -283,7 +278,6 @@ export type MarkdownRendererLinkArgs = _MarkdownRendererLinkArgs;
  * entirely. Supply `onClick` to intercept link clicks.
  *
  * @category Messaging
- * @experimental
  */
 export type MarkdownRendererLinkResult = _MarkdownRendererLinkResult;
 
@@ -293,7 +287,6 @@ export type MarkdownRendererLinkResult = _MarkdownRendererLinkResult;
  * (src, alt, title, attributes) plus the source markdown-it token.
  *
  * @category Messaging
- * @experimental
  */
 export type MarkdownRendererImageArgs = _MarkdownRendererImageArgs;
 
@@ -302,7 +295,6 @@ export type MarkdownRendererImageArgs = _MarkdownRendererImageArgs;
  * `attributes`). Return `null` to keep the defaults.
  *
  * @category Messaging
- * @experimental
  */
 export type MarkdownRendererImageResult = _MarkdownRendererImageResult;
 
@@ -311,7 +303,6 @@ export type MarkdownRendererImageResult = _MarkdownRendererImageResult;
  * an optional `getChecked` source-of-truth. See {@link MarkdownRendererChecklist}.
  *
  * @category Messaging
- * @experimental
  */
 export type MarkdownRendererChecklist = _MarkdownRendererChecklist;
 
@@ -320,7 +311,6 @@ export type MarkdownRendererChecklist = _MarkdownRendererChecklist;
  * `checklist.getChecked`.
  *
  * @category Messaging
- * @experimental
  */
 export type MarkdownRendererChecklistItemArgs =
   _MarkdownRendererChecklistItemArgs;
@@ -330,7 +320,6 @@ export type MarkdownRendererChecklistItemArgs =
  * (item identity + new checked state).
  *
  * @category Messaging
- * @experimental
  */
 export type MarkdownRendererChecklistToggleArgs =
   _MarkdownRendererChecklistToggleArgs;
@@ -344,7 +333,6 @@ export type MarkdownRendererChecklistToggleArgs =
  * than this baseline directly.
  *
  * @category Messaging
- * @experimental
  */
 export type MarkdownCustomRenderers = _MarkdownCustomRenderers;
 
@@ -361,7 +349,6 @@ export type MarkdownCustomRenderers = _MarkdownCustomRenderers;
  * row, more code lines), the same `slotName` is reused and the callback is
  * invoked again with the updated payload.
  *
- * @experimental
  * @category React
  */
 interface CustomMarkdownRenderers {
@@ -406,7 +393,6 @@ interface CustomMarkdownRenderers {
  * Callbacks fire once per matching element per render pass; return the same
  * element reference across renders to avoid unnecessary DOM churn.
  *
- * @experimental
  * @category Web component
  */
 interface WCCustomMarkdownRenderers {
@@ -445,7 +431,6 @@ interface WCCustomMarkdownRenderers {
  * React-layer `markdown` config — extends {@link PublicConfigMarkdown} with
  * React renderers.
  *
- * @experimental
  * @category React
  */
 interface ChatContainerPropsMarkdown extends PublicConfigMarkdown {
@@ -453,8 +438,6 @@ interface ChatContainerPropsMarkdown extends PublicConfigMarkdown {
    * Per-element renderer overrides — see {@link CustomMarkdownRenderers}.
    * Pass a stable reference (`useMemo`) — an inline object literal will be a
    * fresh reference each render.
-   *
-   * @experimental
    */
   customRenderers?: CustomMarkdownRenderers;
 }
@@ -463,7 +446,6 @@ interface ChatContainerPropsMarkdown extends PublicConfigMarkdown {
  * Web-component-layer `markdown` config — extends {@link PublicConfigMarkdown}
  * with renderers returning `HTMLElement` (or `null`).
  *
- * @experimental
  * @category Web component
  */
 interface WCMarkdown extends PublicConfigMarkdown {
@@ -471,8 +453,6 @@ interface WCMarkdown extends PublicConfigMarkdown {
    * Per-element renderer overrides — see {@link WCCustomMarkdownRenderers}.
    * Return the same element reference across renders to avoid unnecessary DOM
    * churn.
-   *
-   * @experimental
    */
   customRenderers?: WCCustomMarkdownRenderers;
 }
@@ -492,8 +472,6 @@ interface ChatContainerProps extends Omit<PublicConfig, 'markdown'> {
   /**
    * Markdown rendering customization. Extends the framework-neutral
    * {@link PublicConfigMarkdown} with React-layer custom renderers.
-   *
-   * @experimental
    */
   markdown?: ChatContainerPropsMarkdown;
 

--- a/packages/ai-chat/src/types/component/ChatContainer.ts
+++ b/packages/ai-chat/src/types/component/ChatContainer.ts
@@ -21,7 +21,6 @@ import type {
   MarkdownRendererLinkResult as _MarkdownRendererLinkResult,
   MarkdownRendererTableArgs as _MarkdownRendererTableArgs,
   MarkdownRendererTableData as _MarkdownRendererTableData,
-  TokenTree as _TokenTree,
 } from '@carbon/ai-chat-components/es/components/markdown/index.js';
 import { type ChatInstance } from '../instance/ChatInstance';
 import { WriteableElements } from '../instance/WriteableElements';
@@ -224,17 +223,6 @@ type RenderWriteableElementResponse = {
 };
 
 /**
- * Markdown-it parser node tree, surfaced on the `node` field of
- * {@link MarkdownRendererTableArgs} and {@link MarkdownRendererCodeBlockArgs}
- * so custom renderers can inspect the parsed token structure when the
- * high-level data payload isn't enough.
- *
- * @category Messaging
- * @experimental
- */
-export type TokenTree = _TokenTree;
-
-/**
  * Parsed table payload extended by {@link MarkdownRendererTableArgs} — the
  * argument shape the table renderer callback actually receives. Carries the
  * headers, rows, and streaming/loading flags.
@@ -258,8 +246,8 @@ export type MarkdownRendererCodeBlockData = _MarkdownRendererCodeBlockData;
  * Argument passed to the markdown table renderer callbacks on
  * {@link CustomMarkdownRenderers.table} and
  * {@link WCCustomMarkdownRenderers.table}. Extends
- * {@link MarkdownRendererTableData} with the source token, full
- * {@link TokenTree} node, and a stable `slotName` suitable for use as a key.
+ * {@link MarkdownRendererTableData} with the source markdown-it token and a
+ * stable `slotName` suitable for use as a key.
  *
  * @category Messaging
  * @experimental
@@ -270,8 +258,8 @@ export type MarkdownRendererTableArgs = _MarkdownRendererTableArgs;
  * Argument passed to the fenced code-block renderer callbacks on
  * {@link CustomMarkdownRenderers.codeBlock} and
  * {@link WCCustomMarkdownRenderers.codeBlock}. Extends
- * {@link MarkdownRendererCodeBlockData} with the source token, full
- * {@link TokenTree} node, and a stable `slotName` suitable for use as a key.
+ * {@link MarkdownRendererCodeBlockData} with the source markdown-it token and
+ * a stable `slotName` suitable for use as a key.
  *
  * @category Messaging
  * @experimental
@@ -281,7 +269,7 @@ export type MarkdownRendererCodeBlockArgs = _MarkdownRendererCodeBlockArgs;
 /**
  * Argument passed to a {@link CustomMarkdownRenderers.link} /
  * {@link WCCustomMarkdownRenderers.link} callback — the parsed link data
- * (href, title, text, attributes) plus the source token and node.
+ * (href, title, text, attributes) plus the source markdown-it token.
  *
  * @category Messaging
  * @experimental
@@ -302,7 +290,7 @@ export type MarkdownRendererLinkResult = _MarkdownRendererLinkResult;
 /**
  * Argument passed to an {@link CustomMarkdownRenderers.image} /
  * {@link WCCustomMarkdownRenderers.image} callback — the parsed image data
- * (src, alt, title, attributes) plus the source token and node.
+ * (src, alt, title, attributes) plus the source markdown-it token.
  *
  * @category Messaging
  * @experimental

--- a/packages/ai-chat/src/types/config/PublicConfig.ts
+++ b/packages/ai-chat/src/types/config/PublicConfig.ts
@@ -239,8 +239,6 @@ export interface PublicConfig {
   /**
    * Markdown rendering customization. The framework-neutral subset; React and
    * web-component layers extend this with their own `customRenderers` member.
-   *
-   * @experimental
    */
   markdown?: PublicConfigMarkdown;
 }
@@ -251,7 +249,6 @@ export interface PublicConfig {
  * matching `MarkdownIt.use(...)`.
  *
  * @category Config
- * @experimental
  */
 export type MarkdownItPlugin = _MarkdownItPlugin;
 
@@ -262,7 +259,6 @@ export type MarkdownItPlugin = _MarkdownItPlugin;
  * (`ReactNode` vs `HTMLElement | null`).
  *
  * @category Config
- * @experimental
  */
 export interface PublicConfigMarkdown {
   /**
@@ -270,8 +266,6 @@ export interface PublicConfigMarkdown {
    * (markdown-it-attrs, markdown-it-highlight, markdown-it-task-lists).
    * Memoize this array — a new reference each render rebuilds the
    * markdown-it instance.
-   *
-   * @experimental
    */
   markdownItPlugins?: MarkdownItPlugin[];
 }

--- a/packages/ai-chat/src/web-components/cds-aichat-container/index.ts
+++ b/packages/ai-chat/src/web-components/cds-aichat-container/index.ts
@@ -722,8 +722,6 @@ interface CdsAiChatContainerAttributes extends Omit<PublicConfig, 'markdown'> {
   /**
    * Markdown rendering customization. Extends the framework-neutral
    * `PublicConfig.markdown` with web-component `customRenderers`.
-   *
-   * @experimental
    */
   markdown?: WCMarkdown;
 

--- a/packages/ai-chat/src/web-components/cds-aichat-custom-element/index.ts
+++ b/packages/ai-chat/src/web-components/cds-aichat-custom-element/index.ts
@@ -442,8 +442,6 @@ interface CdsAiChatCustomElementAttributes extends Omit<
   /**
    * Markdown rendering customization. Extends the framework-neutral
    * `PublicConfig.markdown` with web-component `customRenderers`.
-   *
-   * @experimental
    */
   markdown?: WCMarkdown;
 


### PR DESCRIPTION
Closes #2069

Settles the markdown extensibility contract. Two commits, in order: pull `TokenTree` off the public surface, then drop `@experimental` from what is left.

`TokenTree` is the streaming-diff structure. It went public by accident. The five renderer arg types carried a `node: Readonly<TokenTree>` escape hatch, and JSDoc on two of them linked to it — enough to force the export (see the note below on which validation actually did it). Its `cachedHtml` field is already `@internal`, so the published page describes a shape no consumer gets.

#### Changelog

**Changed**

- `PublicConfig.markdown`, `PublicConfigMarkdown`, `markdownItPlugins`, and `MarkdownItPlugin` are stable API. No experimental badge.
- Same for the renderer arg and result types, `customRenderers` on both the React and web-component layers, and the `markdown` attribute on `cds-aichat-container` and `cds-aichat-custom-element`.
- `MarkdownItPlugin` also loses the tag at its declaration in `@carbon/ai-chat-components`, which publishes on its own.

**Removed**

- `node` from `MarkdownRendererTableArgs`, `MarkdownRendererCodeBlockArgs`, `MarkdownRendererLinkArgs`, `MarkdownRendererImageArgs`, and `MarkdownRendererChecklistItemArgs`. A compile-time break for anyone reading it. The surface was still experimental.
- `TokenTree` from `aiChatEntry.tsx`, `serverEntry.ts`, and the components markdown index.
- `node` from the `@internal` `MarkdownRendererSlotDescriptor`. The element read it only to pass along. Now write-only, so it goes.

**New**

- Test asserting no callback receives `node` and all five still receive `token`.

#### Testing / Reviewing

No runtime behavior change. The second commit is JSDoc only.

Read the commits apart. The first is the shape change and is the one to scrutinize; the second is a tag sweep.

```bash
cd packages/ai-chat-components && npx web-test-runner "src/components/markdown/**/*.test.ts" --node-resolve
cd packages/ai-chat && npx jest
```

The new guard is meaningful — put `node: descriptor.node` back in `markdown.ts` and "does not pass the internal token tree to any callback" fails.

The markdown examples exercise every affected callback. Build the packages first, then:

```bash
npm run start --workspace=@carbon/ai-chat-examples-react-markdown-override
npm run start --workspace=@carbon/ai-chat-examples-react-workspace-table-markdown-override
```

None of them read `node`, so a clean type-check there is the removal's real proof.

Two things to confirm. A build was off limits while this was written:

- `npm run build --workspace=@carbon/ai-chat` reports no `notExported` or `invalidLink` warning for `TokenTree`. `treatValidationWarningsAsErrors` is on. This is the gate that matters most.
- The rendered TypeDoc shows no experimental badge on the markdown symbols.

#### Semver marker

The first commit takes a documented field off five interfaces. Every one was still `@experimental`. Typed as `feat`, not `feat!`. A breaking marker forces lerna to a major, and the majors are planned windows.

The rule in `packages/ai-chat/src/types/AGENTS.md` had no carve-out for experimental, so a third commit writes one in. Removing a tagged symbol is a `feat`; the tag was the notice. The rule now also says that taking a tag off is the commitment to keep the symbol.

#### One open question

**Why `TokenTree` was exported.** The stated reason is `validation.notExported`. The evidence points at `invalidLink` instead. `MarkdownRendererTableData.headers` is `TableCellData[]`. `TableCellData` carries `tokens: TokenTree[] | null`. Yet it is exported nowhere and warns about nothing on `main`. TypeDoc renders these re-declarations as opaque aliases and never walks their members. What did force the export: two `{@link TokenTree}` references in `ChatContainer.ts` JSDoc. Both are gone, so the outcome holds either way.

`packages/ai-chat/docs/api/**` still lists `TokenTree`. That directory is generated at release time, not per PR. Out of scope here.
