### PR TITLE
fix(examples): apply IBM Plex Sans to body where it is missing

### DIFF
--- a/examples/react/feedback/src/App.tsx
+++ b/examples/react/feedback/src/App.tsx
@@ -37,6 +37,7 @@ import React from 'react';
 import { createRoot } from 'react-dom/client';
 
 import { customSendMessage } from './customSendMessage';
+import '@carbon/styles/css/styles.css';
 
 const config: PublicConfig = {
   messaging: {

--- a/examples/react/history-user-defined-responses/src/App.tsx
+++ b/examples/react/history-user-defined-responses/src/App.tsx
@@ -41,6 +41,7 @@ import { createRoot } from 'react-dom/client';
 import { customLoadHistory } from './customLoadHistory';
 import { customSendMessage } from './customSendMessage';
 import { renderUserDefinedResponseFactory } from './renderUserDefinedResponse';
+import '@carbon/styles/css/styles.css';
 
 const config: PublicConfig = {
   messaging: {

--- a/examples/react/prompt-line-mentions-and-commands/src/App.tsx
+++ b/examples/react/prompt-line-mentions-and-commands/src/App.tsx
@@ -39,6 +39,7 @@ import { createRoot } from 'react-dom/client';
 
 import { customSendMessage } from './customSendMessage';
 import { mentionItems, commandItems } from './suggestions';
+import '@carbon/styles/css/styles.css';
 
 function App() {
   const instanceRef = useRef<ChatInstance | null>(null);

--- a/examples/react/prompt-line-typeahead-custom/src/App.tsx
+++ b/examples/react/prompt-line-typeahead-custom/src/App.tsx
@@ -31,6 +31,7 @@ import { createRoot } from 'react-dom/client';
 import { customSendMessage } from './customSendMessage';
 import { CANNED_SUGGESTIONS } from './suggestions';
 import { CustomSuggestionList } from './CustomSuggestionList';
+import '@carbon/styles/css/styles.css';
 
 function App() {
   const config: PublicConfig = useMemo(

--- a/examples/react/prompt-line-typeahead/src/App.tsx
+++ b/examples/react/prompt-line-typeahead/src/App.tsx
@@ -29,6 +29,7 @@ import { createRoot } from 'react-dom/client';
 
 import { customSendMessage } from './customSendMessage';
 import { CANNED_SUGGESTIONS } from './suggestions';
+import '@carbon/styles/css/styles.css';
 
 function App() {
   const config: PublicConfig = useMemo(

--- a/examples/react/user-defined-responses/src/App.tsx
+++ b/examples/react/user-defined-responses/src/App.tsx
@@ -37,6 +37,7 @@ import { createRoot } from 'react-dom/client';
 
 import { customSendMessage } from './customSendMessage';
 import { renderUserDefinedResponseFactory } from './renderUserDefinedResponse';
+import '@carbon/styles/css/styles.css';
 
 const config: PublicConfig = {
   messaging: {

--- a/examples/web-components/basic-custom-element-fullscreen/index.html
+++ b/examples/web-components/basic-custom-element-fullscreen/index.html
@@ -17,6 +17,15 @@
         margin: 0;
         padding: 0;
       }
+      body {
+        font-family:
+          'IBM Plex Sans',
+          system-ui,
+          -apple-system,
+          BlinkMacSystemFont,
+          '.SFNSText-Regular',
+          sans-serif;
+      }
     </style>
     <link
       rel="stylesheet"

--- a/examples/web-components/basic-custom-element-sidebar-narrow/index.html
+++ b/examples/web-components/basic-custom-element-sidebar-narrow/index.html
@@ -19,6 +19,15 @@
         margin: 0;
         padding: 0;
       }
+      body {
+        font-family:
+          'IBM Plex Sans',
+          system-ui,
+          -apple-system,
+          BlinkMacSystemFont,
+          '.SFNSText-Regular',
+          sans-serif;
+      }
     </style>
     <link
       rel="stylesheet"

--- a/examples/web-components/basic-custom-element-sidebar/index.html
+++ b/examples/web-components/basic-custom-element-sidebar/index.html
@@ -17,6 +17,15 @@
         margin: 0;
         padding: 0;
       }
+      body {
+        font-family:
+          'IBM Plex Sans',
+          system-ui,
+          -apple-system,
+          BlinkMacSystemFont,
+          '.SFNSText-Regular',
+          sans-serif;
+      }
     </style>
     <link
       rel="stylesheet"

--- a/examples/web-components/basic-float/index.html
+++ b/examples/web-components/basic-float/index.html
@@ -14,6 +14,17 @@
     <link
       rel="stylesheet"
       href="https://1.www.s81c.com/common/carbon/plex/sans.css" />
+    <style>
+      body {
+        font-family:
+          'IBM Plex Sans',
+          system-ui,
+          -apple-system,
+          BlinkMacSystemFont,
+          '.SFNSText-Regular',
+          sans-serif;
+      }
+    </style>
   </head>
   <body>
     <h3>Basic web component example</h3>

--- a/examples/web-components/chain-of-thought/index.html
+++ b/examples/web-components/chain-of-thought/index.html
@@ -14,6 +14,17 @@
     <link
       rel="stylesheet"
       href="https://1.www.s81c.com/common/carbon/plex/sans.css" />
+    <style>
+      body {
+        font-family:
+          'IBM Plex Sans',
+          system-ui,
+          -apple-system,
+          BlinkMacSystemFont,
+          '.SFNSText-Regular',
+          sans-serif;
+      }
+    </style>
   </head>
   <body>
     <my-app></my-app>

--- a/examples/web-components/custom-element-as-float-lazy-load/index.html
+++ b/examples/web-components/custom-element-as-float-lazy-load/index.html
@@ -8,14 +8,25 @@
 <!doctype html>
 <html lang="en">
   <head>
-    <meta charset="utf-8"/>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>@carbon/ai-chat - web components - custom element as float (lazy load)</title>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>
+      @carbon/ai-chat - web components - custom element as float (lazy load)
+    </title>
     <style>
-      html, body {
+      html,
+      body {
         margin: 0;
         padding: 0;
-        font-family: sans-serif;
+      }
+      body {
+        font-family:
+          'IBM Plex Sans',
+          system-ui,
+          -apple-system,
+          BlinkMacSystemFont,
+          '.SFNSText-Regular',
+          sans-serif;
       }
       main {
         padding: 2rem;
@@ -30,7 +41,9 @@
         transition: opacity 200ms;
       }
     </style>
-    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/plex/sans.css" />
+    <link
+      rel="stylesheet"
+      href="https://1.www.s81c.com/common/carbon/plex/sans.css" />
   </head>
   <body>
     <main>

--- a/examples/web-components/custom-element-as-float/index.html
+++ b/examples/web-components/custom-element-as-float/index.html
@@ -8,14 +8,23 @@
 <!doctype html>
 <html lang="en">
   <head>
-    <meta charset="utf-8"/>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>@carbon/ai-chat - web components - custom element as float</title>
     <style>
-      html, body {
+      html,
+      body {
         margin: 0;
         padding: 0;
-        font-family: sans-serif;
+      }
+      body {
+        font-family:
+          'IBM Plex Sans',
+          system-ui,
+          -apple-system,
+          BlinkMacSystemFont,
+          '.SFNSText-Regular',
+          sans-serif;
       }
       main {
         padding: 2rem;
@@ -23,7 +32,9 @@
         margin: 0 auto;
       }
     </style>
-    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/plex/sans.css" />
+    <link
+      rel="stylesheet"
+      href="https://1.www.s81c.com/common/carbon/plex/sans.css" />
   </head>
   <body>
     <main>

--- a/examples/web-components/custom-element-lazy-load/index.html
+++ b/examples/web-components/custom-element-lazy-load/index.html
@@ -8,13 +8,23 @@
 <!doctype html>
 <html lang="en">
   <head>
-    <meta charset="utf-8"/>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>@carbon/ai-chat - web components - custom element lazy load</title>
     <style>
-      html, body {
+      html,
+      body {
         margin: 0;
         padding: 0;
+      }
+      body {
+        font-family:
+          'IBM Plex Sans',
+          system-ui,
+          -apple-system,
+          BlinkMacSystemFont,
+          '.SFNSText-Regular',
+          sans-serif;
       }
       .chat-custom-element {
         height: 100vh;
@@ -25,7 +35,9 @@
         inset: 0;
       }
     </style>
-    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/plex/sans.css" />
+    <link
+      rel="stylesheet"
+      href="https://1.www.s81c.com/common/carbon/plex/sans.css" />
   </head>
   <body>
     <my-app></my-app>

--- a/examples/web-components/feedback/index.html
+++ b/examples/web-components/feedback/index.html
@@ -20,6 +20,15 @@
         margin: 0;
         padding: 0;
       }
+      body {
+        font-family:
+          'IBM Plex Sans',
+          system-ui,
+          -apple-system,
+          BlinkMacSystemFont,
+          '.SFNSText-Regular',
+          sans-serif;
+      }
     </style>
   </head>
   <body>

--- a/examples/web-components/history-file-attachments/index.html
+++ b/examples/web-components/history-file-attachments/index.html
@@ -17,11 +17,19 @@
         margin: 0;
         padding: 0;
       }
+      body {
+        font-family:
+          'IBM Plex Sans',
+          system-ui,
+          -apple-system,
+          BlinkMacSystemFont,
+          '.SFNSText-Regular',
+          sans-serif;
+      }
     </style>
     <link
       rel="stylesheet"
-      href="https://1.www.s81c.com/common/carbon/plex/sans.css"
-    />
+      href="https://1.www.s81c.com/common/carbon/plex/sans.css" />
   </head>
   <body>
     <my-app></my-app>

--- a/examples/web-components/history-float/index.html
+++ b/examples/web-components/history-float/index.html
@@ -14,6 +14,17 @@
     <link
       rel="stylesheet"
       href="https://1.www.s81c.com/common/carbon/plex/sans.css" />
+    <style>
+      body {
+        font-family:
+          'IBM Plex Sans',
+          system-ui,
+          -apple-system,
+          BlinkMacSystemFont,
+          '.SFNSText-Regular',
+          sans-serif;
+      }
+    </style>
   </head>
   <body>
     <h3>Chat history web component example</h3>

--- a/examples/web-components/history-fullscreen/index.html
+++ b/examples/web-components/history-fullscreen/index.html
@@ -17,6 +17,15 @@
         margin: 0;
         padding: 0;
       }
+      body {
+        font-family:
+          'IBM Plex Sans',
+          system-ui,
+          -apple-system,
+          BlinkMacSystemFont,
+          '.SFNSText-Regular',
+          sans-serif;
+      }
     </style>
     <link
       rel="stylesheet"

--- a/examples/web-components/history-host-driven/index.html
+++ b/examples/web-components/history-host-driven/index.html
@@ -14,6 +14,17 @@
     <link
       rel="stylesheet"
       href="https://1.www.s81c.com/common/carbon/plex/sans.css" />
+    <style>
+      body {
+        font-family:
+          'IBM Plex Sans',
+          system-ui,
+          -apple-system,
+          BlinkMacSystemFont,
+          '.SFNSText-Regular',
+          sans-serif;
+      }
+    </style>
   </head>
   <body>
     <my-app></my-app>

--- a/examples/web-components/history-user-defined-responses/index.html
+++ b/examples/web-components/history-user-defined-responses/index.html
@@ -22,6 +22,15 @@
         margin: 0;
         padding: 0;
       }
+      body {
+        font-family:
+          'IBM Plex Sans',
+          system-ui,
+          -apple-system,
+          BlinkMacSystemFont,
+          '.SFNSText-Regular',
+          sans-serif;
+      }
     </style>
   </head>
   <body>

--- a/examples/web-components/human-agent/index.html
+++ b/examples/web-components/human-agent/index.html
@@ -14,6 +14,17 @@
     <link
       rel="stylesheet"
       href="https://1.www.s81c.com/common/carbon/plex/sans.css" />
+    <style>
+      body {
+        font-family:
+          'IBM Plex Sans',
+          system-ui,
+          -apple-system,
+          BlinkMacSystemFont,
+          '.SFNSText-Regular',
+          sans-serif;
+      }
+    </style>
   </head>
   <body>
     <my-app></my-app>

--- a/examples/web-components/integrations-watsonx/index.html
+++ b/examples/web-components/integrations-watsonx/index.html
@@ -14,6 +14,17 @@
     <link
       rel="stylesheet"
       href="https://1.www.s81c.com/common/carbon/plex/sans.css" />
+    <style>
+      body {
+        font-family:
+          'IBM Plex Sans',
+          system-ui,
+          -apple-system,
+          BlinkMacSystemFont,
+          '.SFNSText-Regular',
+          sans-serif;
+      }
+    </style>
   </head>
   <body>
     <my-app></my-app>

--- a/examples/web-components/markdown-override/index.html
+++ b/examples/web-components/markdown-override/index.html
@@ -15,13 +15,21 @@
     </title>
     <link
       rel="stylesheet"
-      href="https://1.www.s81c.com/common/carbon/plex/sans.css"
-    />
+      href="https://1.www.s81c.com/common/carbon/plex/sans.css" />
     <style>
       html,
       body {
         margin: 0;
         padding: 0;
+      }
+      body {
+        font-family:
+          'IBM Plex Sans',
+          system-ui,
+          -apple-system,
+          BlinkMacSystemFont,
+          '.SFNSText-Regular',
+          sans-serif;
       }
       cds-aichat-custom-element.chat-custom-element {
         display: block;
@@ -32,7 +40,6 @@
   </head>
   <body>
     <cds-aichat-custom-element
-      class="chat-custom-element"
-    ></cds-aichat-custom-element>
+      class="chat-custom-element"></cds-aichat-custom-element>
   </body>
 </html>

--- a/examples/web-components/markdown-plugin/index.html
+++ b/examples/web-components/markdown-plugin/index.html
@@ -21,17 +21,24 @@
     -->
     <link
       rel="stylesheet"
-      href="https://cdn.jsdelivr.net/npm/katex@0.16.4/dist/katex.min.css"
-    />
+      href="https://cdn.jsdelivr.net/npm/katex@0.16.4/dist/katex.min.css" />
     <link
       rel="stylesheet"
-      href="https://1.www.s81c.com/common/carbon/plex/sans.css"
-    />
+      href="https://1.www.s81c.com/common/carbon/plex/sans.css" />
     <style>
       html,
       body {
         margin: 0;
         padding: 0;
+      }
+      body {
+        font-family:
+          'IBM Plex Sans',
+          system-ui,
+          -apple-system,
+          BlinkMacSystemFont,
+          '.SFNSText-Regular',
+          sans-serif;
       }
       cds-aichat-custom-element.chat-custom-element {
         display: block;
@@ -48,7 +55,6 @@
       config object properties on this element once the script loads.
     -->
     <cds-aichat-custom-element
-      class="chat-custom-element"
-    ></cds-aichat-custom-element>
+      class="chat-custom-element"></cds-aichat-custom-element>
   </body>
 </html>

--- a/examples/web-components/messages-custom-footer/index.html
+++ b/examples/web-components/messages-custom-footer/index.html
@@ -17,11 +17,19 @@
         margin: 0;
         padding: 0;
       }
+      body {
+        font-family:
+          'IBM Plex Sans',
+          system-ui,
+          -apple-system,
+          BlinkMacSystemFont,
+          '.SFNSText-Regular',
+          sans-serif;
+      }
     </style>
     <link
       rel="stylesheet"
-      href="https://1.www.s81c.com/common/carbon/plex/sans.css"
-    />
+      href="https://1.www.s81c.com/common/carbon/plex/sans.css" />
   </head>
   <body>
     <my-app></my-app>

--- a/examples/web-components/prompt-line-file-upload/index.html
+++ b/examples/web-components/prompt-line-file-upload/index.html
@@ -14,6 +14,17 @@
     <link
       rel="stylesheet"
       href="https://1.www.s81c.com/common/carbon/plex/sans.css" />
+    <style>
+      body {
+        font-family:
+          'IBM Plex Sans',
+          system-ui,
+          -apple-system,
+          BlinkMacSystemFont,
+          '.SFNSText-Regular',
+          sans-serif;
+      }
+    </style>
   </head>
   <body>
     <my-app></my-app>

--- a/examples/web-components/prompt-line-mentions-and-commands-custom-render/index.html
+++ b/examples/web-components/prompt-line-mentions-and-commands-custom-render/index.html
@@ -14,11 +14,23 @@
       @carbon/ai-chat - web components - Prompt line / Mentions & commands
       (custom render)
     </title>
+    <link
+      rel="stylesheet"
+      href="https://1.www.s81c.com/common/carbon/plex/sans.css" />
     <style>
       html,
       body {
         margin: 0;
         padding: 0;
+      }
+      body {
+        font-family:
+          'IBM Plex Sans',
+          system-ui,
+          -apple-system,
+          BlinkMacSystemFont,
+          '.SFNSText-Regular',
+          sans-serif;
       }
       .mention-token-wrapper {
         display: inline-block;

--- a/examples/web-components/prompt-line-mentions-and-commands/index.html
+++ b/examples/web-components/prompt-line-mentions-and-commands/index.html
@@ -13,11 +13,23 @@
     <title>
       @carbon/ai-chat - web components - Prompt line / Mentions & commands
     </title>
+    <link
+      rel="stylesheet"
+      href="https://1.www.s81c.com/common/carbon/plex/sans.css" />
     <style>
       html,
       body {
         margin: 0;
         padding: 0;
+      }
+      body {
+        font-family:
+          'IBM Plex Sans',
+          system-ui,
+          -apple-system,
+          BlinkMacSystemFont,
+          '.SFNSText-Regular',
+          sans-serif;
       }
     </style>
   </head>

--- a/examples/web-components/prompt-line-typeahead-custom/index.html
+++ b/examples/web-components/prompt-line-typeahead-custom/index.html
@@ -13,11 +13,23 @@
     <title>
       @carbon/ai-chat - web components - Prompt line / Typeahead (custom list)
     </title>
+    <link
+      rel="stylesheet"
+      href="https://1.www.s81c.com/common/carbon/plex/sans.css" />
     <style>
       html,
       body {
         margin: 0;
         padding: 0;
+      }
+      body {
+        font-family:
+          'IBM Plex Sans',
+          system-ui,
+          -apple-system,
+          BlinkMacSystemFont,
+          '.SFNSText-Regular',
+          sans-serif;
       }
     </style>
   </head>

--- a/examples/web-components/prompt-line-typeahead/index.html
+++ b/examples/web-components/prompt-line-typeahead/index.html
@@ -11,11 +11,23 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta charset="utf-8" />
     <title>@carbon/ai-chat - web components - Prompt line / Typeahead</title>
+    <link
+      rel="stylesheet"
+      href="https://1.www.s81c.com/common/carbon/plex/sans.css" />
     <style>
       html,
       body {
         margin: 0;
         padding: 0;
+      }
+      body {
+        font-family:
+          'IBM Plex Sans',
+          system-ui,
+          -apple-system,
+          BlinkMacSystemFont,
+          '.SFNSText-Regular',
+          sans-serif;
       }
     </style>
   </head>

--- a/examples/web-components/reasoning-steps-controlled/index.html
+++ b/examples/web-components/reasoning-steps-controlled/index.html
@@ -16,6 +16,17 @@
     <link
       rel="stylesheet"
       href="https://1.www.s81c.com/common/carbon/plex/sans.css" />
+    <style>
+      body {
+        font-family:
+          'IBM Plex Sans',
+          system-ui,
+          -apple-system,
+          BlinkMacSystemFont,
+          '.SFNSText-Regular',
+          sans-serif;
+      }
+    </style>
   </head>
   <body>
     <my-app></my-app>

--- a/examples/web-components/reasoning-steps/index.html
+++ b/examples/web-components/reasoning-steps/index.html
@@ -14,6 +14,17 @@
     <link
       rel="stylesheet"
       href="https://1.www.s81c.com/common/carbon/plex/sans.css" />
+    <style>
+      body {
+        font-family:
+          'IBM Plex Sans',
+          system-ui,
+          -apple-system,
+          BlinkMacSystemFont,
+          '.SFNSText-Regular',
+          sans-serif;
+      }
+    </style>
   </head>
   <body>
     <my-app></my-app>

--- a/examples/web-components/reasoning-with-streaming-generic-items/index.html
+++ b/examples/web-components/reasoning-with-streaming-generic-items/index.html
@@ -15,8 +15,18 @@
     </title>
     <link
       rel="stylesheet"
-      href="https://1.www.s81c.com/common/carbon/plex/sans.css"
-    />
+      href="https://1.www.s81c.com/common/carbon/plex/sans.css" />
+    <style>
+      body {
+        font-family:
+          'IBM Plex Sans',
+          system-ui,
+          -apple-system,
+          BlinkMacSystemFont,
+          '.SFNSText-Regular',
+          sans-serif;
+      }
+    </style>
   </head>
   <body>
     <h3>Reasoning steps with streaming GenericItem content (web components)</h3>

--- a/examples/web-components/upsert-message-reasoning-steps-controlled/index.html
+++ b/examples/web-components/upsert-message-reasoning-steps-controlled/index.html
@@ -16,8 +16,18 @@
     </title>
     <link
       rel="stylesheet"
-      href="https://1.www.s81c.com/common/carbon/plex/sans.css"
-    />
+      href="https://1.www.s81c.com/common/carbon/plex/sans.css" />
+    <style>
+      body {
+        font-family:
+          'IBM Plex Sans',
+          system-ui,
+          -apple-system,
+          BlinkMacSystemFont,
+          '.SFNSText-Regular',
+          sans-serif;
+      }
+    </style>
   </head>
   <body>
     <my-app></my-app>

--- a/examples/web-components/upsert-message-reasoning-steps/index.html
+++ b/examples/web-components/upsert-message-reasoning-steps/index.html
@@ -15,8 +15,18 @@
     </title>
     <link
       rel="stylesheet"
-      href="https://1.www.s81c.com/common/carbon/plex/sans.css"
-    />
+      href="https://1.www.s81c.com/common/carbon/plex/sans.css" />
+    <style>
+      body {
+        font-family:
+          'IBM Plex Sans',
+          system-ui,
+          -apple-system,
+          BlinkMacSystemFont,
+          '.SFNSText-Regular',
+          sans-serif;
+      }
+    </style>
   </head>
   <body>
     <my-app></my-app>

--- a/examples/web-components/upsert-message-reasoning-with-streaming-generic-items/index.html
+++ b/examples/web-components/upsert-message-reasoning-with-streaming-generic-items/index.html
@@ -16,13 +16,21 @@
     </title>
     <link
       rel="stylesheet"
-      href="https://1.www.s81c.com/common/carbon/plex/sans.css"
-    />
+      href="https://1.www.s81c.com/common/carbon/plex/sans.css" />
     <style>
       html,
       body {
         margin: 0;
         padding: 0;
+      }
+      body {
+        font-family:
+          'IBM Plex Sans',
+          system-ui,
+          -apple-system,
+          BlinkMacSystemFont,
+          '.SFNSText-Regular',
+          sans-serif;
       }
       .chat-custom-element {
         height: 100vh;

--- a/examples/web-components/upsert-message-user-defined/index.html
+++ b/examples/web-components/upsert-message-user-defined/index.html
@@ -20,10 +20,13 @@
         padding: 0;
       }
       body {
-        /* Carbon's notification/card shadow roots use `font-family: inherit`,
-           so the body font propagates into them. Without this rule the
-           browser default (Times) leaks into the toast and slotted content. */
-        font-family: "IBM Plex Sans Var", "IBM Plex Sans", sans-serif;
+        font-family:
+          'IBM Plex Sans',
+          system-ui,
+          -apple-system,
+          BlinkMacSystemFont,
+          '.SFNSText-Regular',
+          sans-serif;
       }
       .chat-custom-element {
         block-size: 100vh;
@@ -45,8 +48,7 @@
     </style>
     <link
       rel="stylesheet"
-      href="https://1.www.s81c.com/common/carbon/plex/sans.css"
-    />
+      href="https://1.www.s81c.com/common/carbon/plex/sans.css" />
   </head>
   <body>
     <my-app></my-app>

--- a/examples/web-components/user-defined-responses/index.html
+++ b/examples/web-components/user-defined-responses/index.html
@@ -20,6 +20,15 @@
         margin: 0;
         padding: 0;
       }
+      body {
+        font-family:
+          'IBM Plex Sans',
+          system-ui,
+          -apple-system,
+          BlinkMacSystemFont,
+          '.SFNSText-Regular',
+          sans-serif;
+      }
     </style>
   </head>
   <body>

--- a/examples/web-components/watch-state/index.html
+++ b/examples/web-components/watch-state/index.html
@@ -14,6 +14,17 @@
     <link
       rel="stylesheet"
       href="https://1.www.s81c.com/common/carbon/plex/sans.css" />
+    <style>
+      body {
+        font-family:
+          'IBM Plex Sans',
+          system-ui,
+          -apple-system,
+          BlinkMacSystemFont,
+          '.SFNSText-Regular',
+          sans-serif;
+      }
+    </style>
   </head>
   <body>
     <my-app></my-app>

--- a/examples/web-components/workspace-sidebar/index.html
+++ b/examples/web-components/workspace-sidebar/index.html
@@ -8,16 +8,28 @@
 <!doctype html>
 <html lang="en">
   <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta charset="utf-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta charset="utf-8" />
     <title>@carbon/ai-chat - web components - workspace-sidebar</title>
     <style>
-      html, body {
+      html,
+      body {
         margin: 0;
         padding: 0;
       }
+      body {
+        font-family:
+          'IBM Plex Sans',
+          system-ui,
+          -apple-system,
+          BlinkMacSystemFont,
+          '.SFNSText-Regular',
+          sans-serif;
+      }
     </style>
-    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/plex/sans.css" />
+    <link
+      rel="stylesheet"
+      href="https://1.www.s81c.com/common/carbon/plex/sans.css" />
   </head>
   <body>
     <my-app></my-app>

--- a/examples/web-components/workspace-table-markdown-override/index.html
+++ b/examples/web-components/workspace-table-markdown-override/index.html
@@ -15,13 +15,21 @@
     </title>
     <link
       rel="stylesheet"
-      href="https://1.www.s81c.com/common/carbon/plex/sans.css"
-    />
+      href="https://1.www.s81c.com/common/carbon/plex/sans.css" />
     <style>
       html,
       body {
         margin: 0;
         padding: 0;
+      }
+      body {
+        font-family:
+          'IBM Plex Sans',
+          system-ui,
+          -apple-system,
+          BlinkMacSystemFont,
+          '.SFNSText-Regular',
+          sans-serif;
       }
       cds-aichat-custom-element.chat-custom-element {
         display: block;
@@ -32,7 +40,6 @@
   </head>
   <body>
     <cds-aichat-custom-element
-      class="chat-custom-element"
-    ></cds-aichat-custom-element>
+      class="chat-custom-element"></cds-aichat-custom-element>
   </body>
 </html>

--- a/examples/web-components/workspace/index.html
+++ b/examples/web-components/workspace/index.html
@@ -8,16 +8,28 @@
 <!doctype html>
 <html lang="en">
   <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta charset="utf-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta charset="utf-8" />
     <title>@carbon/ai-chat - web components - workspace</title>
     <style>
-      html, body {
+      html,
+      body {
         margin: 0;
         padding: 0;
       }
+      body {
+        font-family:
+          'IBM Plex Sans',
+          system-ui,
+          -apple-system,
+          BlinkMacSystemFont,
+          '.SFNSText-Regular',
+          sans-serif;
+      }
     </style>
-    <link rel="stylesheet" href="https://1.www.s81c.com/common/carbon/plex/sans.css" />
+    <link
+      rel="stylesheet"
+      href="https://1.www.s81c.com/common/carbon/plex/sans.css" />
   </head>
   <body>
     <my-app></my-app>


### PR DESCRIPTION
Closes #2120

Examples in both flavors came back in the browser default serif. Two causes.

Web component examples linked the Plex stylesheet but never applied the family. `@font-face` rules only register a font. Something still has to use it.

Six React examples never imported `@carbon/styles`. No React example links the Plex CDN, so that sheet is the only font source on that side.

`AppShell` and the Lit components are `font-family: inherit`. So the whole chat came back serif, not just host page text.

#### Changelog

**Changed**

- 36 web component examples now set `body { font-family }`. Same stack `@carbon/styles` emits.
- Four `prompt-line` examples also gain the Plex `<link>`: `typeahead`, `typeahead-custom`, `mentions-and-commands`, and `mentions-and-commands-custom-render`. They had no Plex at all.
- `custom-element-as-float` and its lazy-load twin no longer override Plex with `font-family: sans-serif`.
- `upsert-message-user-defined` drops `IBM Plex Sans Var`. That sheet does not serve it.
- Six React examples import `@carbon/styles`, matching every other React example: `feedback`, `history-user-defined-responses`, `prompt-line-mentions-and-commands`, `prompt-line-typeahead`, `prompt-line-typeahead-custom`, `user-defined-responses`.

Five web component examples stay as they are. Four import `@carbon/styles` and already get Plex. `theme-plex-override` overrides the font as its whole point.

#### Testing / Reviewing

Prettier reformatted 16 of the 36 HTML files on the first commit. `lint-staged` covers `**/*.html`, but the root `format` glob does not. So these had drifted. Expect tag and wrapping churn, plus one missing EOF newline. To skip it:

```
git show 54c8ce97 -w -- examples/web-components
```

The React commit is six one-line imports, no churn.

Then:

1. `npm run start --workspace=@carbon/ai-chat-examples-web-components-basic-float`
2. In the console, `getComputedStyle(document.body).fontFamily` starts with `"IBM Plex Sans"`.
3. `document.fonts.check('16px "IBM Plex Sans"')` is `true`.
4. Open the chat and send a message. Type matches `examples/react/basic-float`.
5. Repeat on `prompt-line-typeahead`. It had zero Plex faces. Now 112.
6. Repeat on `examples/react/feedback`. It computed `Times` with zero Plex faces. Now Plex with 30.
7. `theme-plex-override` still gives `"Permanent Marker"`.

Turn the new rule off on a live page and the body snaps back to `Times`. That is the bug.
