### PR TITLE
feat(messaging): graduate upsertMessage and MessageState

### DIFF
--- a/demo/src/customSendMessage/doAudio.ts
+++ b/demo/src/customSendMessage/doAudio.ts
@@ -7,10 +7,17 @@
  *  @license
  */
 
-import { ChatInstance, MessageResponseTypes } from '@carbon/ai-chat';
+import {
+  ChatInstance,
+  MessageResponseTypes,
+  MessageState,
+} from '@carbon/ai-chat';
+import { uuid } from '@carbon/ai-chat-components/es/globals/utils/uuid.js';
 
 function doAudio(instance: ChatInstance) {
-  instance.messaging.addMessage({
+  const messageID = uuid();
+  instance.messaging.upsertMessage(messageID, MessageState.COMPLETE, () => ({
+    id: messageID,
     output: {
       generic: [
         {
@@ -41,11 +48,13 @@ function doAudio(instance: ChatInstance) {
         },
       ],
     },
-  });
+  }));
 }
 
 function doAudioSoundCloud(instance: ChatInstance) {
-  instance.messaging.addMessage({
+  const messageID = uuid();
+  instance.messaging.upsertMessage(messageID, MessageState.COMPLETE, () => ({
+    id: messageID,
     output: {
       generic: [
         {
@@ -61,11 +70,13 @@ function doAudioSoundCloud(instance: ChatInstance) {
         },
       ],
     },
-  });
+  }));
 }
 
 function doAudioMp3(instance: ChatInstance) {
-  instance.messaging.addMessage({
+  const messageID = uuid();
+  instance.messaging.upsertMessage(messageID, MessageState.COMPLETE, () => ({
+    id: messageID,
     output: {
       generic: [
         {
@@ -89,7 +100,7 @@ function doAudioMp3(instance: ChatInstance) {
         },
       ],
     },
-  });
+  }));
 }
 
 export { doAudio, doAudioSoundCloud, doAudioMp3 };

--- a/demo/src/customSendMessage/doButton.ts
+++ b/demo/src/customSendMessage/doButton.ts
@@ -11,14 +11,18 @@ import {
   ButtonItemType,
   ChatInstance,
   MessageResponseTypes,
+  MessageState,
 } from '@carbon/ai-chat';
+import { uuid } from '@carbon/ai-chat-components/es/globals/utils/uuid.js';
 import {
   CHAT_BUTTON_KIND,
   CHAT_BUTTON_SIZE,
 } from '@carbon/ai-chat-components/es/react/chat-button.js';
 
 function doButton(instance: ChatInstance) {
-  instance.messaging.addMessage({
+  const messageID = uuid();
+  instance.messaging.upsertMessage(messageID, MessageState.COMPLETE, () => ({
+    id: messageID,
     output: {
       generic: [
         {
@@ -84,7 +88,7 @@ function doButton(instance: ChatInstance) {
         },
       ],
     },
-  });
+  }));
 }
 
 export { doButton };

--- a/demo/src/customSendMessage/doCard.ts
+++ b/demo/src/customSendMessage/doCard.ts
@@ -11,12 +11,16 @@ import {
   ButtonItemType,
   ChatInstance,
   MessageResponseTypes,
+  MessageState,
   WidthOptions,
 } from '@carbon/ai-chat';
+import { uuid } from '@carbon/ai-chat-components/es/globals/utils/uuid.js';
 import { BUTTON_KIND } from '@carbon/web-components/es/components/button/defs.js';
 
 function doCard(instance: ChatInstance) {
-  instance.messaging.addMessage({
+  const messageID = uuid();
+  instance.messaging.upsertMessage(messageID, MessageState.COMPLETE, () => ({
+    id: messageID,
     output: {
       generic: [
         {
@@ -275,7 +279,7 @@ function doCard(instance: ChatInstance) {
         },
       ],
     },
-  });
+  }));
 }
 
 export { doCard };

--- a/demo/src/customSendMessage/doCarousel.ts
+++ b/demo/src/customSendMessage/doCarousel.ts
@@ -11,11 +11,15 @@ import {
   ChatInstance,
   GenericItem,
   MessageResponseTypes,
+  MessageState,
   TextItem,
 } from '@carbon/ai-chat';
+import { uuid } from '@carbon/ai-chat-components/es/globals/utils/uuid.js';
 
 function doCarousel(instance: ChatInstance) {
-  instance.messaging.addMessage({
+  const messageID = uuid();
+  instance.messaging.upsertMessage(messageID, MessageState.COMPLETE, () => ({
+    id: messageID,
     output: {
       generic: [
         {
@@ -125,7 +129,7 @@ function doCarousel(instance: ChatInstance) {
         } as unknown as GenericItem,
       ],
     },
-  });
+  }));
 }
 
 export { doCarousel };

--- a/demo/src/customSendMessage/doCode.ts
+++ b/demo/src/customSendMessage/doCode.ts
@@ -11,13 +11,17 @@ import {
   ChatInstance,
   CustomSendMessageOptions,
   MessageResponseTypes,
+  MessageState,
 } from '@carbon/ai-chat';
+import { uuid } from '@carbon/ai-chat-components/es/globals/utils/uuid.js';
 
 import { CODE } from './constants';
-import { doTextStreaming } from './doText';
+import { doTextStreamingUpsert } from './doText';
 
 function doCode(instance: ChatInstance) {
-  instance.messaging.addMessage({
+  const messageID = uuid();
+  instance.messaging.upsertMessage(messageID, MessageState.COMPLETE, () => ({
+    id: messageID,
     output: {
       generic: [
         {
@@ -26,24 +30,17 @@ function doCode(instance: ChatInstance) {
         },
       ],
     },
-  });
+  }));
 }
 
 function doCodeStreaming(
   instance: ChatInstance,
   requestOptions?: CustomSendMessageOptions
 ) {
-  doTextStreaming(
-    instance,
-    CODE,
-    true,
-    undefined,
-    undefined,
-    undefined,
-    undefined,
-    undefined,
-    requestOptions
-  );
+  doTextStreamingUpsert(instance, {
+    text: CODE,
+    requestOptions,
+  });
 }
 
 export { doCode, doCodeStreaming };

--- a/demo/src/customSendMessage/doConversationalSearch.ts
+++ b/demo/src/customSendMessage/doConversationalSearch.ts
@@ -9,10 +9,10 @@
 
 import {
   ChatInstance,
-  CustomSendMessageOptions,
   ConversationalSearchItem,
+  CustomSendMessageOptions,
   MessageResponseTypes,
-  StreamChunk,
+  MessageState,
 } from '@carbon/ai-chat';
 
 import { uuid } from '@carbon/ai-chat-components/es/globals/utils/uuid.js';
@@ -70,11 +70,13 @@ function doConversationalSearch(instance: ChatInstance) {
     ...META,
   };
 
-  instance.messaging.addMessage({
+  const messageID = uuid();
+  instance.messaging.upsertMessage(messageID, MessageState.COMPLETE, () => ({
+    id: messageID,
     output: {
       generic: [response],
     },
-  });
+  }));
 }
 
 async function doConversationalSearchStreaming(
@@ -83,84 +85,56 @@ async function doConversationalSearchStreaming(
   requestOptions?: CustomSendMessageOptions
 ) {
   const signal = requestOptions?.signal;
-  const responseID = uuid();
+  const messageID = uuid();
   const words = text.split(' ');
-  let isCanceled = false;
-  let lastWordIndex = 0;
 
-  // Listen to abort signal (handles both stop button and restart/clear)
+  // The accumulated answer lives here rather than being sent as deltas.
+  let streamedText = '';
+  let isCanceled = signal?.aborted ?? false;
+
   const abortHandler = () => {
     isCanceled = true;
   };
   signal?.addEventListener('abort', abortHandler);
 
+  // Search citations only make sense once the answer is whole, so they attach
+  // on the completing update rather than on every tick.
+  const apply = (state: MessageState) =>
+    instance.messaging.upsertMessage(messageID, state, () => {
+      const isComplete = state === MessageState.COMPLETE;
+      return {
+        id: messageID,
+        output: {
+          generic: [
+            {
+              response_type: MessageResponseTypes.CONVERSATIONAL_SEARCH,
+              text: streamedText,
+              streaming_metadata: {
+                id: '1',
+                cancellable: true,
+                stream_stopped: isComplete && isCanceled,
+              },
+              ...(isComplete && !isCanceled ? META : {}),
+            },
+          ],
+        },
+      };
+    });
+
   try {
     for (let index = 0; index < words.length && !isCanceled; index++) {
-      const word = words[index];
-      lastWordIndex = index;
-
       await sleep(WORD_DELAY);
-      // Each time you get a chunk back, you can call `addMessageChunk`.
-      instance.messaging.addMessageChunk({
-        partial_item: {
-          response_type: MessageResponseTypes.CONVERSATIONAL_SEARCH,
-          // The next chunk, the chat component will deal with appending these chunks.
-          text: `${word} `,
-          streaming_metadata: {
-            // This is the id of the item inside the response. If you have multiple items in this message they will be
-            // ordered in the view in the order of the first message chunk received. If you want message item 1 to
-            // appear above message item 2, be sure to seed it with a chunk first, even if its empty to start.
-            id: '1',
-            cancellable: true,
-          },
-        },
-        streaming_metadata: {
-          // This is the id of the entire message response.
-          response_id: responseID,
-        },
-      });
+      if (isCanceled) {
+        break;
+      }
+      streamedText += `${words[index]} `;
+      await apply(MessageState.STREAMING);
     }
-
-    // When you are done streaming this item in the response, you should call the complete item.
-    // This requires ALL the concatenated final text. If you want to append text, run a post processing safety check, or anything
-    // else that mutates the data, you can do so here.
-    let completeItem = {
-      response_type: MessageResponseTypes.CONVERSATIONAL_SEARCH,
-      text: isCanceled ? words.splice(0, lastWordIndex).join(' ') : text,
-      streaming_metadata: {
-        // This is the id of the item inside the response.
-        id: '1',
-        stream_stopped: isCanceled,
-      },
-    };
 
     if (!isCanceled) {
-      completeItem = {
-        ...completeItem,
-        ...META,
-      };
-      instance.messaging.addMessageChunk({
-        complete_item: completeItem,
-        streaming_metadata: {
-          // This is the id of the entire message response.
-          response_id: responseID,
-        },
-      } as StreamChunk);
+      streamedText = text;
     }
-
-    // When all and any chunks are complete, you send a final response.
-    // You can rearrange or re-write everything here, but what you send here is what the chat will display when streaming
-    // has been completed.
-    const finalResponse = {
-      id: responseID,
-      output: {
-        generic: [completeItem],
-      },
-    };
-
-    await instance.messaging.addMessageChunk({
-      final_response: finalResponse,
-    } as StreamChunk);
+    await apply(MessageState.COMPLETE);
   } finally {
     signal?.removeEventListener('abort', abortHandler);
   }

--- a/demo/src/customSendMessage/doDate.ts
+++ b/demo/src/customSendMessage/doDate.ts
@@ -7,10 +7,17 @@
  *  @license
  */
 
-import { ChatInstance, MessageResponseTypes } from '@carbon/ai-chat';
+import {
+  ChatInstance,
+  MessageResponseTypes,
+  MessageState,
+} from '@carbon/ai-chat';
+import { uuid } from '@carbon/ai-chat-components/es/globals/utils/uuid.js';
 
 function doDate(instance: ChatInstance) {
-  instance.messaging.addMessage({
+  const messageID = uuid();
+  instance.messaging.upsertMessage(messageID, MessageState.COMPLETE, () => ({
+    id: messageID,
     output: {
       generic: [
         {
@@ -18,7 +25,7 @@ function doDate(instance: ChatInstance) {
         },
       ],
     },
-  });
+  }));
 }
 
 export { doDate };

--- a/demo/src/customSendMessage/doError.ts
+++ b/demo/src/customSendMessage/doError.ts
@@ -7,10 +7,17 @@
  *  @license
  */
 
-import { ChatInstance, MessageResponseTypes } from '@carbon/ai-chat';
+import {
+  ChatInstance,
+  MessageResponseTypes,
+  MessageState,
+} from '@carbon/ai-chat';
+import { uuid } from '@carbon/ai-chat-components/es/globals/utils/uuid.js';
 
 function doError(instance: ChatInstance) {
-  instance.messaging.addMessage({
+  const messageID = uuid();
+  instance.messaging.upsertMessage(messageID, MessageState.COMPLETE, () => ({
+    id: messageID,
     output: {
       generic: [
         {
@@ -18,7 +25,7 @@ function doError(instance: ChatInstance) {
         },
       ],
     },
-  });
+  }));
 }
 
 export { doError };

--- a/demo/src/customSendMessage/doFileUpload.ts
+++ b/demo/src/customSendMessage/doFileUpload.ts
@@ -12,6 +12,7 @@ import {
   ExternalFileReference,
   MessageRequest,
   MessageResponseTypes,
+  MessageState,
   StructuredData,
   StructuredField,
 } from '@carbon/ai-chat';
@@ -149,7 +150,9 @@ function doFileUploadResponse(
     lines.push('');
   }
 
-  instance.messaging.addMessage({
+  const messageID = uuid();
+  instance.messaging.upsertMessage(messageID, MessageState.COMPLETE, () => ({
+    id: messageID,
     output: {
       generic: [
         {
@@ -158,7 +161,7 @@ function doFileUploadResponse(
         },
       ],
     },
-  });
+  }));
 }
 
 export { mockOnFileUpload, doFileUploadResponse };

--- a/demo/src/customSendMessage/doGrid.ts
+++ b/demo/src/customSendMessage/doGrid.ts
@@ -10,11 +10,15 @@
 import {
   ChatInstance,
   MessageResponseTypes,
+  MessageState,
   WidthOptions,
 } from '@carbon/ai-chat';
+import { uuid } from '@carbon/ai-chat-components/es/globals/utils/uuid.js';
 
 function doGrid(instance: ChatInstance) {
-  instance.messaging.addMessage({
+  const messageID = uuid();
+  instance.messaging.upsertMessage(messageID, MessageState.COMPLETE, () => ({
+    id: messageID,
     output: {
       generic: [
         {
@@ -485,7 +489,7 @@ function doGrid(instance: ChatInstance) {
         },
       ],
     },
-  });
+  }));
 }
 
 export { doGrid };

--- a/demo/src/customSendMessage/doHumanAgent.ts
+++ b/demo/src/customSendMessage/doHumanAgent.ts
@@ -7,10 +7,17 @@
  *  @license
  */
 
-import { ChatInstance, MessageResponseTypes } from '@carbon/ai-chat';
+import {
+  ChatInstance,
+  MessageResponseTypes,
+  MessageState,
+} from '@carbon/ai-chat';
+import { uuid } from '@carbon/ai-chat-components/es/globals/utils/uuid.js';
 
 function doHumanAgent(instance: ChatInstance) {
-  instance.messaging.addMessage({
+  const messageID = uuid();
+  instance.messaging.upsertMessage(messageID, MessageState.COMPLETE, () => ({
+    id: messageID,
     output: {
       generic: [
         {
@@ -18,7 +25,7 @@ function doHumanAgent(instance: ChatInstance) {
         },
       ],
     },
-  });
+  }));
 }
 
 export { doHumanAgent };

--- a/demo/src/customSendMessage/doIFrame.ts
+++ b/demo/src/customSendMessage/doIFrame.ts
@@ -11,11 +11,15 @@ import {
   ChatInstance,
   IFrameItem,
   MessageResponseTypes,
+  MessageState,
   TextItem,
 } from '@carbon/ai-chat';
+import { uuid } from '@carbon/ai-chat-components/es/globals/utils/uuid.js';
 
 function doIFrame(instance: ChatInstance) {
-  instance.messaging.addMessage({
+  const messageID = uuid();
+  instance.messaging.upsertMessage(messageID, MessageState.COMPLETE, () => ({
+    id: messageID,
     output: {
       generic: [
         {
@@ -43,7 +47,7 @@ function doIFrame(instance: ChatInstance) {
         } as IFrameItem,
       ],
     },
-  });
+  }));
 }
 
 export { doIFrame };

--- a/demo/src/customSendMessage/doImage.ts
+++ b/demo/src/customSendMessage/doImage.ts
@@ -11,10 +11,14 @@ import {
   ButtonItemType,
   ChatInstance,
   MessageResponseTypes,
+  MessageState,
 } from '@carbon/ai-chat';
+import { uuid } from '@carbon/ai-chat-components/es/globals/utils/uuid.js';
 import { BUTTON_KIND } from '@carbon/web-components/es/components/button/defs.js';
 function doImage(instance: ChatInstance) {
-  instance.messaging.addMessage({
+  const messageID = uuid();
+  instance.messaging.upsertMessage(messageID, MessageState.COMPLETE, () => ({
+    id: messageID,
     output: {
       generic: [
         {
@@ -111,7 +115,7 @@ function doImage(instance: ChatInstance) {
         },
       ],
     },
-  });
+  }));
 }
 
 export { doImage };

--- a/demo/src/customSendMessage/doMentionCommand.ts
+++ b/demo/src/customSendMessage/doMentionCommand.ts
@@ -11,8 +11,10 @@ import {
   ChatInstance,
   MessageRequest,
   MessageResponseTypes,
+  MessageState,
   SuggestionItem,
 } from '@carbon/ai-chat';
+import { uuid } from '@carbon/ai-chat-components/es/globals/utils/uuid.js';
 
 /**
  * Mock `InputConfig.mention` / `InputConfig.command` fixtures and callbacks
@@ -147,7 +149,9 @@ function doMentionCommandResponse(
     parts.push(`**Commands:** ${cmds}`);
   }
 
-  instance.messaging.addMessage({
+  const messageID = uuid();
+  instance.messaging.upsertMessage(messageID, MessageState.COMPLETE, () => ({
+    id: messageID,
     output: {
       generic: [
         {
@@ -156,7 +160,7 @@ function doMentionCommandResponse(
         },
       ],
     },
-  });
+  }));
 }
 
 export {

--- a/demo/src/customSendMessage/doOption.ts
+++ b/demo/src/customSendMessage/doOption.ts
@@ -7,7 +7,12 @@
  *  @license
  */
 
-import { ChatInstance, MessageResponseTypes } from '@carbon/ai-chat';
+import {
+  ChatInstance,
+  MessageResponseTypes,
+  MessageState,
+} from '@carbon/ai-chat';
+import { uuid } from '@carbon/ai-chat-components/es/globals/utils/uuid.js';
 
 import { RESPONSE_MAP } from './responseMap';
 
@@ -16,7 +21,9 @@ function doOption(instance: ChatInstance) {
     label: key,
     value: { input: { text: key } },
   }));
-  instance.messaging.addMessage({
+  const messageID = uuid();
+  instance.messaging.upsertMessage(messageID, MessageState.COMPLETE, () => ({
+    id: messageID,
     output: {
       generic: [
         {
@@ -34,7 +41,7 @@ function doOption(instance: ChatInstance) {
         },
       ],
     },
-  });
+  }));
 }
 
 export { doOption };

--- a/demo/src/customSendMessage/doPreviewCard.ts
+++ b/demo/src/customSendMessage/doPreviewCard.ts
@@ -7,7 +7,11 @@
  *  @license
  */
 
-import { ChatInstance, MessageResponseTypes } from '@carbon/ai-chat';
+import {
+  ChatInstance,
+  MessageResponseTypes,
+  MessageState,
+} from '@carbon/ai-chat';
 import { uuid } from '@carbon/ai-chat-components/es/globals/utils/uuid.js';
 
 function doPreviewCard(
@@ -16,7 +20,9 @@ function doPreviewCard(
 ) {
   const workspaceId = uuid();
 
-  instance.messaging.addMessage({
+  const messageID = uuid();
+  instance.messaging.upsertMessage(messageID, MessageState.COMPLETE, () => ({
+    id: messageID,
     output: {
       generic: [
         {
@@ -37,7 +43,7 @@ function doPreviewCard(
         },
       ],
     },
-  });
+  }));
 }
 
 export { doPreviewCard };

--- a/demo/src/customSendMessage/doSystemMessage.ts
+++ b/demo/src/customSendMessage/doSystemMessage.ts
@@ -10,8 +10,10 @@
 import {
   ChatInstance,
   MessageResponseTypes,
+  MessageState,
   SystemMessageVariant,
 } from '@carbon/ai-chat';
+import { uuid } from '@carbon/ai-chat-components/es/globals/utils/uuid.js';
 import { MARKDOWN } from './constants';
 
 function doSystemMessage(
@@ -20,7 +22,9 @@ function doSystemMessage(
   variant?: SystemMessageVariant
 ) {
   if (inline) {
-    instance.messaging.addMessage({
+    const messageID = uuid();
+    instance.messaging.upsertMessage(messageID, MessageState.COMPLETE, () => ({
+      id: messageID,
       output: {
         generic: [
           {
@@ -33,21 +37,29 @@ function doSystemMessage(
           },
         ],
       },
-    });
+    }));
   }
   if (variant === 'agent') {
-    instance.messaging.addMessage({
-      output: {
-        generic: [
-          {
-            response_type: MessageResponseTypes.SYSTEM,
-            title: 'Agent joined the chat',
-            variant: 'agent',
-          },
-        ],
-      },
-    });
-    instance.messaging.addMessage({
+    const systemMessageID = uuid();
+    instance.messaging.upsertMessage(
+      systemMessageID,
+      MessageState.COMPLETE,
+      () => ({
+        id: systemMessageID,
+        output: {
+          generic: [
+            {
+              response_type: MessageResponseTypes.SYSTEM,
+              title: 'Agent joined the chat',
+              variant: 'agent',
+            },
+          ],
+        },
+      })
+    );
+    const messageID = uuid();
+    instance.messaging.upsertMessage(messageID, MessageState.COMPLETE, () => ({
+      id: messageID,
       output: {
         generic: [
           {
@@ -56,21 +68,29 @@ function doSystemMessage(
           },
         ],
       },
-    });
+    }));
   }
   if (variant === 'date') {
-    instance.messaging.addMessage({
-      output: {
-        generic: [
-          {
-            response_type: MessageResponseTypes.SYSTEM,
-            title: 'Monday, June 14th 2025',
-            variant: 'date',
-          },
-        ],
-      },
-    });
-    instance.messaging.addMessage({
+    const systemMessageID = uuid();
+    instance.messaging.upsertMessage(
+      systemMessageID,
+      MessageState.COMPLETE,
+      () => ({
+        id: systemMessageID,
+        output: {
+          generic: [
+            {
+              response_type: MessageResponseTypes.SYSTEM,
+              title: 'Monday, June 14th 2025',
+              variant: 'date',
+            },
+          ],
+        },
+      })
+    );
+    const messageID = uuid();
+    instance.messaging.upsertMessage(messageID, MessageState.COMPLETE, () => ({
+      id: messageID,
       output: {
         generic: [
           {
@@ -79,21 +99,29 @@ function doSystemMessage(
           },
         ],
       },
-    });
+    }));
   } else {
-    instance.messaging.addMessage({
-      output: {
-        generic: [
-          {
-            response_type: MessageResponseTypes.SYSTEM,
-            title: 'This is a system message',
-            variant: 'default',
-          },
-        ],
-      },
-    });
+    const systemMessageID = uuid();
+    instance.messaging.upsertMessage(
+      systemMessageID,
+      MessageState.COMPLETE,
+      () => ({
+        id: systemMessageID,
+        output: {
+          generic: [
+            {
+              response_type: MessageResponseTypes.SYSTEM,
+              title: 'This is a system message',
+              variant: 'default',
+            },
+          ],
+        },
+      })
+    );
 
-    instance.messaging.addMessage({
+    const messageID = uuid();
+    instance.messaging.upsertMessage(messageID, MessageState.COMPLETE, () => ({
+      id: messageID,
       output: {
         generic: [
           {
@@ -102,7 +130,7 @@ function doSystemMessage(
           },
         ],
       },
-    });
+    }));
   }
 }
 

--- a/demo/src/customSendMessage/doTable.ts
+++ b/demo/src/customSendMessage/doTable.ts
@@ -10,7 +10,7 @@
 import { ChatInstance, CustomSendMessageOptions } from '@carbon/ai-chat';
 
 import { TABLE } from './constants';
-import { doText, doTextStreaming } from './doText';
+import { doText, doTextStreamingUpsert } from './doText';
 
 function doTable(instance: ChatInstance) {
   doText(instance, `A periodic table in markdown format.\n\n${TABLE}`);
@@ -20,17 +20,10 @@ async function doTableStreaming(
   instance: ChatInstance,
   requestOptions?: CustomSendMessageOptions
 ) {
-  await doTextStreaming(
-    instance,
-    `A periodic table in markdown format.\n\n${TABLE}`,
-    true,
-    undefined,
-    undefined,
-    undefined,
-    undefined,
-    undefined,
-    requestOptions
-  );
+  await doTextStreamingUpsert(instance, {
+    text: `A periodic table in markdown format.\n\n${TABLE}`,
+    requestOptions,
+  });
 }
 
 export { doTable, doTableStreaming };

--- a/demo/src/customSendMessage/doText.ts
+++ b/demo/src/customSendMessage/doText.ts
@@ -15,9 +15,10 @@ import {
   GenericItemMessageFeedbackOptions,
   MessageResponse,
   MessageResponseTypes,
+  MessageState,
   ReasoningStep,
-  ReasoningSteps,
   ReasoningStepOpenState,
+  ReasoningSteps,
   ResponseUserProfile,
   StreamChunk,
   UserType,
@@ -547,12 +548,231 @@ async function doTextStreaming(
   }
 }
 
+/**
+ * Options for {@link doTextStreamingUpsert}. An object rather than the positional
+ * list `doTextStreaming` takes, so callers name only what they need.
+ */
+interface TextStreamingOptions {
+  text?: string;
+  cancellable?: boolean;
+  wordDelay?: number;
+  userProfile?: ResponseUserProfile;
+  chainOfThought?: ChainOfThoughtStep[];
+  reasoning?: ReasoningSteps;
+  feedback?: GenericItemMessageFeedbackOptions;
+  requestOptions?: CustomSendMessageOptions;
+}
+
+/**
+ * The same streaming response as {@link doTextStreaming}, driven by
+ * `upsertMessage` instead of `addMessageChunk`.
+ *
+ * The difference is where the accumulated state lives. With chunks, you send
+ * deltas and the chat concatenates them. Here you keep the state in your own
+ * app — `streamedText`, `reasoningPayload`, `chainOfThoughtSteps` below — and
+ * hand back the whole message on every update. There is no chunk-shape
+ * contract to satisfy, and the same call inserts, updates, and finishes.
+ */
+async function doTextStreamingUpsert(
+  instance: ChatInstance,
+  options: TextStreamingOptions = {}
+) {
+  const {
+    text = MARKDOWN,
+    cancellable = true,
+    wordDelay = WORD_DELAY,
+    userProfile,
+    chainOfThought,
+    reasoning,
+    feedback,
+    requestOptions,
+  } = options;
+
+  const signal = requestOptions?.signal;
+  const messageID = uuid();
+  const words = text.split(' ');
+
+  // All of the response state lives here, in app code.
+  let streamedText = '';
+  let reasoningPayload: ReasoningSteps | undefined;
+  let chainOfThoughtSteps: ChainOfThoughtStep[] | undefined;
+  let isCanceled = signal?.aborted ?? false;
+
+  // Build the entire message from the current state. Called on every update.
+  const buildMessage = (isComplete: boolean): MessageResponse => ({
+    id: messageID,
+    output: {
+      generic: [
+        {
+          response_type: MessageResponseTypes.TEXT,
+          text: streamedText,
+          streaming_metadata: {
+            id: '1',
+            cancellable,
+            stream_stopped: isComplete && isCanceled,
+          },
+          ...(isComplete && feedback
+            ? { message_item_options: { feedback } }
+            : {}),
+        },
+      ],
+    },
+    message_options: {
+      response_user_profile: userProfile,
+      chain_of_thought: chainOfThoughtSteps,
+      reasoning: reasoningPayload,
+    },
+  });
+
+  const apply = (state: MessageState) =>
+    instance.messaging.upsertMessage(messageID, state, () =>
+      buildMessage(state === MessageState.COMPLETE)
+    );
+
+  const abortHandler = () => {
+    isCanceled = true;
+  };
+  signal?.addEventListener('abort', abortHandler);
+
+  try {
+    // 1. Reasoning steps reveal one at a time, each typing in its content.
+    const reasoningSteps = reasoning?.steps;
+    const reasoningContent = reasoning?.content;
+    const reasoningOpenState = reasoning?.open_state;
+
+    if (reasoningSteps?.length) {
+      const displaySteps = reasoningSteps.map((step) => ({
+        ...step,
+        content: step.content ? '' : step.content,
+      }));
+
+      for (let index = 0; index < displaySteps.length && !isCanceled; index++) {
+        await sleep(wordDelay);
+        if (isCanceled) {
+          break;
+        }
+        reasoningPayload = buildReasoningPayload(
+          displaySteps,
+          index + 1,
+          false,
+          reasoningOpenState
+        );
+        await apply(MessageState.STREAMING);
+
+        const fullContent = reasoningSteps[index].content;
+        if (!fullContent) {
+          continue;
+        }
+
+        let partial = '';
+        for (const token of fullContent.match(/\S+\s*/g) ?? [fullContent]) {
+          if (isCanceled) {
+            break;
+          }
+          partial += token;
+          displaySteps[index].content = partial;
+          await sleep(wordDelay);
+          reasoningPayload = buildReasoningPayload(
+            displaySteps,
+            index + 1,
+            false,
+            reasoningOpenState
+          );
+          await apply(MessageState.STREAMING);
+        }
+        displaySteps[index].content = fullContent;
+      }
+    }
+
+    // 2. A single reasoning trace types in the same way.
+    if (typeof reasoningContent === 'string' && !isCanceled) {
+      let partial = '';
+      for (const token of reasoningContent.match(/\S+\s*/g) ?? [
+        reasoningContent,
+      ]) {
+        if (isCanceled) {
+          break;
+        }
+        partial += token;
+        await sleep(wordDelay);
+        reasoningPayload = buildReasoningPayload(
+          undefined,
+          0,
+          false,
+          reasoningOpenState,
+          partial
+        );
+        await apply(MessageState.STREAMING);
+      }
+    }
+
+    // 3. The answer streams in a word at a time. Chain-of-thought steps flip to
+    // processing, then success, at fixed word offsets — the same schedule
+    // `doTextStreaming` uses so both entries look identical on screen.
+    const chainOfThoughtByWord: Record<number, ChainOfThoughtStep[]> = {};
+    if (chainOfThought) {
+      const stepWordAmount = Math.floor(
+        words.length / (chainOfThought.length * 2)
+      );
+      for (let i = 0; i < chainOfThought.length - 1; i++) {
+        const word = Math.max(stepWordAmount * 2 * i, 1);
+        chainOfThoughtByWord[word] = returnChainOfStepByStatus(
+          chainOfThought,
+          i,
+          ChainOfThoughtStepStatus.PROCESSING
+        );
+        chainOfThoughtByWord[word + stepWordAmount] = returnChainOfStepByStatus(
+          chainOfThought,
+          i,
+          ChainOfThoughtStepStatus.SUCCESS
+        );
+      }
+    }
+
+    for (let index = 0; index < words.length && !isCanceled; index++) {
+      await sleep(wordDelay);
+      if (isCanceled) {
+        break;
+      }
+      streamedText += `${words[index]} `;
+
+      if (chainOfThoughtByWord[index]) {
+        chainOfThoughtSteps = chainOfThoughtByWord[index];
+      }
+
+      await apply(MessageState.STREAMING);
+    }
+
+    // 4. Settle on the final shape. On cancel, keep what streamed; otherwise
+    // swap in the authoritative full text.
+    if (!isCanceled) {
+      streamedText = text;
+      chainOfThoughtSteps = chainOfThought;
+    }
+    if (reasoningSteps?.length || typeof reasoningContent === 'string') {
+      reasoningPayload = buildReasoningPayload(
+        reasoningSteps,
+        reasoningSteps?.length ?? 0,
+        true,
+        reasoningOpenState,
+        reasoningContent
+      );
+    }
+
+    await apply(MessageState.COMPLETE);
+  } finally {
+    signal?.removeEventListener('abort', abortHandler);
+  }
+}
+
 function doWelcomeText(instance: ChatInstance) {
   const options = Object.keys(RESPONSE_MAP).map((key) => ({
     label: key,
     value: { input: { text: key } },
   }));
-  instance.messaging.addMessage({
+  const messageID = uuid();
+  instance.messaging.upsertMessage(messageID, MessageState.COMPLETE, () => ({
+    id: messageID,
     output: {
       generic: [
         {
@@ -566,7 +786,7 @@ function doWelcomeText(instance: ChatInstance) {
         },
       ],
     },
-  });
+  }));
 }
 
 function doText(
@@ -647,7 +867,11 @@ function doText(
     };
   }
 
-  instance.messaging.addMessage(message);
+  const messageID = uuid();
+  instance.messaging.upsertMessage(messageID, MessageState.COMPLETE, () => ({
+    ...message,
+    id: messageID,
+  }));
 }
 
 function doTextWithHumanProfile(
@@ -681,17 +905,12 @@ async function doTextStreamingWithNonWatsonAssistantProfile(
   userProfile: ResponseUserProfile = defaultAlternativeAssistantProfile,
   requestOptions?: CustomSendMessageOptions
 ) {
-  return doTextStreaming(
-    instance,
+  return doTextStreamingUpsert(instance, {
     text,
     cancellable,
-    WORD_DELAY,
     userProfile,
-    undefined,
-    undefined,
-    undefined,
-    requestOptions
-  );
+    requestOptions,
+  });
 }
 
 async function doTextChainOfThoughtStreaming(
@@ -702,17 +921,14 @@ async function doTextChainOfThoughtStreaming(
   chainOfThought: ChainOfThoughtStep[] = fullChainOfThought,
   requestOptions?: CustomSendMessageOptions
 ) {
-  doTextStreaming(
-    instance,
+  doTextStreamingUpsert(instance, {
     text,
     cancellable,
-    300,
+    wordDelay: 300,
     userProfile,
     chainOfThought,
-    undefined,
-    undefined,
-    requestOptions
-  );
+    requestOptions,
+  });
 }
 
 function doTextChainOfThought(
@@ -728,38 +944,20 @@ async function doTextWithReasoningStepsStreaming(
   instance: ChatInstance,
   requestOptions?: CustomSendMessageOptions
 ) {
-  await doTextStreaming(
-    instance,
-    MARKDOWN,
-    true,
-    WORD_DELAY,
-    undefined,
-    undefined,
-    {
-      steps: defaultReasoningSteps,
-    },
-    undefined,
-    requestOptions
-  );
+  await doTextStreamingUpsert(instance, {
+    reasoning: { steps: defaultReasoningSteps },
+    requestOptions,
+  });
 }
 
 async function doTextWithReasoningTraceStreaming(
   instance: ChatInstance,
   requestOptions?: CustomSendMessageOptions
 ) {
-  await doTextStreaming(
-    instance,
-    MARKDOWN,
-    true,
-    WORD_DELAY,
-    undefined,
-    undefined,
-    {
-      content: defaultReasoningTraceContent,
-    },
-    undefined,
-    requestOptions
-  );
+  await doTextStreamingUpsert(instance, {
+    reasoning: { content: defaultReasoningTraceContent },
+    requestOptions,
+  });
 }
 
 function doHTML(
@@ -775,24 +973,9 @@ function doHTML(
 
 async function doHTMLStreaming(
   instance: ChatInstance,
-  text: string = HTML,
-  cancellable = true,
-  wordDelay = WORD_DELAY,
-  userProfile?: ResponseUserProfile,
-  chainOfThought?: ChainOfThoughtStep[],
   requestOptions?: CustomSendMessageOptions
 ) {
-  await doTextStreaming(
-    instance,
-    text,
-    cancellable,
-    wordDelay,
-    userProfile,
-    chainOfThought,
-    undefined,
-    undefined,
-    requestOptions
-  );
+  await doTextStreamingUpsert(instance, { text: HTML, requestOptions });
 }
 
 function doTextWithFeedback(instance: ChatInstance) {
@@ -833,21 +1016,17 @@ async function doTextWithFeedbackStreaming(
     },
   };
 
-  await doTextStreaming(
-    instance,
-    feedbackText,
-    true,
-    WORD_DELAY,
-    undefined,
-    undefined,
-    undefined,
+  await doTextStreamingUpsert(instance, {
+    text: feedbackText,
     feedback,
-    requestOptions
-  );
+    requestOptions,
+  });
 }
 
 function doTextWithCustomFooter(instance: ChatInstance) {
-  instance.messaging.addMessage({
+  const messageID = uuid();
+  instance.messaging.upsertMessage(messageID, MessageState.COMPLETE, () => ({
+    id: messageID,
     output: {
       generic: [
         {
@@ -870,7 +1049,7 @@ function doTextWithCustomFooter(instance: ChatInstance) {
         },
       ],
     },
-  });
+  }));
 }
 /**
  * Tests the edge case where customSendMessage resolves early but streaming continues.
@@ -981,6 +1160,7 @@ export {
   doTextChainOfThoughtStreaming,
   doTextChainOfThought,
   doTextStreaming,
+  doTextStreamingUpsert,
   doTextStreamingEarlyResolve,
   doTextWithReasoningStepsStreaming,
   doTextWithReasoningTraceStreaming,

--- a/demo/src/customSendMessage/doUserDefined.ts
+++ b/demo/src/customSendMessage/doUserDefined.ts
@@ -11,6 +11,7 @@ import {
   ChatInstance,
   CustomSendMessageOptions,
   MessageResponseTypes,
+  MessageState,
   StreamChunk,
 } from '@carbon/ai-chat';
 import { uuid } from '@carbon/ai-chat-components/es/globals/utils/uuid.js';
@@ -24,7 +25,9 @@ async function sleep(milliseconds: number) {
 const FAKE_DATA = `Some text that came from the server inside the user_defined object. Bacon ipsum dolor amet salami capicola chislic, meatball tail beef ham hock brisket cow ground round chuck. Turkey pork loin pastrami, ribeye jerky meatball drumstick kielbasa corned beef shankle picanha. Spare ribs leberkas hamburger strip steak beef ribs sirloin brisket capicola, sausage meatball drumstick ham swine alcatra. Pastrami filet mignon salami, flank short loin t-bone tenderloin ribeye brisket.`;
 
 function doUserDefined(instance: ChatInstance) {
-  instance.messaging.addMessage({
+  const messageID = uuid();
+  instance.messaging.upsertMessage(messageID, MessageState.COMPLETE, () => ({
+    id: messageID,
     output: {
       generic: [
         {
@@ -44,7 +47,7 @@ function doUserDefined(instance: ChatInstance) {
         },
       ],
     },
-  });
+  }));
 }
 
 async function doUserDefinedStreaming(
@@ -136,4 +139,71 @@ async function doUserDefinedStreaming(
   }
 }
 
-export { doUserDefined, doUserDefinedStreaming };
+/**
+ * The same streaming `user_defined` response as
+ * {@link doUserDefinedStreaming}, driven by `upsertMessage`.
+ *
+ * With chunks you send each word as a delta and the chat concatenates them —
+ * which is why the renderer has to reassemble partial JSON. Here you keep the
+ * accumulated text in app state and hand back the whole item every time, so
+ * the renderer always receives a complete `user_defined` payload.
+ */
+async function doUserDefinedStreamingUpsert(
+  instance: ChatInstance,
+  requestOptions?: CustomSendMessageOptions
+) {
+  const signal = requestOptions?.signal;
+  const WORD_DELAY = 50;
+  const messageID = uuid();
+  const words = FAKE_DATA.split(' ');
+
+  let streamedText = '';
+  let isCanceled = signal?.aborted ?? false;
+
+  const abortHandler = () => {
+    isCanceled = true;
+  };
+  signal?.addEventListener('abort', abortHandler);
+
+  const apply = (state: MessageState) =>
+    instance.messaging.upsertMessage(messageID, state, () => ({
+      id: messageID,
+      output: {
+        generic: [
+          {
+            response_type: MessageResponseTypes.USER_DEFINED,
+            user_defined: {
+              user_defined_type: 'green',
+              text: streamedText,
+            },
+            streaming_metadata: {
+              id: '1',
+              cancellable: true,
+              stream_stopped: state === MessageState.COMPLETE && isCanceled,
+            },
+          },
+        ],
+      },
+    }));
+
+  try {
+    for (let index = 0; index < words.length && !isCanceled; index++) {
+      await sleep(WORD_DELAY);
+      if (isCanceled) {
+        break;
+      }
+      streamedText += `${words[index]},`;
+      await apply(MessageState.STREAMING);
+    }
+
+    // On a clean run, settle on the authoritative full text.
+    if (!isCanceled) {
+      streamedText = FAKE_DATA;
+    }
+    await apply(MessageState.COMPLETE);
+  } finally {
+    signal?.removeEventListener('abort', abortHandler);
+  }
+}
+
+export { doUserDefined, doUserDefinedStreaming, doUserDefinedStreamingUpsert };

--- a/demo/src/customSendMessage/doVideo.ts
+++ b/demo/src/customSendMessage/doVideo.ts
@@ -7,10 +7,17 @@
  *  @license
  */
 
-import { ChatInstance, MessageResponseTypes } from '@carbon/ai-chat';
+import {
+  ChatInstance,
+  MessageResponseTypes,
+  MessageState,
+} from '@carbon/ai-chat';
+import { uuid } from '@carbon/ai-chat-components/es/globals/utils/uuid.js';
 
 function doVideo(instance: ChatInstance) {
-  instance.messaging.addMessage({
+  const messageID = uuid();
+  instance.messaging.upsertMessage(messageID, MessageState.COMPLETE, () => ({
+    id: messageID,
     output: {
       generic: [
         {
@@ -38,11 +45,13 @@ function doVideo(instance: ChatInstance) {
         },
       ],
     },
-  });
+  }));
 }
 
 function doVideoYouTube(instance: ChatInstance) {
-  instance.messaging.addMessage({
+  const messageID = uuid();
+  instance.messaging.upsertMessage(messageID, MessageState.COMPLETE, () => ({
+    id: messageID,
     output: {
       generic: [
         {
@@ -56,11 +65,13 @@ function doVideoYouTube(instance: ChatInstance) {
         },
       ],
     },
-  });
+  }));
 }
 
 function doVideoVimeo(instance: ChatInstance) {
-  instance.messaging.addMessage({
+  const messageID = uuid();
+  instance.messaging.upsertMessage(messageID, MessageState.COMPLETE, () => ({
+    id: messageID,
     output: {
       generic: [
         {
@@ -74,11 +85,13 @@ function doVideoVimeo(instance: ChatInstance) {
         },
       ],
     },
-  });
+  }));
 }
 
 function doVideoKaltura(instance: ChatInstance) {
-  instance.messaging.addMessage({
+  const messageID = uuid();
+  instance.messaging.upsertMessage(messageID, MessageState.COMPLETE, () => ({
+    id: messageID,
     output: {
       generic: [
         {
@@ -96,7 +109,7 @@ function doVideoKaltura(instance: ChatInstance) {
         },
       ],
     },
-  });
+  }));
 }
 
 export { doVideo, doVideoYouTube, doVideoVimeo, doVideoKaltura };

--- a/demo/src/customSendMessage/responseMap.ts
+++ b/demo/src/customSendMessage/responseMap.ts
@@ -36,6 +36,7 @@ import {
   doTextChainOfThought,
   doTextChainOfThoughtStreaming,
   doTextStreaming,
+  doTextStreamingUpsert,
   doTextStreamingEarlyResolve,
   doTextStreamingWithNonWatsonAssistantProfile,
   doTextWithCustomFooter,
@@ -47,7 +48,11 @@ import {
   doTextWithReasoningTraceStreaming,
   doTextWithWatsonAgentProfile,
 } from './doText';
-import { doUserDefined, doUserDefinedStreaming } from './doUserDefined';
+import {
+  doUserDefined,
+  doUserDefinedStreaming,
+  doUserDefinedStreamingUpsert,
+} from './doUserDefined';
 import { doSystemMessage } from './doSystemMessage';
 import { doVideoYouTube, doVideoVimeo, doVideoKaltura } from './doVideo';
 
@@ -101,6 +106,8 @@ const RESPONSE_MAP: Record<
     doTableStreaming(instance, requestOptions),
   text: (instance) => doText(instance),
   'text (stream)': (instance, requestOptions) =>
+    doTextStreamingUpsert(instance, { requestOptions }),
+  'text (stream) (legacy addMessageChunk API)': (instance, requestOptions) =>
     doTextStreaming(
       instance,
       undefined,
@@ -112,8 +119,10 @@ const RESPONSE_MAP: Record<
       undefined,
       requestOptions
     ),
-  'text (stream early resolve)': (instance, requestOptions) =>
-    doTextStreamingEarlyResolve(instance, requestOptions),
+  'text (stream early resolve) (legacy addMessageChunk API)': (
+    instance,
+    requestOptions
+  ) => doTextStreamingEarlyResolve(instance, requestOptions),
   'text with feedback': (instance) => doTextWithFeedback(instance),
   'text with feedback (stream)': (instance, requestOptions) =>
     doTextWithFeedbackStreaming(instance, requestOptions),
@@ -199,17 +208,7 @@ const RESPONSE_MAP: Record<
         }
         instance.updateIsMessageLoadingCounter('decrease');
         try {
-          await doTextStreaming(
-            instance,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            undefined,
-            requestOptions
-          );
+          await doTextStreamingUpsert(instance, { requestOptions });
           resolve();
         } catch (error) {
           reject(error);
@@ -237,18 +236,14 @@ const RESPONSE_MAP: Record<
   },
   html: (instance) => doHTML(instance),
   'html (stream)': (instance, requestOptions) =>
-    doHTMLStreaming(
-      instance,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      requestOptions
-    ),
+    doHTMLStreaming(instance, requestOptions),
   user_defined: (instance) => doUserDefined(instance),
   'user_defined (stream)': (instance, requestOptions) =>
-    doUserDefinedStreaming(instance, requestOptions),
+    doUserDefinedStreamingUpsert(instance, requestOptions),
+  'user_defined (stream) (legacy addMessageChunk API)': (
+    instance,
+    requestOptions
+  ) => doUserDefinedStreaming(instance, requestOptions),
   'video - youtube': (instance) => doVideoYouTube(instance),
   'video - vimeo': (instance) => doVideoVimeo(instance),
   'video - kaltura': (instance) => doVideoKaltura(instance),

--- a/examples/react/upsert-message-reasoning-steps-controlled/src/customSendMessage.ts
+++ b/examples/react/upsert-message-reasoning-steps-controlled/src/customSendMessage.ts
@@ -58,10 +58,12 @@ async function customSendMessage(
   // scenario. A fresh `messageID` per call keeps repeated welcomes from
   // colliding; COMPLETE makes it a one-shot insert.
   if (request.input.text === '') {
+    const messageID = uuid();
     await instance.messaging.upsertMessage(
-      uuid(),
+      messageID,
       MessageState.COMPLETE,
       () => ({
+        id: messageID,
         output: {
           generic: [
             {

--- a/examples/react/upsert-message-reasoning-steps/src/customSendMessage.ts
+++ b/examples/react/upsert-message-reasoning-steps/src/customSendMessage.ts
@@ -56,10 +56,12 @@ function sendWelcome(instance: ChatInstance) {
   // A fresh `messageID` per call means repeated welcomes never collide; COMPLETE
   // makes this a one-shot insert (the chat assigns the id to the returned
   // message since it has none of its own).
+  const messageID = uuid();
   return instance.messaging.upsertMessage(
-    uuid(),
+    messageID,
     MessageState.COMPLETE,
     () => ({
+      id: messageID,
       output: {
         generic: [
           {

--- a/examples/react/upsert-message-reasoning-with-streaming-generic-items/src/customSendMessage.ts
+++ b/examples/react/upsert-message-reasoning-with-streaming-generic-items/src/customSendMessage.ts
@@ -270,10 +270,12 @@ function sendWelcome(instance: ChatInstance) {
   // Deliver the static welcome through upsertMessage too: a brand-new COMPLETE
   // insert under a fresh messageID fires `receive` once, matching addMessage.
   // The post-back button kicks off the scenario when clicked.
+  const messageID = crypto.randomUUID();
   return instance.messaging.upsertMessage(
-    crypto.randomUUID(),
+    messageID,
     MessageState.COMPLETE,
     () => ({
+      id: messageID,
       output: {
         generic: [
           {

--- a/examples/web-components/upsert-message-reasoning-steps-controlled/src/customSendMessage.ts
+++ b/examples/web-components/upsert-message-reasoning-steps-controlled/src/customSendMessage.ts
@@ -57,10 +57,12 @@ async function customSendMessage(
   // scenario. A fresh `messageID` per call keeps repeated welcomes from
   // colliding; COMPLETE makes it a one-shot insert.
   if (request.input.text === '') {
+    const messageID = uuid();
     await instance.messaging.upsertMessage(
-      uuid(),
+      messageID,
       MessageState.COMPLETE,
       () => ({
+        id: messageID,
         output: {
           generic: [
             {

--- a/examples/web-components/upsert-message-reasoning-steps/src/customSendMessage.ts
+++ b/examples/web-components/upsert-message-reasoning-steps/src/customSendMessage.ts
@@ -57,10 +57,12 @@ function sendWelcome(instance: ChatInstance) {
   // with a static welcome plus a dropdown listing every demo scenario. A fresh
   // `messageID` per call keeps repeated welcomes from colliding; COMPLETE makes
   // it a one-shot insert.
+  const messageID = uuid();
   return instance.messaging.upsertMessage(
-    uuid(),
+    messageID,
     MessageState.COMPLETE,
     () => ({
+      id: messageID,
       output: {
         generic: [
           {

--- a/examples/web-components/upsert-message-reasoning-with-streaming-generic-items/src/customSendMessage.ts
+++ b/examples/web-components/upsert-message-reasoning-with-streaming-generic-items/src/customSendMessage.ts
@@ -270,10 +270,12 @@ function sendWelcome(instance: ChatInstance) {
   // Deliver the static welcome through upsertMessage too: a brand-new COMPLETE
   // insert under a fresh messageID fires `receive` once, matching addMessage.
   // The post-back button kicks off the scenario when clicked.
+  const messageID = crypto.randomUUID();
   return instance.messaging.upsertMessage(
-    crypto.randomUUID(),
+    messageID,
     MessageState.COMPLETE,
     () => ({
+      id: messageID,
       output: {
         generic: [
           {

--- a/packages/ai-chat/docs/AddMessageChunk.md
+++ b/packages/ai-chat/docs/AddMessageChunk.md
@@ -10,9 +10,9 @@ Stream a response onto the screen as your assistant produces it with {@link Chat
 - **Complete item chunks** — finalize one item while others keep streaming.
 - **Final response chunks** — the authoritative final state for the whole message.
 
-For a one-shot, non-streaming insert, use {@link ChatInstanceMessaging.addMessage | addMessage} instead; your assistant can return either format and switch between them. To build up state in your app and apply it with one call per update, see [Adding messages (experimental)](./UpsertMessage.md). It also covers regenerate and optimistic updates.
+For a one-shot, non-streaming insert, use {@link ChatInstanceMessaging.addMessage | addMessage} instead; your assistant can return either format and switch between them. To build up state in your app and apply it with one call per update, see [Adding messages](./UpsertMessage.md). It also covers regenerate and optimistic updates.
 
-> **Note:** Before you build on `addMessageChunk`, look at {@link ChatInstanceMessaging.upsertMessage | upsertMessage}. A single method inserts or updates a message by ID through an updater function, covering streaming, regenerate, post-stream corrections, and optimistic updates. It's the recommended path for new code, but experimental — its semantics and updater signature may still change. See [Adding messages (experimental)](./UpsertMessage.md).
+> **Note:** Before you build on `addMessageChunk`, look at {@link ChatInstanceMessaging.upsertMessage | upsertMessage}. A single method inserts or updates a message by ID through an updater function, covering streaming, regenerate, post-stream corrections, and optimistic updates. It's the recommended path for new code. See [Adding messages](./UpsertMessage.md).
 
 [Message format](./MessageFormat.md) documents the item and response shapes used below.
 
@@ -135,6 +135,6 @@ The "stop streaming" button appears when a partial item chunk sets `streaming_me
 
 ## Related
 
-- [Adding messages (experimental)](./UpsertMessage.md) — build up state in your app and apply one update per call.
+- [Adding messages](./UpsertMessage.md) — build up state in your app and apply one update per call.
 - [Message format](./MessageFormat.md) — the item and response shapes used here.
 - [Server communication](./CustomServer.md#cancelling-request-stop-streaming) — the shared cancellation pattern.

--- a/packages/ai-chat/docs/CustomHistory.md
+++ b/packages/ai-chat/docs/CustomHistory.md
@@ -232,5 +232,5 @@ instance.on({
 - [Slots](./WriteableElements.md) — render your own content into the history panel slot.
 - [Message format](./MessageFormat.md) — the request/response shapes history items wrap.
 - [Session state persistence](./StatePersistence.md) — own where the chat stores its session and UI state (views, disclaimer, human-agent connection), apart from conversation messages.
+- [Adding messages](./UpsertMessage.md) — revising a message after it renders.
 - [Adding messages (legacy)](./AddMessageChunk.md) — getting live responses onscreen.
-- [Adding messages (experimental)](./UpsertMessage.md) — revising a message after it renders.

--- a/packages/ai-chat/docs/CustomServer.md
+++ b/packages/ai-chat/docs/CustomServer.md
@@ -19,8 +19,8 @@ Connect the Carbon AI Chat to your own server. It supports streaming results, no
 Where you go next depends on what you build:
 
 - [Message format](./MessageFormat.md) — the shape of the requests you receive and responses you return (for server / API authors).
+- [Adding messages](./UpsertMessage.md) — the preferred insert-or-update-by-ID flow.
 - [Adding messages (legacy)](./AddMessageChunk.md) — the stable chunk-based streaming flow.
-- [Adding messages (experimental)](./UpsertMessage.md) — the preferred, experimental insert-or-update-by-ID flow.
 - [Structured data](./StructuredData.md) — send typed fields and uploaded files alongside the user's text.
 - [Conversation history](./CustomHistory.md) — load and restore past conversations.
 - [Session state persistence](./StatePersistence.md) — own where the chat's session and UI state is stored.
@@ -49,8 +49,8 @@ If you do not return a promise, the chat does not queue your messages, and it sk
 
 When you have a response, or part of one, push it to the screen through {@link ChatInstanceMessaging | messaging}. You have two flows, and your assistant can return either format and switch between them:
 
-- **Stable flow** — use {@link ChatInstanceMessaging.addMessage | addMessage} for one-shot, non-streaming inserts, and {@link ChatInstanceMessaging.addMessageChunk | addMessageChunk} for chunked streaming. Both are fully supported, with no deprecation. See [Adding messages (legacy)](./AddMessageChunk.md).
-- **Preferred flow (experimental)** — {@link ChatInstanceMessaging.upsertMessage | upsertMessage} inserts or updates a message by ID through an updater function, covering streaming, regenerate, post-stream fixes, and optimistic updates with one method. It is the recommended path for new code, but experimental: its semantics and updater signature may still change. See [Adding messages (experimental)](./UpsertMessage.md).
+- **Chunk flow** — use {@link ChatInstanceMessaging.addMessage | addMessage} for one-shot, non-streaming inserts, and {@link ChatInstanceMessaging.addMessageChunk | addMessageChunk} for chunked streaming. Both are fully supported, with no deprecation. See [Adding messages (legacy)](./AddMessageChunk.md).
+- **Preferred flow** — {@link ChatInstanceMessaging.upsertMessage | upsertMessage} inserts or updates a message by ID through an updater function, covering streaming, regenerate, post-stream fixes, and optimistic updates with one method. It is the recommended path for new code. See [Adding messages](./UpsertMessage.md).
 
 For the data shape in either flow, see [Message format](./MessageFormat.md).
 
@@ -222,7 +222,7 @@ By default, the chat shows a loading indicator if no chunk or message arrives be
 ## Related
 
 - [Message format](./MessageFormat.md) — the shape of the requests you receive and responses you return.
+- [Adding messages](./UpsertMessage.md) — insert or update a message by ID.
 - [Adding messages (legacy)](./AddMessageChunk.md) — the chunk-based streaming flow.
-- [Adding messages (experimental)](./UpsertMessage.md) — insert or update a message by ID.
 - [Structured data](./StructuredData.md) — send typed fields and uploaded files alongside the user's text.
 - [Conversation history](./CustomHistory.md) — load and restore past conversations.

--- a/packages/ai-chat/docs/MessageFormat.md
+++ b/packages/ai-chat/docs/MessageFormat.md
@@ -45,8 +45,8 @@ const response: MessageResponse = {
 
 The shapes above describe a complete message. To build a response piece by piece, wrap items in chunk envelopes and apply them one at a time. You can deliver a response two ways:
 
+- [Adding messages](./UpsertMessage.md) — the forward-thinking flow. You accumulate state in your app code and apply each update with one call, which sidesteps the chunk-shape contract.
 - [Adding messages (legacy)](./AddMessageChunk.md) — the current flow. It documents the full chunk reference: {@link StreamChunk}, {@link PartialItemChunk}, {@link CompleteItemChunk}, and {@link FinalResponseChunk}.
-- [Adding messages (experimental)](./UpsertMessage.md) — the forward-thinking flow. You accumulate state in your app code and apply each update with one call, which sidesteps the chunk-shape contract.
 
 Both render the same {@link MessageResponse | response} shape shown above.
 
@@ -54,6 +54,6 @@ Both render the same {@link MessageResponse | response} shape shown above.
 
 - [Server communication](./CustomServer.md) — wire the chat to your server.
 - [Structured data](./StructuredData.md) — send typed fields and uploaded files on the request.
+- [Adding messages](./UpsertMessage.md) — accumulate state and apply each update with one call.
 - [Adding messages (legacy)](./AddMessageChunk.md) — deliver a response piece by piece.
-- [Adding messages (experimental)](./UpsertMessage.md) — accumulate state and apply each update with one call.
 - [Conversation history](./CustomHistory.md) — persist and replay responses.

--- a/packages/ai-chat/docs/Responses.md
+++ b/packages/ai-chat/docs/Responses.md
@@ -58,9 +58,9 @@ For each `user_defined` response, your framework renderer receives the accumulat
 
 ### Streaming and updates
 
-Prefer {@link ChatInstanceMessaging.upsertMessage | upsertMessage} to insert, stream, correct, and regenerate `user_defined` responses. One method covers all four. It drives a streaming UI from any source: SSE, WebSocket, polling, or whole-message snapshots. It also preserves component identity across updates. You accumulate state in your app and apply it with one call per update. This skips the chunk-shape contract below. It is the recommended direction for new code, but experimental. Its semantics and updater signature may still evolve. See [Adding messages (experimental)](./UpsertMessage.md). The chat supports nested `user_defined` items inside {@link MessageResponseTypes.CARD | card}, {@link MessageResponseTypes.CAROUSEL | carousel}, and {@link MessageResponseTypes.GRID | grid} containers.
+Prefer {@link ChatInstanceMessaging.upsertMessage | upsertMessage} to insert, stream, correct, and regenerate `user_defined` responses. One method covers all four. It drives a streaming UI from any source: SSE, WebSocket, polling, or whole-message snapshots. It also preserves component identity across updates. You accumulate state in your app and apply it with one call per update. This skips the chunk-shape contract below. It is the recommended direction for new code. See [Adding messages](./UpsertMessage.md). The chat supports nested `user_defined` items inside {@link MessageResponseTypes.CARD | card}, {@link MessageResponseTypes.CAROUSEL | carousel}, and {@link MessageResponseTypes.GRID | grid} containers.
 
-{@link ChatInstanceMessaging.addMessageChunk | addMessageChunk} is the stable streaming path. It is fully supported with no deprecation, and the right choice if you prefer a settled API. If you stream with it, read [Adding messages (legacy)](./AddMessageChunk.md) first. The model is the same in every framework:
+{@link ChatInstanceMessaging.addMessageChunk | addMessageChunk} is the legacy streaming path. It is fully supported with no deprecation, but is generally more verbose than using `upsertMessage`. If you stream with it, read [Adding messages (legacy)](./AddMessageChunk.md) first. The model is the same in every framework:
 
 - {@link RenderUserDefinedState.partialItems | `partialItems`} is an array of every chunk received, **not** concatenated for you. The streaming API sends string chunks, not partial JSON. So stringify your JSON, then concatenate and parse the chunks in your renderer with `try`/`catch` or an optimistic parser.
 - Include `streaming_metadata.response_id` for the message and {@link ItemStreamingMetadata.id | `id`} for each item so chunks correlate correctly.
@@ -69,5 +69,5 @@ Prefer {@link ChatInstanceMessaging.upsertMessage | upsertMessage} to insert, st
 
 - [Using with React](./React.md#user-defined-responses) — render user-defined responses in React.
 - [Using as a Web component](./WebComponent.md#user-defined-responses) — render user-defined responses with web components.
-- [Adding messages (experimental)](./UpsertMessage.md) — insert, stream, and regenerate responses while preserving component identity.
+- [Adding messages](./UpsertMessage.md) — insert, stream, and regenerate responses while preserving component identity.
 - [Adding messages (legacy)](./AddMessageChunk.md) — stream message chunks with {@link ChatInstanceMessaging.addMessageChunk}.

--- a/packages/ai-chat/docs/UpsertMessage.md
+++ b/packages/ai-chat/docs/UpsertMessage.md
@@ -1,12 +1,12 @@
 ---
-title: Adding messages (experimental)
+title: Adding messages
 ---
 
 ## Overview
 
 {@link ChatInstanceMessaging.upsertMessage | upsertMessage} inserts or updates one message by a stable `messageID`. One method covers inserting, streaming, correcting, and regenerating — you pass an updater that receives the current message and returns what replaces it.
 
-Prefer this flow for new code, but note it's experimental. Its behavior and the updater signature may still change. For a settled API, the stable {@link ChatInstanceMessaging.addMessageChunk | addMessageChunk} flow is still fully supported. See [Adding messages (legacy)](./AddMessageChunk.md).
+Prefer this flow for new code. The {@link ChatInstanceMessaging.addMessageChunk | addMessageChunk} flow remains fully supported. See [Adding messages (legacy)](./AddMessageChunk.md).
 
 The examples below call `instance.messaging`, so get a {@link ChatInstance | ChatInstance} from the `onBeforeRender` prop first.
 

--- a/packages/ai-chat/src/chat/components-legacy/responseTypes/conversationalSearch/ConversationalSearchText.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/responseTypes/conversationalSearch/ConversationalSearchText.tsx
@@ -25,6 +25,7 @@ import { useServiceManager } from '../../../hooks/useServiceManager';
 import { shallowEqual } from '../../../store/appStore';
 import OperationalTag from '../../../components/carbon/OperationalTag';
 import { carbonIconToReact } from '../../../utils/carbonIcon';
+import { deriveStreamingItemText } from '../../../utils/streamingUtils';
 
 const ChevronDown = carbonIconToReact(ChevronDown16);
 const ChevronUp = carbonIconToReact(ChevronUp16);
@@ -88,12 +89,9 @@ function ConversationalSearchText(props: ConversationalSearchTextProps) {
   }`;
   const [html, setHtml] = useState('');
 
-  let text: string;
-  if (streamingState && !streamingState.isDone) {
-    text = streamingState.chunks.map((chunk) => chunk.text).join('');
-  } else {
-    text = searchItem.item.text;
-  }
+  // Chunk-delivered items accumulate their text in `streamingState.chunks`;
+  // upsert-delivered items carry the whole text on the item with empty chunks.
+  const text = deriveStreamingItemText(searchItem.item.text, streamingState);
 
   useEffect(() => {
     const processedText = insertHighlightMarkdown(text, highlightCitation);

--- a/packages/ai-chat/src/chat/components/helpers/MarkdownWithErrorHandling/MarkdownWithErrorHandling.tsx
+++ b/packages/ai-chat/src/chat/components/helpers/MarkdownWithErrorHandling/MarkdownWithErrorHandling.tsx
@@ -15,6 +15,7 @@ import { AppState } from '../../../../types/state/AppState';
 import { LocalMessageItemStreamingState } from '../../../../types/messaging/LocalMessageItem';
 import InlineError from '../../responseTypes/error/InlineError';
 import { MarkdownWithDefaults } from '../MarkdownWithDefaults/MarkdownWithDefaults';
+import { deriveStreamingItemText } from '../../../utils/streamingUtils';
 import { TextItem } from '../../../../types/messaging/Messages';
 
 interface MarkdownWithErrorHandlingProps {
@@ -54,13 +55,9 @@ function MarkdownWithErrorHandling(props: MarkdownWithErrorHandlingProps) {
     shallowEqual
   );
 
-  let textToUse;
-  if (streamingState && !streamingState.isDone) {
-    // If we're streaming, then concatenate all the chunks together.
-    textToUse = streamingState.chunks.map((chunk) => chunk.text).join('');
-  } else {
-    textToUse = text;
-  }
+  // Chunk-delivered items accumulate their text in `streamingState.chunks`;
+  // upsert-delivered items carry the whole text on the item with empty chunks.
+  const textToUse = deriveStreamingItemText(text, streamingState);
 
   return (
     <>

--- a/packages/ai-chat/src/chat/services/ChatActionsImpl.ts
+++ b/packages/ai-chat/src/chat/services/ChatActionsImpl.ts
@@ -1457,6 +1457,13 @@ class ChatActionsImpl {
     await this.receive(finalResponse, options.isLatestWelcomeNode, null);
 
     if (messageID) {
+      // Belt and braces: `receive` normally rebuilds the local items without any
+      // streaming state, but that only holds when the final response carries matching
+      // streaming ids. Settle the flags explicitly so a malformed final response can't
+      // leave items rendering as mid-stream.
+      this.serviceManager.store.dispatch(
+        actions.endMessageStreaming(messageID)
+      );
       this.serviceManager.messageService.finalizeStreamingMessage(messageID);
     }
   }

--- a/packages/ai-chat/src/chat/services/ChatActionsImpl.ts
+++ b/packages/ai-chat/src/chat/services/ChatActionsImpl.ts
@@ -1338,7 +1338,7 @@ class ChatActionsImpl {
           (isCompleteItem || isFinalResponse) &&
           stopStreamingState.isVisible
         ) {
-          resetStopStreamingButton(store);
+          this.serviceManager.messageService.hideStopStreamingButtonIfNoUpsertStreaming();
         }
       };
 
@@ -1588,7 +1588,10 @@ class ChatActionsImpl {
     chunk: StreamChunk
   ) {
     if (isCompleteItem || isStreamFinalResponse(chunk)) {
-      resetStopStreamingButton(this.serviceManager.store);
+      // The chunk flow has always hidden on its own `complete_item`, so this asks only
+      // whether an `upsertMessage` stream is still running. Consulting the chunk state
+      // here would keep the button up past `complete_item` — a different change.
+      this.serviceManager.messageService.hideStopStreamingButtonIfNoUpsertStreaming();
     }
   }
 
@@ -1799,14 +1802,11 @@ class ChatActionsImpl {
     store.dispatch(actions.addMessage(fullMessage));
 
     // When addMessage is called with showStopButtonImmediately enabled, hide the stop button
-    // and revert to legacy behavior (button will show on first chunk if streaming)
-    // Pass streamingMessageID to keep button visible if there's an active stream
+    // and revert to legacy behavior (button will show on first chunk if streaming).
+    // Anything still streaming — chunk or upsert — keeps the button visible.
     const messagingConfig = config.public.messaging || {};
     if (messagingConfig.showStopButtonImmediately) {
-      resetStopStreamingButton(
-        store,
-        this.serviceManager.messageService.inboundStreaming.streamingMessageID
-      );
+      this.serviceManager.messageService.hideStopStreamingButtonIfIdle();
     }
 
     // The ID of the previous (visible) message item that was added to the store. When adding new items from the
@@ -2233,7 +2233,9 @@ class ChatActionsImpl {
 
       await this.serviceManager.messageService.cancelAllMessageRequests();
 
-      // Hide the stop streaming button since we've cancelled all streams
+      // Hide the stop streaming button since we've cancelled all streams. Unconditional
+      // on purpose — everything was just cancelled, so there is no other stream to keep
+      // it visible for.
       resetStopStreamingButton(store);
 
       // Drop any in-flight upsertMessage chains and recorded state so upserts queued

--- a/packages/ai-chat/src/chat/services/MessageService.ts
+++ b/packages/ai-chat/src/chat/services/MessageService.ts
@@ -836,6 +836,16 @@ class MessageService {
       reason
     );
 
+    // A cancelled stream often ends without a `complete_item` or `final_response` — the
+    // host simply breaks out of its loop. Nothing else would settle the items' streaming
+    // flags, which left streaming-aware rendering (an in-progress markdown table, for
+    // one) engaged for the rest of the session.
+    if (streamingEntry) {
+      this.serviceManager.store.dispatch(
+        actions.endMessageStreaming(responseId)
+      );
+    }
+
     if (!pendingRequest && wasStreamingCurrent) {
       this.moveToNextQueueItem();
     }

--- a/packages/ai-chat/src/chat/services/MessageService.ts
+++ b/packages/ai-chat/src/chat/services/MessageService.ts
@@ -224,7 +224,8 @@ class MessageService {
       () => this.moveToNextQueueItem(),
       (pendingRequest, received) =>
         this.processSuccess(pendingRequest, received),
-      () => this.serviceManager.store.getState().config.public.messaging || {}
+      () => this.serviceManager.store.getState().config.public.messaging || {},
+      () => this.hideStopStreamingButtonIfIdle()
     );
     this.queue = {
       waiting: [],
@@ -306,12 +307,9 @@ class MessageService {
     // For streaming messages, don't clear the queue yet - wait for FinalResponseChunk to arrive
     // For non-streaming messages (addMessage), clear immediately
     if (!current.isStreaming) {
-      // Hide stop streaming button if it was shown for showStopButtonImmediately
-      // Pass streamingMessageID to keep button visible if there's an active stream
-      resetStopStreamingButton(
-        this.serviceManager.store,
-        this.inboundStreaming.streamingMessageID
-      );
+      // Hide stop streaming button if it was shown for showStopButtonImmediately, unless
+      // some other message is still streaming.
+      this.hideStopStreamingButtonIfIdle();
       this.moveToNextQueueItem();
     }
   }
@@ -675,8 +673,50 @@ class MessageService {
   }
 
   /**
+   * Returns true when any message is still streaming, whichever API is driving it —
+   * `addMessageChunk` (tracked by {@link inboundStreaming}) or `upsertMessage` (tracked
+   * by the upsert coordinator). This is the single source of truth for "is the chat still
+   * producing output", so the stop streaming button does not vanish when one of several
+   * concurrent streams finishes.
+   */
+  public isAnyMessageStreaming(): boolean {
+    if (this.inboundStreaming.streamingMessageID) {
+      return true;
+    }
+    return this.serviceManager.messageUpsertCoordinator.hasStreamingMessages();
+  }
+
+  /**
+   * Hides the stop streaming button unless something is still streaming.
+   */
+  public hideStopStreamingButtonIfIdle() {
+    if (!this.isAnyMessageStreaming()) {
+      resetStopStreamingButton(this.serviceManager.store);
+    }
+  }
+
+  /**
+   * Hides the stop streaming button unless an `upsertMessage` stream is still running.
+   *
+   * The chunk flow has always hidden the button on its own `complete_item`, and that
+   * behavior is deliberately preserved — so these call sites must ignore
+   * {@link inboundStreaming} and ask only whether the *other* flow is live. Consulting the
+   * chunk state here would keep the button up past a `complete_item`, which is a different
+   * change than the one this method exists to make.
+   */
+  public hideStopStreamingButtonIfNoUpsertStreaming() {
+    if (!this.serviceManager.messageUpsertCoordinator.hasStreamingMessages()) {
+      resetStopStreamingButton(this.serviceManager.store);
+    }
+  }
+
+  /**
    * Cancels the current message request if one is in progress.
    * Also handles streaming messages that may have been cleared from the queue.
+   *
+   * TODO(#1816): this only consults `inboundStreaming.streamingMessageID` and
+   * `queue.current`, so it cannot target a stream driven purely by `upsertMessage`.
+   * Routing the stop path through `instance.messaging.stop()` is that issue's scope.
    */
   public async cancelCurrentMessageRequest(
     reason: string = CancellationReason.STOP_STREAMING
@@ -793,7 +833,9 @@ class MessageService {
         pendingRequest.isProcessed = true;
         // Hide and re-enable the stop streaming button now that cancellation has
         // completed; processSuccess/processError will short-circuit on isProcessed.
-        resetStopStreamingButton(this.serviceManager.store);
+        // `clearStreamingResponse` above already dropped this stream, so this only
+        // hides when nothing else is still running.
+        this.hideStopStreamingButtonIfIdle();
         if (pendingRequest === this.queue.current) {
           this.moveToNextQueueItem();
         }

--- a/packages/ai-chat/src/chat/services/MessageService.ts
+++ b/packages/ai-chat/src/chat/services/MessageService.ts
@@ -647,6 +647,8 @@ class MessageService {
       );
       this.clearCurrentQueueItem();
     }
+
+    this.serviceManager.messageUpsertCoordinator.endAllStreaming();
   }
 
   /**
@@ -714,13 +716,34 @@ class MessageService {
    * Cancels the current message request if one is in progress.
    * Also handles streaming messages that may have been cleared from the queue.
    *
-   * TODO(#1816): this only consults `inboundStreaming.streamingMessageID` and
-   * `queue.current`, so it cannot target a stream driven purely by `upsertMessage`.
-   * Routing the stop path through `instance.messaging.stop()` is that issue's scope.
+   * Streaming *state* settles for both flows: the chunk stream through the branches
+   * below, and every `upsertMessage` stream through `endAllStreaming`.
+   *
+   * TODO(#1816): what still doesn't work is *targeted* cancellation of one upsert stream.
+   * Not for want of an id — the host passed one to `upsertMessage` and the coordinator
+   * tracks it. The problem is discovery: the two branches below look up a victim in
+   * `inboundStreaming.streamingMessageID`, which only the chunk pipeline populates, and
+   * in `queue.current.message.id`, which is the outbound *request* id rather than the
+   * response id the host chose. Nothing associates a cancelled request with the upsert
+   * ids created under it, and `upsertMessage` can be called with no request in flight at
+   * all. So the abort fires for the queued request, and `endAllStreaming` settles every
+   * id the coordinator knows about rather than the one that was cancelled. Building that
+   * association, via `instance.messaging.stop()`, is #1816's scope.
    */
   public async cancelCurrentMessageRequest(
     reason: string = CancellationReason.STOP_STREAMING
   ) {
+    // Settle upsert-driven streams up front — the chunk branch below returns early, and
+    // this has to run either way. Neither branch can reach them: an upsert stream is
+    // registered with the coordinator, not with `inboundStreaming` or the send queue,
+    // which is where those branches look. See the TODO above.
+    this.serviceManager.messageUpsertCoordinator.endAllStreaming();
+
+    // A pure-upsert stream reaches neither branch below, so this is the only thing that
+    // takes the button down for it. Guarded, so a chunk stream that is still live keeps
+    // it up and hides it through its own cancellation path.
+    this.hideStopStreamingButtonIfIdle();
+
     // If there's a streaming message, cancel it even if not in queue
     if (this.inboundStreaming.streamingMessageID) {
       await this.cancelMessageRequestByID(

--- a/packages/ai-chat/src/chat/services/MessageUpsertCoordinator.ts
+++ b/packages/ai-chat/src/chat/services/MessageUpsertCoordinator.ts
@@ -25,6 +25,7 @@ import { LocalMessageItem } from '../../types/messaging/LocalMessageItem';
 import actions from '../store/actions';
 import { addDefaultsToMessage, isRequest } from '../utils/messageUtils';
 import { consoleError } from '../utils/miscUtils';
+import { shouldShowStopStreaming } from '../utils/streamingUtils';
 import { ServiceManager } from './ServiceManager';
 
 const VALID_STATES = new Set<MessageState>([
@@ -46,13 +47,29 @@ const noop = () => {
  * - Track the most recent {@link MessageState} for each message ID. `addMessage` and
  *   `addMessageChunk` call {@link markComplete} / {@link markStreaming} so that mixing
  *   those APIs with `upsertMessage` does not double-fire `pre:receive` / `receive`.
+ * - Track which message IDs are currently mid-stream, so the stop streaming button
+ *   survives one concurrent stream finishing while another is still running.
  */
 class MessageUpsertCoordinator {
   private readonly serviceManager: ServiceManager;
 
   private readonly chainByID = new Map<string, Promise<void>>();
 
+  /**
+   * Receive-dedup record, **not** a liveness record. `addMessage` and `addMessageChunk`
+   * write it too, it deliberately retains {@link MessageState.COMPLETE} for the life of
+   * the session, and nothing drains it when a stream is cancelled. Use
+   * {@link streamingIDs} to ask whether a message is still streaming.
+   */
   private readonly stateByID = new Map<string, MessageState>();
+
+  /**
+   * IDs currently mid-stream via `upsertMessage`. Written only by {@link runOne}, which
+   * adds on {@link MessageState.STREAMING} and removes on {@link MessageState.COMPLETE} /
+   * {@link MessageState.ERROR}, so the two operations stay symmetric and the set cannot
+   * leak the way {@link stateByID} does.
+   */
+  private readonly streamingIDs = new Set<string>();
 
   constructor(serviceManager: ServiceManager) {
     this.serviceManager = serviceManager;
@@ -87,23 +104,31 @@ class MessageUpsertCoordinator {
   }
 
   /**
-   * Drops both the in-flight promise chain and recorded state for a single message ID.
-   * Called from `removeMessages` and after `finalizeStreamingMessage` to keep the maps
-   * draining for idle IDs.
+   * Returns true when any message is currently mid-stream via `upsertMessage`.
+   */
+  hasStreamingMessages(): boolean {
+    return this.streamingIDs.size > 0;
+  }
+
+  /**
+   * Drops the in-flight promise chain, the recorded state, and any streaming registration
+   * for a single message ID. Called from `removeMessages`.
    */
   clear(messageID: string) {
     this.stateByID.delete(messageID);
     this.chainByID.delete(messageID);
+    this.streamingIDs.delete(messageID);
   }
 
   /**
-   * Drops every entry from both maps. Called from `restartConversation` and from
-   * {@link ChatInstance#destroy} so a torn-down chat does not carry stale state into a
-   * fresh session.
+   * Drops every entry from all three collections. Called from `restartConversation` and
+   * from {@link ChatInstance#destroy} so a torn-down chat does not carry stale state into
+   * a fresh session.
    */
   clearAll() {
     this.chainByID.clear();
     this.stateByID.clear();
+    this.streamingIDs.clear();
   }
 
   /**
@@ -172,13 +197,64 @@ class MessageUpsertCoordinator {
     this.serviceManager.store.dispatch(
       actions.upsertMessage(result, nextState === MessageState.STREAMING)
     );
+
+    // Settle streaming liveness before the slot fan-out below. `serviceManager.fire` does
+    // not swallow listener exceptions, so a throwing user-defined-response handler would
+    // skip everything after `fanOutChangedSlots` — and a message left registered here
+    // would hold the stop button up for every other message, not just this one.
+    if (nextState === MessageState.STREAMING) {
+      this.streamingIDs.add(messageID);
+    } else {
+      this.streamingIDs.delete(messageID);
+    }
+
     await this.fanOutChangedSlots(messageID, result, nextState, refsBefore);
 
     this.stateByID.set(messageID, nextState);
+    this.syncStopStreamingButton(nextState, result);
 
     if (willFireReceive) {
       await this.firePostReceiveAndFinalize(messageID, result);
     }
+  }
+
+  /**
+   * Drives the stop streaming button from the upsert lifecycle.
+   *
+   * The chunk flow shows the button when a partial item arrives carrying
+   * `cancellable`, and hides it on the completing chunk. This is the same
+   * contract read off the upserted message instead: any item marked
+   * `cancellable` shows the button while the message is
+   * {@link MessageState.STREAMING}, and reaching {@link MessageState.COMPLETE}
+   * or {@link MessageState.ERROR} hides it.
+   *
+   * Unlike the chunk flow this needs no
+   * {@link PublicConfigMessaging.showStopButtonImmediately} opt-in — the first
+   * streaming upsert is already the earliest point the chat knows the message
+   * is cancellable, so the button appears there.
+   */
+  private syncStopStreamingButton(
+    nextState: MessageState,
+    result: MessageResponse
+  ) {
+    const { store } = this.serviceManager;
+
+    if (nextState === MessageState.STREAMING) {
+      const isCancellable = (result.output?.generic ?? []).some(
+        (item) => item?.streaming_metadata?.cancellable
+      );
+      const { isVisible } =
+        store.getState().assistantInputState.stopStreamingButtonState;
+      if (shouldShowStopStreaming({ cancellable: isCancellable }, isVisible)) {
+        store.dispatch(actions.setStopStreamingButtonVisible(true));
+      }
+      return;
+    }
+
+    // COMPLETE and ERROR are both terminal for this message — but the affordance only
+    // goes away once nothing else is streaming. `runOne` already dropped this message
+    // from `streamingIDs` above, so the check below reads "is anything *else* live".
+    this.serviceManager.messageService.hideStopStreamingButtonIfIdle();
   }
 
   /**

--- a/packages/ai-chat/src/chat/services/MessageUpsertCoordinator.ts
+++ b/packages/ai-chat/src/chat/services/MessageUpsertCoordinator.ts
@@ -111,6 +111,30 @@ class MessageUpsertCoordinator {
   }
 
   /**
+   * Settles every message still registered as mid-stream and drops the registrations.
+   *
+   * A cancelled `upsertMessage` stream has no terminal upsert to settle it — the host is
+   * told to stop and simply stops calling. Nothing else drains {@link streamingIDs}, so
+   * without this the stop streaming button stays visible and the items keep rendering
+   * mid-stream for the rest of the session.
+   *
+   * Deliberately settles *every* registered id rather than one. The ids are known — they
+   * are exactly {@link streamingIDs} — but nothing associates them with the request that
+   * was cancelled, so there is no basis for picking a subset (see the `TODO(#1816)` on
+   * {@link MessageService#cancelCurrentMessageRequest}). Settling all of them is right for
+   * both callers, which already mean "stop everything". A host that ignores the abort and
+   * keeps streaming re-registers on its next `STREAMING` upsert.
+   */
+  endAllStreaming() {
+    for (const messageID of this.streamingIDs) {
+      this.serviceManager.store.dispatch(
+        actions.endMessageStreaming(messageID)
+      );
+    }
+    this.streamingIDs.clear();
+  }
+
+  /**
    * Drops the in-flight promise chain, the recorded state, and any streaming registration
    * for a single message ID. Called from `removeMessages`.
    */

--- a/packages/ai-chat/src/chat/services/MessageUpsertCoordinator.ts
+++ b/packages/ai-chat/src/chat/services/MessageUpsertCoordinator.ts
@@ -169,7 +169,9 @@ class MessageUpsertCoordinator {
     }
 
     const refsBefore = this.snapshotLocalItemRefs(messageID);
-    this.serviceManager.store.dispatch(actions.upsertMessage(result));
+    this.serviceManager.store.dispatch(
+      actions.upsertMessage(result, nextState === MessageState.STREAMING)
+    );
     await this.fanOutChangedSlots(messageID, result, nextState, refsBefore);
 
     this.stateByID.set(messageID, nextState);

--- a/packages/ai-chat/src/chat/services/OutboundMessageCoordinator.ts
+++ b/packages/ai-chat/src/chat/services/OutboundMessageCoordinator.ts
@@ -57,7 +57,8 @@ class OutboundMessageCoordinator {
       current: PendingMessageRequest,
       received?: MessageResponse
     ) => Promise<void>,
-    private getMessagingConfig: () => PublicConfigMessaging
+    private getMessagingConfig: () => PublicConfigMessaging,
+    private hideStopStreamingButtonIfIdle: () => void
   ) {}
 
   /**
@@ -103,7 +104,10 @@ class OutboundMessageCoordinator {
       otherData: resultText,
     });
 
-    // Hide stop streaming button if visible
+    // Hide stop streaming button if visible. Unconditional on purpose, unlike
+    // `resolveCancelledMessage` below: a `customSendMessage` that throws mid-stream never
+    // drains `inboundStreaming` (the queue advance clears only the queue), so a guarded
+    // hide would leave the button stranded visible with no further chunk to hide it.
     resetStopStreamingButton(this.serviceManager.store);
 
     this.rejectFinalErrorOnMessage(pendingRequest, resultText);
@@ -196,8 +200,9 @@ class OutboundMessageCoordinator {
       this.messageLoadingManager.end();
     }
 
-    // Hide stop streaming button if visible
-    resetStopStreamingButton(this.serviceManager.store);
+    // Hide stop streaming button if visible. This request was not streaming and its
+    // streaming state is already cleared, so only hide when nothing else is running.
+    this.hideStopStreamingButtonIfIdle();
 
     sendMessagePromise.doResolve();
     pendingRequest.isProcessed = true;

--- a/packages/ai-chat/src/chat/store/actions.ts
+++ b/packages/ai-chat/src/chat/store/actions.ts
@@ -78,6 +78,7 @@ const UPDATE_PERSISTED_STATE = 'UPDATE_PERSISTED_STATE';
 const SET_HOME_SCREEN_IS_OPEN = 'SET_HOME_SCREEN_IS_OPEN';
 const UPDATE_MESSAGE = 'UPDATE_MESSAGE';
 const UPSERT_MESSAGE = 'UPSERT_MESSAGE';
+const END_MESSAGE_STREAMING = 'END_MESSAGE_STREAMING';
 const SET_LAUNCHER_MINIMIZED = 'SET_LAUNCHER_MINIMIZED';
 const CLOSE_IFRAME_PANEL = 'CLOSE_IFRAME_PANEL';
 const OPEN_IFRAME_CONTENT = 'OPEN_IFRAME_CONTENT';
@@ -214,8 +215,22 @@ const actions = {
    * existing `LocalMessageItem` references for items deep-equal to their predecessor so
    * components that subscribe to unchanged siblings do not re-render.
    */
-  upsertMessage(message: Message) {
-    return { type: UPSERT_MESSAGE, message };
+  upsertMessage(message: Message, isStreaming = false) {
+    return { type: UPSERT_MESSAGE, message, isStreaming };
+  },
+
+  /**
+   * Marks every local item belonging to `messageID` as no longer streaming.
+   *
+   * Streaming UI (the markdown element's in-progress table treatment, for one) keys off
+   * `ui_state.streamingState.isDone`. Reaching that state used to depend on the host
+   * sending a `complete_item` or `final_response` chunk, so a stream that ended any other
+   * way — the user pressing stop, `customSendMessage` throwing, a timeout — left items
+   * stuck mid-stream forever. Dispatch this wherever a stream terminates so the end state
+   * does not depend on host cooperation.
+   */
+  endMessageStreaming(messageID: string) {
+    return { type: END_MESSAGE_STREAMING, messageID };
   },
 
   messageSetOptionSelected(messageID: string, sentMessage: MessageRequest) {
@@ -736,6 +751,7 @@ export {
   SET_MESSAGE_RESPONSE_HISTORY_PROPERTY,
   UPDATE_MESSAGE,
   UPSERT_MESSAGE,
+  END_MESSAGE_STREAMING,
   SET_LAUNCHER_PROPERTY,
   SET_LAUNCHER_MINIMIZED,
   CLOSE_IFRAME_PANEL,

--- a/packages/ai-chat/src/chat/store/reducerUtils.ts
+++ b/packages/ai-chat/src/chat/store/reducerUtils.ts
@@ -471,7 +471,8 @@ function collectNestedLocalIDs(
  */
 function rebuildLocalItemsForUpsert(
   state: AppState,
-  message: MessageResponse
+  message: MessageResponse,
+  isStreaming = false
 ): {
   newLocalItemsByID: ObjectMap<LocalMessageItem>;
   newLocalIDsForMessage: string[];
@@ -526,7 +527,20 @@ function rebuildLocalItemsForUpsert(
     let localID: string;
     let localItem: LocalMessageItem;
 
-    if (matchedPrev && isEqual(matchedPrev.item, item)) {
+    // Streaming UI reads `ui_state.streamingState.isDone`. Comparing it alongside the
+    // item keeps the reference-stable path below from swallowing a STREAMING → COMPLETE
+    // transition whose payload happened not to change — which would leave the item
+    // rendering as mid-stream forever.
+    const prevIsStreaming = Boolean(
+      matchedPrev?.ui_state.streamingState &&
+      !matchedPrev.ui_state.streamingState.isDone
+    );
+
+    if (
+      matchedPrev &&
+      prevIsStreaming === isStreaming &&
+      isEqual(matchedPrev.item, item)
+    ) {
       // Reference-stable path: deep-equal to the prior item, keep the exact object so
       // selectors comparing by `===` see no change.
       //
@@ -543,6 +557,10 @@ function rebuildLocalItemsForUpsert(
       localItem = outputItemToLocalItem(item, message, false);
       localItem.ui_state.id = localID;
       localItem.fullMessageID = messageID;
+      // Mirror what the chunk pipeline records, so streaming-aware rendering behaves the
+      // same whichever API delivered the message.
+      localItem.ui_state.isIntermediateStreaming = isStreaming;
+      localItem.ui_state.streamingState = { chunks: [], isDone: !isStreaming };
 
       if (isResponseWithNestedItems(localItem.item)) {
         const nestedLocalItems: LocalMessageItem[] = [];
@@ -554,6 +572,10 @@ function rebuildLocalItemsForUpsert(
           true
         );
         for (const nested of nestedLocalItems) {
+          // Nested items render markdown too, so a table inside a card or grid needs the
+          // same streaming flags as a top-level one.
+          nested.ui_state.isIntermediateStreaming = isStreaming;
+          nested.ui_state.streamingState = { chunks: [], isDone: !isStreaming };
           newLocalItemsByID[nested.ui_state.id] = nested;
         }
       }

--- a/packages/ai-chat/src/chat/store/reducers.ts
+++ b/packages/ai-chat/src/chat/store/reducers.ts
@@ -98,6 +98,7 @@ import {
   UPDATE_STRUCTURED_DATA,
   UPDATE_MESSAGE,
   UPSERT_MESSAGE,
+  END_MESSAGE_STREAMING,
   UPDATE_PERSISTED_STATE,
   UPDATE_THEME_STATE,
   RESET_IS_HYDRATING_COUNTER,
@@ -489,9 +490,9 @@ const reducers: { [key: string]: ReducerType } = {
 
   [UPSERT_MESSAGE]: (
     state: AppState,
-    action: { message: Message }
+    action: { message: Message; isStreaming?: boolean }
   ): AppState => {
-    const { message } = action;
+    const { message, isStreaming = false } = action;
     const messageID = message.id;
 
     if (!isResponse(message)) {
@@ -501,7 +502,7 @@ const reducers: { [key: string]: ReducerType } = {
     const messageResponse = message;
 
     const { newLocalItemsByID, newLocalIDsForMessage } =
-      rebuildLocalItemsForUpsert(state, messageResponse);
+      rebuildLocalItemsForUpsert(state, messageResponse, isStreaming);
 
     // Splice the new ordered IDs back into localMessageIDs at the same position the
     // existing block occupied. Brand-new messages append.
@@ -548,6 +549,45 @@ const reducers: { [key: string]: ReducerType } = {
         activeResponseId: messageID,
       },
     };
+  },
+
+  [END_MESSAGE_STREAMING]: (
+    state: AppState,
+    action: { messageID: string }
+  ): AppState => {
+    const { messageID } = action;
+
+    let changed = false;
+    const newLocalItems: Record<string, LocalMessageItem> = {
+      ...state.allMessageItemsByID,
+    };
+
+    for (const localID of Object.keys(newLocalItems)) {
+      const localItem = newLocalItems[localID];
+      if (localItem?.fullMessageID !== messageID) {
+        continue;
+      }
+      const { streamingState, isIntermediateStreaming } = localItem.ui_state;
+      if (!isIntermediateStreaming && streamingState?.isDone !== false) {
+        // Already settled — leave the reference alone so subscribers don't re-render.
+        continue;
+      }
+      newLocalItems[localID] = {
+        ...localItem,
+        ui_state: {
+          ...localItem.ui_state,
+          isIntermediateStreaming: false,
+          streamingState: { ...streamingState, chunks: [], isDone: true },
+        },
+      };
+      changed = true;
+    }
+
+    if (!changed) {
+      return state;
+    }
+
+    return { ...state, allMessageItemsByID: newLocalItems };
   },
 
   [ADD_MESSAGE]: (state: AppState, action: { message: Message }): AppState => {

--- a/packages/ai-chat/src/chat/utils/streamingUtils.ts
+++ b/packages/ai-chat/src/chat/utils/streamingUtils.ts
@@ -10,6 +10,7 @@
 import actions from '../store/actions';
 import {
   CompleteItemChunk,
+  ConversationalSearchItem,
   FinalResponseChunk,
   GenericItem,
   MessageResponseTypes,
@@ -20,7 +21,10 @@ import {
   UserDefinedItem,
 } from '../../types/messaging/Messages';
 import { DeepPartial } from '../../types/utilities/DeepPartial';
-import { LocalMessageItem } from '../../types/messaging/LocalMessageItem';
+import {
+  LocalMessageItem,
+  LocalMessageItemStreamingState,
+} from '../../types/messaging/LocalMessageItem';
 import {
   isStreamCompleteItem,
   isStreamFinalResponse,
@@ -176,6 +180,32 @@ function resetStopStreamingButton(store: StoreLike) {
 }
 
 /**
+ * The text a streaming-aware renderer should display for a text-bearing item.
+ *
+ * The two delivery flows store mid-stream text differently. The chunk flow streams
+ * deltas: the accumulated text lives in `streamingState.chunks` (the item's own `text`
+ * holds only the first chunk). The upsert flow streams snapshots: the item's `text` is
+ * complete on every update and `chunks` stays empty. Joining chunks unconditionally
+ * rendered upsert-streamed text as blank until COMPLETE, so the chunks win only when
+ * there are any.
+ */
+function deriveStreamingItemText(
+  text: string,
+  streamingState:
+    | LocalMessageItemStreamingState<TextItem | ConversationalSearchItem>
+    | undefined
+): string {
+  if (
+    streamingState &&
+    !streamingState.isDone &&
+    streamingState.chunks.length
+  ) {
+    return streamingState.chunks.map((chunk) => chunk.text ?? '').join('');
+  }
+  return text;
+}
+
+/**
  * Merge message options only, ignoring unexpected partial_response fields.
  */
 function mergePartialResponseOptions(
@@ -281,6 +311,7 @@ function messageHasDisplayableContent(
 
 export {
   chunkHasDisplayableContent,
+  deriveStreamingItemText,
   FinalResponseChunk,
   mergePartialResponseOptions,
   messageHasDisplayableContent,

--- a/packages/ai-chat/src/chat/utils/streamingUtils.ts
+++ b/packages/ai-chat/src/chat/utils/streamingUtils.ts
@@ -160,22 +160,16 @@ function shouldShowStopStreaming(
 /**
  * Hides and re-enables the stop streaming button if currently visible.
  *
+ * This hides unconditionally. Deciding *whether* to hide belongs to `MessageService` —
+ * see its `hideStopStreamingButtonIfIdle` / `hideStopStreamingButtonIfNoUpsertStreaming`,
+ * which own that policy so concurrent streams cannot hide each other's button.
+ *
  * @param store - The store instance
- * @param streamingMessageID - Optional ID of currently streaming message. If provided and not null,
- *                             the button will remain visible (used with showStopButtonImmediately
- *                             to keep button visible during active streaming).
  */
-function resetStopStreamingButton(
-  store: StoreLike,
-  streamingMessageID?: string | null
-) {
+function resetStopStreamingButton(store: StoreLike) {
   const stopStreamingState =
     store.getState().assistantInputState.stopStreamingButtonState;
   if (stopStreamingState.isVisible) {
-    // If there's an active streaming message, keep the button visible
-    if (streamingMessageID) {
-      return;
-    }
     store.dispatch(actions.setStopStreamingButtonDisabled(false));
     store.dispatch(actions.setStopStreamingButtonVisible(false));
   }

--- a/packages/ai-chat/src/types/component/ChatContainer.ts
+++ b/packages/ai-chat/src/types/component/ChatContainer.ts
@@ -70,9 +70,6 @@ interface RenderUserDefinedState {
    * The current {@link MessageState} of the containing message at the moment the renderer
    * was invoked. Use this to drive in-widget streaming indicators or error treatments
    * without inspecting the message items directly.
-   *
-   * @experimental Field is additive; its presence and semantics may evolve as the
-   * lifecycle model stabilizes.
    */
   state?: MessageState;
 }

--- a/packages/ai-chat/src/types/config/MessagingConfig.ts
+++ b/packages/ai-chat/src/types/config/MessagingConfig.ts
@@ -19,10 +19,11 @@ import { BusEventSend } from '../events/eventBusTypes';
  * `addMessage`, `addMessageChunk`, and `upsertMessage` may all target the same message
  * id without producing duplicate `pre:receive` / `receive` events — Carbon AI Chat tracks
  * the recorded state per id and fires those events only on the first transition to
- * {@link COMPLETE}.
+ * {@link COMPLETE}. Mixing them for the same message still works, but drive a given
+ * conversation with one of them; see
+ * {@link ChatInstanceMessaging.upsertMessage | upsertMessage}.
  *
  * @category Messaging
- * @experimental
  */
 export enum MessageState {
   /**
@@ -59,7 +60,6 @@ export enum MessageState {
  *   first upsert of a new id.
  * @returns The {@link MessageResponse} to store, optionally as a Promise.
  * @category Messaging
- * @experimental
  */
 export type UpsertMessageUpdater = (
   previous: MessageResponse | undefined
@@ -113,7 +113,13 @@ export interface ChatInstanceMessaging {
    *
    * Calls targeting the same `messageID` are serialized — each call awaits the previous
    * call for that ID before running. Calls targeting different `messageID`s run
-   * independently.
+   * independently, so several messages can stream at once.
+   *
+   * Drive a conversation with either this method or
+   * {@link ChatInstanceMessaging.addMessageChunk | addMessageChunk}, rather than both.
+   * The two are supported together and will not duplicate `pre:receive` / `receive`
+   * events, but they track streaming progress separately, so a single flow is simpler to
+   * reason about.
    *
    * The `state` argument describes the {@link MessageState} the chat records for this
    * message after the upsert completes; it is applied uniformly to every item in the
@@ -135,7 +141,6 @@ export interface ChatInstanceMessaging {
    * @throws `TypeError` when the updater returns `null`/`undefined`, returns a message
    *   whose `id` differs from `messageID`, or returns a non-assistant message (a request
    *   or a human-agent message).
-   * @experimental Upsert semantics and the updater signature may evolve based on consumer feedback.
    */
   upsertMessage: (
     messageID: string,

--- a/packages/ai-chat/src/types/config/PublicConfigMessaging.ts
+++ b/packages/ai-chat/src/types/config/PublicConfigMessaging.ts
@@ -70,6 +70,16 @@ export interface PublicConfigMessaging {
   /**
    * Controls when the stop streaming button becomes visible during message streaming.
    *
+   * This setting is independent of how you deliver the response — it is applied when
+   * `customSendMessage` is called, before either flow has started.
+   *
+   * Without it, the two flows reach the same result by their own route.
+   * {@link ChatInstanceMessaging.addMessageChunk} shows the button on the first partial
+   * chunk marked `cancellable`. {@link ChatInstanceMessaging.upsertMessage} shows it on
+   * the first upsert recorded as {@link MessageState.STREAMING} whose message carries
+   * `streaming_metadata.cancellable`, and hides it once that message reaches
+   * {@link MessageState.COMPLETE} or {@link MessageState.ERROR}.
+   *
    * You must have {@link PublicConfigMessaging.customSendMessage} return a promise for
    * this setting to work correctly.
    *

--- a/packages/ai-chat/src/types/events/eventBusTypes.ts
+++ b/packages/ai-chat/src/types/events/eventBusTypes.ts
@@ -584,9 +584,6 @@ export interface BusEventUserDefinedResponse extends BusEvent {
      * {@link ChatInstanceMessaging.upsertMessage}, {@link ChatInstanceMessaging.addMessage},
      * and the final-response transition of {@link ChatInstanceMessaging.addMessageChunk}.
      * See {@link MessageState} for the lifecycle values.
-     *
-     * @experimental Field is additive; its presence and semantics may evolve as the
-     * lifecycle model stabilizes.
      */
     state?: MessageState;
   };

--- a/packages/ai-chat/tests/instance/spec/messaging/addMessageChunk_spec.ts
+++ b/packages/ai-chat/tests/instance/spec/messaging/addMessageChunk_spec.ts
@@ -469,6 +469,68 @@ describe('ChatInstance.messaging.addMessageChunk', () => {
     ).toBeUndefined();
   });
 
+  // The reported symptom: a stream cancelled mid-flight never receives a complete_item
+  // or final_response, so nothing used to settle its items and the markdown table kept
+  // rendering in its in-progress treatment for the rest of the session. The
+  // stream_stopped test below covers the case where the host *does* send a closing
+  // chunk; this covers the case where it just stops calling.
+  it('settles streaming flags when a stream is cancelled with no closing chunk', async () => {
+    const responseId = 'cancelled-no-close';
+    const itemId = 'item-1';
+    let stopped = false;
+
+    const config = {
+      ...createBaseConfig(),
+      messaging: {
+        ...createBaseConfig().messaging,
+        customSendMessage: async (
+          _request: any,
+          options: any,
+          chatInstance: ChatInstance
+        ) => {
+          options.signal?.addEventListener('abort', () => {
+            stopped = true;
+          });
+
+          await chatInstance.messaging.addMessageChunk({
+            streaming_metadata: { response_id: responseId },
+            partial_item: {
+              streaming_metadata: { id: itemId, cancellable: true },
+              response_type: MessageResponseTypes.TEXT,
+              text: '| a | b |',
+            },
+          } as PartialItemChunk);
+
+          // Break out on abort and send nothing further — the whole point of the case.
+          while (!stopped) {
+            await new Promise((resolve) => setTimeout(resolve, 10));
+          }
+        },
+      },
+    };
+
+    const { instance, store } = await renderChatAndGetInstanceWithStore(
+      config as any
+    );
+
+    const sendPromise = instance.send('go');
+    await new Promise((resolve) => setTimeout(resolve, 60));
+
+    const localItemID = `${responseId}-${itemId}`;
+    const before = store.getState().allMessageItemsByID[localItemID];
+    expect(before.ui_state.streamingState.isDone).toBe(false);
+    expect(before.ui_state.isIntermediateStreaming).toBe(true);
+
+    await (
+      instance as any
+    ).serviceManager.messageService.cancelCurrentMessageRequest();
+    await sendPromise.catch(() => {});
+
+    const after = store.getState().allMessageItemsByID[localItemID];
+    expect(after.ui_state.streamingState.isDone).toBe(true);
+    expect(after.ui_state.isIntermediateStreaming).toBe(false);
+  });
+
   describe('stop streaming button', () => {
     const isVisible = (store: { getState: () => any }) =>
       store.getState().assistantInputState.stopStreamingButtonState.isVisible;

--- a/packages/ai-chat/tests/instance/spec/messaging/addMessageChunk_spec.ts
+++ b/packages/ai-chat/tests/instance/spec/messaging/addMessageChunk_spec.ts
@@ -469,6 +469,72 @@ describe('ChatInstance.messaging.addMessageChunk', () => {
     ).toBeUndefined();
   });
 
+  describe('stop streaming button', () => {
+    const isVisible = (store: { getState: () => any }) =>
+      store.getState().assistantInputState.stopStreamingButtonState.isVisible;
+
+    // The chunk flow has always hidden the button on its own complete_item. Making the
+    // stop button concurrency-aware must not change that, so pin it here.
+    it('hides the button on complete_item when nothing else is streaming', async () => {
+      const config = createBaseConfig();
+      const { instance, store } =
+        await renderChatAndGetInstanceWithStore(config);
+      const responseId = 'chunk-stop-1';
+      const itemId = 'chunk-stop-item-1';
+
+      await instance.messaging.addMessageChunk({
+        streaming_metadata: { response_id: responseId },
+        partial_item: {
+          streaming_metadata: { id: itemId, cancellable: true },
+          response_type: MessageResponseTypes.TEXT,
+          text: 'Partial ',
+        },
+      } as PartialItemChunk);
+
+      expect(isVisible(store)).toBe(true);
+
+      await instance.messaging.addMessageChunk({
+        streaming_metadata: { response_id: responseId },
+        complete_item: {
+          streaming_metadata: { id: itemId },
+          response_type: MessageResponseTypes.TEXT,
+          text: 'Partial complete',
+        },
+      } as CompleteItemChunk);
+
+      expect(isVisible(store)).toBe(false);
+    });
+
+    // A complete_item carrying no streaming_metadata leaves the resolved message id
+    // undefined while the coordinator fell back to the queued request id. Any fix that
+    // compared those two ids would silently stop hiding here.
+    it('hides the button on a complete_item with no streaming metadata', async () => {
+      const config = createBaseConfig();
+      const { instance, store } =
+        await renderChatAndGetInstanceWithStore(config);
+
+      await instance.messaging.addMessageChunk({
+        streaming_metadata: { response_id: 'chunk-stop-2' },
+        partial_item: {
+          streaming_metadata: { id: 'chunk-stop-item-2', cancellable: true },
+          response_type: MessageResponseTypes.TEXT,
+          text: 'Partial ',
+        },
+      } as PartialItemChunk);
+
+      expect(isVisible(store)).toBe(true);
+
+      await instance.messaging.addMessageChunk({
+        complete_item: {
+          response_type: MessageResponseTypes.TEXT,
+          text: 'Done',
+        },
+      } as CompleteItemChunk);
+
+      expect(isVisible(store)).toBe(false);
+    });
+  });
+
   describe('Abort signal behavior during streaming', () => {
     it('should trigger abort signal with STOP_STREAMING reason when stop button is used', async () => {
       const config = createBaseConfig();

--- a/packages/ai-chat/tests/instance/spec/messaging/upsertMessage_spec.ts
+++ b/packages/ai-chat/tests/instance/spec/messaging/upsertMessage_spec.ts
@@ -271,4 +271,306 @@ describe('ChatInstance.messaging.upsertMessage', () => {
       expect(state.allMessagesByID['u11']).toBeDefined();
     });
   });
+
+  describe('stop streaming button', () => {
+    function cancellableResponse(id: string, text: string): MessageResponse {
+      return {
+        id,
+        output: {
+          generic: [
+            {
+              response_type: MessageResponseTypes.TEXT,
+              text,
+              streaming_metadata: { id: '1', cancellable: true },
+            },
+          ],
+        },
+      };
+    }
+
+    const isVisible = (store: { getState: () => any }) =>
+      store.getState().assistantInputState.stopStreamingButtonState.isVisible;
+
+    it('shows the button on a cancellable streaming upsert', async () => {
+      const { instance, store } =
+        await renderChatAndGetInstanceWithStore(createBaseConfig());
+
+      expect(isVisible(store)).toBe(false);
+
+      await instance.messaging.upsertMessage(
+        'stop-1',
+        MessageState.STREAMING,
+        () => cancellableResponse('stop-1', 'partial')
+      );
+
+      expect(isVisible(store)).toBe(true);
+    });
+
+    it('hides the button once the message completes', async () => {
+      const { instance, store } =
+        await renderChatAndGetInstanceWithStore(createBaseConfig());
+
+      await instance.messaging.upsertMessage(
+        'stop-2',
+        MessageState.STREAMING,
+        () => cancellableResponse('stop-2', 'partial')
+      );
+      expect(isVisible(store)).toBe(true);
+
+      await instance.messaging.upsertMessage(
+        'stop-2',
+        MessageState.COMPLETE,
+        () => cancellableResponse('stop-2', 'all of it')
+      );
+
+      expect(isVisible(store)).toBe(false);
+    });
+
+    it('hides the button when the message errors', async () => {
+      const { instance, store } =
+        await renderChatAndGetInstanceWithStore(createBaseConfig());
+
+      await instance.messaging.upsertMessage(
+        'stop-3',
+        MessageState.STREAMING,
+        () => cancellableResponse('stop-3', 'partial')
+      );
+      expect(isVisible(store)).toBe(true);
+
+      await instance.messaging.upsertMessage('stop-3', MessageState.ERROR, () =>
+        cancellableResponse('stop-3', 'partial')
+      );
+
+      expect(isVisible(store)).toBe(false);
+    });
+
+    it('leaves the button hidden when the message is not cancellable', async () => {
+      const { instance, store } =
+        await renderChatAndGetInstanceWithStore(createBaseConfig());
+
+      await instance.messaging.upsertMessage(
+        'stop-4',
+        MessageState.STREAMING,
+        () => textResponse('stop-4', 'partial')
+      );
+
+      expect(isVisible(store)).toBe(false);
+    });
+
+    describe('with more than one message streaming', () => {
+      it('keeps the button visible when one of two streams completes', async () => {
+        const { instance, store } =
+          await renderChatAndGetInstanceWithStore(createBaseConfig());
+
+        await instance.messaging.upsertMessage(
+          'multi-a',
+          MessageState.STREAMING,
+          () => cancellableResponse('multi-a', 'a partial')
+        );
+        await instance.messaging.upsertMessage(
+          'multi-b',
+          MessageState.STREAMING,
+          () => cancellableResponse('multi-b', 'b partial')
+        );
+        expect(isVisible(store)).toBe(true);
+
+        await instance.messaging.upsertMessage(
+          'multi-a',
+          MessageState.COMPLETE,
+          () => cancellableResponse('multi-a', 'a done')
+        );
+
+        // multi-b is still streaming, so the affordance has to survive.
+        expect(isVisible(store)).toBe(true);
+
+        await instance.messaging.upsertMessage(
+          'multi-b',
+          MessageState.COMPLETE,
+          () => cancellableResponse('multi-b', 'b done')
+        );
+
+        expect(isVisible(store)).toBe(false);
+      });
+
+      it('keeps the button visible when one of two streams errors', async () => {
+        const { instance, store } =
+          await renderChatAndGetInstanceWithStore(createBaseConfig());
+
+        await instance.messaging.upsertMessage(
+          'multi-err-a',
+          MessageState.STREAMING,
+          () => cancellableResponse('multi-err-a', 'a partial')
+        );
+        await instance.messaging.upsertMessage(
+          'multi-err-b',
+          MessageState.STREAMING,
+          () => cancellableResponse('multi-err-b', 'b partial')
+        );
+
+        await instance.messaging.upsertMessage(
+          'multi-err-a',
+          MessageState.ERROR,
+          () => cancellableResponse('multi-err-a', 'a failed')
+        );
+
+        expect(isVisible(store)).toBe(true);
+
+        await instance.messaging.upsertMessage(
+          'multi-err-b',
+          MessageState.ERROR,
+          () => cancellableResponse('multi-err-b', 'b failed')
+        );
+
+        expect(isVisible(store)).toBe(false);
+      });
+
+      it('does not strand the button when a terminal upsert throws', async () => {
+        const { instance, store } =
+          await renderChatAndGetInstanceWithStore(createBaseConfig());
+
+        await instance.messaging.upsertMessage(
+          'throw-a',
+          MessageState.STREAMING,
+          () => cancellableResponse('throw-a', 'a partial')
+        );
+        await instance.messaging.upsertMessage(
+          'throw-b',
+          MessageState.STREAMING,
+          () => cancellableResponse('throw-b', 'b partial')
+        );
+
+        await expect(
+          instance.messaging.upsertMessage(
+            'throw-a',
+            MessageState.COMPLETE,
+            () =>
+              // Returning the wrong id makes the coordinator reject.
+              cancellableResponse('a-different-id', 'nope')
+          )
+        ).rejects.toThrow();
+
+        // throw-a never settled, so it stays registered and holds the button up.
+        expect(isVisible(store)).toBe(true);
+
+        // The surviving stream completing must still be able to hide it once throw-a
+        // is dropped, so removing throw-a has to drain its registration too.
+        await instance.messaging.removeMessages(['throw-a']);
+        await instance.messaging.upsertMessage(
+          'throw-b',
+          MessageState.COMPLETE,
+          () => cancellableResponse('throw-b', 'b done')
+        );
+
+        expect(isVisible(store)).toBe(false);
+      });
+
+      it('drains streaming registrations on conversation restart', async () => {
+        const { instance, store } =
+          await renderChatAndGetInstanceWithStore(createBaseConfig());
+
+        await instance.messaging.upsertMessage(
+          'restart-a',
+          MessageState.STREAMING,
+          () => cancellableResponse('restart-a', 'partial')
+        );
+        expect(isVisible(store)).toBe(true);
+
+        await instance.messaging.restartConversation();
+        expect(isVisible(store)).toBe(false);
+
+        // A fresh stream after the restart must still hide on its own completion —
+        // proves restart-a's registration did not survive.
+        await instance.messaging.upsertMessage(
+          'restart-b',
+          MessageState.STREAMING,
+          () => cancellableResponse('restart-b', 'partial')
+        );
+        expect(isVisible(store)).toBe(true);
+
+        await instance.messaging.upsertMessage(
+          'restart-b',
+          MessageState.COMPLETE,
+          () => cancellableResponse('restart-b', 'done')
+        );
+        expect(isVisible(store)).toBe(false);
+      });
+    });
+
+    describe('mixed with addMessageChunk', () => {
+      const partialChunk = (responseId: string) => ({
+        streaming_metadata: { response_id: responseId },
+        partial_item: {
+          streaming_metadata: { id: `${responseId}-item`, cancellable: true },
+          response_type: MessageResponseTypes.TEXT,
+          text: 'chunk partial ',
+        },
+      });
+
+      const finalChunk = (responseId: string) => ({
+        final_response: {
+          id: responseId,
+          output: {
+            generic: [
+              {
+                streaming_metadata: { id: `${responseId}-item` },
+                response_type: MessageResponseTypes.TEXT,
+                text: 'chunk done',
+              },
+            ],
+          },
+        },
+      });
+
+      it('keeps the button visible when the chunk stream finishes first', async () => {
+        const { instance, store } =
+          await renderChatAndGetInstanceWithStore(createBaseConfig());
+
+        await instance.messaging.addMessageChunk(partialChunk('mix-c1') as any);
+        await instance.messaging.upsertMessage(
+          'mix-u1',
+          MessageState.STREAMING,
+          () => cancellableResponse('mix-u1', 'upsert partial')
+        );
+        expect(isVisible(store)).toBe(true);
+
+        await instance.messaging.addMessageChunk(finalChunk('mix-c1') as any);
+
+        // The upsert stream is still running.
+        expect(isVisible(store)).toBe(true);
+
+        await instance.messaging.upsertMessage(
+          'mix-u1',
+          MessageState.COMPLETE,
+          () => cancellableResponse('mix-u1', 'upsert done')
+        );
+
+        expect(isVisible(store)).toBe(false);
+      });
+
+      it('keeps the button visible when the upsert stream finishes first', async () => {
+        const { instance, store } =
+          await renderChatAndGetInstanceWithStore(createBaseConfig());
+
+        await instance.messaging.addMessageChunk(partialChunk('mix-c2') as any);
+        await instance.messaging.upsertMessage(
+          'mix-u2',
+          MessageState.STREAMING,
+          () => cancellableResponse('mix-u2', 'upsert partial')
+        );
+
+        await instance.messaging.upsertMessage(
+          'mix-u2',
+          MessageState.COMPLETE,
+          () => cancellableResponse('mix-u2', 'upsert done')
+        );
+
+        // The chunk stream is still running.
+        expect(isVisible(store)).toBe(true);
+
+        await instance.messaging.addMessageChunk(finalChunk('mix-c2') as any);
+
+        expect(isVisible(store)).toBe(false);
+      });
+    });
+  });
 });

--- a/packages/ai-chat/tests/instance/spec/messaging/upsertMessage_spec.ts
+++ b/packages/ai-chat/tests/instance/spec/messaging/upsertMessage_spec.ts
@@ -572,5 +572,67 @@ describe('ChatInstance.messaging.upsertMessage', () => {
         expect(isVisible(store)).toBe(false);
       });
     });
+
+    describe('cancellation', () => {
+      const itemsFor = (store: { getState: () => any }, messageID: string) =>
+        Object.values(
+          store.getState().allMessageItemsByID as Record<string, any>
+        ).filter((item) => item.fullMessageID === messageID);
+
+      // Cancellation looks for a victim in the chunk registry and the send queue, and an
+      // upsert stream is registered in neither — so it cannot target one individually,
+      // even though the id is known. See the TODO(#1816) on cancelCurrentMessageRequest.
+      // What it can do is settle every registered stream, which is what stops the button
+      // and the items stranding when a cancelled host simply stops calling.
+      it('settles a streaming upsert that never receives a terminal call', async () => {
+        const { instance, store } =
+          await renderChatAndGetInstanceWithStore(createBaseConfig());
+
+        await instance.messaging.upsertMessage(
+          'cancel-1',
+          MessageState.STREAMING,
+          () => cancellableResponse('cancel-1', 'partial')
+        );
+        expect(isVisible(store)).toBe(true);
+
+        const [before] = itemsFor(store, 'cancel-1');
+        expect(before.ui_state.streamingState?.isDone).toBe(false);
+
+        await (
+          instance as any
+        ).serviceManager.messageService.cancelCurrentMessageRequest();
+
+        const [after] = itemsFor(store, 'cancel-1');
+        expect(after.ui_state.streamingState?.isDone).toBe(true);
+        expect(after.ui_state.isIntermediateStreaming).toBe(false);
+        expect(isVisible(store)).toBe(false);
+      });
+
+      it('settles every streaming upsert, not just one', async () => {
+        const { instance, store } =
+          await renderChatAndGetInstanceWithStore(createBaseConfig());
+
+        await instance.messaging.upsertMessage(
+          'cancel-a',
+          MessageState.STREAMING,
+          () => cancellableResponse('cancel-a', 'a')
+        );
+        await instance.messaging.upsertMessage(
+          'cancel-b',
+          MessageState.STREAMING,
+          () => cancellableResponse('cancel-b', 'b')
+        );
+
+        await (
+          instance as any
+        ).serviceManager.messageService.cancelCurrentMessageRequest();
+
+        for (const id of ['cancel-a', 'cancel-b']) {
+          const [item] = itemsFor(store, id);
+          expect(item.ui_state.streamingState?.isDone).toBe(true);
+        }
+        expect(isVisible(store)).toBe(false);
+      });
+    });
   });
 });

--- a/packages/ai-chat/tests/services/spec/MessageService_spec.ts
+++ b/packages/ai-chat/tests/services/spec/MessageService_spec.ts
@@ -74,11 +74,18 @@ const createServiceManagerStub = (
     fire: jest.fn().mockResolvedValue(undefined),
   };
 
+  // MessageService resolves this collaborator through ServiceManager to answer
+  // "is an upsertMessage stream still running".
+  const messageUpsertCoordinator = {
+    hasStreamingMessages: jest.fn().mockReturnValue(false),
+  };
+
   const serviceManager = {
     store,
     actions,
     eventBus,
     instance: {},
+    messageUpsertCoordinator,
   } as unknown as ServiceManager;
 
   return serviceManager;
@@ -478,6 +485,108 @@ describe('MessageService', () => {
 
       // Verify the controller was aborted
       expect(controller.signal.aborted).toBe(true);
+    });
+  });
+
+  describe('isAnyMessageStreaming', () => {
+    const build = (stopStreamingButtonState?: {
+      isVisible: boolean;
+      isDisabled: boolean;
+    }) => {
+      const serviceManager = createServiceManagerStub(
+        jest.fn().mockResolvedValue(undefined),
+        stopStreamingButtonState
+      );
+      const messageService = new MessageService(serviceManager, {
+        messaging: { messageTimeoutSecs: 0 },
+      } as any);
+      return { serviceManager, messageService };
+    };
+
+    it('is false when nothing is streaming', () => {
+      const { messageService } = build();
+      expect(messageService.isAnyMessageStreaming()).toBe(false);
+    });
+
+    it('is true while a chunk stream is active', () => {
+      const { messageService } = build();
+      messageService.inboundStreaming.streamingMessageID = 'chunk-1';
+      expect(messageService.isAnyMessageStreaming()).toBe(true);
+    });
+
+    it('is true while an upsert stream is active', () => {
+      const { serviceManager, messageService } = build();
+      (
+        serviceManager.messageUpsertCoordinator
+          .hasStreamingMessages as jest.Mock
+      ).mockReturnValue(true);
+
+      // The chunk registry is null for a pure-upsert flow, which is exactly why the
+      // predicate cannot be built on inboundStreaming alone.
+      expect(messageService.inboundStreaming.streamingMessageID).toBeNull();
+      expect(messageService.isAnyMessageStreaming()).toBe(true);
+    });
+
+    it('hideStopStreamingButtonIfIdle leaves the button alone while anything streams', () => {
+      const { serviceManager, messageService } = build({
+        isVisible: true,
+        isDisabled: false,
+      });
+      (
+        serviceManager.messageUpsertCoordinator
+          .hasStreamingMessages as jest.Mock
+      ).mockReturnValue(true);
+
+      messageService.hideStopStreamingButtonIfIdle();
+
+      expect(serviceManager.store.dispatch).not.toHaveBeenCalled();
+    });
+
+    it('hideStopStreamingButtonIfIdle hides once nothing streams', () => {
+      const { serviceManager, messageService } = build({
+        isVisible: true,
+        isDisabled: false,
+      });
+
+      messageService.hideStopStreamingButtonIfIdle();
+
+      const types = (serviceManager.store.dispatch as jest.Mock).mock.calls.map(
+        (call) => call[0]?.type
+      );
+      expect(types).toContain('SET_STOP_STREAMING_BUTTON_VISIBLE');
+      expect(types).toContain('SET_STOP_STREAMING_BUTTON_DISABLED');
+    });
+
+    it('hideStopStreamingButtonIfNoUpsertStreaming ignores an active chunk stream', () => {
+      const { serviceManager, messageService } = build({
+        isVisible: true,
+        isDisabled: false,
+      });
+      messageService.inboundStreaming.streamingMessageID = 'chunk-1';
+
+      // The chunk flow has always hidden on its own complete_item, so this variant must
+      // not consult inboundStreaming — otherwise complete_item would stop hiding.
+      messageService.hideStopStreamingButtonIfNoUpsertStreaming();
+
+      const types = (serviceManager.store.dispatch as jest.Mock).mock.calls.map(
+        (call) => call[0]?.type
+      );
+      expect(types).toContain('SET_STOP_STREAMING_BUTTON_VISIBLE');
+    });
+
+    it('hideStopStreamingButtonIfNoUpsertStreaming respects an active upsert stream', () => {
+      const { serviceManager, messageService } = build({
+        isVisible: true,
+        isDisabled: false,
+      });
+      (
+        serviceManager.messageUpsertCoordinator
+          .hasStreamingMessages as jest.Mock
+      ).mockReturnValue(true);
+
+      messageService.hideStopStreamingButtonIfNoUpsertStreaming();
+
+      expect(serviceManager.store.dispatch).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/ai-chat/tests/services/spec/MessageService_spec.ts
+++ b/packages/ai-chat/tests/services/spec/MessageService_spec.ts
@@ -78,6 +78,9 @@ const createServiceManagerStub = (
   // "is an upsertMessage stream still running".
   const messageUpsertCoordinator = {
     hasStreamingMessages: jest.fn().mockReturnValue(false),
+    // Cancellation settles every registered upsert stream, since none of them can be
+    // targeted by a chunk response id or a queued request id.
+    endAllStreaming: jest.fn(),
   };
 
   const serviceManager = {

--- a/packages/ai-chat/tests/services/spec/MessageUpsertCoordinator_spec.ts
+++ b/packages/ai-chat/tests/services/spec/MessageUpsertCoordinator_spec.ts
@@ -20,6 +20,9 @@ interface StubState {
   allMessagesByID: Record<string, unknown>;
   allMessageItemsByID: Record<string, unknown>;
   assistantMessageState: { localMessageIDs: string[] };
+  assistantInputState: {
+    stopStreamingButtonState: { isVisible: boolean; isDisabled: boolean };
+  };
 }
 
 function makeStubManager(initialMessages: Record<string, unknown> = {}) {
@@ -27,6 +30,11 @@ function makeStubManager(initialMessages: Record<string, unknown> = {}) {
     allMessagesByID: { ...initialMessages },
     allMessageItemsByID: {},
     assistantMessageState: { localMessageIDs: [] },
+    // The coordinator drives the stop streaming button from the upsert lifecycle,
+    // so it reads this slice on every call.
+    assistantInputState: {
+      stopStreamingButtonState: { isVisible: false, isDisabled: false },
+    },
   };
   const dispatch = jest.fn((action: { type: string; message?: any }) => {
     if (action.type === 'UPSERT_MESSAGE' && action.message?.id) {
@@ -45,6 +53,9 @@ function makeStubManager(initialMessages: Record<string, unknown> = {}) {
     ),
   };
   const finalizeStreamingMessage = jest.fn();
+  // The coordinator asks MessageService to hide the stop streaming button on a terminal
+  // upsert; MessageService is the one that decides whether anything else is still live.
+  const hideStopStreamingButtonIfIdle = jest.fn();
 
   const manager = {
     store: {
@@ -53,7 +64,7 @@ function makeStubManager(initialMessages: Record<string, unknown> = {}) {
     },
     fire,
     actions: chatActions,
-    messageService: { finalizeStreamingMessage },
+    messageService: { finalizeStreamingMessage, hideStopStreamingButtonIfIdle },
   } as unknown as ServiceManager;
 
   return {
@@ -63,6 +74,7 @@ function makeStubManager(initialMessages: Record<string, unknown> = {}) {
     fire,
     chatActions,
     finalizeStreamingMessage,
+    hideStopStreamingButtonIfIdle,
   };
 }
 
@@ -340,6 +352,126 @@ describe('MessageUpsertCoordinator', () => {
       const types = fire.mock.calls.map((c) => c[0].type);
       expect(types).toContain(BusEventType.PRE_RECEIVE);
       expect(types).toContain(BusEventType.RECEIVE);
+    });
+
+    it('markStreaming does not register streaming liveness', async () => {
+      const { manager } = makeStubManager();
+      const coord = new MessageUpsertCoordinator(manager);
+
+      // markStreaming is the receive-dedup hook the chunk path calls before the
+      // generation check. Treating it as liveness would re-register stale ids after a
+      // restart and pin the stop button on forever.
+      coord.markStreaming('m1');
+
+      expect(coord.hasStreamingMessages()).toBe(false);
+    });
+  });
+
+  describe('streaming liveness', () => {
+    it('registers on STREAMING and drops on COMPLETE', async () => {
+      const { manager } = makeStubManager();
+      const coord = new MessageUpsertCoordinator(manager);
+
+      await coord.upsert('m1', MessageState.STREAMING, () =>
+        textResponse('m1', 'partial')
+      );
+      expect(coord.hasStreamingMessages()).toBe(true);
+
+      await coord.upsert('m1', MessageState.COMPLETE, () =>
+        textResponse('m1', 'done')
+      );
+      expect(coord.hasStreamingMessages()).toBe(false);
+    });
+
+    it('drops on ERROR', async () => {
+      const { manager } = makeStubManager();
+      const coord = new MessageUpsertCoordinator(manager);
+
+      await coord.upsert('m1', MessageState.STREAMING, () =>
+        textResponse('m1', 'partial')
+      );
+      await coord.upsert('m1', MessageState.ERROR, () =>
+        textResponse('m1', 'failed')
+      );
+
+      // ERROR never reaches firePostReceiveAndFinalize, so the drop has to happen in
+      // runOne rather than in the finalize phase.
+      expect(coord.hasStreamingMessages()).toBe(false);
+    });
+
+    it('tracks ids independently', async () => {
+      const { manager } = makeStubManager();
+      const coord = new MessageUpsertCoordinator(manager);
+
+      await coord.upsert('m1', MessageState.STREAMING, () =>
+        textResponse('m1', 'a')
+      );
+      await coord.upsert('m2', MessageState.STREAMING, () =>
+        textResponse('m2', 'b')
+      );
+
+      await coord.upsert('m1', MessageState.COMPLETE, () =>
+        textResponse('m1', 'a done')
+      );
+      expect(coord.hasStreamingMessages()).toBe(true);
+
+      await coord.upsert('m2', MessageState.COMPLETE, () =>
+        textResponse('m2', 'b done')
+      );
+      expect(coord.hasStreamingMessages()).toBe(false);
+    });
+
+    it('drains on clear and clearAll', async () => {
+      const { manager } = makeStubManager();
+      const coord = new MessageUpsertCoordinator(manager);
+
+      await coord.upsert('m1', MessageState.STREAMING, () =>
+        textResponse('m1', 'a')
+      );
+      coord.clear('m1');
+      expect(coord.hasStreamingMessages()).toBe(false);
+
+      await coord.upsert('m2', MessageState.STREAMING, () =>
+        textResponse('m2', 'b')
+      );
+      coord.clearAll();
+      expect(coord.hasStreamingMessages()).toBe(false);
+    });
+
+    it('drops the registration even when the slot fan-out throws', async () => {
+      const { manager, state, dispatch, chatActions } = makeStubManager();
+      const coord = new MessageUpsertCoordinator(manager);
+
+      await coord.upsert('m1', MessageState.STREAMING, () =>
+        textResponse('m1', 'partial')
+      );
+
+      // Make the fan-out loop actually run for m1. It skips items whose reference the
+      // reducer reused verbatim, so the dispatch has to hand back a fresh object the way
+      // the real reducer does for a changed item.
+      state.assistantMessageState.localMessageIDs = ['local1'];
+      dispatch.mockImplementation((action: { type: string; message?: any }) => {
+        if (action.type === 'UPSERT_MESSAGE' && action.message?.id) {
+          state.allMessagesByID[action.message.id] = action.message;
+          state.allMessageItemsByID = {
+            local1: { ui_state: { id: 'local1' }, fullMessageID: 'm1' },
+          };
+        }
+      });
+
+      // The event bus does not swallow listener exceptions, so everything after
+      // fanOutChangedSlots is skipped — the registration has to already be gone by then.
+      chatActions.handleUserDefinedResponseItems.mockRejectedValueOnce(
+        new Error('listener blew up')
+      );
+
+      await expect(
+        coord.upsert('m1', MessageState.COMPLETE, () =>
+          textResponse('m1', 'done')
+        )
+      ).rejects.toThrow('listener blew up');
+
+      expect(coord.hasStreamingMessages()).toBe(false);
     });
   });
 });

--- a/packages/ai-chat/tests/services/spec/MessageUpsertCoordinator_spec.ts
+++ b/packages/ai-chat/tests/services/spec/MessageUpsertCoordinator_spec.ts
@@ -421,6 +421,42 @@ describe('MessageUpsertCoordinator', () => {
       expect(coord.hasStreamingMessages()).toBe(false);
     });
 
+    it('endAllStreaming settles every registered id and drains', async () => {
+      const { manager, dispatch } = makeStubManager();
+      const coord = new MessageUpsertCoordinator(manager);
+
+      await coord.upsert('m1', MessageState.STREAMING, () =>
+        textResponse('m1', 'a')
+      );
+      await coord.upsert('m2', MessageState.STREAMING, () =>
+        textResponse('m2', 'b')
+      );
+
+      dispatch.mockClear();
+      coord.endAllStreaming();
+
+      const ended = dispatch.mock.calls
+        .map((call) => call[0] as { type: string; messageID?: string })
+        .filter((action) => action?.type === 'END_MESSAGE_STREAMING')
+        .map((action) => action.messageID);
+      expect(ended.sort()).toEqual(['m1', 'm2']);
+      expect(coord.hasStreamingMessages()).toBe(false);
+    });
+
+    it('endAllStreaming is a no-op when nothing is registered', async () => {
+      const { manager, dispatch } = makeStubManager();
+      const coord = new MessageUpsertCoordinator(manager);
+
+      await coord.upsert('m1', MessageState.COMPLETE, () =>
+        textResponse('m1', 'done')
+      );
+
+      dispatch.mockClear();
+      coord.endAllStreaming();
+
+      expect(dispatch).not.toHaveBeenCalled();
+    });
+
     it('drains on clear and clearAll', async () => {
       const { manager } = makeStubManager();
       const coord = new MessageUpsertCoordinator(manager);

--- a/packages/ai-chat/tests/store/spec/upsertMessageReducer_spec.ts
+++ b/packages/ai-chat/tests/store/spec/upsertMessageReducer_spec.ts
@@ -309,4 +309,107 @@ describe('[UPSERT_MESSAGE] reducer', () => {
     expect(after.allMessagesByID['m1']).toBe(m1MessageRefBefore);
     expect(after.allMessagesByID['m3']).toBe(m3MessageRefBefore);
   });
+
+  describe('streaming flags', () => {
+    it('marks items as streaming while the message is streaming', () => {
+      store.dispatch(
+        actions.upsertMessage(makeTextResponse('s1', ['partial']), true)
+      );
+
+      const [local] = localItemsForMessage(store.getState() as AppState, 's1');
+      expect(local.ui_state.isIntermediateStreaming).toBe(true);
+      expect(local.ui_state.streamingState?.isDone).toBe(false);
+    });
+
+    it('settles the flags when the message stops streaming', () => {
+      store.dispatch(
+        actions.upsertMessage(makeTextResponse('s2', ['partial']), true)
+      );
+      store.dispatch(
+        actions.upsertMessage(makeTextResponse('s2', ['all of it']), false)
+      );
+
+      const [local] = localItemsForMessage(store.getState() as AppState, 's2');
+      expect(local.ui_state.isIntermediateStreaming).toBe(false);
+      expect(local.ui_state.streamingState?.isDone).toBe(true);
+    });
+
+    it('settles the flags even when the payload did not change', () => {
+      // The reference-stability path would otherwise reuse the streaming item
+      // verbatim and leave it rendering as mid-stream forever.
+      store.dispatch(
+        actions.upsertMessage(makeTextResponse('s3', ['same'], ['1']), true)
+      );
+      store.dispatch(
+        actions.upsertMessage(makeTextResponse('s3', ['same'], ['1']), false)
+      );
+
+      const [local] = localItemsForMessage(store.getState() as AppState, 's3');
+      expect(local.ui_state.streamingState?.isDone).toBe(true);
+    });
+
+    it('applies the flags to nested items too', () => {
+      const card: MessageResponse = {
+        id: 's4',
+        output: {
+          generic: [
+            {
+              response_type: MessageResponseTypes.CARD,
+              body: [
+                { response_type: MessageResponseTypes.TEXT, text: 'in a card' },
+              ],
+            } as CardItem,
+          ],
+        },
+      };
+
+      store.dispatch(actions.upsertMessage(card, true));
+
+      const state = store.getState() as AppState;
+      const nested = Object.values(state.allMessageItemsByID).filter(
+        (item) => item.fullMessageID === 's4'
+      );
+      expect(nested.length).toBeGreaterThan(1);
+      for (const item of nested) {
+        expect(item.ui_state.streamingState?.isDone).toBe(false);
+      }
+    });
+  });
+
+  describe('[END_MESSAGE_STREAMING] reducer', () => {
+    it('settles a streaming message left mid-stream', () => {
+      store.dispatch(
+        actions.upsertMessage(makeTextResponse('e1', ['partial']), true)
+      );
+
+      store.dispatch(actions.endMessageStreaming('e1'));
+
+      const [local] = localItemsForMessage(store.getState() as AppState, 'e1');
+      expect(local.ui_state.isIntermediateStreaming).toBe(false);
+      expect(local.ui_state.streamingState?.isDone).toBe(true);
+    });
+
+    it('leaves other messages alone', () => {
+      store.dispatch(
+        actions.upsertMessage(makeTextResponse('e2', ['a']), true)
+      );
+      store.dispatch(
+        actions.upsertMessage(makeTextResponse('e3', ['b']), true)
+      );
+
+      store.dispatch(actions.endMessageStreaming('e2'));
+
+      const [other] = localItemsForMessage(store.getState() as AppState, 'e3');
+      expect(other.ui_state.streamingState?.isDone).toBe(false);
+    });
+
+    it('returns the same state object when nothing was streaming', () => {
+      store.dispatch(actions.upsertMessage(makeTextResponse('e4', ['done'])));
+      const before = store.getState();
+
+      store.dispatch(actions.endMessageStreaming('e4'));
+
+      expect(store.getState()).toBe(before);
+    });
+  });
 });

--- a/packages/ai-chat/tests/utils/spec/streamingUtils_spec.ts
+++ b/packages/ai-chat/tests/utils/spec/streamingUtils_spec.ts
@@ -9,6 +9,7 @@
 
 import {
   chunkHasDisplayableContent,
+  deriveStreamingItemText,
   mergePartialResponseOptions,
   messageHasDisplayableContent,
   resetStopStreamingButton,
@@ -29,6 +30,55 @@ describe('streamingUtils', () => {
       }),
     };
   };
+
+  describe('deriveStreamingItemText', () => {
+    // The chunk flow accumulates text in `chunks` — the item's own text holds only the
+    // first chunk, so the join must win while chunks exist.
+    it('joins chunks for a chunk-delivered item mid-stream', () => {
+      expect(
+        deriveStreamingItemText('Hello ', {
+          isDone: false,
+          chunks: [{ text: 'Hello ' }, { text: 'world' }],
+        })
+      ).toBe('Hello world');
+    });
+
+    // The upsert flow streams whole-message snapshots: `chunks` is always empty and the
+    // item's text is complete on every update. Joining the empty array rendered
+    // upsert-streamed text as blank until COMPLETE — the regression this pins.
+    it('falls back to the item text for a snapshot-delivered item mid-stream', () => {
+      expect(
+        deriveStreamingItemText('Hello world so far', {
+          isDone: false,
+          chunks: [],
+        })
+      ).toBe('Hello world so far');
+    });
+
+    it('uses the item text once streaming is done', () => {
+      expect(
+        deriveStreamingItemText('The final text', {
+          isDone: true,
+          chunks: [{ text: 'stale ' }, { text: 'chunks' }],
+        })
+      ).toBe('The final text');
+    });
+
+    it('uses the item text when there is no streaming state', () => {
+      expect(deriveStreamingItemText('Plain text', undefined)).toBe(
+        'Plain text'
+      );
+    });
+
+    it('treats chunks with missing text as empty rather than "undefined"', () => {
+      expect(
+        deriveStreamingItemText('', {
+          isDone: false,
+          chunks: [{ text: 'a' }, {}, { text: 'b' }],
+        })
+      ).toBe('ab');
+    });
+  });
 
   describe('resolveChunkContext', () => {
     it('extracts metadata for partial chunks', () => {

--- a/packages/ai-chat/tests/utils/spec/streamingUtils_spec.ts
+++ b/packages/ai-chat/tests/utils/spec/streamingUtils_spec.ts
@@ -109,53 +109,10 @@ describe('streamingUtils', () => {
         expect(store.dispatch).not.toHaveBeenCalled();
       });
 
-      describe('with streamingMessageID parameter', () => {
-        it('keeps button visible when streaming is active (edge case fix)', () => {
-          const store = createStore(true);
-
-          // Simulate: customSendMessage resolved but streaming still active
-          resetStopStreamingButton(store as any, 'active-stream-123');
-
-          // Button should STAY visible
-          expect(store.dispatch).not.toHaveBeenCalled();
-        });
-
-        it('hides button when no streaming active (streamingMessageID is null)', () => {
-          const store = createStore(true);
-
-          // Simulate: no active streaming
-          resetStopStreamingButton(store as any, null);
-
-          // Button should be hidden
-          expect(store.dispatch).toHaveBeenCalledTimes(2);
-        });
-
-        it('hides button when streamingMessageID is undefined', () => {
-          const store = createStore(true);
-
-          resetStopStreamingButton(store as any, undefined);
-
-          // Button should be hidden
-          expect(store.dispatch).toHaveBeenCalledTimes(2);
-        });
-
-        it('maintains backward compatibility (no parameter)', () => {
-          const store = createStore(true);
-
-          // Old behavior: always hide when called
-          resetStopStreamingButton(store as any);
-
-          expect(store.dispatch).toHaveBeenCalledTimes(2);
-        });
-
-        it('does nothing when button not visible, regardless of streamingMessageID', () => {
-          const store = createStore(false);
-
-          resetStopStreamingButton(store as any, 'active-stream');
-
-          expect(store.dispatch).not.toHaveBeenCalled();
-        });
-      });
+      // This helper hides unconditionally. Deciding *whether* to hide while other
+      // messages are still streaming belongs to MessageService — see its
+      // hideStopStreamingButtonIfIdle / hideStopStreamingButtonIfNoUpsertStreaming,
+      // covered in MessageService_spec and the upsertMessage instance specs.
     });
   });
 


### PR DESCRIPTION


Part of the #1454 epic; the epic stays open for #2074 and #2075.

> Stacked on #2077. The demo's streaming twins need that PR's
> `ui_state.streamingState` wiring — landing this first would visibly regress the demo on
> the very API these docs start recommending. Review #2077 first; its three commits are the
> base of this branch, so the diff here includes them until it merges.

`upsertMessage` shipped in 1.15.0, its shape has not changed through 1.18.0, and the guides have called it the recommended flow for new code since #1453. It still carried `@experimental`, and the demo still delivered every response the old way — so a consumer following the docs reached a method the API reference warned them off, demonstrated by an app that did the opposite.

This graduates the tag and makes the demo match the advice.

Under ADR-0007 (#2038) there is no 3.0.0, so `@experimental` is the only thing that legitimizes removing public API after 2.0.0. Graduating is a one-way door and these symbols are being frozen deliberately. Per `packages/ai-chat/src/types/AGENTS.md` this ships as `feat`, not a breaking change — a `!` bumps the major, and majors are planned windows.

#### Changelog

**Changed**

- `upsertMessage`, `UpsertMessageUpdater`, `MessageState`, `RenderUserDefinedState.state`, and `BusEventUserDefinedResponse.data.state` are no longer `@experimental`. No shape changes — JSDoc only.
- `UpsertMessage.md` retitled from "Adding messages (experimental)" to "Adding messages"; the "semantics and updater signature may still change" caveat removed from the six guides carrying it.
- `addMessageChunk` is now framed as the **legacy** flow rather than the *stable* one. It stays fully supported and is **not** deprecated — the contrast is verbosity, not stability.
- The demo's non-streaming responses go through `upsertMessage`.
- `doTextStreamingUpsert` takes an options object instead of the nine positional arguments `doTextStreaming` had accumulated, which is what collapses the call sites in `doCode`, `doTable`, and the reasoning and chain-of-thought entries to the two or three fields each actually sets.

**New**

- Demo `upsertMessage` twins for the streaming entries — `doTextStreamingUpsert`, `doUserDefinedStreamingUpsert`, and an upsert-driven `doConversationalSearchStreaming`. The chunk versions are retained and relabelled `(legacy addMessageChunk API)`, so both flows stay demonstrable side by side rather than one replacing the other.
- Documented that `upsertMessage` and `addMessageChunk` track streaming progress separately, so a conversation is simpler to reason about driven by one rather than both.

#### Testing / Reviewing

`npm run test --workspace=@carbon/ai-chat` — 106 suites, 1195 tests, green. `npm run lint`, `npm run lint:license`, `npm run format:write`, and `tsc --noEmit` on `packages/ai-chat` all clean.

Worth a reviewer's attention:

- **Every `upsertMessage` call sets `id` explicitly.** `MessageUpsertCoordinator` backfills a missing `id` from the `messageID` argument, and the demo originally leaned on that. It has been changed to bind the id to a local and set it on the returned message — a demo should show the contract, not the lenient path through it. The last commit applies the same fix to the six `upsert-message-*` examples, whose welcome upserts had the same reliance. Their streaming paths already did it correctly via their `buildSnapshot` / `buildResponse` helpers.

- **What this does *not* do, against the original #1454.** That issue also asked for `@deprecated` tags on `addMessage` / `addMessageChunk`, a new chunk-flow reference example, and migrating all 113 example source files. #1454 is now an epic and those are #2074 and #2075. The deprecation in particular is deliberately dropped from 1.x scope: it needs an ADR and would not land before 2.0.0, and `main`'s docs already said "fully supported, with no deprecation" before this branch existed.

- **Known, pre-existing, and not a gate.** `tsc --noEmit -p demo/tsconfig.json` is not run by anything — `ci-check` omits it and `npm run lint` is `eslint packages`. Run by hand it reports 11 errors in `demo/src` on `main`; this branch nets +2 (fixes 1 in `doOption.ts`, adds 3 in `doText.ts` where `doTextStreamingUpsert` reproduces the same `ReasoningStep.content` looseness the existing `doTextStreaming` already has). Filed as #2076 to bring the demo into the typecheck gate and fix the backlog properly, rather than papering over it here.

Manual check, once built: open the demo and walk the response menu. `text (stream)` and `user_defined (stream)` now run the upsert twins; the chunk versions are the `(legacy addMessageChunk API)` entries. Both should look identical on screen.
