### PR TITLE
docs(ai-chat): correct stale send promise contract in JSDoc

### DIFF
--- a/packages/ai-chat/src/chat/services/ChatActionsImpl.ts
+++ b/packages/ai-chat/src/chat/services/ChatActionsImpl.ts
@@ -824,10 +824,10 @@ class ChatActionsImpl {
   }
 
   /**
-   * Sends the given message to the assistant on the remote server. This will result in a "pre:send" and "send" event
-   * being fired on the event bus. The returned promise will resolve once a response has received and processed and
-   * both the "pre:receive" and "receive" events have fired. It will reject when too many errors have occurred and
-   * the system gives up retrying.
+   * Sends the given message to the assistant. Fires `pre:send` then `send` on
+   * the event bus before delegating to `customSendMessage`. Resolves when
+   * `customSendMessage` completes or when the turn is stopped; rejects when
+   * `customSendMessage` throws or the send path fails terminally.
    *
    * @param message The message to send.
    * @param source The source of the message.
@@ -890,10 +890,10 @@ class ChatActionsImpl {
   }
 
   /**
-   * Sends the given message to the assistant on the remote server. This will result in a "pre:send" and "send" event
-   * being fired on the event bus. The returned promise will resolve once a response has received and processed and
-   * both the "pre:receive" and "receive" events have fired. It will reject when too many errors have occurred and
-   * the system gives up retrying.
+   * Inner send: fires `pre:send` and `send`, then calls `customSendMessage` via
+   * `MessageService`. Resolves when `customSendMessage` completes or the turn
+   * is stopped; rejects when `customSendMessage` throws or the send path fails
+   * terminally. Retries are handled upstream by `customSendMessage`.
    *
    * @param message The message to send.
    * @param source The source of the message.

--- a/packages/ai-chat/src/chat/services/MessageService.ts
+++ b/packages/ai-chat/src/chat/services/MessageService.ts
@@ -81,7 +81,7 @@ interface ResponseTrackData {
   numErrors: number;
 
   /**
-   * The total time that all the requests took (including the time spent waiting before retries).
+   * The total time that all the requests took, in milliseconds.
    */
   totalRequestTime: number;
 }

--- a/packages/ai-chat/src/types/instance/ChatInstance.ts
+++ b/packages/ai-chat/src/types/instance/ChatInstance.ts
@@ -76,17 +76,28 @@ interface ChatActions {
   requestFocus: () => boolean | void;
 
   /**
-   * Sends the given message to the assistant on the remote server. This will result in a "pre:send" and "send" event
-   * being fired on the event bus. The returned promise will resolve once a response has received and processed and
-   * both the "pre:receive" and "receive" events have fired. It will reject when too many errors have occurred and
-   * the system gives up retrying.
+   * Sends the given message to the assistant. Fires `pre:send` then `send` on
+   * the event bus before delegating to `customSendMessage`.
+   *
+   * **Settlement points:**
+   * - Resolves when `customSendMessage` completes, or when the turn is stopped
+   *   or the conversation restarted while the message is in flight.
+   * - Rejects when `customSendMessage` throws, when the send path fails
+   *   terminally (for example a timeout), or when called in read-only mode.
+   *
+   * The promise settling does **not** mean a response has arrived. Response
+   * delivery is handled asynchronously by `customSendMessage` itself; use
+   * `{@link EventHandlers.on}` with the `receive` event to react to incoming
+   * messages.
    *
    * @param message The message to send.
    * @param options Options for the message sent.
    *
-   * @example Send a plain-text message and await the response
+   * @example Send a plain-text message
    * ```ts
    * await instance.send("What is the weather today?");
+   * // The promise resolves once customSendMessage has completed.
+   * // Listen for the receive event to handle the assistant's response.
    * ```
    *
    * @example Send a message to the assistant without showing it in the UI


### PR DESCRIPTION
Closes #2040

The `send` JSDoc said the promise waits for a response and the system retries on error. Both claims are wrong. Corrects all three copies and one stale inline comment.

#### Changelog

**Changed**

- `ChatInstance.send` JSDoc: corrected settlement points.
  - Resolves when `customSendMessage` settles or the turn stops.
  - Rejects on throw, fatal failure, or read-only mode.
- Notes that the promise settling does **not** mean a response arrived.
- `@example` no longer says "await the response"; points to the `receive` event.
- Two internal `ChatActionsImpl.ts` copies updated to match.
- `ResponseTrackData.totalRequestTime`: removed stale "waiting before retries" phrase.

#### Testing / Reviewing

Documentation-only. No behavior change.

1. `grep -rn "retrying\|gives up" packages/ai-chat/src` — should hit only `LocalMessageItem.ts` enum docs, not the `send` contract.
2. `npx jest --testPathPatterns="send_spec|MessageService_spec"` in `packages/ai-chat` — 34 tests pass.
3. Settlement bullets in `ChatInstance.send` match the code paths below.
   - Resolves: `OutboundMessageCoordinator` lines 202, 265; `MessageService` lines 299, 792.
   - Rejects: `OutboundMessageCoordinator` line 137.
   - Read-only guard: `ChatInstanceImpl` line 87.
