### PR TITLE
fix(messaging): wire upsertMessage into the streaming lifecycle

### DIFF
--- a/packages/ai-chat/src/chat/components-legacy/responseTypes/conversationalSearch/ConversationalSearchText.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/responseTypes/conversationalSearch/ConversationalSearchText.tsx
@@ -25,6 +25,7 @@ import { useServiceManager } from '../../../hooks/useServiceManager';
 import { shallowEqual } from '../../../store/appStore';
 import OperationalTag from '../../../components/carbon/OperationalTag';
 import { carbonIconToReact } from '../../../utils/carbonIcon';
+import { deriveStreamingItemText } from '../../../utils/streamingUtils';
 
 const ChevronDown = carbonIconToReact(ChevronDown16);
 const ChevronUp = carbonIconToReact(ChevronUp16);
@@ -88,12 +89,9 @@ function ConversationalSearchText(props: ConversationalSearchTextProps) {
   }`;
   const [html, setHtml] = useState('');
 
-  let text: string;
-  if (streamingState && !streamingState.isDone) {
-    text = streamingState.chunks.map((chunk) => chunk.text).join('');
-  } else {
-    text = searchItem.item.text;
-  }
+  // Chunk-delivered items accumulate their text in `streamingState.chunks`;
+  // upsert-delivered items carry the whole text on the item with empty chunks.
+  const text = deriveStreamingItemText(searchItem.item.text, streamingState);
 
   useEffect(() => {
     const processedText = insertHighlightMarkdown(text, highlightCitation);

--- a/packages/ai-chat/src/chat/components/helpers/MarkdownWithErrorHandling/MarkdownWithErrorHandling.tsx
+++ b/packages/ai-chat/src/chat/components/helpers/MarkdownWithErrorHandling/MarkdownWithErrorHandling.tsx
@@ -15,6 +15,7 @@ import { AppState } from '../../../../types/state/AppState';
 import { LocalMessageItemStreamingState } from '../../../../types/messaging/LocalMessageItem';
 import InlineError from '../../responseTypes/error/InlineError';
 import { MarkdownWithDefaults } from '../MarkdownWithDefaults/MarkdownWithDefaults';
+import { deriveStreamingItemText } from '../../../utils/streamingUtils';
 import { TextItem } from '../../../../types/messaging/Messages';
 
 interface MarkdownWithErrorHandlingProps {
@@ -54,13 +55,9 @@ function MarkdownWithErrorHandling(props: MarkdownWithErrorHandlingProps) {
     shallowEqual
   );
 
-  let textToUse;
-  if (streamingState && !streamingState.isDone) {
-    // If we're streaming, then concatenate all the chunks together.
-    textToUse = streamingState.chunks.map((chunk) => chunk.text).join('');
-  } else {
-    textToUse = text;
-  }
+  // Chunk-delivered items accumulate their text in `streamingState.chunks`;
+  // upsert-delivered items carry the whole text on the item with empty chunks.
+  const textToUse = deriveStreamingItemText(text, streamingState);
 
   return (
     <>

--- a/packages/ai-chat/src/chat/services/ChatActionsImpl.ts
+++ b/packages/ai-chat/src/chat/services/ChatActionsImpl.ts
@@ -1457,6 +1457,13 @@ class ChatActionsImpl {
     await this.receive(finalResponse, options.isLatestWelcomeNode, null);
 
     if (messageID) {
+      // Belt and braces: `receive` normally rebuilds the local items without any
+      // streaming state, but that only holds when the final response carries matching
+      // streaming ids. Settle the flags explicitly so a malformed final response can't
+      // leave items rendering as mid-stream.
+      this.serviceManager.store.dispatch(
+        actions.endMessageStreaming(messageID)
+      );
       this.serviceManager.messageService.finalizeStreamingMessage(messageID);
     }
   }

--- a/packages/ai-chat/src/chat/services/ChatActionsImpl.ts
+++ b/packages/ai-chat/src/chat/services/ChatActionsImpl.ts
@@ -1338,7 +1338,7 @@ class ChatActionsImpl {
           (isCompleteItem || isFinalResponse) &&
           stopStreamingState.isVisible
         ) {
-          resetStopStreamingButton(store);
+          this.serviceManager.messageService.hideStopStreamingButtonIfNoUpsertStreaming();
         }
       };
 
@@ -1588,7 +1588,10 @@ class ChatActionsImpl {
     chunk: StreamChunk
   ) {
     if (isCompleteItem || isStreamFinalResponse(chunk)) {
-      resetStopStreamingButton(this.serviceManager.store);
+      // The chunk flow has always hidden on its own `complete_item`, so this asks only
+      // whether an `upsertMessage` stream is still running. Consulting the chunk state
+      // here would keep the button up past `complete_item` — a different change.
+      this.serviceManager.messageService.hideStopStreamingButtonIfNoUpsertStreaming();
     }
   }
 
@@ -1799,14 +1802,11 @@ class ChatActionsImpl {
     store.dispatch(actions.addMessage(fullMessage));
 
     // When addMessage is called with showStopButtonImmediately enabled, hide the stop button
-    // and revert to legacy behavior (button will show on first chunk if streaming)
-    // Pass streamingMessageID to keep button visible if there's an active stream
+    // and revert to legacy behavior (button will show on first chunk if streaming).
+    // Anything still streaming — chunk or upsert — keeps the button visible.
     const messagingConfig = config.public.messaging || {};
     if (messagingConfig.showStopButtonImmediately) {
-      resetStopStreamingButton(
-        store,
-        this.serviceManager.messageService.inboundStreaming.streamingMessageID
-      );
+      this.serviceManager.messageService.hideStopStreamingButtonIfIdle();
     }
 
     // The ID of the previous (visible) message item that was added to the store. When adding new items from the
@@ -2233,7 +2233,9 @@ class ChatActionsImpl {
 
       await this.serviceManager.messageService.cancelAllMessageRequests();
 
-      // Hide the stop streaming button since we've cancelled all streams
+      // Hide the stop streaming button since we've cancelled all streams. Unconditional
+      // on purpose — everything was just cancelled, so there is no other stream to keep
+      // it visible for.
       resetStopStreamingButton(store);
 
       // Drop any in-flight upsertMessage chains and recorded state so upserts queued

--- a/packages/ai-chat/src/chat/services/MessageService.ts
+++ b/packages/ai-chat/src/chat/services/MessageService.ts
@@ -836,6 +836,16 @@ class MessageService {
       reason
     );
 
+    // A cancelled stream often ends without a `complete_item` or `final_response` — the
+    // host simply breaks out of its loop. Nothing else would settle the items' streaming
+    // flags, which left streaming-aware rendering (an in-progress markdown table, for
+    // one) engaged for the rest of the session.
+    if (streamingEntry) {
+      this.serviceManager.store.dispatch(
+        actions.endMessageStreaming(responseId)
+      );
+    }
+
     if (!pendingRequest && wasStreamingCurrent) {
       this.moveToNextQueueItem();
     }

--- a/packages/ai-chat/src/chat/services/MessageService.ts
+++ b/packages/ai-chat/src/chat/services/MessageService.ts
@@ -224,7 +224,8 @@ class MessageService {
       () => this.moveToNextQueueItem(),
       (pendingRequest, received) =>
         this.processSuccess(pendingRequest, received),
-      () => this.serviceManager.store.getState().config.public.messaging || {}
+      () => this.serviceManager.store.getState().config.public.messaging || {},
+      () => this.hideStopStreamingButtonIfIdle()
     );
     this.queue = {
       waiting: [],
@@ -306,12 +307,9 @@ class MessageService {
     // For streaming messages, don't clear the queue yet - wait for FinalResponseChunk to arrive
     // For non-streaming messages (addMessage), clear immediately
     if (!current.isStreaming) {
-      // Hide stop streaming button if it was shown for showStopButtonImmediately
-      // Pass streamingMessageID to keep button visible if there's an active stream
-      resetStopStreamingButton(
-        this.serviceManager.store,
-        this.inboundStreaming.streamingMessageID
-      );
+      // Hide stop streaming button if it was shown for showStopButtonImmediately, unless
+      // some other message is still streaming.
+      this.hideStopStreamingButtonIfIdle();
       this.moveToNextQueueItem();
     }
   }
@@ -675,8 +673,50 @@ class MessageService {
   }
 
   /**
+   * Returns true when any message is still streaming, whichever API is driving it —
+   * `addMessageChunk` (tracked by {@link inboundStreaming}) or `upsertMessage` (tracked
+   * by the upsert coordinator). This is the single source of truth for "is the chat still
+   * producing output", so the stop streaming button does not vanish when one of several
+   * concurrent streams finishes.
+   */
+  public isAnyMessageStreaming(): boolean {
+    if (this.inboundStreaming.streamingMessageID) {
+      return true;
+    }
+    return this.serviceManager.messageUpsertCoordinator.hasStreamingMessages();
+  }
+
+  /**
+   * Hides the stop streaming button unless something is still streaming.
+   */
+  public hideStopStreamingButtonIfIdle() {
+    if (!this.isAnyMessageStreaming()) {
+      resetStopStreamingButton(this.serviceManager.store);
+    }
+  }
+
+  /**
+   * Hides the stop streaming button unless an `upsertMessage` stream is still running.
+   *
+   * The chunk flow has always hidden the button on its own `complete_item`, and that
+   * behavior is deliberately preserved — so these call sites must ignore
+   * {@link inboundStreaming} and ask only whether the *other* flow is live. Consulting the
+   * chunk state here would keep the button up past a `complete_item`, which is a different
+   * change than the one this method exists to make.
+   */
+  public hideStopStreamingButtonIfNoUpsertStreaming() {
+    if (!this.serviceManager.messageUpsertCoordinator.hasStreamingMessages()) {
+      resetStopStreamingButton(this.serviceManager.store);
+    }
+  }
+
+  /**
    * Cancels the current message request if one is in progress.
    * Also handles streaming messages that may have been cleared from the queue.
+   *
+   * TODO(#1816): this only consults `inboundStreaming.streamingMessageID` and
+   * `queue.current`, so it cannot target a stream driven purely by `upsertMessage`.
+   * Routing the stop path through `instance.messaging.stop()` is that issue's scope.
    */
   public async cancelCurrentMessageRequest(
     reason: string = CancellationReason.STOP_STREAMING
@@ -793,7 +833,9 @@ class MessageService {
         pendingRequest.isProcessed = true;
         // Hide and re-enable the stop streaming button now that cancellation has
         // completed; processSuccess/processError will short-circuit on isProcessed.
-        resetStopStreamingButton(this.serviceManager.store);
+        // `clearStreamingResponse` above already dropped this stream, so this only
+        // hides when nothing else is still running.
+        this.hideStopStreamingButtonIfIdle();
         if (pendingRequest === this.queue.current) {
           this.moveToNextQueueItem();
         }

--- a/packages/ai-chat/src/chat/services/MessageService.ts
+++ b/packages/ai-chat/src/chat/services/MessageService.ts
@@ -647,6 +647,8 @@ class MessageService {
       );
       this.clearCurrentQueueItem();
     }
+
+    this.serviceManager.messageUpsertCoordinator.endAllStreaming();
   }
 
   /**
@@ -714,13 +716,34 @@ class MessageService {
    * Cancels the current message request if one is in progress.
    * Also handles streaming messages that may have been cleared from the queue.
    *
-   * TODO(#1816): this only consults `inboundStreaming.streamingMessageID` and
-   * `queue.current`, so it cannot target a stream driven purely by `upsertMessage`.
-   * Routing the stop path through `instance.messaging.stop()` is that issue's scope.
+   * Streaming *state* settles for both flows: the chunk stream through the branches
+   * below, and every `upsertMessage` stream through `endAllStreaming`.
+   *
+   * TODO(#1816): what still doesn't work is *targeted* cancellation of one upsert stream.
+   * Not for want of an id — the host passed one to `upsertMessage` and the coordinator
+   * tracks it. The problem is discovery: the two branches below look up a victim in
+   * `inboundStreaming.streamingMessageID`, which only the chunk pipeline populates, and
+   * in `queue.current.message.id`, which is the outbound *request* id rather than the
+   * response id the host chose. Nothing associates a cancelled request with the upsert
+   * ids created under it, and `upsertMessage` can be called with no request in flight at
+   * all. So the abort fires for the queued request, and `endAllStreaming` settles every
+   * id the coordinator knows about rather than the one that was cancelled. Building that
+   * association, via `instance.messaging.stop()`, is #1816's scope.
    */
   public async cancelCurrentMessageRequest(
     reason: string = CancellationReason.STOP_STREAMING
   ) {
+    // Settle upsert-driven streams up front — the chunk branch below returns early, and
+    // this has to run either way. Neither branch can reach them: an upsert stream is
+    // registered with the coordinator, not with `inboundStreaming` or the send queue,
+    // which is where those branches look. See the TODO above.
+    this.serviceManager.messageUpsertCoordinator.endAllStreaming();
+
+    // A pure-upsert stream reaches neither branch below, so this is the only thing that
+    // takes the button down for it. Guarded, so a chunk stream that is still live keeps
+    // it up and hides it through its own cancellation path.
+    this.hideStopStreamingButtonIfIdle();
+
     // If there's a streaming message, cancel it even if not in queue
     if (this.inboundStreaming.streamingMessageID) {
       await this.cancelMessageRequestByID(

--- a/packages/ai-chat/src/chat/services/MessageUpsertCoordinator.ts
+++ b/packages/ai-chat/src/chat/services/MessageUpsertCoordinator.ts
@@ -25,6 +25,7 @@ import { LocalMessageItem } from '../../types/messaging/LocalMessageItem';
 import actions from '../store/actions';
 import { addDefaultsToMessage, isRequest } from '../utils/messageUtils';
 import { consoleError } from '../utils/miscUtils';
+import { shouldShowStopStreaming } from '../utils/streamingUtils';
 import { ServiceManager } from './ServiceManager';
 
 const VALID_STATES = new Set<MessageState>([
@@ -46,13 +47,29 @@ const noop = () => {
  * - Track the most recent {@link MessageState} for each message ID. `addMessage` and
  *   `addMessageChunk` call {@link markComplete} / {@link markStreaming} so that mixing
  *   those APIs with `upsertMessage` does not double-fire `pre:receive` / `receive`.
+ * - Track which message IDs are currently mid-stream, so the stop streaming button
+ *   survives one concurrent stream finishing while another is still running.
  */
 class MessageUpsertCoordinator {
   private readonly serviceManager: ServiceManager;
 
   private readonly chainByID = new Map<string, Promise<void>>();
 
+  /**
+   * Receive-dedup record, **not** a liveness record. `addMessage` and `addMessageChunk`
+   * write it too, it deliberately retains {@link MessageState.COMPLETE} for the life of
+   * the session, and nothing drains it when a stream is cancelled. Use
+   * {@link streamingIDs} to ask whether a message is still streaming.
+   */
   private readonly stateByID = new Map<string, MessageState>();
+
+  /**
+   * IDs currently mid-stream via `upsertMessage`. Written only by {@link runOne}, which
+   * adds on {@link MessageState.STREAMING} and removes on {@link MessageState.COMPLETE} /
+   * {@link MessageState.ERROR}, so the two operations stay symmetric and the set cannot
+   * leak the way {@link stateByID} does.
+   */
+  private readonly streamingIDs = new Set<string>();
 
   constructor(serviceManager: ServiceManager) {
     this.serviceManager = serviceManager;
@@ -87,23 +104,31 @@ class MessageUpsertCoordinator {
   }
 
   /**
-   * Drops both the in-flight promise chain and recorded state for a single message ID.
-   * Called from `removeMessages` and after `finalizeStreamingMessage` to keep the maps
-   * draining for idle IDs.
+   * Returns true when any message is currently mid-stream via `upsertMessage`.
+   */
+  hasStreamingMessages(): boolean {
+    return this.streamingIDs.size > 0;
+  }
+
+  /**
+   * Drops the in-flight promise chain, the recorded state, and any streaming registration
+   * for a single message ID. Called from `removeMessages`.
    */
   clear(messageID: string) {
     this.stateByID.delete(messageID);
     this.chainByID.delete(messageID);
+    this.streamingIDs.delete(messageID);
   }
 
   /**
-   * Drops every entry from both maps. Called from `restartConversation` and from
-   * {@link ChatInstance#destroy} so a torn-down chat does not carry stale state into a
-   * fresh session.
+   * Drops every entry from all three collections. Called from `restartConversation` and
+   * from {@link ChatInstance#destroy} so a torn-down chat does not carry stale state into
+   * a fresh session.
    */
   clearAll() {
     this.chainByID.clear();
     this.stateByID.clear();
+    this.streamingIDs.clear();
   }
 
   /**
@@ -172,13 +197,64 @@ class MessageUpsertCoordinator {
     this.serviceManager.store.dispatch(
       actions.upsertMessage(result, nextState === MessageState.STREAMING)
     );
+
+    // Settle streaming liveness before the slot fan-out below. `serviceManager.fire` does
+    // not swallow listener exceptions, so a throwing user-defined-response handler would
+    // skip everything after `fanOutChangedSlots` — and a message left registered here
+    // would hold the stop button up for every other message, not just this one.
+    if (nextState === MessageState.STREAMING) {
+      this.streamingIDs.add(messageID);
+    } else {
+      this.streamingIDs.delete(messageID);
+    }
+
     await this.fanOutChangedSlots(messageID, result, nextState, refsBefore);
 
     this.stateByID.set(messageID, nextState);
+    this.syncStopStreamingButton(nextState, result);
 
     if (willFireReceive) {
       await this.firePostReceiveAndFinalize(messageID, result);
     }
+  }
+
+  /**
+   * Drives the stop streaming button from the upsert lifecycle.
+   *
+   * The chunk flow shows the button when a partial item arrives carrying
+   * `cancellable`, and hides it on the completing chunk. This is the same
+   * contract read off the upserted message instead: any item marked
+   * `cancellable` shows the button while the message is
+   * {@link MessageState.STREAMING}, and reaching {@link MessageState.COMPLETE}
+   * or {@link MessageState.ERROR} hides it.
+   *
+   * Unlike the chunk flow this needs no
+   * {@link PublicConfigMessaging.showStopButtonImmediately} opt-in — the first
+   * streaming upsert is already the earliest point the chat knows the message
+   * is cancellable, so the button appears there.
+   */
+  private syncStopStreamingButton(
+    nextState: MessageState,
+    result: MessageResponse
+  ) {
+    const { store } = this.serviceManager;
+
+    if (nextState === MessageState.STREAMING) {
+      const isCancellable = (result.output?.generic ?? []).some(
+        (item) => item?.streaming_metadata?.cancellable
+      );
+      const { isVisible } =
+        store.getState().assistantInputState.stopStreamingButtonState;
+      if (shouldShowStopStreaming({ cancellable: isCancellable }, isVisible)) {
+        store.dispatch(actions.setStopStreamingButtonVisible(true));
+      }
+      return;
+    }
+
+    // COMPLETE and ERROR are both terminal for this message — but the affordance only
+    // goes away once nothing else is streaming. `runOne` already dropped this message
+    // from `streamingIDs` above, so the check below reads "is anything *else* live".
+    this.serviceManager.messageService.hideStopStreamingButtonIfIdle();
   }
 
   /**

--- a/packages/ai-chat/src/chat/services/MessageUpsertCoordinator.ts
+++ b/packages/ai-chat/src/chat/services/MessageUpsertCoordinator.ts
@@ -111,6 +111,30 @@ class MessageUpsertCoordinator {
   }
 
   /**
+   * Settles every message still registered as mid-stream and drops the registrations.
+   *
+   * A cancelled `upsertMessage` stream has no terminal upsert to settle it — the host is
+   * told to stop and simply stops calling. Nothing else drains {@link streamingIDs}, so
+   * without this the stop streaming button stays visible and the items keep rendering
+   * mid-stream for the rest of the session.
+   *
+   * Deliberately settles *every* registered id rather than one. The ids are known — they
+   * are exactly {@link streamingIDs} — but nothing associates them with the request that
+   * was cancelled, so there is no basis for picking a subset (see the `TODO(#1816)` on
+   * {@link MessageService#cancelCurrentMessageRequest}). Settling all of them is right for
+   * both callers, which already mean "stop everything". A host that ignores the abort and
+   * keeps streaming re-registers on its next `STREAMING` upsert.
+   */
+  endAllStreaming() {
+    for (const messageID of this.streamingIDs) {
+      this.serviceManager.store.dispatch(
+        actions.endMessageStreaming(messageID)
+      );
+    }
+    this.streamingIDs.clear();
+  }
+
+  /**
    * Drops the in-flight promise chain, the recorded state, and any streaming registration
    * for a single message ID. Called from `removeMessages`.
    */

--- a/packages/ai-chat/src/chat/services/MessageUpsertCoordinator.ts
+++ b/packages/ai-chat/src/chat/services/MessageUpsertCoordinator.ts
@@ -169,7 +169,9 @@ class MessageUpsertCoordinator {
     }
 
     const refsBefore = this.snapshotLocalItemRefs(messageID);
-    this.serviceManager.store.dispatch(actions.upsertMessage(result));
+    this.serviceManager.store.dispatch(
+      actions.upsertMessage(result, nextState === MessageState.STREAMING)
+    );
     await this.fanOutChangedSlots(messageID, result, nextState, refsBefore);
 
     this.stateByID.set(messageID, nextState);

--- a/packages/ai-chat/src/chat/services/OutboundMessageCoordinator.ts
+++ b/packages/ai-chat/src/chat/services/OutboundMessageCoordinator.ts
@@ -57,7 +57,8 @@ class OutboundMessageCoordinator {
       current: PendingMessageRequest,
       received?: MessageResponse
     ) => Promise<void>,
-    private getMessagingConfig: () => PublicConfigMessaging
+    private getMessagingConfig: () => PublicConfigMessaging,
+    private hideStopStreamingButtonIfIdle: () => void
   ) {}
 
   /**
@@ -103,7 +104,10 @@ class OutboundMessageCoordinator {
       otherData: resultText,
     });
 
-    // Hide stop streaming button if visible
+    // Hide stop streaming button if visible. Unconditional on purpose, unlike
+    // `resolveCancelledMessage` below: a `customSendMessage` that throws mid-stream never
+    // drains `inboundStreaming` (the queue advance clears only the queue), so a guarded
+    // hide would leave the button stranded visible with no further chunk to hide it.
     resetStopStreamingButton(this.serviceManager.store);
 
     this.rejectFinalErrorOnMessage(pendingRequest, resultText);
@@ -196,8 +200,9 @@ class OutboundMessageCoordinator {
       this.messageLoadingManager.end();
     }
 
-    // Hide stop streaming button if visible
-    resetStopStreamingButton(this.serviceManager.store);
+    // Hide stop streaming button if visible. This request was not streaming and its
+    // streaming state is already cleared, so only hide when nothing else is running.
+    this.hideStopStreamingButtonIfIdle();
 
     sendMessagePromise.doResolve();
     pendingRequest.isProcessed = true;

--- a/packages/ai-chat/src/chat/store/actions.ts
+++ b/packages/ai-chat/src/chat/store/actions.ts
@@ -78,6 +78,7 @@ const UPDATE_PERSISTED_STATE = 'UPDATE_PERSISTED_STATE';
 const SET_HOME_SCREEN_IS_OPEN = 'SET_HOME_SCREEN_IS_OPEN';
 const UPDATE_MESSAGE = 'UPDATE_MESSAGE';
 const UPSERT_MESSAGE = 'UPSERT_MESSAGE';
+const END_MESSAGE_STREAMING = 'END_MESSAGE_STREAMING';
 const SET_LAUNCHER_MINIMIZED = 'SET_LAUNCHER_MINIMIZED';
 const CLOSE_IFRAME_PANEL = 'CLOSE_IFRAME_PANEL';
 const OPEN_IFRAME_CONTENT = 'OPEN_IFRAME_CONTENT';
@@ -214,8 +215,22 @@ const actions = {
    * existing `LocalMessageItem` references for items deep-equal to their predecessor so
    * components that subscribe to unchanged siblings do not re-render.
    */
-  upsertMessage(message: Message) {
-    return { type: UPSERT_MESSAGE, message };
+  upsertMessage(message: Message, isStreaming = false) {
+    return { type: UPSERT_MESSAGE, message, isStreaming };
+  },
+
+  /**
+   * Marks every local item belonging to `messageID` as no longer streaming.
+   *
+   * Streaming UI (the markdown element's in-progress table treatment, for one) keys off
+   * `ui_state.streamingState.isDone`. Reaching that state used to depend on the host
+   * sending a `complete_item` or `final_response` chunk, so a stream that ended any other
+   * way — the user pressing stop, `customSendMessage` throwing, a timeout — left items
+   * stuck mid-stream forever. Dispatch this wherever a stream terminates so the end state
+   * does not depend on host cooperation.
+   */
+  endMessageStreaming(messageID: string) {
+    return { type: END_MESSAGE_STREAMING, messageID };
   },
 
   messageSetOptionSelected(messageID: string, sentMessage: MessageRequest) {
@@ -736,6 +751,7 @@ export {
   SET_MESSAGE_RESPONSE_HISTORY_PROPERTY,
   UPDATE_MESSAGE,
   UPSERT_MESSAGE,
+  END_MESSAGE_STREAMING,
   SET_LAUNCHER_PROPERTY,
   SET_LAUNCHER_MINIMIZED,
   CLOSE_IFRAME_PANEL,

--- a/packages/ai-chat/src/chat/store/reducerUtils.ts
+++ b/packages/ai-chat/src/chat/store/reducerUtils.ts
@@ -471,7 +471,8 @@ function collectNestedLocalIDs(
  */
 function rebuildLocalItemsForUpsert(
   state: AppState,
-  message: MessageResponse
+  message: MessageResponse,
+  isStreaming = false
 ): {
   newLocalItemsByID: ObjectMap<LocalMessageItem>;
   newLocalIDsForMessage: string[];
@@ -526,7 +527,20 @@ function rebuildLocalItemsForUpsert(
     let localID: string;
     let localItem: LocalMessageItem;
 
-    if (matchedPrev && isEqual(matchedPrev.item, item)) {
+    // Streaming UI reads `ui_state.streamingState.isDone`. Comparing it alongside the
+    // item keeps the reference-stable path below from swallowing a STREAMING → COMPLETE
+    // transition whose payload happened not to change — which would leave the item
+    // rendering as mid-stream forever.
+    const prevIsStreaming = Boolean(
+      matchedPrev?.ui_state.streamingState &&
+      !matchedPrev.ui_state.streamingState.isDone
+    );
+
+    if (
+      matchedPrev &&
+      prevIsStreaming === isStreaming &&
+      isEqual(matchedPrev.item, item)
+    ) {
       // Reference-stable path: deep-equal to the prior item, keep the exact object so
       // selectors comparing by `===` see no change.
       //
@@ -543,6 +557,10 @@ function rebuildLocalItemsForUpsert(
       localItem = outputItemToLocalItem(item, message, false);
       localItem.ui_state.id = localID;
       localItem.fullMessageID = messageID;
+      // Mirror what the chunk pipeline records, so streaming-aware rendering behaves the
+      // same whichever API delivered the message.
+      localItem.ui_state.isIntermediateStreaming = isStreaming;
+      localItem.ui_state.streamingState = { chunks: [], isDone: !isStreaming };
 
       if (isResponseWithNestedItems(localItem.item)) {
         const nestedLocalItems: LocalMessageItem[] = [];
@@ -554,6 +572,10 @@ function rebuildLocalItemsForUpsert(
           true
         );
         for (const nested of nestedLocalItems) {
+          // Nested items render markdown too, so a table inside a card or grid needs the
+          // same streaming flags as a top-level one.
+          nested.ui_state.isIntermediateStreaming = isStreaming;
+          nested.ui_state.streamingState = { chunks: [], isDone: !isStreaming };
           newLocalItemsByID[nested.ui_state.id] = nested;
         }
       }

--- a/packages/ai-chat/src/chat/store/reducers.ts
+++ b/packages/ai-chat/src/chat/store/reducers.ts
@@ -98,6 +98,7 @@ import {
   UPDATE_STRUCTURED_DATA,
   UPDATE_MESSAGE,
   UPSERT_MESSAGE,
+  END_MESSAGE_STREAMING,
   UPDATE_PERSISTED_STATE,
   UPDATE_THEME_STATE,
   RESET_IS_HYDRATING_COUNTER,
@@ -489,9 +490,9 @@ const reducers: { [key: string]: ReducerType } = {
 
   [UPSERT_MESSAGE]: (
     state: AppState,
-    action: { message: Message }
+    action: { message: Message; isStreaming?: boolean }
   ): AppState => {
-    const { message } = action;
+    const { message, isStreaming = false } = action;
     const messageID = message.id;
 
     if (!isResponse(message)) {
@@ -501,7 +502,7 @@ const reducers: { [key: string]: ReducerType } = {
     const messageResponse = message;
 
     const { newLocalItemsByID, newLocalIDsForMessage } =
-      rebuildLocalItemsForUpsert(state, messageResponse);
+      rebuildLocalItemsForUpsert(state, messageResponse, isStreaming);
 
     // Splice the new ordered IDs back into localMessageIDs at the same position the
     // existing block occupied. Brand-new messages append.
@@ -548,6 +549,45 @@ const reducers: { [key: string]: ReducerType } = {
         activeResponseId: messageID,
       },
     };
+  },
+
+  [END_MESSAGE_STREAMING]: (
+    state: AppState,
+    action: { messageID: string }
+  ): AppState => {
+    const { messageID } = action;
+
+    let changed = false;
+    const newLocalItems: Record<string, LocalMessageItem> = {
+      ...state.allMessageItemsByID,
+    };
+
+    for (const localID of Object.keys(newLocalItems)) {
+      const localItem = newLocalItems[localID];
+      if (localItem?.fullMessageID !== messageID) {
+        continue;
+      }
+      const { streamingState, isIntermediateStreaming } = localItem.ui_state;
+      if (!isIntermediateStreaming && streamingState?.isDone !== false) {
+        // Already settled — leave the reference alone so subscribers don't re-render.
+        continue;
+      }
+      newLocalItems[localID] = {
+        ...localItem,
+        ui_state: {
+          ...localItem.ui_state,
+          isIntermediateStreaming: false,
+          streamingState: { ...streamingState, chunks: [], isDone: true },
+        },
+      };
+      changed = true;
+    }
+
+    if (!changed) {
+      return state;
+    }
+
+    return { ...state, allMessageItemsByID: newLocalItems };
   },
 
   [ADD_MESSAGE]: (state: AppState, action: { message: Message }): AppState => {

--- a/packages/ai-chat/src/chat/utils/streamingUtils.ts
+++ b/packages/ai-chat/src/chat/utils/streamingUtils.ts
@@ -10,6 +10,7 @@
 import actions from '../store/actions';
 import {
   CompleteItemChunk,
+  ConversationalSearchItem,
   FinalResponseChunk,
   GenericItem,
   MessageResponseTypes,
@@ -20,7 +21,10 @@ import {
   UserDefinedItem,
 } from '../../types/messaging/Messages';
 import { DeepPartial } from '../../types/utilities/DeepPartial';
-import { LocalMessageItem } from '../../types/messaging/LocalMessageItem';
+import {
+  LocalMessageItem,
+  LocalMessageItemStreamingState,
+} from '../../types/messaging/LocalMessageItem';
 import {
   isStreamCompleteItem,
   isStreamFinalResponse,
@@ -176,6 +180,32 @@ function resetStopStreamingButton(store: StoreLike) {
 }
 
 /**
+ * The text a streaming-aware renderer should display for a text-bearing item.
+ *
+ * The two delivery flows store mid-stream text differently. The chunk flow streams
+ * deltas: the accumulated text lives in `streamingState.chunks` (the item's own `text`
+ * holds only the first chunk). The upsert flow streams snapshots: the item's `text` is
+ * complete on every update and `chunks` stays empty. Joining chunks unconditionally
+ * rendered upsert-streamed text as blank until COMPLETE, so the chunks win only when
+ * there are any.
+ */
+function deriveStreamingItemText(
+  text: string,
+  streamingState:
+    | LocalMessageItemStreamingState<TextItem | ConversationalSearchItem>
+    | undefined
+): string {
+  if (
+    streamingState &&
+    !streamingState.isDone &&
+    streamingState.chunks.length
+  ) {
+    return streamingState.chunks.map((chunk) => chunk.text ?? '').join('');
+  }
+  return text;
+}
+
+/**
  * Merge message options only, ignoring unexpected partial_response fields.
  */
 function mergePartialResponseOptions(
@@ -281,6 +311,7 @@ function messageHasDisplayableContent(
 
 export {
   chunkHasDisplayableContent,
+  deriveStreamingItemText,
   FinalResponseChunk,
   mergePartialResponseOptions,
   messageHasDisplayableContent,

--- a/packages/ai-chat/src/chat/utils/streamingUtils.ts
+++ b/packages/ai-chat/src/chat/utils/streamingUtils.ts
@@ -160,22 +160,16 @@ function shouldShowStopStreaming(
 /**
  * Hides and re-enables the stop streaming button if currently visible.
  *
+ * This hides unconditionally. Deciding *whether* to hide belongs to `MessageService` —
+ * see its `hideStopStreamingButtonIfIdle` / `hideStopStreamingButtonIfNoUpsertStreaming`,
+ * which own that policy so concurrent streams cannot hide each other's button.
+ *
  * @param store - The store instance
- * @param streamingMessageID - Optional ID of currently streaming message. If provided and not null,
- *                             the button will remain visible (used with showStopButtonImmediately
- *                             to keep button visible during active streaming).
  */
-function resetStopStreamingButton(
-  store: StoreLike,
-  streamingMessageID?: string | null
-) {
+function resetStopStreamingButton(store: StoreLike) {
   const stopStreamingState =
     store.getState().assistantInputState.stopStreamingButtonState;
   if (stopStreamingState.isVisible) {
-    // If there's an active streaming message, keep the button visible
-    if (streamingMessageID) {
-      return;
-    }
     store.dispatch(actions.setStopStreamingButtonDisabled(false));
     store.dispatch(actions.setStopStreamingButtonVisible(false));
   }

--- a/packages/ai-chat/src/types/config/PublicConfigMessaging.ts
+++ b/packages/ai-chat/src/types/config/PublicConfigMessaging.ts
@@ -70,6 +70,16 @@ export interface PublicConfigMessaging {
   /**
    * Controls when the stop streaming button becomes visible during message streaming.
    *
+   * This setting is independent of how you deliver the response — it is applied when
+   * `customSendMessage` is called, before either flow has started.
+   *
+   * Without it, the two flows reach the same result by their own route.
+   * {@link ChatInstanceMessaging.addMessageChunk} shows the button on the first partial
+   * chunk marked `cancellable`. {@link ChatInstanceMessaging.upsertMessage} shows it on
+   * the first upsert recorded as {@link MessageState.STREAMING} whose message carries
+   * `streaming_metadata.cancellable`, and hides it once that message reaches
+   * {@link MessageState.COMPLETE} or {@link MessageState.ERROR}.
+   *
    * You must have {@link PublicConfigMessaging.customSendMessage} return a promise for
    * this setting to work correctly.
    *

--- a/packages/ai-chat/tests/instance/spec/messaging/addMessageChunk_spec.ts
+++ b/packages/ai-chat/tests/instance/spec/messaging/addMessageChunk_spec.ts
@@ -469,6 +469,68 @@ describe('ChatInstance.messaging.addMessageChunk', () => {
     ).toBeUndefined();
   });
 
+  // The reported symptom: a stream cancelled mid-flight never receives a complete_item
+  // or final_response, so nothing used to settle its items and the markdown table kept
+  // rendering in its in-progress treatment for the rest of the session. The
+  // stream_stopped test below covers the case where the host *does* send a closing
+  // chunk; this covers the case where it just stops calling.
+  it('settles streaming flags when a stream is cancelled with no closing chunk', async () => {
+    const responseId = 'cancelled-no-close';
+    const itemId = 'item-1';
+    let stopped = false;
+
+    const config = {
+      ...createBaseConfig(),
+      messaging: {
+        ...createBaseConfig().messaging,
+        customSendMessage: async (
+          _request: any,
+          options: any,
+          chatInstance: ChatInstance
+        ) => {
+          options.signal?.addEventListener('abort', () => {
+            stopped = true;
+          });
+
+          await chatInstance.messaging.addMessageChunk({
+            streaming_metadata: { response_id: responseId },
+            partial_item: {
+              streaming_metadata: { id: itemId, cancellable: true },
+              response_type: MessageResponseTypes.TEXT,
+              text: '| a | b |',
+            },
+          } as PartialItemChunk);
+
+          // Break out on abort and send nothing further — the whole point of the case.
+          while (!stopped) {
+            await new Promise((resolve) => setTimeout(resolve, 10));
+          }
+        },
+      },
+    };
+
+    const { instance, store } = await renderChatAndGetInstanceWithStore(
+      config as any
+    );
+
+    const sendPromise = instance.send('go');
+    await new Promise((resolve) => setTimeout(resolve, 60));
+
+    const localItemID = `${responseId}-${itemId}`;
+    const before = store.getState().allMessageItemsByID[localItemID];
+    expect(before.ui_state.streamingState.isDone).toBe(false);
+    expect(before.ui_state.isIntermediateStreaming).toBe(true);
+
+    await (
+      instance as any
+    ).serviceManager.messageService.cancelCurrentMessageRequest();
+    await sendPromise.catch(() => {});
+
+    const after = store.getState().allMessageItemsByID[localItemID];
+    expect(after.ui_state.streamingState.isDone).toBe(true);
+    expect(after.ui_state.isIntermediateStreaming).toBe(false);
+  });
+
   describe('stop streaming button', () => {
     const isVisible = (store: { getState: () => any }) =>
       store.getState().assistantInputState.stopStreamingButtonState.isVisible;

--- a/packages/ai-chat/tests/instance/spec/messaging/addMessageChunk_spec.ts
+++ b/packages/ai-chat/tests/instance/spec/messaging/addMessageChunk_spec.ts
@@ -469,6 +469,72 @@ describe('ChatInstance.messaging.addMessageChunk', () => {
     ).toBeUndefined();
   });
 
+  describe('stop streaming button', () => {
+    const isVisible = (store: { getState: () => any }) =>
+      store.getState().assistantInputState.stopStreamingButtonState.isVisible;
+
+    // The chunk flow has always hidden the button on its own complete_item. Making the
+    // stop button concurrency-aware must not change that, so pin it here.
+    it('hides the button on complete_item when nothing else is streaming', async () => {
+      const config = createBaseConfig();
+      const { instance, store } =
+        await renderChatAndGetInstanceWithStore(config);
+      const responseId = 'chunk-stop-1';
+      const itemId = 'chunk-stop-item-1';
+
+      await instance.messaging.addMessageChunk({
+        streaming_metadata: { response_id: responseId },
+        partial_item: {
+          streaming_metadata: { id: itemId, cancellable: true },
+          response_type: MessageResponseTypes.TEXT,
+          text: 'Partial ',
+        },
+      } as PartialItemChunk);
+
+      expect(isVisible(store)).toBe(true);
+
+      await instance.messaging.addMessageChunk({
+        streaming_metadata: { response_id: responseId },
+        complete_item: {
+          streaming_metadata: { id: itemId },
+          response_type: MessageResponseTypes.TEXT,
+          text: 'Partial complete',
+        },
+      } as CompleteItemChunk);
+
+      expect(isVisible(store)).toBe(false);
+    });
+
+    // A complete_item carrying no streaming_metadata leaves the resolved message id
+    // undefined while the coordinator fell back to the queued request id. Any fix that
+    // compared those two ids would silently stop hiding here.
+    it('hides the button on a complete_item with no streaming metadata', async () => {
+      const config = createBaseConfig();
+      const { instance, store } =
+        await renderChatAndGetInstanceWithStore(config);
+
+      await instance.messaging.addMessageChunk({
+        streaming_metadata: { response_id: 'chunk-stop-2' },
+        partial_item: {
+          streaming_metadata: { id: 'chunk-stop-item-2', cancellable: true },
+          response_type: MessageResponseTypes.TEXT,
+          text: 'Partial ',
+        },
+      } as PartialItemChunk);
+
+      expect(isVisible(store)).toBe(true);
+
+      await instance.messaging.addMessageChunk({
+        complete_item: {
+          response_type: MessageResponseTypes.TEXT,
+          text: 'Done',
+        },
+      } as CompleteItemChunk);
+
+      expect(isVisible(store)).toBe(false);
+    });
+  });
+
   describe('Abort signal behavior during streaming', () => {
     it('should trigger abort signal with STOP_STREAMING reason when stop button is used', async () => {
       const config = createBaseConfig();

--- a/packages/ai-chat/tests/instance/spec/messaging/upsertMessage_spec.ts
+++ b/packages/ai-chat/tests/instance/spec/messaging/upsertMessage_spec.ts
@@ -271,4 +271,306 @@ describe('ChatInstance.messaging.upsertMessage', () => {
       expect(state.allMessagesByID['u11']).toBeDefined();
     });
   });
+
+  describe('stop streaming button', () => {
+    function cancellableResponse(id: string, text: string): MessageResponse {
+      return {
+        id,
+        output: {
+          generic: [
+            {
+              response_type: MessageResponseTypes.TEXT,
+              text,
+              streaming_metadata: { id: '1', cancellable: true },
+            },
+          ],
+        },
+      };
+    }
+
+    const isVisible = (store: { getState: () => any }) =>
+      store.getState().assistantInputState.stopStreamingButtonState.isVisible;
+
+    it('shows the button on a cancellable streaming upsert', async () => {
+      const { instance, store } =
+        await renderChatAndGetInstanceWithStore(createBaseConfig());
+
+      expect(isVisible(store)).toBe(false);
+
+      await instance.messaging.upsertMessage(
+        'stop-1',
+        MessageState.STREAMING,
+        () => cancellableResponse('stop-1', 'partial')
+      );
+
+      expect(isVisible(store)).toBe(true);
+    });
+
+    it('hides the button once the message completes', async () => {
+      const { instance, store } =
+        await renderChatAndGetInstanceWithStore(createBaseConfig());
+
+      await instance.messaging.upsertMessage(
+        'stop-2',
+        MessageState.STREAMING,
+        () => cancellableResponse('stop-2', 'partial')
+      );
+      expect(isVisible(store)).toBe(true);
+
+      await instance.messaging.upsertMessage(
+        'stop-2',
+        MessageState.COMPLETE,
+        () => cancellableResponse('stop-2', 'all of it')
+      );
+
+      expect(isVisible(store)).toBe(false);
+    });
+
+    it('hides the button when the message errors', async () => {
+      const { instance, store } =
+        await renderChatAndGetInstanceWithStore(createBaseConfig());
+
+      await instance.messaging.upsertMessage(
+        'stop-3',
+        MessageState.STREAMING,
+        () => cancellableResponse('stop-3', 'partial')
+      );
+      expect(isVisible(store)).toBe(true);
+
+      await instance.messaging.upsertMessage('stop-3', MessageState.ERROR, () =>
+        cancellableResponse('stop-3', 'partial')
+      );
+
+      expect(isVisible(store)).toBe(false);
+    });
+
+    it('leaves the button hidden when the message is not cancellable', async () => {
+      const { instance, store } =
+        await renderChatAndGetInstanceWithStore(createBaseConfig());
+
+      await instance.messaging.upsertMessage(
+        'stop-4',
+        MessageState.STREAMING,
+        () => textResponse('stop-4', 'partial')
+      );
+
+      expect(isVisible(store)).toBe(false);
+    });
+
+    describe('with more than one message streaming', () => {
+      it('keeps the button visible when one of two streams completes', async () => {
+        const { instance, store } =
+          await renderChatAndGetInstanceWithStore(createBaseConfig());
+
+        await instance.messaging.upsertMessage(
+          'multi-a',
+          MessageState.STREAMING,
+          () => cancellableResponse('multi-a', 'a partial')
+        );
+        await instance.messaging.upsertMessage(
+          'multi-b',
+          MessageState.STREAMING,
+          () => cancellableResponse('multi-b', 'b partial')
+        );
+        expect(isVisible(store)).toBe(true);
+
+        await instance.messaging.upsertMessage(
+          'multi-a',
+          MessageState.COMPLETE,
+          () => cancellableResponse('multi-a', 'a done')
+        );
+
+        // multi-b is still streaming, so the affordance has to survive.
+        expect(isVisible(store)).toBe(true);
+
+        await instance.messaging.upsertMessage(
+          'multi-b',
+          MessageState.COMPLETE,
+          () => cancellableResponse('multi-b', 'b done')
+        );
+
+        expect(isVisible(store)).toBe(false);
+      });
+
+      it('keeps the button visible when one of two streams errors', async () => {
+        const { instance, store } =
+          await renderChatAndGetInstanceWithStore(createBaseConfig());
+
+        await instance.messaging.upsertMessage(
+          'multi-err-a',
+          MessageState.STREAMING,
+          () => cancellableResponse('multi-err-a', 'a partial')
+        );
+        await instance.messaging.upsertMessage(
+          'multi-err-b',
+          MessageState.STREAMING,
+          () => cancellableResponse('multi-err-b', 'b partial')
+        );
+
+        await instance.messaging.upsertMessage(
+          'multi-err-a',
+          MessageState.ERROR,
+          () => cancellableResponse('multi-err-a', 'a failed')
+        );
+
+        expect(isVisible(store)).toBe(true);
+
+        await instance.messaging.upsertMessage(
+          'multi-err-b',
+          MessageState.ERROR,
+          () => cancellableResponse('multi-err-b', 'b failed')
+        );
+
+        expect(isVisible(store)).toBe(false);
+      });
+
+      it('does not strand the button when a terminal upsert throws', async () => {
+        const { instance, store } =
+          await renderChatAndGetInstanceWithStore(createBaseConfig());
+
+        await instance.messaging.upsertMessage(
+          'throw-a',
+          MessageState.STREAMING,
+          () => cancellableResponse('throw-a', 'a partial')
+        );
+        await instance.messaging.upsertMessage(
+          'throw-b',
+          MessageState.STREAMING,
+          () => cancellableResponse('throw-b', 'b partial')
+        );
+
+        await expect(
+          instance.messaging.upsertMessage(
+            'throw-a',
+            MessageState.COMPLETE,
+            () =>
+              // Returning the wrong id makes the coordinator reject.
+              cancellableResponse('a-different-id', 'nope')
+          )
+        ).rejects.toThrow();
+
+        // throw-a never settled, so it stays registered and holds the button up.
+        expect(isVisible(store)).toBe(true);
+
+        // The surviving stream completing must still be able to hide it once throw-a
+        // is dropped, so removing throw-a has to drain its registration too.
+        await instance.messaging.removeMessages(['throw-a']);
+        await instance.messaging.upsertMessage(
+          'throw-b',
+          MessageState.COMPLETE,
+          () => cancellableResponse('throw-b', 'b done')
+        );
+
+        expect(isVisible(store)).toBe(false);
+      });
+
+      it('drains streaming registrations on conversation restart', async () => {
+        const { instance, store } =
+          await renderChatAndGetInstanceWithStore(createBaseConfig());
+
+        await instance.messaging.upsertMessage(
+          'restart-a',
+          MessageState.STREAMING,
+          () => cancellableResponse('restart-a', 'partial')
+        );
+        expect(isVisible(store)).toBe(true);
+
+        await instance.messaging.restartConversation();
+        expect(isVisible(store)).toBe(false);
+
+        // A fresh stream after the restart must still hide on its own completion —
+        // proves restart-a's registration did not survive.
+        await instance.messaging.upsertMessage(
+          'restart-b',
+          MessageState.STREAMING,
+          () => cancellableResponse('restart-b', 'partial')
+        );
+        expect(isVisible(store)).toBe(true);
+
+        await instance.messaging.upsertMessage(
+          'restart-b',
+          MessageState.COMPLETE,
+          () => cancellableResponse('restart-b', 'done')
+        );
+        expect(isVisible(store)).toBe(false);
+      });
+    });
+
+    describe('mixed with addMessageChunk', () => {
+      const partialChunk = (responseId: string) => ({
+        streaming_metadata: { response_id: responseId },
+        partial_item: {
+          streaming_metadata: { id: `${responseId}-item`, cancellable: true },
+          response_type: MessageResponseTypes.TEXT,
+          text: 'chunk partial ',
+        },
+      });
+
+      const finalChunk = (responseId: string) => ({
+        final_response: {
+          id: responseId,
+          output: {
+            generic: [
+              {
+                streaming_metadata: { id: `${responseId}-item` },
+                response_type: MessageResponseTypes.TEXT,
+                text: 'chunk done',
+              },
+            ],
+          },
+        },
+      });
+
+      it('keeps the button visible when the chunk stream finishes first', async () => {
+        const { instance, store } =
+          await renderChatAndGetInstanceWithStore(createBaseConfig());
+
+        await instance.messaging.addMessageChunk(partialChunk('mix-c1') as any);
+        await instance.messaging.upsertMessage(
+          'mix-u1',
+          MessageState.STREAMING,
+          () => cancellableResponse('mix-u1', 'upsert partial')
+        );
+        expect(isVisible(store)).toBe(true);
+
+        await instance.messaging.addMessageChunk(finalChunk('mix-c1') as any);
+
+        // The upsert stream is still running.
+        expect(isVisible(store)).toBe(true);
+
+        await instance.messaging.upsertMessage(
+          'mix-u1',
+          MessageState.COMPLETE,
+          () => cancellableResponse('mix-u1', 'upsert done')
+        );
+
+        expect(isVisible(store)).toBe(false);
+      });
+
+      it('keeps the button visible when the upsert stream finishes first', async () => {
+        const { instance, store } =
+          await renderChatAndGetInstanceWithStore(createBaseConfig());
+
+        await instance.messaging.addMessageChunk(partialChunk('mix-c2') as any);
+        await instance.messaging.upsertMessage(
+          'mix-u2',
+          MessageState.STREAMING,
+          () => cancellableResponse('mix-u2', 'upsert partial')
+        );
+
+        await instance.messaging.upsertMessage(
+          'mix-u2',
+          MessageState.COMPLETE,
+          () => cancellableResponse('mix-u2', 'upsert done')
+        );
+
+        // The chunk stream is still running.
+        expect(isVisible(store)).toBe(true);
+
+        await instance.messaging.addMessageChunk(finalChunk('mix-c2') as any);
+
+        expect(isVisible(store)).toBe(false);
+      });
+    });
+  });
 });

--- a/packages/ai-chat/tests/instance/spec/messaging/upsertMessage_spec.ts
+++ b/packages/ai-chat/tests/instance/spec/messaging/upsertMessage_spec.ts
@@ -572,5 +572,67 @@ describe('ChatInstance.messaging.upsertMessage', () => {
         expect(isVisible(store)).toBe(false);
       });
     });
+
+    describe('cancellation', () => {
+      const itemsFor = (store: { getState: () => any }, messageID: string) =>
+        Object.values(
+          store.getState().allMessageItemsByID as Record<string, any>
+        ).filter((item) => item.fullMessageID === messageID);
+
+      // Cancellation looks for a victim in the chunk registry and the send queue, and an
+      // upsert stream is registered in neither — so it cannot target one individually,
+      // even though the id is known. See the TODO(#1816) on cancelCurrentMessageRequest.
+      // What it can do is settle every registered stream, which is what stops the button
+      // and the items stranding when a cancelled host simply stops calling.
+      it('settles a streaming upsert that never receives a terminal call', async () => {
+        const { instance, store } =
+          await renderChatAndGetInstanceWithStore(createBaseConfig());
+
+        await instance.messaging.upsertMessage(
+          'cancel-1',
+          MessageState.STREAMING,
+          () => cancellableResponse('cancel-1', 'partial')
+        );
+        expect(isVisible(store)).toBe(true);
+
+        const [before] = itemsFor(store, 'cancel-1');
+        expect(before.ui_state.streamingState?.isDone).toBe(false);
+
+        await (
+          instance as any
+        ).serviceManager.messageService.cancelCurrentMessageRequest();
+
+        const [after] = itemsFor(store, 'cancel-1');
+        expect(after.ui_state.streamingState?.isDone).toBe(true);
+        expect(after.ui_state.isIntermediateStreaming).toBe(false);
+        expect(isVisible(store)).toBe(false);
+      });
+
+      it('settles every streaming upsert, not just one', async () => {
+        const { instance, store } =
+          await renderChatAndGetInstanceWithStore(createBaseConfig());
+
+        await instance.messaging.upsertMessage(
+          'cancel-a',
+          MessageState.STREAMING,
+          () => cancellableResponse('cancel-a', 'a')
+        );
+        await instance.messaging.upsertMessage(
+          'cancel-b',
+          MessageState.STREAMING,
+          () => cancellableResponse('cancel-b', 'b')
+        );
+
+        await (
+          instance as any
+        ).serviceManager.messageService.cancelCurrentMessageRequest();
+
+        for (const id of ['cancel-a', 'cancel-b']) {
+          const [item] = itemsFor(store, id);
+          expect(item.ui_state.streamingState?.isDone).toBe(true);
+        }
+        expect(isVisible(store)).toBe(false);
+      });
+    });
   });
 });

--- a/packages/ai-chat/tests/services/spec/MessageService_spec.ts
+++ b/packages/ai-chat/tests/services/spec/MessageService_spec.ts
@@ -74,11 +74,18 @@ const createServiceManagerStub = (
     fire: jest.fn().mockResolvedValue(undefined),
   };
 
+  // MessageService resolves this collaborator through ServiceManager to answer
+  // "is an upsertMessage stream still running".
+  const messageUpsertCoordinator = {
+    hasStreamingMessages: jest.fn().mockReturnValue(false),
+  };
+
   const serviceManager = {
     store,
     actions,
     eventBus,
     instance: {},
+    messageUpsertCoordinator,
   } as unknown as ServiceManager;
 
   return serviceManager;
@@ -478,6 +485,108 @@ describe('MessageService', () => {
 
       // Verify the controller was aborted
       expect(controller.signal.aborted).toBe(true);
+    });
+  });
+
+  describe('isAnyMessageStreaming', () => {
+    const build = (stopStreamingButtonState?: {
+      isVisible: boolean;
+      isDisabled: boolean;
+    }) => {
+      const serviceManager = createServiceManagerStub(
+        jest.fn().mockResolvedValue(undefined),
+        stopStreamingButtonState
+      );
+      const messageService = new MessageService(serviceManager, {
+        messaging: { messageTimeoutSecs: 0 },
+      } as any);
+      return { serviceManager, messageService };
+    };
+
+    it('is false when nothing is streaming', () => {
+      const { messageService } = build();
+      expect(messageService.isAnyMessageStreaming()).toBe(false);
+    });
+
+    it('is true while a chunk stream is active', () => {
+      const { messageService } = build();
+      messageService.inboundStreaming.streamingMessageID = 'chunk-1';
+      expect(messageService.isAnyMessageStreaming()).toBe(true);
+    });
+
+    it('is true while an upsert stream is active', () => {
+      const { serviceManager, messageService } = build();
+      (
+        serviceManager.messageUpsertCoordinator
+          .hasStreamingMessages as jest.Mock
+      ).mockReturnValue(true);
+
+      // The chunk registry is null for a pure-upsert flow, which is exactly why the
+      // predicate cannot be built on inboundStreaming alone.
+      expect(messageService.inboundStreaming.streamingMessageID).toBeNull();
+      expect(messageService.isAnyMessageStreaming()).toBe(true);
+    });
+
+    it('hideStopStreamingButtonIfIdle leaves the button alone while anything streams', () => {
+      const { serviceManager, messageService } = build({
+        isVisible: true,
+        isDisabled: false,
+      });
+      (
+        serviceManager.messageUpsertCoordinator
+          .hasStreamingMessages as jest.Mock
+      ).mockReturnValue(true);
+
+      messageService.hideStopStreamingButtonIfIdle();
+
+      expect(serviceManager.store.dispatch).not.toHaveBeenCalled();
+    });
+
+    it('hideStopStreamingButtonIfIdle hides once nothing streams', () => {
+      const { serviceManager, messageService } = build({
+        isVisible: true,
+        isDisabled: false,
+      });
+
+      messageService.hideStopStreamingButtonIfIdle();
+
+      const types = (serviceManager.store.dispatch as jest.Mock).mock.calls.map(
+        (call) => call[0]?.type
+      );
+      expect(types).toContain('SET_STOP_STREAMING_BUTTON_VISIBLE');
+      expect(types).toContain('SET_STOP_STREAMING_BUTTON_DISABLED');
+    });
+
+    it('hideStopStreamingButtonIfNoUpsertStreaming ignores an active chunk stream', () => {
+      const { serviceManager, messageService } = build({
+        isVisible: true,
+        isDisabled: false,
+      });
+      messageService.inboundStreaming.streamingMessageID = 'chunk-1';
+
+      // The chunk flow has always hidden on its own complete_item, so this variant must
+      // not consult inboundStreaming — otherwise complete_item would stop hiding.
+      messageService.hideStopStreamingButtonIfNoUpsertStreaming();
+
+      const types = (serviceManager.store.dispatch as jest.Mock).mock.calls.map(
+        (call) => call[0]?.type
+      );
+      expect(types).toContain('SET_STOP_STREAMING_BUTTON_VISIBLE');
+    });
+
+    it('hideStopStreamingButtonIfNoUpsertStreaming respects an active upsert stream', () => {
+      const { serviceManager, messageService } = build({
+        isVisible: true,
+        isDisabled: false,
+      });
+      (
+        serviceManager.messageUpsertCoordinator
+          .hasStreamingMessages as jest.Mock
+      ).mockReturnValue(true);
+
+      messageService.hideStopStreamingButtonIfNoUpsertStreaming();
+
+      expect(serviceManager.store.dispatch).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/ai-chat/tests/services/spec/MessageService_spec.ts
+++ b/packages/ai-chat/tests/services/spec/MessageService_spec.ts
@@ -78,6 +78,9 @@ const createServiceManagerStub = (
   // "is an upsertMessage stream still running".
   const messageUpsertCoordinator = {
     hasStreamingMessages: jest.fn().mockReturnValue(false),
+    // Cancellation settles every registered upsert stream, since none of them can be
+    // targeted by a chunk response id or a queued request id.
+    endAllStreaming: jest.fn(),
   };
 
   const serviceManager = {

--- a/packages/ai-chat/tests/services/spec/MessageUpsertCoordinator_spec.ts
+++ b/packages/ai-chat/tests/services/spec/MessageUpsertCoordinator_spec.ts
@@ -20,6 +20,9 @@ interface StubState {
   allMessagesByID: Record<string, unknown>;
   allMessageItemsByID: Record<string, unknown>;
   assistantMessageState: { localMessageIDs: string[] };
+  assistantInputState: {
+    stopStreamingButtonState: { isVisible: boolean; isDisabled: boolean };
+  };
 }
 
 function makeStubManager(initialMessages: Record<string, unknown> = {}) {
@@ -27,6 +30,11 @@ function makeStubManager(initialMessages: Record<string, unknown> = {}) {
     allMessagesByID: { ...initialMessages },
     allMessageItemsByID: {},
     assistantMessageState: { localMessageIDs: [] },
+    // The coordinator drives the stop streaming button from the upsert lifecycle,
+    // so it reads this slice on every call.
+    assistantInputState: {
+      stopStreamingButtonState: { isVisible: false, isDisabled: false },
+    },
   };
   const dispatch = jest.fn((action: { type: string; message?: any }) => {
     if (action.type === 'UPSERT_MESSAGE' && action.message?.id) {
@@ -45,6 +53,9 @@ function makeStubManager(initialMessages: Record<string, unknown> = {}) {
     ),
   };
   const finalizeStreamingMessage = jest.fn();
+  // The coordinator asks MessageService to hide the stop streaming button on a terminal
+  // upsert; MessageService is the one that decides whether anything else is still live.
+  const hideStopStreamingButtonIfIdle = jest.fn();
 
   const manager = {
     store: {
@@ -53,7 +64,7 @@ function makeStubManager(initialMessages: Record<string, unknown> = {}) {
     },
     fire,
     actions: chatActions,
-    messageService: { finalizeStreamingMessage },
+    messageService: { finalizeStreamingMessage, hideStopStreamingButtonIfIdle },
   } as unknown as ServiceManager;
 
   return {
@@ -63,6 +74,7 @@ function makeStubManager(initialMessages: Record<string, unknown> = {}) {
     fire,
     chatActions,
     finalizeStreamingMessage,
+    hideStopStreamingButtonIfIdle,
   };
 }
 
@@ -340,6 +352,126 @@ describe('MessageUpsertCoordinator', () => {
       const types = fire.mock.calls.map((c) => c[0].type);
       expect(types).toContain(BusEventType.PRE_RECEIVE);
       expect(types).toContain(BusEventType.RECEIVE);
+    });
+
+    it('markStreaming does not register streaming liveness', async () => {
+      const { manager } = makeStubManager();
+      const coord = new MessageUpsertCoordinator(manager);
+
+      // markStreaming is the receive-dedup hook the chunk path calls before the
+      // generation check. Treating it as liveness would re-register stale ids after a
+      // restart and pin the stop button on forever.
+      coord.markStreaming('m1');
+
+      expect(coord.hasStreamingMessages()).toBe(false);
+    });
+  });
+
+  describe('streaming liveness', () => {
+    it('registers on STREAMING and drops on COMPLETE', async () => {
+      const { manager } = makeStubManager();
+      const coord = new MessageUpsertCoordinator(manager);
+
+      await coord.upsert('m1', MessageState.STREAMING, () =>
+        textResponse('m1', 'partial')
+      );
+      expect(coord.hasStreamingMessages()).toBe(true);
+
+      await coord.upsert('m1', MessageState.COMPLETE, () =>
+        textResponse('m1', 'done')
+      );
+      expect(coord.hasStreamingMessages()).toBe(false);
+    });
+
+    it('drops on ERROR', async () => {
+      const { manager } = makeStubManager();
+      const coord = new MessageUpsertCoordinator(manager);
+
+      await coord.upsert('m1', MessageState.STREAMING, () =>
+        textResponse('m1', 'partial')
+      );
+      await coord.upsert('m1', MessageState.ERROR, () =>
+        textResponse('m1', 'failed')
+      );
+
+      // ERROR never reaches firePostReceiveAndFinalize, so the drop has to happen in
+      // runOne rather than in the finalize phase.
+      expect(coord.hasStreamingMessages()).toBe(false);
+    });
+
+    it('tracks ids independently', async () => {
+      const { manager } = makeStubManager();
+      const coord = new MessageUpsertCoordinator(manager);
+
+      await coord.upsert('m1', MessageState.STREAMING, () =>
+        textResponse('m1', 'a')
+      );
+      await coord.upsert('m2', MessageState.STREAMING, () =>
+        textResponse('m2', 'b')
+      );
+
+      await coord.upsert('m1', MessageState.COMPLETE, () =>
+        textResponse('m1', 'a done')
+      );
+      expect(coord.hasStreamingMessages()).toBe(true);
+
+      await coord.upsert('m2', MessageState.COMPLETE, () =>
+        textResponse('m2', 'b done')
+      );
+      expect(coord.hasStreamingMessages()).toBe(false);
+    });
+
+    it('drains on clear and clearAll', async () => {
+      const { manager } = makeStubManager();
+      const coord = new MessageUpsertCoordinator(manager);
+
+      await coord.upsert('m1', MessageState.STREAMING, () =>
+        textResponse('m1', 'a')
+      );
+      coord.clear('m1');
+      expect(coord.hasStreamingMessages()).toBe(false);
+
+      await coord.upsert('m2', MessageState.STREAMING, () =>
+        textResponse('m2', 'b')
+      );
+      coord.clearAll();
+      expect(coord.hasStreamingMessages()).toBe(false);
+    });
+
+    it('drops the registration even when the slot fan-out throws', async () => {
+      const { manager, state, dispatch, chatActions } = makeStubManager();
+      const coord = new MessageUpsertCoordinator(manager);
+
+      await coord.upsert('m1', MessageState.STREAMING, () =>
+        textResponse('m1', 'partial')
+      );
+
+      // Make the fan-out loop actually run for m1. It skips items whose reference the
+      // reducer reused verbatim, so the dispatch has to hand back a fresh object the way
+      // the real reducer does for a changed item.
+      state.assistantMessageState.localMessageIDs = ['local1'];
+      dispatch.mockImplementation((action: { type: string; message?: any }) => {
+        if (action.type === 'UPSERT_MESSAGE' && action.message?.id) {
+          state.allMessagesByID[action.message.id] = action.message;
+          state.allMessageItemsByID = {
+            local1: { ui_state: { id: 'local1' }, fullMessageID: 'm1' },
+          };
+        }
+      });
+
+      // The event bus does not swallow listener exceptions, so everything after
+      // fanOutChangedSlots is skipped — the registration has to already be gone by then.
+      chatActions.handleUserDefinedResponseItems.mockRejectedValueOnce(
+        new Error('listener blew up')
+      );
+
+      await expect(
+        coord.upsert('m1', MessageState.COMPLETE, () =>
+          textResponse('m1', 'done')
+        )
+      ).rejects.toThrow('listener blew up');
+
+      expect(coord.hasStreamingMessages()).toBe(false);
     });
   });
 });

--- a/packages/ai-chat/tests/services/spec/MessageUpsertCoordinator_spec.ts
+++ b/packages/ai-chat/tests/services/spec/MessageUpsertCoordinator_spec.ts
@@ -421,6 +421,42 @@ describe('MessageUpsertCoordinator', () => {
       expect(coord.hasStreamingMessages()).toBe(false);
     });
 
+    it('endAllStreaming settles every registered id and drains', async () => {
+      const { manager, dispatch } = makeStubManager();
+      const coord = new MessageUpsertCoordinator(manager);
+
+      await coord.upsert('m1', MessageState.STREAMING, () =>
+        textResponse('m1', 'a')
+      );
+      await coord.upsert('m2', MessageState.STREAMING, () =>
+        textResponse('m2', 'b')
+      );
+
+      dispatch.mockClear();
+      coord.endAllStreaming();
+
+      const ended = dispatch.mock.calls
+        .map((call) => call[0] as { type: string; messageID?: string })
+        .filter((action) => action?.type === 'END_MESSAGE_STREAMING')
+        .map((action) => action.messageID);
+      expect(ended.sort()).toEqual(['m1', 'm2']);
+      expect(coord.hasStreamingMessages()).toBe(false);
+    });
+
+    it('endAllStreaming is a no-op when nothing is registered', async () => {
+      const { manager, dispatch } = makeStubManager();
+      const coord = new MessageUpsertCoordinator(manager);
+
+      await coord.upsert('m1', MessageState.COMPLETE, () =>
+        textResponse('m1', 'done')
+      );
+
+      dispatch.mockClear();
+      coord.endAllStreaming();
+
+      expect(dispatch).not.toHaveBeenCalled();
+    });
+
     it('drains on clear and clearAll', async () => {
       const { manager } = makeStubManager();
       const coord = new MessageUpsertCoordinator(manager);

--- a/packages/ai-chat/tests/store/spec/upsertMessageReducer_spec.ts
+++ b/packages/ai-chat/tests/store/spec/upsertMessageReducer_spec.ts
@@ -309,4 +309,107 @@ describe('[UPSERT_MESSAGE] reducer', () => {
     expect(after.allMessagesByID['m1']).toBe(m1MessageRefBefore);
     expect(after.allMessagesByID['m3']).toBe(m3MessageRefBefore);
   });
+
+  describe('streaming flags', () => {
+    it('marks items as streaming while the message is streaming', () => {
+      store.dispatch(
+        actions.upsertMessage(makeTextResponse('s1', ['partial']), true)
+      );
+
+      const [local] = localItemsForMessage(store.getState() as AppState, 's1');
+      expect(local.ui_state.isIntermediateStreaming).toBe(true);
+      expect(local.ui_state.streamingState?.isDone).toBe(false);
+    });
+
+    it('settles the flags when the message stops streaming', () => {
+      store.dispatch(
+        actions.upsertMessage(makeTextResponse('s2', ['partial']), true)
+      );
+      store.dispatch(
+        actions.upsertMessage(makeTextResponse('s2', ['all of it']), false)
+      );
+
+      const [local] = localItemsForMessage(store.getState() as AppState, 's2');
+      expect(local.ui_state.isIntermediateStreaming).toBe(false);
+      expect(local.ui_state.streamingState?.isDone).toBe(true);
+    });
+
+    it('settles the flags even when the payload did not change', () => {
+      // The reference-stability path would otherwise reuse the streaming item
+      // verbatim and leave it rendering as mid-stream forever.
+      store.dispatch(
+        actions.upsertMessage(makeTextResponse('s3', ['same'], ['1']), true)
+      );
+      store.dispatch(
+        actions.upsertMessage(makeTextResponse('s3', ['same'], ['1']), false)
+      );
+
+      const [local] = localItemsForMessage(store.getState() as AppState, 's3');
+      expect(local.ui_state.streamingState?.isDone).toBe(true);
+    });
+
+    it('applies the flags to nested items too', () => {
+      const card: MessageResponse = {
+        id: 's4',
+        output: {
+          generic: [
+            {
+              response_type: MessageResponseTypes.CARD,
+              body: [
+                { response_type: MessageResponseTypes.TEXT, text: 'in a card' },
+              ],
+            } as CardItem,
+          ],
+        },
+      };
+
+      store.dispatch(actions.upsertMessage(card, true));
+
+      const state = store.getState() as AppState;
+      const nested = Object.values(state.allMessageItemsByID).filter(
+        (item) => item.fullMessageID === 's4'
+      );
+      expect(nested.length).toBeGreaterThan(1);
+      for (const item of nested) {
+        expect(item.ui_state.streamingState?.isDone).toBe(false);
+      }
+    });
+  });
+
+  describe('[END_MESSAGE_STREAMING] reducer', () => {
+    it('settles a streaming message left mid-stream', () => {
+      store.dispatch(
+        actions.upsertMessage(makeTextResponse('e1', ['partial']), true)
+      );
+
+      store.dispatch(actions.endMessageStreaming('e1'));
+
+      const [local] = localItemsForMessage(store.getState() as AppState, 'e1');
+      expect(local.ui_state.isIntermediateStreaming).toBe(false);
+      expect(local.ui_state.streamingState?.isDone).toBe(true);
+    });
+
+    it('leaves other messages alone', () => {
+      store.dispatch(
+        actions.upsertMessage(makeTextResponse('e2', ['a']), true)
+      );
+      store.dispatch(
+        actions.upsertMessage(makeTextResponse('e3', ['b']), true)
+      );
+
+      store.dispatch(actions.endMessageStreaming('e2'));
+
+      const [other] = localItemsForMessage(store.getState() as AppState, 'e3');
+      expect(other.ui_state.streamingState?.isDone).toBe(false);
+    });
+
+    it('returns the same state object when nothing was streaming', () => {
+      store.dispatch(actions.upsertMessage(makeTextResponse('e4', ['done'])));
+      const before = store.getState();
+
+      store.dispatch(actions.endMessageStreaming('e4'));
+
+      expect(store.getState()).toBe(before);
+    });
+  });
 });

--- a/packages/ai-chat/tests/utils/spec/streamingUtils_spec.ts
+++ b/packages/ai-chat/tests/utils/spec/streamingUtils_spec.ts
@@ -9,6 +9,7 @@
 
 import {
   chunkHasDisplayableContent,
+  deriveStreamingItemText,
   mergePartialResponseOptions,
   messageHasDisplayableContent,
   resetStopStreamingButton,
@@ -29,6 +30,55 @@ describe('streamingUtils', () => {
       }),
     };
   };
+
+  describe('deriveStreamingItemText', () => {
+    // The chunk flow accumulates text in `chunks` — the item's own text holds only the
+    // first chunk, so the join must win while chunks exist.
+    it('joins chunks for a chunk-delivered item mid-stream', () => {
+      expect(
+        deriveStreamingItemText('Hello ', {
+          isDone: false,
+          chunks: [{ text: 'Hello ' }, { text: 'world' }],
+        })
+      ).toBe('Hello world');
+    });
+
+    // The upsert flow streams whole-message snapshots: `chunks` is always empty and the
+    // item's text is complete on every update. Joining the empty array rendered
+    // upsert-streamed text as blank until COMPLETE — the regression this pins.
+    it('falls back to the item text for a snapshot-delivered item mid-stream', () => {
+      expect(
+        deriveStreamingItemText('Hello world so far', {
+          isDone: false,
+          chunks: [],
+        })
+      ).toBe('Hello world so far');
+    });
+
+    it('uses the item text once streaming is done', () => {
+      expect(
+        deriveStreamingItemText('The final text', {
+          isDone: true,
+          chunks: [{ text: 'stale ' }, { text: 'chunks' }],
+        })
+      ).toBe('The final text');
+    });
+
+    it('uses the item text when there is no streaming state', () => {
+      expect(deriveStreamingItemText('Plain text', undefined)).toBe(
+        'Plain text'
+      );
+    });
+
+    it('treats chunks with missing text as empty rather than "undefined"', () => {
+      expect(
+        deriveStreamingItemText('', {
+          isDone: false,
+          chunks: [{ text: 'a' }, {}, { text: 'b' }],
+        })
+      ).toBe('ab');
+    });
+  });
 
   describe('resolveChunkContext', () => {
     it('extracts metadata for partial chunks', () => {

--- a/packages/ai-chat/tests/utils/spec/streamingUtils_spec.ts
+++ b/packages/ai-chat/tests/utils/spec/streamingUtils_spec.ts
@@ -109,53 +109,10 @@ describe('streamingUtils', () => {
         expect(store.dispatch).not.toHaveBeenCalled();
       });
 
-      describe('with streamingMessageID parameter', () => {
-        it('keeps button visible when streaming is active (edge case fix)', () => {
-          const store = createStore(true);
-
-          // Simulate: customSendMessage resolved but streaming still active
-          resetStopStreamingButton(store as any, 'active-stream-123');
-
-          // Button should STAY visible
-          expect(store.dispatch).not.toHaveBeenCalled();
-        });
-
-        it('hides button when no streaming active (streamingMessageID is null)', () => {
-          const store = createStore(true);
-
-          // Simulate: no active streaming
-          resetStopStreamingButton(store as any, null);
-
-          // Button should be hidden
-          expect(store.dispatch).toHaveBeenCalledTimes(2);
-        });
-
-        it('hides button when streamingMessageID is undefined', () => {
-          const store = createStore(true);
-
-          resetStopStreamingButton(store as any, undefined);
-
-          // Button should be hidden
-          expect(store.dispatch).toHaveBeenCalledTimes(2);
-        });
-
-        it('maintains backward compatibility (no parameter)', () => {
-          const store = createStore(true);
-
-          // Old behavior: always hide when called
-          resetStopStreamingButton(store as any);
-
-          expect(store.dispatch).toHaveBeenCalledTimes(2);
-        });
-
-        it('does nothing when button not visible, regardless of streamingMessageID', () => {
-          const store = createStore(false);
-
-          resetStopStreamingButton(store as any, 'active-stream');
-
-          expect(store.dispatch).not.toHaveBeenCalled();
-        });
-      });
+      // This helper hides unconditionally. Deciding *whether* to hide while other
+      // messages are still streaming belongs to MessageService — see its
+      // hideStopStreamingButtonIfIdle / hideStopStreamingButtonIfNoUpsertStreaming,
+      // covered in MessageService_spec and the upsertMessage instance specs.
     });
   });
 


### PR DESCRIPTION

`upsertMessage` was never wired into the chat's streaming lifecycle state. Two user-visible symptoms fall out of that, and the fix for the second also closes a pre-existing defect on the `addMessageChunk` path.

**Items stuck rendering mid-stream.** Streaming-aware rendering keys off `ui_state.streamingState.isDone` — most visibly `cds-aichat-markdown`, which holds a table in an in-progress treatment until that flips. The chunk pipeline wrote those flags; the upsert reducer never did, so a table streamed through `upsertMessage` never left loading. And a stream that ended without a terminal chunk — cancelled, or a `customSendMessage` that threw — never had its flags cleared at all, which is the `addMessageChunk` half and matches the existing stuck-table reports.

**The stop button vanishing early.** `resetStopStreamingButton` was called bare from most call sites, and the two flows track streaming in separate registries — `InboundStreamingCoordinator.streamingMessageID` for chunks, the upsert coordinator's own record for upserts. Neither could see the other, so whichever stream finished first hid the button for both.

**Cancelled upsert streams settling nothing.** Cancellation resolves its target by chunk response id or queued request id, and an upsert stream has neither — so cancelling one left its items mid-stream *and* left its id in the coordinator's streaming registry, pinning the stop button up for the rest of the session. Only `restartConversation` recovered, by tearing the session down.

Three commits: one per symptom, then the cancellation gap.

#### Changelog

**New**

- `MessageService.isAnyMessageStreaming()` — single source of truth for "is the chat still producing output", consulting both registries.
- `MessageService.hideStopStreamingButtonIfIdle()` and `hideStopStreamingButtonIfNoUpsertStreaming()` — the two hide policies. The second deliberately ignores the chunk registry so `complete_item` keeps hiding the button exactly as it always has.
- `END_MESSAGE_STREAMING` action — settles a message's items wherever a stream terminates, so the end state no longer depends on the host sending a `complete_item` or `final_response`.
- `MessageUpsertCoordinator.hasStreamingMessages()`, backed by a `streamingIDs` set written only on the `STREAMING` ⇄ terminal transitions so it cannot leak the way the receive-dedup record does.
- `MessageUpsertCoordinator.endAllStreaming()` — settles every registered upsert stream and drains the registry. Called from `cancelCurrentMessageRequest` and `cancelAllMessageRequests`.

**Changed**

- `UPSERT_MESSAGE` carries an `isStreaming` flag; `rebuildLocalItemsForUpsert` mirrors the chunk pipeline's flags onto top-level *and* nested items, so a table inside a card or grid behaves the same as a top-level one.
- The streaming flag joins the reference-stability comparison. Without it a `STREAMING` → `COMPLETE` transition whose payload happened not to change was swallowed, leaving the item mid-stream forever. Reference stability for genuinely unchanged items is preserved — `fanOutChangedSlots` depends on it for `USER_DEFINED_RESPONSE` dedupe.
- A streaming `upsertMessage` whose message carries `streaming_metadata.cancellable` now shows the stop button, and `COMPLETE` / `ERROR` hides it. Previously the upsert flow never drove the button at all.

**Removed**

- `resetStopStreamingButton`'s `streamingMessageID` parameter. It now hides unconditionally; deciding *whether* to hide is `MessageService` policy, which is what lets concurrent streams stop hiding each other's button.

#### Testing / Reviewing

`npm run test --workspace=@carbon/ai-chat` — 106 suites, 1195 tests, green. New coverage:

- `upsertMessageReducer_spec` — streaming flags set and settled, including the unchanged-payload case, nested items, and the `END_MESSAGE_STREAMING` reducer's no-op path.
- `MessageUpsertCoordinator_spec` — `streamingIDs` lifecycle, independence across ids, draining on `clear`/`clearAll`, and that the registration is dropped even when the slot fan-out throws.
- `MessageService_spec` — `isAnyMessageStreaming` across both registries, and that the two hide variants differ in exactly the intended way.
- `upsertMessage_spec` — button behavior end to end, including two concurrent upsert streams and both orderings of a mixed chunk/upsert pair.
- `addMessageChunk_spec` — two regression pins that `complete_item` still hides the button, including the no-streaming-metadata case, plus the original report: a stream cancelled with **no** closing chunk now settles its flags. The pre-existing cancellation coverage only had the case where the host *does* send a `complete_item` carrying `stream_stopped` — the path that already worked.
- `upsertMessage_spec` / `MessageUpsertCoordinator_spec` — a cancelled upsert stream settles and releases the button, all registered streams settle rather than one, and `endAllStreaming` no-ops when nothing is registered.

Worth a reviewer's attention:

- **The `hideStopStreamingButtonIfNoUpsertStreaming` split is deliberate.** Making the chunk call sites fully concurrency-aware would keep the button up past `complete_item`, which is a behavior change this PR is not making. The two pinned chunk tests exist to catch anyone collapsing the two methods into one.
- **`endAllStreaming` settles every stream, not one — deliberately.** Both callers already mean "stop everything", and the coordinator cannot map a cancelled request back to the upsert ids it produced. *Targeted* cancellation of a single upsert stream still needs the id routing in #1816, and the `TODO` there now says exactly that rather than implying the state is unreachable. A host that ignores the abort and keeps streaming simply re-registers on its next `STREAMING` upsert.

Manual check, once built: stream a markdown table through `upsertMessage` and confirm it leaves loading mode; start two concurrent streams and confirm the stop button survives the first one finishing; hit stop mid-stream and confirm both the table and the button settle.
