### PR TITLE
docs: correct @carbon/ai-chat-components/react import specifiers

### DIFF
--- a/docs/focus-management-pattern.md
+++ b/docs/focus-management-pattern.md
@@ -203,7 +203,7 @@ export interface ComponentHandle {
 import { useRef } from 'react';
 import ChatHeader, {
   ChatHeaderHandle,
-} from '@carbon/ai-chat-components/react/chat-header';
+} from '@carbon/ai-chat-components/es/react/chat-header.js';
 
 function ParentComponent() {
   const headerRef = useRef<ChatHeaderHandle>(null);

--- a/examples/react/README.md
+++ b/examples/react/README.md
@@ -579,8 +579,8 @@ A custom Tiptap input rule converts triple backticks (` ``` `) in the chat input
 | `InputRule` | `@tiptap/core` API | Triggers the node swap when the user finishes typing three backticks. |
 | `addKeyboardShortcuts` / keydown | `@tiptap/core` / DOM | Escape exits the block to a new paragraph below. |
 | `<cds-aichat-code-snippet>` | `@carbon/ai-chat-components` element | Editable CodeMirror-backed snippet inside the input; read-only in the bubble. |
-| `CodeSnippet` | `@carbon/ai-chat-components/react` | React wrapper for the snippet, used in the sent message bubble. |
-| `Card` | `@carbon/ai-chat-components/react` | React wrapper for the card that frames the editable snippet. |
+| `CodeSnippet` | `@carbon/ai-chat-components/es/react/code-snippet.js` | React wrapper for the snippet, used in the sent message bubble. |
+| `Card` | `@carbon/ai-chat-components/es/react/card.js` | React wrapper for the card that frames the editable snippet. |
 
 </details>
 

--- a/examples/react/prompt-line-code-snippet/README.md
+++ b/examples/react/prompt-line-code-snippet/README.md
@@ -37,8 +37,8 @@ A custom Tiptap input rule converts triple backticks (` ``` `) in the chat input
 | `InputRule` | `@tiptap/core` API | Triggers the node swap when the user finishes typing three backticks. |
 | `addKeyboardShortcuts` / keydown | `@tiptap/core` / DOM | Escape exits the block to a new paragraph below. |
 | `<cds-aichat-code-snippet>` | `@carbon/ai-chat-components` element | Editable CodeMirror-backed snippet inside the input; read-only in the bubble. |
-| `CodeSnippet` | `@carbon/ai-chat-components/react` | React wrapper for the snippet, used in the sent message bubble. |
-| `Card` | `@carbon/ai-chat-components/react` | React wrapper for the card that frames the editable snippet. |
+| `CodeSnippet` | `@carbon/ai-chat-components/es/react/code-snippet.js` | React wrapper for the snippet, used in the sent message bubble. |
+| `Card` | `@carbon/ai-chat-components/es/react/card.js` | React wrapper for the card that frames the editable snippet. |
 
 ## Run it
 

--- a/packages/ai-chat-components/src/react/code-snippet.tsx
+++ b/packages/ai-chat-components/src/react/code-snippet.tsx
@@ -53,7 +53,7 @@ const BaseCodeSnippet = withWebComponentBridge(
  * @example
  * ```tsx
  * import { Download } from '@carbon/icons-react';
- * import CodeSnippet from '@carbon/ai-chat-components/react/code-snippet';
+ * import CodeSnippet from '@carbon/ai-chat-components/es/react/code-snippet.js';
  *
  * const actions = [
  *   { text: 'Download', icon: Download, onClick: () => console.log('Download') }

--- a/packages/ai-chat-components/src/react/toolbar.tsx
+++ b/packages/ai-chat-components/src/react/toolbar.tsx
@@ -49,7 +49,7 @@ const BaseToolbar = withWebComponentBridge(
  * @example
  * ```tsx
  * import { Add, Edit } from '@carbon/icons-react';
- * import Toolbar from '@carbon/ai-chat-components/react/toolbar';
+ * import Toolbar from '@carbon/ai-chat-components/es/react/toolbar.js';
  *
  * const actions = [
  *   { text: 'Add', icon: Add, onClick: () => console.log('Add') },


### PR DESCRIPTION
Closes #1895

The subpath `@carbon/ai-chat-components/react` does not exist. Neither does `/react/<name>`. Copying any of the five affected snippets caused a module-resolution error. All five are updated to `./es/react/<name>.js`, which resolves via the `./es/*` export in `package.json`.

#### Changelog

**Changed**

- `examples/react/README.md` — corrected `CodeSnippet` and `Card` import paths
- `examples/react/prompt-line-code-snippet/README.md` — same two paths corrected
- `docs/focus-management-pattern.md` — corrected `ChatHeader`/`ChatHeaderHandle` import
- `src/react/toolbar.tsx` JSDoc `@example` — corrected import path
- `src/react/code-snippet.tsx` JSDoc `@example` — corrected import path

#### Testing / Reviewing

String-only changes. No runtime behaviour affected.

1. `grep -rn '@carbon/ai-chat-components/react' . --include='*.md' --include='*.tsx' --exclude-dir=node_modules --exclude-dir=es` — should return nothing.
2. Open React Storybook (port 7007). Check the `@example` blocks in `toolbar.tsx` and `code-snippet.tsx` — the import path should show `…/es/react/…`.
