### PR TITLE
fix: toolbar overflow after 2

### DIFF
--- a/packages/ai-chat-components/src/components/toolbar/src/toolbar.ts
+++ b/packages/ai-chat-components/src/components/toolbar/src/toolbar.ts
@@ -285,10 +285,17 @@ class CDSAIChatToolbar extends LitElement {
   }
 
   render() {
-    const { hiddenActions, visibleActions } = this.getActions();
-    const showOverflowMenu = hiddenActions.length > 0;
+    const {
+      hiddenActions: rawHiddenActions,
+      visibleActions: rawVisibleActions,
+    } = this.getActions();
+    const showOverflowMenu = rawHiddenActions.length > 1;
+    const visibleActions = showOverflowMenu
+      ? rawVisibleActions
+      : [...rawVisibleActions, ...rawHiddenActions];
+    const hiddenActions = showOverflowMenu ? rawHiddenActions : [];
     const showInitialActions =
-      visibleActions.length === 0 && hiddenActions.length === 0;
+      rawVisibleActions.length === 0 && rawHiddenActions.length === 0;
 
     return html`
       <div data-rounded="top" class=${blockClass}>


### PR DESCRIPTION
Closes #1832 

Updates the overflow handler logic in `toolbar.ts` so that the overflow menu doesn't show up until more than one item needs to be hidden, because it doesn't make sense to just replace one hidden item with the overflow menu

#### Changelog

**Changed**

- `packages/ai-chat-components/src/components/toolbar/src/toolbar.ts` updates the overflow logic

#### Testing / Reviewing

go to the `toolbar` story in storybook - resize the window until the overflow menu shows up - verify that when it appears that there are two items in the overflow menu
