### PR TITLE
docs(skills): improve caic-review skill

### DIFF
--- a/.bob/skills/README.md
+++ b/.bob/skills/README.md
@@ -12,7 +12,7 @@ Skills exist because always-on guidance and task guidance need different deliver
 | [caic-plan](caic-plan/SKILL.md)     | shaping upcoming work at any size — a plan, an epic, or a single issue-sized slice | the plan-review rubric it closes with |
 | [caic-issue](caic-issue/SKILL.md)   | filing a GitHub issue or sub-issue                                                 | epic authoring, for umbrella work     |
 | [caic-pr](caic-pr/SKILL.md)         | drafting a PR description                                                          | —                                     |
-| [caic-review](caic-review/SKILL.md) | reviewing a diff, including self-review before marking a task done                 | —                                     |
+| [caic-review](caic-review/SKILL.md) | reviewing a diff, including self-review before marking a task done                 | PR posting, and large-diff triage     |
 
 `carbon-builder` also lives here. It is a vendored Carbon Design System skill from upstream, not a repo workflow — the sync and mirror rules below apply to it, but its content is not ours to edit.
 

--- a/.bob/skills/caic-review/SKILL.md
+++ b/.bob/skills/caic-review/SKILL.md
@@ -9,7 +9,7 @@ This rubric governs every code review in this repo — both user-requested revie
 
 Two jobs share this rubric. Settle which one you're doing before reading any code — ask the user when the request doesn't make it obvious:
 
-- **Own work** — a self-review of the working diff before marking a task done. Findings come back as text; nothing is posted anywhere. Hand it to a sub-agent when you have one: the context that wrote the diff already justified every choice in it, and re-reading it there replays those justifications instead of testing them. Give the sub-agent the diff and this rubric — not your reasoning for the changes, which is the bias you're trying to escape.
+- **Own work** — a self-review of the working diff before marking a task done. Findings come back as text; nothing is posted anywhere. Name the range first: `git diff` while the work is uncommitted, `git diff <base>...HEAD` once it is committed, where `<base>` is the branch you will merge into. An empty range means you picked the wrong one, not that the work is clean. Hand it to a sub-agent when you have one: the context that wrote the diff already justified every choice in it, and re-reading it there replays those justifications instead of testing them. Give the sub-agent the diff and this rubric — not your reasoning for the changes, which is the bias you're trying to escape.
 - **A pull request** — someone else's branch, or your own PR up for review. Findings can be posted as line comments with a verdict. Read [reviewing-a-pr.md](references/reviewing-a-pr.md) before you diff: it carries base-branch resolution and the posting payload.
 
 ## How to review
@@ -22,6 +22,7 @@ Two jobs share this rubric. Settle which one you're doing before reading any cod
   - **Blocker** — must fix before merge: bug, regression, security issue, broken build/tests, violated repo convention, accidental edit to generated output.
   - **Important** — should fix: unclear naming, missing test for changed behavior, unhandled edge case, scope creep.
   - **Nit** — optional, and it still has to earn its place: a concrete one-edit fix a later reader benefits from. Everything else is noise — see [What isn't a finding](#what-isnt-a-finding).
+- Read enough to be sure before you call something a **Blocker**. A false Blocker costs the author as much as a missed one. If you have only read the happy path, file it as **Important** and say what you did not read.
 
 ## How to write a finding
 
@@ -61,21 +62,24 @@ A pass — or a whole review — that surfaces nothing is finished, not failed. 
 
 ## Run one dimension at a time
 
-One pass over every check spends its attention on the first dimension and skims the rest. Split the review into independent passes, each holding the whole diff and one job. Pick the passes from the changed paths — a docs-only diff gets two, not seven:
+One pass over every check spends its attention on the first dimension and skims the rest. Split the review into independent passes, each holding the whole diff and one job. Pick the passes from the changed paths — a docs-only diff gets two of them, not the whole table:
 
 | Changed | Passes |
 | --- | --- |
 | Any code | correctness & security, simplicity & scope creep, test coverage |
-| `*.scss`, or any component | accessibility, prefix & SCSS, logic trapped in a component |
-| `*.md`, or JSDoc on public types | tone & docs |
+| `*.scss`, or any component | accessibility, prefix & SCSS, component placement & trapped logic |
+| `AGENTS.md`, `**/references/**`, `.bob/skills/**`, `.github/copilot-instructions.md` | spec conformance, tone & docs |
+| Any other `*.md`, or JSDoc on public types | tone & docs |
 | `package.json` | dependencies |
 | Always | acceptance criteria & ADRs |
 
-Dispatch them in parallel when the harness gives you sub-agents (see [AGENTS.md](../../../AGENTS.md)); run them as separate sequential passes when it doesn't. Either way, every pass gets the same brief: its one dimension, the finding shape above, and [What isn't a finding](#what-isnt-a-finding). A pass told only to find things will manufacture Nits to justify itself.
+Markdown that tells an agent what to do is a specification, not copy. The spec-conformance pass asks whether an agent following the changed text does the right thing, and holds it to [authoring-agents-md.md](../../../references/authoring-agents-md.md) — the line budget, one topic per file, a "read when" trigger on every reference link, and the Related guidance footer.
+
+Dispatch them in parallel when the harness gives you sub-agents (see [AGENTS.md](../../../AGENTS.md)); run them as separate sequential passes when it doesn't. Either way, every pass gets the same brief: the diff, this rubric by path, its one dimension, and the `AGENTS.md` files governing the paths it holds ([Repo-specific checks](#repo-specific-checks)). The finding shape and [What isn't a finding](#what-isnt-a-finding) travel with the rubric. A pass told only to find things will manufacture Nits to justify itself.
 
 A pass returns findings and nothing else — no verdict, no cap, no ranking. It can't rank what it can't see.
 
-**Synthesize before you write anything.** Merge the passes, drop duplicates, rank by severity across all of them, then apply the caps and write the verdict per [Output expectations](#output-expectations). Skip this and you ship N reviews stapled together.
+**Synthesize before you write anything.** Merge the passes, then read them against each other before you rank. Two findings are duplicates when they name the same root cause, not merely the same line — on a merge, keep the higher severity and union the fixes. Where two passes cite the same file or symbol for different reasons, decide whether you hold two findings or one larger defect neither pass could see alone. Then rank by severity, apply the caps, and write the verdict per [Output expectations](#output-expectations). Skip this and you ship N reviews stapled together.
 
 Skip the split when a single reading holds the whole diff in view. Splitting a handful of lines across five passes is ceremony.
 
@@ -104,7 +108,7 @@ Skip the split when a single reading holds the whole diff in view. Splitting a h
 
 - Identify which changed behavior is currently untested.
 - Recommend the test style appropriate to the package:
-  - `@carbon/ai-chat` — Jest, specs under `packages/ai-chat/tests/spec/**/*_spec.ts(x)`.
+  - `@carbon/ai-chat` — Jest, specs under `packages/ai-chat/tests/<area>/spec/**/*_spec.ts(x)` ([tests.md](../../../packages/ai-chat/references/tests.md)).
   - `@carbon/ai-chat-components` — `@web/test-runner` for Lit components (colocated `__tests__/*.test.ts`) and Jest for the React wrappers.
   - `demo/` — Playwright under `demo/tests/`.
   - `examples/**` — Playwright smoke tests (see [playwright.md](../../../examples/references/playwright.md)).

--- a/.bob/skills/caic-review/SKILL.md
+++ b/.bob/skills/caic-review/SKILL.md
@@ -49,7 +49,7 @@ Cap a finding at three sentences plus a snippet. A concern that outgrows that �
 
 Some observations feel like findings and aren't. These stay unsaid at every severity, not just Nit:
 
-- **A tool already decided it.** Husky runs prettier and eslint on TS/JS, prettier and stylelint on SCSS, prettier on markdown, and commitlint on the message ([commit hooks](../../../references/conventions.md#commit-hooks)). Formatting, quote style, import order, and line length are settled before you open the diff.
+- **A tool already decided it.** Husky runs prettier, eslint, stylelint, and commitlint on what you commit ([commit hooks](../../../references/conventions.md#commit-hooks)); `ci-check` adds license headers plus ADR, AGENTS, skill, and example-README validation. Formatting, quote style, import order, line length, and anything else a gate fails on are settled before you open the diff.
 - **A naming swap with no clarity gain** — `data` → `payload`.
 - **An equivalent style alternative** — `for` versus `.map`, ternary versus `if`.
 - **"Add a comment here."** The repo's default is no comments. You are here to flag the ones that restate the code, not to ask for more.
@@ -66,7 +66,7 @@ One pass over every check spends its attention on the first dimension and skims 
 | `*.scss`, or any component | accessibility, prefix & SCSS, logic trapped in a component |
 | `*.md`, or JSDoc on public types | tone & docs |
 | `package.json` | dependencies |
-| Always | acceptance criteria & ADRs, commit format |
+| Always | acceptance criteria & ADRs |
 
 Dispatch them in parallel when the harness gives you sub-agents (see [AGENTS.md](../../../AGENTS.md)); run them as separate sequential passes when it doesn't. Either way, every pass gets the same brief: its one dimension, the finding shape above, and [What isn't a finding](#what-isnt-a-finding). A pass told only to find things will manufacture Nits to justify itself.
 
@@ -116,8 +116,6 @@ For each changed file, read every `AGENTS.md` on the path from its directory up 
 - **Logic trapped in a component** — parsing, formatting, validation, state transitions, or timing/geometry math written inside a React or Lit component instead of a plain module it could call ([framework-agnostic logic](../../../references/code-patterns.md#framework-agnostic-logic)). The tell is a behavior you could only test by rendering.
 - **New components added under `packages/ai-chat/src/chat/components-legacy/`** — that directory is closed to new components ([component placement](../../../references/code-patterns.md#component-placement)).
 - **Prefix / SCSS violations** — hardcoded `cds--`, missing `#{$prefix}--`, descendant nesting, or physical properties instead of logical ones for RTL ([naming & prefix discipline](../../../references/code-patterns.md#naming--prefix-discipline-build-breaking), [SCSS authoring](../../../references/code-patterns.md#scss-authoring)).
-- **Conventional-commit format** on the PR title / squash commit ([commits](../../../references/conventions.md#commits)).
-- **Examples**: each example's README still satisfies the Indexer contract described in [examples/AGENTS.md](../../../examples/AGENTS.md).
 - **Accessibility** on UI changes: keyboard navigation, focus management, ARIA roles/labels, color contrast, and RTL behavior. Carbon is a design system — a11y regressions are blockers.
 - **Dependencies**: new or upgraded packages should be justified; flag peer-dep conflicts, duplicate functionality already available via existing deps, or license incompatibilities.
 

--- a/.bob/skills/caic-review/SKILL.md
+++ b/.bob/skills/caic-review/SKILL.md
@@ -10,48 +10,7 @@ This rubric governs every code review in this repo — both user-requested revie
 Two jobs share this rubric. Settle which one you're doing before reading any code — ask the user when the request doesn't make it obvious:
 
 - **Own work** — a self-review of the working diff before marking a task done. Findings come back as text; nothing is posted anywhere.
-- **A pull request** — someone else's branch, or your own PR up for review. Findings can be posted as line comments with a verdict.
-
-### On a PR, resolve the base branch before diffing
-
-Never assume `main`. A PR usually targets `upstream/main`, but long-running integration branches are common here, and diffing against the wrong base buries the review under unrelated commits.
-
-```bash
-gh pr view <pr> --json baseRefName,headRefName,headRefOid,isCrossRepository,url
-gh pr diff <pr>   # already scoped to the PR's real base
-```
-
-Use `gh pr diff`, or diff explicitly against the reported `baseRefName`. When the base is an integration branch rather than `main`, say so in the summary — it changes what is in scope and what counts as a regression.
-
-## Posting a review on a PR
-
-Line comments beat a wall of prose: they land next to the code they're about. Build the whole review as one payload and submit it once.
-
-**Draft first, submit second. Never run a `gh` command that writes to GitHub before the user has seen the exact payload and said go.** Write it to `.github/pr-drafts/review-<pr>.json` (git-ignored), show the summary and findings, then wait.
-
-```json
-{
-  "commit_id": "<headRefOid from gh pr view>",
-  "event": "COMMENT",
-  "body": "Fix blockers before merge. <assessment, highest-severity concerns, anything dropped>",
-  "comments": [
-    {
-      "path": "packages/ai-chat/src/foo.ts",
-      "line": 42,
-      "side": "RIGHT",
-      "body": "**Blocker** — the early return skips teardown, so the listener leaks on every close. Call `dispose()` before returning."
-    }
-  ]
-}
-```
-
-```bash
-gh api --method POST repos/<owner>/<repo>/pulls/<pr>/reviews --input .github/pr-drafts/review-<pr>.json
-```
-
-- **`event`** is `COMMENT` (feedback only), `APPROVE`, or `REQUEST_CHANGES`. Ask the user which — the verdict is theirs, not yours. GitHub rejects `APPROVE` and `REQUEST_CHANGES` on your own PR, so a self-authored PR can only take `COMMENT`.
-- **`line`** is the line number in the file as of `commit_id`, and it must fall inside the diff. `side: "RIGHT"` is the post-change file; use `"LEFT"` for a removed line. For a range, add `start_line` (and `start_side`).
-- A comment outside the diff hunks returns 422. Put that finding in the summary `body` rather than forcing a line onto it.
+- **A pull request** — someone else's branch, or your own PR up for review. Findings can be posted as line comments with a verdict. Read [reviewing-a-pr.md](references/reviewing-a-pr.md) before you diff: it carries base-branch resolution and the posting payload.
 
 ## How to review
 
@@ -148,6 +107,7 @@ For context on conventions being enforced:
 - **Process conventions**: [conventions.md](../../../references/conventions.md) — commits, branches, license headers, hooks
 - **General overview**: [AGENTS.md](../../../AGENTS.md) — monorepo pointer index
 - **Package-specific rules**: see `AGENTS.md` in each package directory
+- **Reviewing a PR**: [reviewing-a-pr.md](references/reviewing-a-pr.md) — base branch, the review payload, and the `gh` call
 - **PR workflow**: [caic-pr](../caic-pr/SKILL.md) — drafting PR descriptions
 - **Plan-phase analog**: [plan-review.md](../caic-plan/references/plan-review.md) — the same discipline applied before code exists
 

--- a/.bob/skills/caic-review/SKILL.md
+++ b/.bob/skills/caic-review/SKILL.md
@@ -9,7 +9,7 @@ This rubric governs every code review in this repo — both user-requested revie
 
 Two jobs share this rubric. Settle which one you're doing before reading any code — ask the user when the request doesn't make it obvious:
 
-- **Own work** — a self-review of the working diff before marking a task done. Findings come back as text; nothing is posted anywhere.
+- **Own work** — a self-review of the working diff before marking a task done. Findings come back as text; nothing is posted anywhere. Hand it to a sub-agent when you have one: the context that wrote the diff already justified every choice in it, and re-reading it there replays those justifications instead of testing them. Give the sub-agent the diff and this rubric — not your reasoning for the changes, which is the bias you're trying to escape.
 - **A pull request** — someone else's branch, or your own PR up for review. Findings can be posted as line comments with a verdict. Read [reviewing-a-pr.md](references/reviewing-a-pr.md) before you diff: it carries base-branch resolution and the posting payload.
 
 ## How to review
@@ -55,6 +55,8 @@ Some observations feel like findings and aren't. These stay unsaid at every seve
 - **"Add a comment here."** The repo's default is no comments. You are here to flag the ones that restate the code, not to ask for more.
 - **Speculative extraction** — "you might want to pull this out in case…". Scope creep counts from the reviewer's side too.
 - **Code the diff didn't touch.** Real, but not this PR's job — file an issue.
+
+A pass — or a whole review — that surfaces nothing is finished, not failed. Say so and stop. Manufacturing a Nit to look thorough costs the author more than the silence would.
 
 ## Run one dimension at a time
 

--- a/.bob/skills/caic-review/SKILL.md
+++ b/.bob/skills/caic-review/SKILL.md
@@ -23,6 +23,7 @@ Two jobs share this rubric. Settle which one you're doing before reading any cod
   - **Important** — should fix: unclear naming, missing test for changed behavior, unhandled edge case, scope creep.
   - **Nit** — optional, and it still has to earn its place: a concrete one-edit fix a later reader benefits from. Everything else is noise — see [What isn't a finding](#what-isnt-a-finding).
 - Read enough to be sure before you call something a **Blocker**. A false Blocker costs the author as much as a missed one. If you have only read the happy path, file it as **Important** and say what you did not read.
+- When you can run commands, run the read-only gates for what changed before you write anything — `lint`, `lint:license`, `lint:styles`, `validate:*`, `format`. A failure you watched outranks one you inferred. Never start a build or a test run yourself: the rows in [definition-of-done.md](../../../references/definition-of-done.md) all build, and a build races the watcher a developer probably has running. Report an unrun build as a stated gap.
 
 ## How to write a finding
 
@@ -34,6 +35,8 @@ One shape, one order — severity, the defect, what it costs, the fix:
 
 Cite a range when the defect spans lines, and show the fix as a snippet when words alone won't carry it. Never post the objection without the fix. In a line comment on a PR, the `path` and `line` fields carry the citation — drop it from the body and keep the rest of the order.
 
+The consequence names the input or path that reaches the defect — "on every close", "when the list is empty" — not the category. A defect you can't trigger is a guess: drop it, or say what you didn't check.
+
 Hold your own words to [tone.md](../../../references/tone.md) — the same standard you hold the diff's copy to. Three habits show up in reviews and all three go:
 
 - **Hedging** — "I think", "it looks like", "consider possibly", "might be worth". Uncertainty is fine; say what you checked instead. "Read the happy path only — 60% sure this leaks."
@@ -44,6 +47,11 @@ Hold your own words to [tone.md](../../../references/tone.md) — the same stand
 
 - Before: "I might be missing something, but I wonder if it could possibly be worth considering whether this early return may want to clean up the listener it registered above, since otherwise it seems like it might leak? Nice refactor overall though!"
 - After: "**Blocker** — `packages/ai-chat/src/foo.ts:42` — the early return skips teardown, so the listener leaks on every close. Call `dispose()` before returning."
+
+The other two severities, written the same way:
+
+- **Important** — `packages/ai-chat/src/chat/store/fooReducer.ts:88` — the reducer rebuilds every item, so one changed message re-renders the whole list. Copy the array and replace the one index.
+- **Nit** — `packages/ai-chat/src/types/config/FooConfig.ts:12` — the JSDoc says "the timeout" with no unit, so a caller guesses seconds. Say "in milliseconds."
 
 Cap a finding at three sentences plus a snippet. A concern that outgrows that — a design direction, a pattern repeated across the diff — is not a line comment: give it one line in the summary and move on.
 
@@ -79,7 +87,9 @@ Dispatch them in parallel when the harness gives you sub-agents (see [AGENTS.md]
 
 A pass returns findings and nothing else — no verdict, no cap, no ranking. It can't rank what it can't see.
 
-**Synthesize before you write anything.** Merge the passes, then read them against each other before you rank. Two findings are duplicates when they name the same root cause, not merely the same line — on a merge, keep the higher severity and union the fixes. Where two passes cite the same file or symbol for different reasons, decide whether you hold two findings or one larger defect neither pass could see alone. Then rank by severity, apply the caps, and write the verdict per [Output expectations](#output-expectations). Skip this and you ship N reviews stapled together.
+**Refute before you synthesize.** The caps cut volume, never falsity: a wrong Blocker is unique, top-ranked, and never dropped, so it survives every other step. Take each Blocker and Important and argue the other side — name the code path that makes it wrong. A finding you can't refute ships; one you can, dies silently. Hand this to a sub-agent with the diff and the findings, not the passes' reasoning, when the harness has one; run it as your own last pass when it doesn't. Nits skip it — they are cheap to be wrong about.
+
+**Synthesize before you write anything.** Merge the passes, then read them against each other before you rank. Two findings are duplicates when they name the same root cause, not merely the same line — on a merge, keep the higher severity and union the fixes. Where two passes cite the same file or symbol for different reasons, decide whether you hold two findings or one larger defect neither pass could see alone. A finding you create here is new, so refute it before it ships — surviving refutation twice says nothing about the claim that joins them. Then rank by severity, apply the caps, and write the verdict per [Output expectations](#output-expectations). Skip this and you ship N reviews stapled together.
 
 Skip the split when a single reading holds the whole diff in view. Splitting a handful of lines across five passes is ceremony.
 
@@ -117,7 +127,7 @@ Skip the split when a single reading holds the whole diff in view. Splitting a h
 
 ## Repo-specific checks
 
-For each changed file, read every `AGENTS.md` on the path from its directory up to the repo root, plus any topic docs under their `references/` folders they link to — e.g. a change under `packages/ai-chat-components/src/components/audio-player/` is governed by [packages/ai-chat-components/AGENTS.md](../../../packages/ai-chat-components/AGENTS.md) then the root [AGENTS.md](../../../AGENTS.md). Rule definitions live in [code-patterns.md](../../../references/code-patterns.md) and [conventions.md](../../../references/conventions.md); this list is what to flag. Flag any of:
+For each changed file, read every `AGENTS.md` on the path from its directory up to the repo root, plus any topic docs under their `references/` folders they link to — e.g. a change under `packages/ai-chat-components/src/components/audio-player/` is governed by [packages/ai-chat-components/AGENTS.md](../../../packages/ai-chat-components/AGENTS.md) then the root [AGENTS.md](../../../AGENTS.md). Rule definitions live in [code-patterns.md](../../../references/code-patterns.md) and [conventions.md](../../../references/conventions.md); this list is what to flag. A convention finding links the rule it breaks — an anchor in one of those two files, or the governing `AGENTS.md`. No link, no finding: you are quoting a convention this repo may not have. Flag any of:
 
 - **Over-engineering** — code the [laziness ladder](../../../references/code-patterns.md#writing-the-least-code-laziness-ladder) would have avoided: dead code or unused flexibility (delete it), JS re-creating what CSS or a native element/browser API already does, a dependency duplicating Carbon or an existing one, an abstraction with a single caller (YAGNI), or logic expressible in fewer lines. Correctness and security stay in the sections above — this check is only about removable complexity.
 - **Logic trapped in a component** — parsing, formatting, validation, state transitions, or timing/geometry math written inside a React or Lit component instead of a plain module it could call ([framework-agnostic logic](../../../references/code-patterns.md#framework-agnostic-logic)). The tell is a behavior you could only test by rendering.

--- a/.bob/skills/caic-review/SKILL.md
+++ b/.bob/skills/caic-review/SKILL.md
@@ -9,14 +9,17 @@ This rubric governs every code review in this repo — both user-requested revie
 
 Two jobs share this rubric. Settle which one you're doing before reading any code — ask the user when the request doesn't make it obvious:
 
-- **Own work** — a self-review of the working diff before marking a task done. Findings come back as text; nothing is posted anywhere. Name the range first: `git diff` while the work is uncommitted, `git diff <base>...HEAD` once it is committed, where `<base>` is the branch you will merge into. An empty range means you picked the wrong one, not that the work is clean. Hand it to a sub-agent when you have one: the context that wrote the diff already justified every choice in it, and re-reading it there replays those justifications instead of testing them. Give the sub-agent the diff and this rubric — not your reasoning for the changes, which is the bias you're trying to escape.
+- **Own work** — a self-review of the working diff before marking a task done. Findings come back as text; nothing is posted anywhere.
+  - **Name the range first.** `git diff` while the work is uncommitted, `git diff <base>...HEAD` once it is committed, where `<base>` is the branch you will merge into. An empty range means you picked the wrong one, not that the work is clean.
+  - **Hand it to a sub-agent when you have one.** The context that wrote the diff already justified every choice in it, and re-reading it there replays those justifications instead of testing them.
+  - **Pass the requirement, withhold the defense.** The sub-agent gets the diff, this rubric, and what the work had to satisfy — the issue or the user's ask, plus any ADR it cites. It does not get your design notes, the options you ruled out, or the plan's commentary. The requirement is what the review scores against; your reasoning is the bias you're trying to escape. A concern you already resolved comes back cheap — answer it in a line, and if the answer was worth having, it belonged in a comment or an ADR.
 - **A pull request** — someone else's branch, or your own PR up for review. Findings can be posted as line comments with a verdict. Read [reviewing-a-pr.md](references/reviewing-a-pr.md) before you diff: it carries base-branch resolution and the posting payload.
 
 ## How to review
 
 - Read the actual diff (`git diff`, `gh pr diff`, etc.) and referenced files — never a summary of what changed.
 - When reading it all at one depth would mean reading all of it shallowly, rank the files by risk first — [large-diffs.md](references/large-diffs.md).
-- Open the issue the PR closes and walk its acceptance criteria against the diff. A criterion the diff contradicts is a **Blocker** until the issue carries an amendment saying so.
+- Open the issue the work closes and walk its acceptance criteria against the diff — for a self-review, the issue or ask the task came from. A criterion the diff contradicts is a **Blocker** until the issue carries an amendment saying so.
 - If the issue or its epic cites an ADR, read that ADR's Decision outcome and walk the diff against it too. A diff that contradicts an accepted ADR is a **Blocker** until a new ADR supersedes it — an implementation PR is not where a recorded decision gets reversed.
 - Tag every finding with a severity so real problems aren't buried under taste:
   - **Blocker** — must fix before merge: bug, regression, security issue, broken build/tests, violated repo convention, accidental edit to generated output.
@@ -33,7 +36,7 @@ One shape, one order — severity, the defect, what it costs, the fix:
 **<Severity>** — `path/to/file.ts:42` — <what is wrong>, so <what it costs>. <The fix.>
 ```
 
-Cite a range when the defect spans lines, and show the fix as a snippet when words alone won't carry it. Never post the objection without the fix. In a line comment on a PR, the `path` and `line` fields carry the citation — drop it from the body and keep the rest of the order.
+Cite a range when the defect spans lines, and show the fix as a snippet when words alone won't carry it. Never post the objection without the fix. When you genuinely can't name one, name the gap instead — "this drops the second update; whether that's a bug depends on whether the queue is ordered, and I didn't trace it." An objection with a stated gap is workable. An invented fix the author implements is not.
 
 The consequence names the input or path that reaches the defect — "on every close", "when the list is empty" — not the category. A defect you can't trigger is a guess: drop it, or say what you didn't check.
 
@@ -62,9 +65,9 @@ Some observations feel like findings and aren't. These stay unsaid at every seve
 - **A tool already decided it.** Husky runs prettier, eslint, stylelint, and commitlint on what you commit ([commit hooks](../../../references/conventions.md#commit-hooks)); `ci-check` adds license headers plus ADR, AGENTS, skill, and example-README validation. Formatting, quote style, import order, line length, and anything else a gate fails on are settled before you open the diff.
 - **A naming swap with no clarity gain** — `data` → `payload`.
 - **An equivalent style alternative** — `for` versus `.map`, ternary versus `if`.
-- **"Add a comment here."** The repo's default is no comments. You are here to flag the ones that restate the code, not to ask for more.
+- **"Add a comment here."** The repo's default is no comments ([comments](../../../references/code-patterns.md#comments)). You are here to flag the ones that restate the code, not to ask for more. One narrow exception: the diff encodes a _why_ the code cannot show — a workaround for a named bug, a constraint from outside the file, an ordering that looks arbitrary and isn't. Ask for that line, and say what it has to record.
 - **Speculative extraction** — "you might want to pull this out in case…". Scope creep counts from the reviewer's side too.
-- **Code the diff didn't touch.** Real, but not this PR's job — file an issue.
+- **Code the diff didn't touch.** A pre-existing problem is real and is not this PR's job — file an issue. Untouched code the diff _breaks_ is a different thing: a caller left on the old signature, a consumer of a changed default, a doc snippet that no longer runs. That is a regression, and a regression is a **Blocker** wherever it surfaces.
 
 A pass — or a whole review — that surfaces nothing is finished, not failed. Say so and stop. Manufacturing a Nit to look thorough costs the author more than the silence would.
 
@@ -95,7 +98,7 @@ Skip the split when a single reading holds the whole diff in view. Splitting a h
 
 ## Evaluate the changes
 
-### If the PR contains documentation/text updates
+### If the diff contains documentation/text updates
 
 - Hold developer-facing copy to [tone.md](../../../references/tone.md) — voice, word economy, and the cuts it asks for.
 - Identify spelling, grammar, and punctuation errors.
@@ -104,9 +107,9 @@ Skip the split when a single reading holds the whole diff in view. Splitting a h
 - Check consistency of formatting, headings, bullets, and structure.
 - Confirm the docs capture the intent and give clear instructions.
 
-### If the PR contains code changes
+### If the diff contains code changes
 
-- **Favor simplicity** — confirm the diff follows the least-code discipline and simplicity principles in [code-patterns.md](../../../references/code-patterns.md#writing-the-least-code-laziness-ladder); flag violations (over-built code, large multi-job functions, hidden side effects, deep nesting, shared mutable state, single-caller abstractions, cleverness over a plain version).
+- **Favor simplicity** — hold the diff to the least-code discipline in [code-patterns.md](../../../references/code-patterns.md#writing-the-least-code-laziness-ladder). Flag over-built code, large multi-job functions, hidden side effects, deep nesting, shared mutable state, single-caller abstractions (YAGNI), cleverness over a plain version, dead code or unused flexibility, logic expressible in fewer lines, and JS re-creating what CSS or a native element or browser API already does. This check is removable complexity only — correctness and security are the bullets below.
 - Analyze logic for bugs, inefficiencies, and security risks (OWASP-style: injection, XSS, unsafe deserialization, secrets in code).
 - Check variable names, function structure, and error handling for clarity and correctness.
 - Confirm edge-case handling — empty/null inputs, error paths, concurrency, cancellation, large inputs.
@@ -129,7 +132,6 @@ Skip the split when a single reading holds the whole diff in view. Splitting a h
 
 For each changed file, read every `AGENTS.md` on the path from its directory up to the repo root, plus any topic docs under their `references/` folders they link to — e.g. a change under `packages/ai-chat-components/src/components/audio-player/` is governed by [packages/ai-chat-components/AGENTS.md](../../../packages/ai-chat-components/AGENTS.md) then the root [AGENTS.md](../../../AGENTS.md). Rule definitions live in [code-patterns.md](../../../references/code-patterns.md) and [conventions.md](../../../references/conventions.md); this list is what to flag. A convention finding links the rule it breaks — an anchor in one of those two files, or the governing `AGENTS.md`. No link, no finding: you are quoting a convention this repo may not have. Flag any of:
 
-- **Over-engineering** — code the [laziness ladder](../../../references/code-patterns.md#writing-the-least-code-laziness-ladder) would have avoided: dead code or unused flexibility (delete it), JS re-creating what CSS or a native element/browser API already does, a dependency duplicating Carbon or an existing one, an abstraction with a single caller (YAGNI), or logic expressible in fewer lines. Correctness and security stay in the sections above — this check is only about removable complexity.
 - **Logic trapped in a component** — parsing, formatting, validation, state transitions, or timing/geometry math written inside a React or Lit component instead of a plain module it could call ([framework-agnostic logic](../../../references/code-patterns.md#framework-agnostic-logic)). The tell is a behavior you could only test by rendering.
 - **New components added under `packages/ai-chat/src/chat/components-legacy/`** — that directory is closed to new components ([component placement](../../../references/code-patterns.md#component-placement)).
 - **Prefix / SCSS violations** — hardcoded `cds--`, missing `#{$prefix}--`, descendant nesting, or physical properties instead of logical ones for RTL ([naming & prefix discipline](../../../references/code-patterns.md#naming--prefix-discipline-build-breaking), [SCSS authoring](../../../references/code-patterns.md#scss-authoring)).
@@ -141,7 +143,8 @@ For each changed file, read every `AGENTS.md` on the path from its directory up 
 - **Open with the verdict on one line** — ship, fix blockers, or rework. Nothing precedes it: no greeting, no "great work on this", no recap of what the PR does. The author wrote the diff and does not need it read back.
 - **Then at most three lines**, carrying only what the verdict rests on: the blocking concerns, any design-level concern that outgrew a finding, and the dropped-finding count. A strength earns a line only when it was the risk and it landed — "the migration path handles the null case, which was the hard part." Generic praise is padding; cut it.
 - List findings grouped by severity (**Blocker**, **Important**, **Nit**), each written to the shape above.
-- **Cap the review at ten findings and three Nits**, highest severity first. Drop Nits first, then Importants, and name the drop in one summary line: "12 further Nits (naming, comment wording) not listed." A review nobody finishes fixes nothing, and a silent cut reads as full coverage.
+- **Never drop a Blocker.** List every one, however many there are. A Blocker reduced to a count in the summary blocks nothing, and merges.
+- **Cap Important and Nit at ten between them**, no more than three of those Nits, highest severity first. Drop Nits before Importants, and name the drop in one summary line: "12 further Nits (naming, comment wording) not listed." A review nobody finishes fixes nothing, and a silent cut reads as full coverage. When the Blockers alone run past ten, drop the Importants and Nits entirely — the verdict is rework, and a tail of taste under that many must-fixes is noise.
 - End with a **Test / verification gaps** section if the diff lacks coverage for changed behavior.
 
 ## Related guidance

--- a/.bob/skills/caic-review/SKILL.md
+++ b/.bob/skills/caic-review/SKILL.md
@@ -33,13 +33,13 @@ Line comments beat a wall of prose: they land next to the code they're about. Bu
 {
   "commit_id": "<headRefOid from gh pr view>",
   "event": "COMMENT",
-  "body": "Summary — overall assessment and the highest-severity concerns.",
+  "body": "Fix blockers before merge. <assessment, highest-severity concerns, anything dropped>",
   "comments": [
     {
       "path": "packages/ai-chat/src/foo.ts",
       "line": 42,
       "side": "RIGHT",
-      "body": "**Blocker** — the early return skips the teardown; call `dispose()` before returning."
+      "body": "**Blocker** — the early return skips teardown, so the listener leaks on every close. Call `dispose()` before returning."
     }
   ]
 }
@@ -62,8 +62,29 @@ gh api --method POST repos/<owner>/<repo>/pulls/<pr>/reviews --input .github/pr-
   - **Blocker** — must fix before merge: bug, regression, security issue, broken build/tests, violated repo convention, accidental edit to generated output.
   - **Important** — should fix: unclear naming, missing test for changed behavior, unhandled edge case, scope creep.
   - **Nit** — optional/taste. Keep these short and few.
-- Cite every finding with `path/to/file.ts:line` (or range) so the author can jump to it.
-- When you flag a problem, show the fix (snippet or concrete suggestion), not just the objection.
+
+## How to write a finding
+
+One shape, one order — severity, the defect, what it costs, the fix:
+
+```
+**<Severity>** — `path/to/file.ts:42` — <what is wrong>, so <what it costs>. <The fix.>
+```
+
+Cite a range when the defect spans lines, and show the fix as a snippet when words alone won't carry it. Never post the objection without the fix. In a line comment on a PR, the `path` and `line` fields carry the citation — drop it from the body and keep the rest of the order.
+
+Hold your own words to [tone.md](../../../references/tone.md) — the same standard you hold the diff's copy to. Three habits show up in reviews and all three go:
+
+- **Hedging** — "I think", "it looks like", "consider possibly", "might be worth". Uncertainty is fine; say what you checked instead. "Read the happy path only — 60% sure this leaks."
+- **Throat-clearing** — "just", "simply", "one small thing", "it is important to note". Delete the phrase; the sentence gets stronger.
+- **Praise inside a finding** — "nice refactor, but…". Strengths go in the summary. A finding is the defect and the fix.
+
+**A leaked listener**
+
+- Before: "I might be missing something, but I wonder if it could possibly be worth considering whether this early return may want to clean up the listener it registered above, since otherwise it seems like it might leak? Nice refactor overall though!"
+- After: "**Blocker** — `packages/ai-chat/src/foo.ts:42` — the early return skips teardown, so the listener leaks on every close. Call `dispose()` before returning."
+
+Cap a finding at three sentences plus a snippet. A concern that outgrows that — a design direction, a pattern repeated across the diff — is not a line comment: give it one line in the summary and move on.
 
 ## Evaluate the changes
 
@@ -112,16 +133,17 @@ For each changed file, read every `AGENTS.md` on the path from its directory up 
 
 ## Output expectations
 
-- Open with a short **Summary** (2–4 sentences): overall assessment, strengths, highest-severity concerns.
-- List findings grouped by severity (**Blocker**, **Important**, **Nit**), each with a `file:line` reference and a concrete suggested fix (code snippet when useful).
+- **Lead the summary with the verdict on one line** — ship, fix blockers, or rework — before any context. Then 2–3 sentences: what the change does well, and the highest-severity concerns.
+- List findings grouped by severity (**Blocker**, **Important**, **Nit**), each written to the shape above.
+- **Cap the review at ten findings**, highest severity first. Drop Nits first, then Importants, and name the drop in one summary line: "12 further Nits (naming, comment wording) not listed." A review nobody finishes fixes nothing, and a silent cut reads as full coverage.
+- Carry design-level concerns in the summary too, one line each — they are what a finding overflows into.
 - End with a **Test / verification gaps** section if the diff lacks coverage for changed behavior.
-- Keep a polite, constructive tone — note what the change does well, but don't let praise obscure real blockers.
 
 ## Related guidance
 
 For context on conventions being enforced:
 
-- **Voice and tone**: [tone.md](../../../references/tone.md) — what to hold documentation and developer-facing copy to
+- **Voice and tone**: [tone.md](../../../references/tone.md) — what to hold documentation and developer-facing copy to, and the comments you write about it
 - **Code-level patterns**: [code-patterns.md](../../../references/code-patterns.md) — the laziness ladder & simplicity principles, prefix discipline, SCSS, RTL, framework-agnostic logic, component placement, comments
 - **Process conventions**: [conventions.md](../../../references/conventions.md) — commits, branches, license headers, hooks
 - **General overview**: [AGENTS.md](../../../AGENTS.md) — monorepo pointer index

--- a/.bob/skills/caic-review/SKILL.md
+++ b/.bob/skills/caic-review/SKILL.md
@@ -15,6 +15,7 @@ Two jobs share this rubric. Settle which one you're doing before reading any cod
 ## How to review
 
 - Read the actual diff (`git diff`, `gh pr diff`, etc.) and referenced files — never a summary of what changed.
+- When reading it all at one depth would mean reading all of it shallowly, rank the files by risk first — [large-diffs.md](references/large-diffs.md).
 - Open the issue the PR closes and walk its acceptance criteria against the diff. A criterion the diff contradicts is a **Blocker** until the issue carries an amendment saying so.
 - If the issue or its epic cites an ADR, read that ADR's Decision outcome and walk the diff against it too. A diff that contradicts an accepted ADR is a **Blocker** until a new ADR supersedes it — an implementation PR is not where a recorded decision gets reversed.
 - Tag every finding with a severity so real problems aren't buried under taste:
@@ -76,7 +77,7 @@ A pass returns findings and nothing else — no verdict, no cap, no ranking. It 
 
 **Synthesize before you write anything.** Merge the passes, drop duplicates, rank by severity across all of them, then apply the caps and write the verdict per [Output expectations](#output-expectations). Skip this and you ship N reviews stapled together.
 
-Skip the split under ~5 changed files. One pass reads that much without losing the thread.
+Skip the split when a single reading holds the whole diff in view. Splitting a handful of lines across five passes is ceremony.
 
 ## Evaluate the changes
 
@@ -139,6 +140,7 @@ For context on conventions being enforced:
 - **General overview**: [AGENTS.md](../../../AGENTS.md) — monorepo pointer index
 - **Package-specific rules**: see `AGENTS.md` in each package directory
 - **Reviewing a PR**: [reviewing-a-pr.md](references/reviewing-a-pr.md) — base branch, the review payload, and the `gh` call
+- **Large diffs**: [large-diffs.md](references/large-diffs.md) — ranking files by risk when the diff is too big to read evenly
 - **PR workflow**: [caic-pr](../caic-pr/SKILL.md) — drafting PR descriptions
 - **Plan-phase analog**: [plan-review.md](../caic-plan/references/plan-review.md) — the same discipline applied before code exists
 

--- a/.bob/skills/caic-review/SKILL.md
+++ b/.bob/skills/caic-review/SKILL.md
@@ -20,7 +20,7 @@ Two jobs share this rubric. Settle which one you're doing before reading any cod
 - Tag every finding with a severity so real problems aren't buried under taste:
   - **Blocker** — must fix before merge: bug, regression, security issue, broken build/tests, violated repo convention, accidental edit to generated output.
   - **Important** — should fix: unclear naming, missing test for changed behavior, unhandled edge case, scope creep.
-  - **Nit** — optional/taste. Keep these short and few.
+  - **Nit** — optional, and it still has to earn its place: a concrete one-edit fix a later reader benefits from. Everything else is noise — see [What isn't a finding](#what-isnt-a-finding).
 
 ## How to write a finding
 
@@ -36,7 +36,7 @@ Hold your own words to [tone.md](../../../references/tone.md) — the same stand
 
 - **Hedging** — "I think", "it looks like", "consider possibly", "might be worth". Uncertainty is fine; say what you checked instead. "Read the happy path only — 60% sure this leaks."
 - **Throat-clearing** — "just", "simply", "one small thing", "it is important to note". Delete the phrase; the sentence gets stronger.
-- **Praise inside a finding** — "nice refactor, but…". Strengths go in the summary. A finding is the defect and the fix.
+- **Praise inside a finding** — "nice refactor, but…". A finding is the defect and the fix. The summary decides whether a strength is worth a line at all.
 
 **A leaked listener**
 
@@ -44,6 +44,37 @@ Hold your own words to [tone.md](../../../references/tone.md) — the same stand
 - After: "**Blocker** — `packages/ai-chat/src/foo.ts:42` — the early return skips teardown, so the listener leaks on every close. Call `dispose()` before returning."
 
 Cap a finding at three sentences plus a snippet. A concern that outgrows that — a design direction, a pattern repeated across the diff — is not a line comment: give it one line in the summary and move on.
+
+### What isn't a finding
+
+Some observations feel like findings and aren't. These stay unsaid at every severity, not just Nit:
+
+- **A tool already decided it.** Husky runs prettier and eslint on TS/JS, prettier and stylelint on SCSS, prettier on markdown, and commitlint on the message ([commit hooks](../../../references/conventions.md#commit-hooks)). Formatting, quote style, import order, and line length are settled before you open the diff.
+- **A naming swap with no clarity gain** — `data` → `payload`.
+- **An equivalent style alternative** — `for` versus `.map`, ternary versus `if`.
+- **"Add a comment here."** The repo's default is no comments. You are here to flag the ones that restate the code, not to ask for more.
+- **Speculative extraction** — "you might want to pull this out in case…". Scope creep counts from the reviewer's side too.
+- **Code the diff didn't touch.** Real, but not this PR's job — file an issue.
+
+## Run one dimension at a time
+
+One pass over every check spends its attention on the first dimension and skims the rest. Split the review into independent passes, each holding the whole diff and one job. Pick the passes from the changed paths — a docs-only diff gets two, not seven:
+
+| Changed | Passes |
+| --- | --- |
+| Any code | correctness & security, simplicity & scope creep, test coverage |
+| `*.scss`, or any component | accessibility, prefix & SCSS, logic trapped in a component |
+| `*.md`, or JSDoc on public types | tone & docs |
+| `package.json` | dependencies |
+| Always | acceptance criteria & ADRs, commit format |
+
+Dispatch them in parallel when the harness gives you sub-agents (see [AGENTS.md](../../../AGENTS.md)); run them as separate sequential passes when it doesn't. Either way, every pass gets the same brief: its one dimension, the finding shape above, and [What isn't a finding](#what-isnt-a-finding). A pass told only to find things will manufacture Nits to justify itself.
+
+A pass returns findings and nothing else — no verdict, no cap, no ranking. It can't rank what it can't see.
+
+**Synthesize before you write anything.** Merge the passes, drop duplicates, rank by severity across all of them, then apply the caps and write the verdict per [Output expectations](#output-expectations). Skip this and you ship N reviews stapled together.
+
+Skip the split under ~5 changed files. One pass reads that much without losing the thread.
 
 ## Evaluate the changes
 
@@ -92,10 +123,10 @@ For each changed file, read every `AGENTS.md` on the path from its directory up 
 
 ## Output expectations
 
-- **Lead the summary with the verdict on one line** — ship, fix blockers, or rework — before any context. Then 2–3 sentences: what the change does well, and the highest-severity concerns.
+- **Open with the verdict on one line** — ship, fix blockers, or rework. Nothing precedes it: no greeting, no "great work on this", no recap of what the PR does. The author wrote the diff and does not need it read back.
+- **Then at most three lines**, carrying only what the verdict rests on: the blocking concerns, any design-level concern that outgrew a finding, and the dropped-finding count. A strength earns a line only when it was the risk and it landed — "the migration path handles the null case, which was the hard part." Generic praise is padding; cut it.
 - List findings grouped by severity (**Blocker**, **Important**, **Nit**), each written to the shape above.
-- **Cap the review at ten findings**, highest severity first. Drop Nits first, then Importants, and name the drop in one summary line: "12 further Nits (naming, comment wording) not listed." A review nobody finishes fixes nothing, and a silent cut reads as full coverage.
-- Carry design-level concerns in the summary too, one line each — they are what a finding overflows into.
+- **Cap the review at ten findings and three Nits**, highest severity first. Drop Nits first, then Importants, and name the drop in one summary line: "12 further Nits (naming, comment wording) not listed." A review nobody finishes fixes nothing, and a silent cut reads as full coverage.
 - End with a **Test / verification gaps** section if the diff lacks coverage for changed behavior.
 
 ## Related guidance

--- a/.bob/skills/caic-review/references/large-diffs.md
+++ b/.bob/skills/caic-review/references/large-diffs.md
@@ -1,0 +1,47 @@
+# large-diffs.md — reviewing a diff too big to read evenly
+
+Load this when reading the whole diff at one depth would mean reading all of it shallowly: the file list scrolls past a screen, or you catch yourself skimming to keep moving. Rank the files first, then run the dimension passes from [caic-review](../SKILL.md) over whatever the ranking puts on top.
+
+No line count triggers this. A 600-line lockfile bump is not a large diff; four files rewriting the store is.
+
+## Rank before you read
+
+Sort the changed files by risk per line, then spend attention in that order.
+
+**Costs a glance, not a read**
+
+- Pure renames and moves. `git diff -M --stat` reports a similarity index; at 100% there is nothing to review but the new path.
+- `package-lock.json`. Review the `package.json` change that caused it.
+- Generated output, per the never-edit list in [AGENTS.md](../../../../AGENTS.md). None of it belongs in a diff, so finding some is a **Blocker** on sight and costs no reading at all.
+
+**Read in full**
+
+- `packages/ai-chat/src/types/**` — the public contract. A wrong line here ships to consumers and comes back only in a major.
+- `packages/ai-chat/src/chat/store/**` — reducers and state transitions, where a broken reference costs a re-render nobody asked for.
+- Any file whose directory carries its own `AGENTS.md`. That file exists because the area has rules that are easy to get wrong.
+- New files. There is no unchanged context to lean on — all of it is new logic.
+
+**Read the hunks, not the file**
+
+Everything else. Risk concentrates where the diff landed, and the surrounding code was reviewed once already.
+
+## Size is a finding
+
+A diff nobody can review well does not become reviewable by being reviewed anyway. When the change should have been several PRs, say so:
+
+- **Important** by default. Name the seams — which files would have made the second PR.
+- **Blocker** when the PR bundles unrelated work. That is scope creep, already a Blocker on its own; size is just how it surfaced.
+
+Mechanical bulk is not the same thing. A rename sweep across sixty files is one job, and it reviews fine once the ranking above drops it into the glance tier.
+
+## Say what you read
+
+A partial review that reads as a complete one is worse than no review. Close the summary with your coverage, alongside the dropped-finding count:
+
+> Read the store changes and public types in full. Skimmed 14 test-fixture updates and the lockfile.
+
+## Related guidance
+
+- [caic-review](../SKILL.md) — the rubric this triage feeds
+- [reviewing-a-pr.md](reviewing-a-pr.md) — base-branch resolution, which decides how large the diff even is
+- [Root AGENTS.md](../../../../AGENTS.md) — the generated-output list and the repo layout

--- a/.bob/skills/caic-review/references/large-diffs.md
+++ b/.bob/skills/caic-review/references/large-diffs.md
@@ -10,9 +10,9 @@ Sort the changed files by risk per line, then spend attention in that order.
 
 **Costs a glance, not a read**
 
-- Pure renames and moves. `git diff -M --stat` reports a similarity index; at 100% there is nothing to review but the new path.
+- Pure renames and moves. `git diff -M --summary` reports a similarity index; at 100% there is nothing to review but the new path.
 - `package-lock.json`. Review the `package.json` change that caused it.
-- Generated output, per the never-edit list in [AGENTS.md](../../../../AGENTS.md). None of it belongs in a diff, so finding some is a **Blocker** on sight and costs no reading at all.
+- Generated output this repo does not commit, per the never-edit list in [AGENTS.md](../../../../AGENTS.md) — an edit there is a **Blocker** on sight and costs no reading at all. The telemetry configs are the exception on that list: `packages/ai-chat/telemetry.yml` and `packages/ai-chat-components/telemetry.yml` are committed and regenerated, so they belong in the diff. Glance and move on.
 
 **Read in full**
 

--- a/.bob/skills/caic-review/references/reviewing-a-pr.md
+++ b/.bob/skills/caic-review/references/reviewing-a-pr.md
@@ -42,7 +42,7 @@ gh api --method POST repos/<owner>/<repo>/pulls/<pr>/reviews --input .github/pr-
 ```
 
 - **`event`** is `COMMENT` (feedback only), `APPROVE`, or `REQUEST_CHANGES`. Ask the user which — the review event is theirs, not yours. The verdict line still opens the body, per [Output expectations](../SKILL.md#output-expectations). GitHub rejects `APPROVE` and `REQUEST_CHANGES` on your own PR, so a self-authored PR can only take `COMMENT`.
-- **`line`** is the line number in the file as of `commit_id`, and it must fall inside the diff. `side: "RIGHT"` is the post-change file; use `"LEFT"` for a removed line. For a range, add `start_line` (and `start_side`).
+- **`line`** is the line number in the file as of `commit_id`, and it must fall inside the diff. `side: "RIGHT"` is the post-change file; use `"LEFT"` for a removed line. For a range, add `start_line` (and `start_side`). These fields carry the citation, so drop `file:line` from the comment body and keep the rest of the finding's order.
 - A comment outside the diff hunks returns 422. Put that finding in the summary `body` rather than forcing a line onto it.
 - A fix that replaces a line range ships as a fenced `suggestion` block in the comment body, so the author commits it from the PR page. The block replaces exactly the commented range — set `start_line` to match. A fix spanning files stays prose.
 

--- a/.bob/skills/caic-review/references/reviewing-a-pr.md
+++ b/.bob/skills/caic-review/references/reviewing-a-pr.md
@@ -44,6 +44,7 @@ gh api --method POST repos/<owner>/<repo>/pulls/<pr>/reviews --input .github/pr-
 - **`event`** is `COMMENT` (feedback only), `APPROVE`, or `REQUEST_CHANGES`. Ask the user which — the review event is theirs, not yours. The verdict line still opens the body, per [Output expectations](../SKILL.md#output-expectations). GitHub rejects `APPROVE` and `REQUEST_CHANGES` on your own PR, so a self-authored PR can only take `COMMENT`.
 - **`line`** is the line number in the file as of `commit_id`, and it must fall inside the diff. `side: "RIGHT"` is the post-change file; use `"LEFT"` for a removed line. For a range, add `start_line` (and `start_side`).
 - A comment outside the diff hunks returns 422. Put that finding in the summary `body` rather than forcing a line onto it.
+- A fix that replaces a line range ships as a fenced `suggestion` block in the comment body, so the author commits it from the PR page. The block replaces exactly the commented range — set `start_line` to match. A fix spanning files stays prose.
 
 ## Related guidance
 

--- a/.bob/skills/caic-review/references/reviewing-a-pr.md
+++ b/.bob/skills/caic-review/references/reviewing-a-pr.md
@@ -1,6 +1,6 @@
 # reviewing-a-pr.md — what changes when the target is a pull request
 
-Load this when the review target is a PR rather than your own working diff — someone else's branch, or your own PR up for review. A self-review posts nothing, so none of this applies to it.
+Load this when the review target is a PR rather than your own working diff — someone else's branch, or your own PR up for review. Both sections below need a PR number, so neither applies to a self-review; that path names its own range in [caic-review](../SKILL.md#scope-the-review-first).
 
 The rubric itself doesn't change: score the diff with [caic-review](../SKILL.md), then come back here to post.
 
@@ -41,7 +41,7 @@ Line comments beat a wall of prose: they land next to the code they're about. Bu
 gh api --method POST repos/<owner>/<repo>/pulls/<pr>/reviews --input .github/pr-drafts/review-<pr>.json
 ```
 
-- **`event`** is `COMMENT` (feedback only), `APPROVE`, or `REQUEST_CHANGES`. Ask the user which — the verdict is theirs, not yours. GitHub rejects `APPROVE` and `REQUEST_CHANGES` on your own PR, so a self-authored PR can only take `COMMENT`.
+- **`event`** is `COMMENT` (feedback only), `APPROVE`, or `REQUEST_CHANGES`. Ask the user which — the review event is theirs, not yours. The verdict line still opens the body, per [Output expectations](../SKILL.md#output-expectations). GitHub rejects `APPROVE` and `REQUEST_CHANGES` on your own PR, so a self-authored PR can only take `COMMENT`.
 - **`line`** is the line number in the file as of `commit_id`, and it must fall inside the diff. `side: "RIGHT"` is the post-change file; use `"LEFT"` for a removed line. For a range, add `start_line` (and `start_side`).
 - A comment outside the diff hunks returns 422. Put that finding in the summary `body` rather than forcing a line onto it.
 

--- a/.bob/skills/caic-review/references/reviewing-a-pr.md
+++ b/.bob/skills/caic-review/references/reviewing-a-pr.md
@@ -1,0 +1,53 @@
+# reviewing-a-pr.md — what changes when the target is a pull request
+
+Load this when the review target is a PR rather than your own working diff — someone else's branch, or your own PR up for review. A self-review posts nothing, so none of this applies to it.
+
+The rubric itself doesn't change: score the diff with [caic-review](../SKILL.md), then come back here to post.
+
+## Resolve the base branch before diffing
+
+Never assume `main`. A PR usually targets `upstream/main`, but long-running integration branches are common here, and diffing against the wrong base buries the review under unrelated commits.
+
+```bash
+gh pr view <pr> --json baseRefName,headRefName,headRefOid,isCrossRepository,url
+gh pr diff <pr>   # already scoped to the PR's real base
+```
+
+Use `gh pr diff`, or diff explicitly against the reported `baseRefName`. When the base is an integration branch rather than `main`, say so in the summary — it changes what is in scope and what counts as a regression.
+
+## Posting the review
+
+Line comments beat a wall of prose: they land next to the code they're about. Build the whole review as one payload and submit it once.
+
+**Draft first, submit second. Never run a `gh` command that writes to GitHub before the user has seen the exact payload and said go.** Write it to `.github/pr-drafts/review-<pr>.json` (git-ignored), show the summary and findings, then wait.
+
+```json
+{
+  "commit_id": "<headRefOid from gh pr view>",
+  "event": "COMMENT",
+  "body": "Fix blockers before merge. <assessment, highest-severity concerns, anything dropped>",
+  "comments": [
+    {
+      "path": "packages/ai-chat/src/foo.ts",
+      "line": 42,
+      "side": "RIGHT",
+      "body": "**Blocker** — the early return skips teardown, so the listener leaks on every close. Call `dispose()` before returning."
+    }
+  ]
+}
+```
+
+```bash
+gh api --method POST repos/<owner>/<repo>/pulls/<pr>/reviews --input .github/pr-drafts/review-<pr>.json
+```
+
+- **`event`** is `COMMENT` (feedback only), `APPROVE`, or `REQUEST_CHANGES`. Ask the user which — the verdict is theirs, not yours. GitHub rejects `APPROVE` and `REQUEST_CHANGES` on your own PR, so a self-authored PR can only take `COMMENT`.
+- **`line`** is the line number in the file as of `commit_id`, and it must fall inside the diff. `side: "RIGHT"` is the post-change file; use `"LEFT"` for a removed line. For a range, add `start_line` (and `start_side`).
+- A comment outside the diff hunks returns 422. Put that finding in the summary `body` rather than forcing a line onto it.
+
+## Related guidance
+
+- [caic-review](../SKILL.md) — the rubric that produces the findings posted here
+- [caic-pr](../../caic-pr/SKILL.md) — drafting the PR description, and opening the PR itself
+- [conventions.md](../../../../references/conventions.md) — commits, branches, PR titles
+- [Root AGENTS.md](../../../../AGENTS.md) — repo overview and pointer index

--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -12,7 +12,7 @@ Skills exist because always-on guidance and task guidance need different deliver
 | [caic-plan](caic-plan/SKILL.md)     | shaping upcoming work at any size — a plan, an epic, or a single issue-sized slice | the plan-review rubric it closes with |
 | [caic-issue](caic-issue/SKILL.md)   | filing a GitHub issue or sub-issue                                                 | epic authoring, for umbrella work     |
 | [caic-pr](caic-pr/SKILL.md)         | drafting a PR description                                                          | —                                     |
-| [caic-review](caic-review/SKILL.md) | reviewing a diff, including self-review before marking a task done                 | —                                     |
+| [caic-review](caic-review/SKILL.md) | reviewing a diff, including self-review before marking a task done                 | PR posting, and large-diff triage     |
 
 `carbon-builder` also lives here. It is a vendored Carbon Design System skill from upstream, not a repo workflow — the sync and mirror rules below apply to it, but its content is not ours to edit.
 

--- a/.claude/skills/caic-review/SKILL.md
+++ b/.claude/skills/caic-review/SKILL.md
@@ -9,7 +9,7 @@ This rubric governs every code review in this repo — both user-requested revie
 
 Two jobs share this rubric. Settle which one you're doing before reading any code — ask the user when the request doesn't make it obvious:
 
-- **Own work** — a self-review of the working diff before marking a task done. Findings come back as text; nothing is posted anywhere. Hand it to a sub-agent when you have one: the context that wrote the diff already justified every choice in it, and re-reading it there replays those justifications instead of testing them. Give the sub-agent the diff and this rubric — not your reasoning for the changes, which is the bias you're trying to escape.
+- **Own work** — a self-review of the working diff before marking a task done. Findings come back as text; nothing is posted anywhere. Name the range first: `git diff` while the work is uncommitted, `git diff <base>...HEAD` once it is committed, where `<base>` is the branch you will merge into. An empty range means you picked the wrong one, not that the work is clean. Hand it to a sub-agent when you have one: the context that wrote the diff already justified every choice in it, and re-reading it there replays those justifications instead of testing them. Give the sub-agent the diff and this rubric — not your reasoning for the changes, which is the bias you're trying to escape.
 - **A pull request** — someone else's branch, or your own PR up for review. Findings can be posted as line comments with a verdict. Read [reviewing-a-pr.md](references/reviewing-a-pr.md) before you diff: it carries base-branch resolution and the posting payload.
 
 ## How to review
@@ -22,6 +22,7 @@ Two jobs share this rubric. Settle which one you're doing before reading any cod
   - **Blocker** — must fix before merge: bug, regression, security issue, broken build/tests, violated repo convention, accidental edit to generated output.
   - **Important** — should fix: unclear naming, missing test for changed behavior, unhandled edge case, scope creep.
   - **Nit** — optional, and it still has to earn its place: a concrete one-edit fix a later reader benefits from. Everything else is noise — see [What isn't a finding](#what-isnt-a-finding).
+- Read enough to be sure before you call something a **Blocker**. A false Blocker costs the author as much as a missed one. If you have only read the happy path, file it as **Important** and say what you did not read.
 
 ## How to write a finding
 
@@ -61,21 +62,24 @@ A pass — or a whole review — that surfaces nothing is finished, not failed. 
 
 ## Run one dimension at a time
 
-One pass over every check spends its attention on the first dimension and skims the rest. Split the review into independent passes, each holding the whole diff and one job. Pick the passes from the changed paths — a docs-only diff gets two, not seven:
+One pass over every check spends its attention on the first dimension and skims the rest. Split the review into independent passes, each holding the whole diff and one job. Pick the passes from the changed paths — a docs-only diff gets two of them, not the whole table:
 
 | Changed | Passes |
 | --- | --- |
 | Any code | correctness & security, simplicity & scope creep, test coverage |
-| `*.scss`, or any component | accessibility, prefix & SCSS, logic trapped in a component |
-| `*.md`, or JSDoc on public types | tone & docs |
+| `*.scss`, or any component | accessibility, prefix & SCSS, component placement & trapped logic |
+| `AGENTS.md`, `**/references/**`, `.bob/skills/**`, `.github/copilot-instructions.md` | spec conformance, tone & docs |
+| Any other `*.md`, or JSDoc on public types | tone & docs |
 | `package.json` | dependencies |
 | Always | acceptance criteria & ADRs |
 
-Dispatch them in parallel when the harness gives you sub-agents (see [AGENTS.md](../../../AGENTS.md)); run them as separate sequential passes when it doesn't. Either way, every pass gets the same brief: its one dimension, the finding shape above, and [What isn't a finding](#what-isnt-a-finding). A pass told only to find things will manufacture Nits to justify itself.
+Markdown that tells an agent what to do is a specification, not copy. The spec-conformance pass asks whether an agent following the changed text does the right thing, and holds it to [authoring-agents-md.md](../../../references/authoring-agents-md.md) — the line budget, one topic per file, a "read when" trigger on every reference link, and the Related guidance footer.
+
+Dispatch them in parallel when the harness gives you sub-agents (see [AGENTS.md](../../../AGENTS.md)); run them as separate sequential passes when it doesn't. Either way, every pass gets the same brief: the diff, this rubric by path, its one dimension, and the `AGENTS.md` files governing the paths it holds ([Repo-specific checks](#repo-specific-checks)). The finding shape and [What isn't a finding](#what-isnt-a-finding) travel with the rubric. A pass told only to find things will manufacture Nits to justify itself.
 
 A pass returns findings and nothing else — no verdict, no cap, no ranking. It can't rank what it can't see.
 
-**Synthesize before you write anything.** Merge the passes, drop duplicates, rank by severity across all of them, then apply the caps and write the verdict per [Output expectations](#output-expectations). Skip this and you ship N reviews stapled together.
+**Synthesize before you write anything.** Merge the passes, then read them against each other before you rank. Two findings are duplicates when they name the same root cause, not merely the same line — on a merge, keep the higher severity and union the fixes. Where two passes cite the same file or symbol for different reasons, decide whether you hold two findings or one larger defect neither pass could see alone. Then rank by severity, apply the caps, and write the verdict per [Output expectations](#output-expectations). Skip this and you ship N reviews stapled together.
 
 Skip the split when a single reading holds the whole diff in view. Splitting a handful of lines across five passes is ceremony.
 
@@ -104,7 +108,7 @@ Skip the split when a single reading holds the whole diff in view. Splitting a h
 
 - Identify which changed behavior is currently untested.
 - Recommend the test style appropriate to the package:
-  - `@carbon/ai-chat` — Jest, specs under `packages/ai-chat/tests/spec/**/*_spec.ts(x)`.
+  - `@carbon/ai-chat` — Jest, specs under `packages/ai-chat/tests/<area>/spec/**/*_spec.ts(x)` ([tests.md](../../../packages/ai-chat/references/tests.md)).
   - `@carbon/ai-chat-components` — `@web/test-runner` for Lit components (colocated `__tests__/*.test.ts`) and Jest for the React wrappers.
   - `demo/` — Playwright under `demo/tests/`.
   - `examples/**` — Playwright smoke tests (see [playwright.md](../../../examples/references/playwright.md)).

--- a/.claude/skills/caic-review/SKILL.md
+++ b/.claude/skills/caic-review/SKILL.md
@@ -49,7 +49,7 @@ Cap a finding at three sentences plus a snippet. A concern that outgrows that �
 
 Some observations feel like findings and aren't. These stay unsaid at every severity, not just Nit:
 
-- **A tool already decided it.** Husky runs prettier and eslint on TS/JS, prettier and stylelint on SCSS, prettier on markdown, and commitlint on the message ([commit hooks](../../../references/conventions.md#commit-hooks)). Formatting, quote style, import order, and line length are settled before you open the diff.
+- **A tool already decided it.** Husky runs prettier, eslint, stylelint, and commitlint on what you commit ([commit hooks](../../../references/conventions.md#commit-hooks)); `ci-check` adds license headers plus ADR, AGENTS, skill, and example-README validation. Formatting, quote style, import order, line length, and anything else a gate fails on are settled before you open the diff.
 - **A naming swap with no clarity gain** — `data` → `payload`.
 - **An equivalent style alternative** — `for` versus `.map`, ternary versus `if`.
 - **"Add a comment here."** The repo's default is no comments. You are here to flag the ones that restate the code, not to ask for more.
@@ -66,7 +66,7 @@ One pass over every check spends its attention on the first dimension and skims 
 | `*.scss`, or any component | accessibility, prefix & SCSS, logic trapped in a component |
 | `*.md`, or JSDoc on public types | tone & docs |
 | `package.json` | dependencies |
-| Always | acceptance criteria & ADRs, commit format |
+| Always | acceptance criteria & ADRs |
 
 Dispatch them in parallel when the harness gives you sub-agents (see [AGENTS.md](../../../AGENTS.md)); run them as separate sequential passes when it doesn't. Either way, every pass gets the same brief: its one dimension, the finding shape above, and [What isn't a finding](#what-isnt-a-finding). A pass told only to find things will manufacture Nits to justify itself.
 
@@ -116,8 +116,6 @@ For each changed file, read every `AGENTS.md` on the path from its directory up 
 - **Logic trapped in a component** — parsing, formatting, validation, state transitions, or timing/geometry math written inside a React or Lit component instead of a plain module it could call ([framework-agnostic logic](../../../references/code-patterns.md#framework-agnostic-logic)). The tell is a behavior you could only test by rendering.
 - **New components added under `packages/ai-chat/src/chat/components-legacy/`** — that directory is closed to new components ([component placement](../../../references/code-patterns.md#component-placement)).
 - **Prefix / SCSS violations** — hardcoded `cds--`, missing `#{$prefix}--`, descendant nesting, or physical properties instead of logical ones for RTL ([naming & prefix discipline](../../../references/code-patterns.md#naming--prefix-discipline-build-breaking), [SCSS authoring](../../../references/code-patterns.md#scss-authoring)).
-- **Conventional-commit format** on the PR title / squash commit ([commits](../../../references/conventions.md#commits)).
-- **Examples**: each example's README still satisfies the Indexer contract described in [examples/AGENTS.md](../../../examples/AGENTS.md).
 - **Accessibility** on UI changes: keyboard navigation, focus management, ARIA roles/labels, color contrast, and RTL behavior. Carbon is a design system — a11y regressions are blockers.
 - **Dependencies**: new or upgraded packages should be justified; flag peer-dep conflicts, duplicate functionality already available via existing deps, or license incompatibilities.
 

--- a/.claude/skills/caic-review/SKILL.md
+++ b/.claude/skills/caic-review/SKILL.md
@@ -10,48 +10,7 @@ This rubric governs every code review in this repo — both user-requested revie
 Two jobs share this rubric. Settle which one you're doing before reading any code — ask the user when the request doesn't make it obvious:
 
 - **Own work** — a self-review of the working diff before marking a task done. Findings come back as text; nothing is posted anywhere.
-- **A pull request** — someone else's branch, or your own PR up for review. Findings can be posted as line comments with a verdict.
-
-### On a PR, resolve the base branch before diffing
-
-Never assume `main`. A PR usually targets `upstream/main`, but long-running integration branches are common here, and diffing against the wrong base buries the review under unrelated commits.
-
-```bash
-gh pr view <pr> --json baseRefName,headRefName,headRefOid,isCrossRepository,url
-gh pr diff <pr>   # already scoped to the PR's real base
-```
-
-Use `gh pr diff`, or diff explicitly against the reported `baseRefName`. When the base is an integration branch rather than `main`, say so in the summary — it changes what is in scope and what counts as a regression.
-
-## Posting a review on a PR
-
-Line comments beat a wall of prose: they land next to the code they're about. Build the whole review as one payload and submit it once.
-
-**Draft first, submit second. Never run a `gh` command that writes to GitHub before the user has seen the exact payload and said go.** Write it to `.github/pr-drafts/review-<pr>.json` (git-ignored), show the summary and findings, then wait.
-
-```json
-{
-  "commit_id": "<headRefOid from gh pr view>",
-  "event": "COMMENT",
-  "body": "Fix blockers before merge. <assessment, highest-severity concerns, anything dropped>",
-  "comments": [
-    {
-      "path": "packages/ai-chat/src/foo.ts",
-      "line": 42,
-      "side": "RIGHT",
-      "body": "**Blocker** — the early return skips teardown, so the listener leaks on every close. Call `dispose()` before returning."
-    }
-  ]
-}
-```
-
-```bash
-gh api --method POST repos/<owner>/<repo>/pulls/<pr>/reviews --input .github/pr-drafts/review-<pr>.json
-```
-
-- **`event`** is `COMMENT` (feedback only), `APPROVE`, or `REQUEST_CHANGES`. Ask the user which — the verdict is theirs, not yours. GitHub rejects `APPROVE` and `REQUEST_CHANGES` on your own PR, so a self-authored PR can only take `COMMENT`.
-- **`line`** is the line number in the file as of `commit_id`, and it must fall inside the diff. `side: "RIGHT"` is the post-change file; use `"LEFT"` for a removed line. For a range, add `start_line` (and `start_side`).
-- A comment outside the diff hunks returns 422. Put that finding in the summary `body` rather than forcing a line onto it.
+- **A pull request** — someone else's branch, or your own PR up for review. Findings can be posted as line comments with a verdict. Read [reviewing-a-pr.md](references/reviewing-a-pr.md) before you diff: it carries base-branch resolution and the posting payload.
 
 ## How to review
 
@@ -148,6 +107,7 @@ For context on conventions being enforced:
 - **Process conventions**: [conventions.md](../../../references/conventions.md) — commits, branches, license headers, hooks
 - **General overview**: [AGENTS.md](../../../AGENTS.md) — monorepo pointer index
 - **Package-specific rules**: see `AGENTS.md` in each package directory
+- **Reviewing a PR**: [reviewing-a-pr.md](references/reviewing-a-pr.md) — base branch, the review payload, and the `gh` call
 - **PR workflow**: [caic-pr](../caic-pr/SKILL.md) — drafting PR descriptions
 - **Plan-phase analog**: [plan-review.md](../caic-plan/references/plan-review.md) — the same discipline applied before code exists
 

--- a/.claude/skills/caic-review/SKILL.md
+++ b/.claude/skills/caic-review/SKILL.md
@@ -9,7 +9,7 @@ This rubric governs every code review in this repo — both user-requested revie
 
 Two jobs share this rubric. Settle which one you're doing before reading any code — ask the user when the request doesn't make it obvious:
 
-- **Own work** — a self-review of the working diff before marking a task done. Findings come back as text; nothing is posted anywhere.
+- **Own work** — a self-review of the working diff before marking a task done. Findings come back as text; nothing is posted anywhere. Hand it to a sub-agent when you have one: the context that wrote the diff already justified every choice in it, and re-reading it there replays those justifications instead of testing them. Give the sub-agent the diff and this rubric — not your reasoning for the changes, which is the bias you're trying to escape.
 - **A pull request** — someone else's branch, or your own PR up for review. Findings can be posted as line comments with a verdict. Read [reviewing-a-pr.md](references/reviewing-a-pr.md) before you diff: it carries base-branch resolution and the posting payload.
 
 ## How to review
@@ -55,6 +55,8 @@ Some observations feel like findings and aren't. These stay unsaid at every seve
 - **"Add a comment here."** The repo's default is no comments. You are here to flag the ones that restate the code, not to ask for more.
 - **Speculative extraction** — "you might want to pull this out in case…". Scope creep counts from the reviewer's side too.
 - **Code the diff didn't touch.** Real, but not this PR's job — file an issue.
+
+A pass — or a whole review — that surfaces nothing is finished, not failed. Say so and stop. Manufacturing a Nit to look thorough costs the author more than the silence would.
 
 ## Run one dimension at a time
 

--- a/.claude/skills/caic-review/SKILL.md
+++ b/.claude/skills/caic-review/SKILL.md
@@ -23,6 +23,7 @@ Two jobs share this rubric. Settle which one you're doing before reading any cod
   - **Important** — should fix: unclear naming, missing test for changed behavior, unhandled edge case, scope creep.
   - **Nit** — optional, and it still has to earn its place: a concrete one-edit fix a later reader benefits from. Everything else is noise — see [What isn't a finding](#what-isnt-a-finding).
 - Read enough to be sure before you call something a **Blocker**. A false Blocker costs the author as much as a missed one. If you have only read the happy path, file it as **Important** and say what you did not read.
+- When you can run commands, run the read-only gates for what changed before you write anything — `lint`, `lint:license`, `lint:styles`, `validate:*`, `format`. A failure you watched outranks one you inferred. Never start a build or a test run yourself: the rows in [definition-of-done.md](../../../references/definition-of-done.md) all build, and a build races the watcher a developer probably has running. Report an unrun build as a stated gap.
 
 ## How to write a finding
 
@@ -34,6 +35,8 @@ One shape, one order — severity, the defect, what it costs, the fix:
 
 Cite a range when the defect spans lines, and show the fix as a snippet when words alone won't carry it. Never post the objection without the fix. In a line comment on a PR, the `path` and `line` fields carry the citation — drop it from the body and keep the rest of the order.
 
+The consequence names the input or path that reaches the defect — "on every close", "when the list is empty" — not the category. A defect you can't trigger is a guess: drop it, or say what you didn't check.
+
 Hold your own words to [tone.md](../../../references/tone.md) — the same standard you hold the diff's copy to. Three habits show up in reviews and all three go:
 
 - **Hedging** — "I think", "it looks like", "consider possibly", "might be worth". Uncertainty is fine; say what you checked instead. "Read the happy path only — 60% sure this leaks."
@@ -44,6 +47,11 @@ Hold your own words to [tone.md](../../../references/tone.md) — the same stand
 
 - Before: "I might be missing something, but I wonder if it could possibly be worth considering whether this early return may want to clean up the listener it registered above, since otherwise it seems like it might leak? Nice refactor overall though!"
 - After: "**Blocker** — `packages/ai-chat/src/foo.ts:42` — the early return skips teardown, so the listener leaks on every close. Call `dispose()` before returning."
+
+The other two severities, written the same way:
+
+- **Important** — `packages/ai-chat/src/chat/store/fooReducer.ts:88` — the reducer rebuilds every item, so one changed message re-renders the whole list. Copy the array and replace the one index.
+- **Nit** — `packages/ai-chat/src/types/config/FooConfig.ts:12` — the JSDoc says "the timeout" with no unit, so a caller guesses seconds. Say "in milliseconds."
 
 Cap a finding at three sentences plus a snippet. A concern that outgrows that — a design direction, a pattern repeated across the diff — is not a line comment: give it one line in the summary and move on.
 
@@ -79,7 +87,9 @@ Dispatch them in parallel when the harness gives you sub-agents (see [AGENTS.md]
 
 A pass returns findings and nothing else — no verdict, no cap, no ranking. It can't rank what it can't see.
 
-**Synthesize before you write anything.** Merge the passes, then read them against each other before you rank. Two findings are duplicates when they name the same root cause, not merely the same line — on a merge, keep the higher severity and union the fixes. Where two passes cite the same file or symbol for different reasons, decide whether you hold two findings or one larger defect neither pass could see alone. Then rank by severity, apply the caps, and write the verdict per [Output expectations](#output-expectations). Skip this and you ship N reviews stapled together.
+**Refute before you synthesize.** The caps cut volume, never falsity: a wrong Blocker is unique, top-ranked, and never dropped, so it survives every other step. Take each Blocker and Important and argue the other side — name the code path that makes it wrong. A finding you can't refute ships; one you can, dies silently. Hand this to a sub-agent with the diff and the findings, not the passes' reasoning, when the harness has one; run it as your own last pass when it doesn't. Nits skip it — they are cheap to be wrong about.
+
+**Synthesize before you write anything.** Merge the passes, then read them against each other before you rank. Two findings are duplicates when they name the same root cause, not merely the same line — on a merge, keep the higher severity and union the fixes. Where two passes cite the same file or symbol for different reasons, decide whether you hold two findings or one larger defect neither pass could see alone. A finding you create here is new, so refute it before it ships — surviving refutation twice says nothing about the claim that joins them. Then rank by severity, apply the caps, and write the verdict per [Output expectations](#output-expectations). Skip this and you ship N reviews stapled together.
 
 Skip the split when a single reading holds the whole diff in view. Splitting a handful of lines across five passes is ceremony.
 
@@ -117,7 +127,7 @@ Skip the split when a single reading holds the whole diff in view. Splitting a h
 
 ## Repo-specific checks
 
-For each changed file, read every `AGENTS.md` on the path from its directory up to the repo root, plus any topic docs under their `references/` folders they link to — e.g. a change under `packages/ai-chat-components/src/components/audio-player/` is governed by [packages/ai-chat-components/AGENTS.md](../../../packages/ai-chat-components/AGENTS.md) then the root [AGENTS.md](../../../AGENTS.md). Rule definitions live in [code-patterns.md](../../../references/code-patterns.md) and [conventions.md](../../../references/conventions.md); this list is what to flag. Flag any of:
+For each changed file, read every `AGENTS.md` on the path from its directory up to the repo root, plus any topic docs under their `references/` folders they link to — e.g. a change under `packages/ai-chat-components/src/components/audio-player/` is governed by [packages/ai-chat-components/AGENTS.md](../../../packages/ai-chat-components/AGENTS.md) then the root [AGENTS.md](../../../AGENTS.md). Rule definitions live in [code-patterns.md](../../../references/code-patterns.md) and [conventions.md](../../../references/conventions.md); this list is what to flag. A convention finding links the rule it breaks — an anchor in one of those two files, or the governing `AGENTS.md`. No link, no finding: you are quoting a convention this repo may not have. Flag any of:
 
 - **Over-engineering** — code the [laziness ladder](../../../references/code-patterns.md#writing-the-least-code-laziness-ladder) would have avoided: dead code or unused flexibility (delete it), JS re-creating what CSS or a native element/browser API already does, a dependency duplicating Carbon or an existing one, an abstraction with a single caller (YAGNI), or logic expressible in fewer lines. Correctness and security stay in the sections above — this check is only about removable complexity.
 - **Logic trapped in a component** — parsing, formatting, validation, state transitions, or timing/geometry math written inside a React or Lit component instead of a plain module it could call ([framework-agnostic logic](../../../references/code-patterns.md#framework-agnostic-logic)). The tell is a behavior you could only test by rendering.

--- a/.claude/skills/caic-review/SKILL.md
+++ b/.claude/skills/caic-review/SKILL.md
@@ -9,14 +9,17 @@ This rubric governs every code review in this repo — both user-requested revie
 
 Two jobs share this rubric. Settle which one you're doing before reading any code — ask the user when the request doesn't make it obvious:
 
-- **Own work** — a self-review of the working diff before marking a task done. Findings come back as text; nothing is posted anywhere. Name the range first: `git diff` while the work is uncommitted, `git diff <base>...HEAD` once it is committed, where `<base>` is the branch you will merge into. An empty range means you picked the wrong one, not that the work is clean. Hand it to a sub-agent when you have one: the context that wrote the diff already justified every choice in it, and re-reading it there replays those justifications instead of testing them. Give the sub-agent the diff and this rubric — not your reasoning for the changes, which is the bias you're trying to escape.
+- **Own work** — a self-review of the working diff before marking a task done. Findings come back as text; nothing is posted anywhere.
+  - **Name the range first.** `git diff` while the work is uncommitted, `git diff <base>...HEAD` once it is committed, where `<base>` is the branch you will merge into. An empty range means you picked the wrong one, not that the work is clean.
+  - **Hand it to a sub-agent when you have one.** The context that wrote the diff already justified every choice in it, and re-reading it there replays those justifications instead of testing them.
+  - **Pass the requirement, withhold the defense.** The sub-agent gets the diff, this rubric, and what the work had to satisfy — the issue or the user's ask, plus any ADR it cites. It does not get your design notes, the options you ruled out, or the plan's commentary. The requirement is what the review scores against; your reasoning is the bias you're trying to escape. A concern you already resolved comes back cheap — answer it in a line, and if the answer was worth having, it belonged in a comment or an ADR.
 - **A pull request** — someone else's branch, or your own PR up for review. Findings can be posted as line comments with a verdict. Read [reviewing-a-pr.md](references/reviewing-a-pr.md) before you diff: it carries base-branch resolution and the posting payload.
 
 ## How to review
 
 - Read the actual diff (`git diff`, `gh pr diff`, etc.) and referenced files — never a summary of what changed.
 - When reading it all at one depth would mean reading all of it shallowly, rank the files by risk first — [large-diffs.md](references/large-diffs.md).
-- Open the issue the PR closes and walk its acceptance criteria against the diff. A criterion the diff contradicts is a **Blocker** until the issue carries an amendment saying so.
+- Open the issue the work closes and walk its acceptance criteria against the diff — for a self-review, the issue or ask the task came from. A criterion the diff contradicts is a **Blocker** until the issue carries an amendment saying so.
 - If the issue or its epic cites an ADR, read that ADR's Decision outcome and walk the diff against it too. A diff that contradicts an accepted ADR is a **Blocker** until a new ADR supersedes it — an implementation PR is not where a recorded decision gets reversed.
 - Tag every finding with a severity so real problems aren't buried under taste:
   - **Blocker** — must fix before merge: bug, regression, security issue, broken build/tests, violated repo convention, accidental edit to generated output.
@@ -33,7 +36,7 @@ One shape, one order — severity, the defect, what it costs, the fix:
 **<Severity>** — `path/to/file.ts:42` — <what is wrong>, so <what it costs>. <The fix.>
 ```
 
-Cite a range when the defect spans lines, and show the fix as a snippet when words alone won't carry it. Never post the objection without the fix. In a line comment on a PR, the `path` and `line` fields carry the citation — drop it from the body and keep the rest of the order.
+Cite a range when the defect spans lines, and show the fix as a snippet when words alone won't carry it. Never post the objection without the fix. When you genuinely can't name one, name the gap instead — "this drops the second update; whether that's a bug depends on whether the queue is ordered, and I didn't trace it." An objection with a stated gap is workable. An invented fix the author implements is not.
 
 The consequence names the input or path that reaches the defect — "on every close", "when the list is empty" — not the category. A defect you can't trigger is a guess: drop it, or say what you didn't check.
 
@@ -62,9 +65,9 @@ Some observations feel like findings and aren't. These stay unsaid at every seve
 - **A tool already decided it.** Husky runs prettier, eslint, stylelint, and commitlint on what you commit ([commit hooks](../../../references/conventions.md#commit-hooks)); `ci-check` adds license headers plus ADR, AGENTS, skill, and example-README validation. Formatting, quote style, import order, line length, and anything else a gate fails on are settled before you open the diff.
 - **A naming swap with no clarity gain** — `data` → `payload`.
 - **An equivalent style alternative** — `for` versus `.map`, ternary versus `if`.
-- **"Add a comment here."** The repo's default is no comments. You are here to flag the ones that restate the code, not to ask for more.
+- **"Add a comment here."** The repo's default is no comments ([comments](../../../references/code-patterns.md#comments)). You are here to flag the ones that restate the code, not to ask for more. One narrow exception: the diff encodes a _why_ the code cannot show — a workaround for a named bug, a constraint from outside the file, an ordering that looks arbitrary and isn't. Ask for that line, and say what it has to record.
 - **Speculative extraction** — "you might want to pull this out in case…". Scope creep counts from the reviewer's side too.
-- **Code the diff didn't touch.** Real, but not this PR's job — file an issue.
+- **Code the diff didn't touch.** A pre-existing problem is real and is not this PR's job — file an issue. Untouched code the diff _breaks_ is a different thing: a caller left on the old signature, a consumer of a changed default, a doc snippet that no longer runs. That is a regression, and a regression is a **Blocker** wherever it surfaces.
 
 A pass — or a whole review — that surfaces nothing is finished, not failed. Say so and stop. Manufacturing a Nit to look thorough costs the author more than the silence would.
 
@@ -95,7 +98,7 @@ Skip the split when a single reading holds the whole diff in view. Splitting a h
 
 ## Evaluate the changes
 
-### If the PR contains documentation/text updates
+### If the diff contains documentation/text updates
 
 - Hold developer-facing copy to [tone.md](../../../references/tone.md) — voice, word economy, and the cuts it asks for.
 - Identify spelling, grammar, and punctuation errors.
@@ -104,9 +107,9 @@ Skip the split when a single reading holds the whole diff in view. Splitting a h
 - Check consistency of formatting, headings, bullets, and structure.
 - Confirm the docs capture the intent and give clear instructions.
 
-### If the PR contains code changes
+### If the diff contains code changes
 
-- **Favor simplicity** — confirm the diff follows the least-code discipline and simplicity principles in [code-patterns.md](../../../references/code-patterns.md#writing-the-least-code-laziness-ladder); flag violations (over-built code, large multi-job functions, hidden side effects, deep nesting, shared mutable state, single-caller abstractions, cleverness over a plain version).
+- **Favor simplicity** — hold the diff to the least-code discipline in [code-patterns.md](../../../references/code-patterns.md#writing-the-least-code-laziness-ladder). Flag over-built code, large multi-job functions, hidden side effects, deep nesting, shared mutable state, single-caller abstractions (YAGNI), cleverness over a plain version, dead code or unused flexibility, logic expressible in fewer lines, and JS re-creating what CSS or a native element or browser API already does. This check is removable complexity only — correctness and security are the bullets below.
 - Analyze logic for bugs, inefficiencies, and security risks (OWASP-style: injection, XSS, unsafe deserialization, secrets in code).
 - Check variable names, function structure, and error handling for clarity and correctness.
 - Confirm edge-case handling — empty/null inputs, error paths, concurrency, cancellation, large inputs.
@@ -129,7 +132,6 @@ Skip the split when a single reading holds the whole diff in view. Splitting a h
 
 For each changed file, read every `AGENTS.md` on the path from its directory up to the repo root, plus any topic docs under their `references/` folders they link to — e.g. a change under `packages/ai-chat-components/src/components/audio-player/` is governed by [packages/ai-chat-components/AGENTS.md](../../../packages/ai-chat-components/AGENTS.md) then the root [AGENTS.md](../../../AGENTS.md). Rule definitions live in [code-patterns.md](../../../references/code-patterns.md) and [conventions.md](../../../references/conventions.md); this list is what to flag. A convention finding links the rule it breaks — an anchor in one of those two files, or the governing `AGENTS.md`. No link, no finding: you are quoting a convention this repo may not have. Flag any of:
 
-- **Over-engineering** — code the [laziness ladder](../../../references/code-patterns.md#writing-the-least-code-laziness-ladder) would have avoided: dead code or unused flexibility (delete it), JS re-creating what CSS or a native element/browser API already does, a dependency duplicating Carbon or an existing one, an abstraction with a single caller (YAGNI), or logic expressible in fewer lines. Correctness and security stay in the sections above — this check is only about removable complexity.
 - **Logic trapped in a component** — parsing, formatting, validation, state transitions, or timing/geometry math written inside a React or Lit component instead of a plain module it could call ([framework-agnostic logic](../../../references/code-patterns.md#framework-agnostic-logic)). The tell is a behavior you could only test by rendering.
 - **New components added under `packages/ai-chat/src/chat/components-legacy/`** — that directory is closed to new components ([component placement](../../../references/code-patterns.md#component-placement)).
 - **Prefix / SCSS violations** — hardcoded `cds--`, missing `#{$prefix}--`, descendant nesting, or physical properties instead of logical ones for RTL ([naming & prefix discipline](../../../references/code-patterns.md#naming--prefix-discipline-build-breaking), [SCSS authoring](../../../references/code-patterns.md#scss-authoring)).
@@ -141,7 +143,8 @@ For each changed file, read every `AGENTS.md` on the path from its directory up 
 - **Open with the verdict on one line** — ship, fix blockers, or rework. Nothing precedes it: no greeting, no "great work on this", no recap of what the PR does. The author wrote the diff and does not need it read back.
 - **Then at most three lines**, carrying only what the verdict rests on: the blocking concerns, any design-level concern that outgrew a finding, and the dropped-finding count. A strength earns a line only when it was the risk and it landed — "the migration path handles the null case, which was the hard part." Generic praise is padding; cut it.
 - List findings grouped by severity (**Blocker**, **Important**, **Nit**), each written to the shape above.
-- **Cap the review at ten findings and three Nits**, highest severity first. Drop Nits first, then Importants, and name the drop in one summary line: "12 further Nits (naming, comment wording) not listed." A review nobody finishes fixes nothing, and a silent cut reads as full coverage.
+- **Never drop a Blocker.** List every one, however many there are. A Blocker reduced to a count in the summary blocks nothing, and merges.
+- **Cap Important and Nit at ten between them**, no more than three of those Nits, highest severity first. Drop Nits before Importants, and name the drop in one summary line: "12 further Nits (naming, comment wording) not listed." A review nobody finishes fixes nothing, and a silent cut reads as full coverage. When the Blockers alone run past ten, drop the Importants and Nits entirely — the verdict is rework, and a tail of taste under that many must-fixes is noise.
 - End with a **Test / verification gaps** section if the diff lacks coverage for changed behavior.
 
 ## Related guidance

--- a/.claude/skills/caic-review/SKILL.md
+++ b/.claude/skills/caic-review/SKILL.md
@@ -33,13 +33,13 @@ Line comments beat a wall of prose: they land next to the code they're about. Bu
 {
   "commit_id": "<headRefOid from gh pr view>",
   "event": "COMMENT",
-  "body": "Summary — overall assessment and the highest-severity concerns.",
+  "body": "Fix blockers before merge. <assessment, highest-severity concerns, anything dropped>",
   "comments": [
     {
       "path": "packages/ai-chat/src/foo.ts",
       "line": 42,
       "side": "RIGHT",
-      "body": "**Blocker** — the early return skips the teardown; call `dispose()` before returning."
+      "body": "**Blocker** — the early return skips teardown, so the listener leaks on every close. Call `dispose()` before returning."
     }
   ]
 }
@@ -62,8 +62,29 @@ gh api --method POST repos/<owner>/<repo>/pulls/<pr>/reviews --input .github/pr-
   - **Blocker** — must fix before merge: bug, regression, security issue, broken build/tests, violated repo convention, accidental edit to generated output.
   - **Important** — should fix: unclear naming, missing test for changed behavior, unhandled edge case, scope creep.
   - **Nit** — optional/taste. Keep these short and few.
-- Cite every finding with `path/to/file.ts:line` (or range) so the author can jump to it.
-- When you flag a problem, show the fix (snippet or concrete suggestion), not just the objection.
+
+## How to write a finding
+
+One shape, one order — severity, the defect, what it costs, the fix:
+
+```
+**<Severity>** — `path/to/file.ts:42` — <what is wrong>, so <what it costs>. <The fix.>
+```
+
+Cite a range when the defect spans lines, and show the fix as a snippet when words alone won't carry it. Never post the objection without the fix. In a line comment on a PR, the `path` and `line` fields carry the citation — drop it from the body and keep the rest of the order.
+
+Hold your own words to [tone.md](../../../references/tone.md) — the same standard you hold the diff's copy to. Three habits show up in reviews and all three go:
+
+- **Hedging** — "I think", "it looks like", "consider possibly", "might be worth". Uncertainty is fine; say what you checked instead. "Read the happy path only — 60% sure this leaks."
+- **Throat-clearing** — "just", "simply", "one small thing", "it is important to note". Delete the phrase; the sentence gets stronger.
+- **Praise inside a finding** — "nice refactor, but…". Strengths go in the summary. A finding is the defect and the fix.
+
+**A leaked listener**
+
+- Before: "I might be missing something, but I wonder if it could possibly be worth considering whether this early return may want to clean up the listener it registered above, since otherwise it seems like it might leak? Nice refactor overall though!"
+- After: "**Blocker** — `packages/ai-chat/src/foo.ts:42` — the early return skips teardown, so the listener leaks on every close. Call `dispose()` before returning."
+
+Cap a finding at three sentences plus a snippet. A concern that outgrows that — a design direction, a pattern repeated across the diff — is not a line comment: give it one line in the summary and move on.
 
 ## Evaluate the changes
 
@@ -112,16 +133,17 @@ For each changed file, read every `AGENTS.md` on the path from its directory up 
 
 ## Output expectations
 
-- Open with a short **Summary** (2–4 sentences): overall assessment, strengths, highest-severity concerns.
-- List findings grouped by severity (**Blocker**, **Important**, **Nit**), each with a `file:line` reference and a concrete suggested fix (code snippet when useful).
+- **Lead the summary with the verdict on one line** — ship, fix blockers, or rework — before any context. Then 2–3 sentences: what the change does well, and the highest-severity concerns.
+- List findings grouped by severity (**Blocker**, **Important**, **Nit**), each written to the shape above.
+- **Cap the review at ten findings**, highest severity first. Drop Nits first, then Importants, and name the drop in one summary line: "12 further Nits (naming, comment wording) not listed." A review nobody finishes fixes nothing, and a silent cut reads as full coverage.
+- Carry design-level concerns in the summary too, one line each — they are what a finding overflows into.
 - End with a **Test / verification gaps** section if the diff lacks coverage for changed behavior.
-- Keep a polite, constructive tone — note what the change does well, but don't let praise obscure real blockers.
 
 ## Related guidance
 
 For context on conventions being enforced:
 
-- **Voice and tone**: [tone.md](../../../references/tone.md) — what to hold documentation and developer-facing copy to
+- **Voice and tone**: [tone.md](../../../references/tone.md) — what to hold documentation and developer-facing copy to, and the comments you write about it
 - **Code-level patterns**: [code-patterns.md](../../../references/code-patterns.md) — the laziness ladder & simplicity principles, prefix discipline, SCSS, RTL, framework-agnostic logic, component placement, comments
 - **Process conventions**: [conventions.md](../../../references/conventions.md) — commits, branches, license headers, hooks
 - **General overview**: [AGENTS.md](../../../AGENTS.md) — monorepo pointer index

--- a/.claude/skills/caic-review/SKILL.md
+++ b/.claude/skills/caic-review/SKILL.md
@@ -15,6 +15,7 @@ Two jobs share this rubric. Settle which one you're doing before reading any cod
 ## How to review
 
 - Read the actual diff (`git diff`, `gh pr diff`, etc.) and referenced files — never a summary of what changed.
+- When reading it all at one depth would mean reading all of it shallowly, rank the files by risk first — [large-diffs.md](references/large-diffs.md).
 - Open the issue the PR closes and walk its acceptance criteria against the diff. A criterion the diff contradicts is a **Blocker** until the issue carries an amendment saying so.
 - If the issue or its epic cites an ADR, read that ADR's Decision outcome and walk the diff against it too. A diff that contradicts an accepted ADR is a **Blocker** until a new ADR supersedes it — an implementation PR is not where a recorded decision gets reversed.
 - Tag every finding with a severity so real problems aren't buried under taste:
@@ -76,7 +77,7 @@ A pass returns findings and nothing else — no verdict, no cap, no ranking. It 
 
 **Synthesize before you write anything.** Merge the passes, drop duplicates, rank by severity across all of them, then apply the caps and write the verdict per [Output expectations](#output-expectations). Skip this and you ship N reviews stapled together.
 
-Skip the split under ~5 changed files. One pass reads that much without losing the thread.
+Skip the split when a single reading holds the whole diff in view. Splitting a handful of lines across five passes is ceremony.
 
 ## Evaluate the changes
 
@@ -139,6 +140,7 @@ For context on conventions being enforced:
 - **General overview**: [AGENTS.md](../../../AGENTS.md) — monorepo pointer index
 - **Package-specific rules**: see `AGENTS.md` in each package directory
 - **Reviewing a PR**: [reviewing-a-pr.md](references/reviewing-a-pr.md) — base branch, the review payload, and the `gh` call
+- **Large diffs**: [large-diffs.md](references/large-diffs.md) — ranking files by risk when the diff is too big to read evenly
 - **PR workflow**: [caic-pr](../caic-pr/SKILL.md) — drafting PR descriptions
 - **Plan-phase analog**: [plan-review.md](../caic-plan/references/plan-review.md) — the same discipline applied before code exists
 

--- a/.claude/skills/caic-review/SKILL.md
+++ b/.claude/skills/caic-review/SKILL.md
@@ -20,7 +20,7 @@ Two jobs share this rubric. Settle which one you're doing before reading any cod
 - Tag every finding with a severity so real problems aren't buried under taste:
   - **Blocker** — must fix before merge: bug, regression, security issue, broken build/tests, violated repo convention, accidental edit to generated output.
   - **Important** — should fix: unclear naming, missing test for changed behavior, unhandled edge case, scope creep.
-  - **Nit** — optional/taste. Keep these short and few.
+  - **Nit** — optional, and it still has to earn its place: a concrete one-edit fix a later reader benefits from. Everything else is noise — see [What isn't a finding](#what-isnt-a-finding).
 
 ## How to write a finding
 
@@ -36,7 +36,7 @@ Hold your own words to [tone.md](../../../references/tone.md) — the same stand
 
 - **Hedging** — "I think", "it looks like", "consider possibly", "might be worth". Uncertainty is fine; say what you checked instead. "Read the happy path only — 60% sure this leaks."
 - **Throat-clearing** — "just", "simply", "one small thing", "it is important to note". Delete the phrase; the sentence gets stronger.
-- **Praise inside a finding** — "nice refactor, but…". Strengths go in the summary. A finding is the defect and the fix.
+- **Praise inside a finding** — "nice refactor, but…". A finding is the defect and the fix. The summary decides whether a strength is worth a line at all.
 
 **A leaked listener**
 
@@ -44,6 +44,37 @@ Hold your own words to [tone.md](../../../references/tone.md) — the same stand
 - After: "**Blocker** — `packages/ai-chat/src/foo.ts:42` — the early return skips teardown, so the listener leaks on every close. Call `dispose()` before returning."
 
 Cap a finding at three sentences plus a snippet. A concern that outgrows that — a design direction, a pattern repeated across the diff — is not a line comment: give it one line in the summary and move on.
+
+### What isn't a finding
+
+Some observations feel like findings and aren't. These stay unsaid at every severity, not just Nit:
+
+- **A tool already decided it.** Husky runs prettier and eslint on TS/JS, prettier and stylelint on SCSS, prettier on markdown, and commitlint on the message ([commit hooks](../../../references/conventions.md#commit-hooks)). Formatting, quote style, import order, and line length are settled before you open the diff.
+- **A naming swap with no clarity gain** — `data` → `payload`.
+- **An equivalent style alternative** — `for` versus `.map`, ternary versus `if`.
+- **"Add a comment here."** The repo's default is no comments. You are here to flag the ones that restate the code, not to ask for more.
+- **Speculative extraction** — "you might want to pull this out in case…". Scope creep counts from the reviewer's side too.
+- **Code the diff didn't touch.** Real, but not this PR's job — file an issue.
+
+## Run one dimension at a time
+
+One pass over every check spends its attention on the first dimension and skims the rest. Split the review into independent passes, each holding the whole diff and one job. Pick the passes from the changed paths — a docs-only diff gets two, not seven:
+
+| Changed | Passes |
+| --- | --- |
+| Any code | correctness & security, simplicity & scope creep, test coverage |
+| `*.scss`, or any component | accessibility, prefix & SCSS, logic trapped in a component |
+| `*.md`, or JSDoc on public types | tone & docs |
+| `package.json` | dependencies |
+| Always | acceptance criteria & ADRs, commit format |
+
+Dispatch them in parallel when the harness gives you sub-agents (see [AGENTS.md](../../../AGENTS.md)); run them as separate sequential passes when it doesn't. Either way, every pass gets the same brief: its one dimension, the finding shape above, and [What isn't a finding](#what-isnt-a-finding). A pass told only to find things will manufacture Nits to justify itself.
+
+A pass returns findings and nothing else — no verdict, no cap, no ranking. It can't rank what it can't see.
+
+**Synthesize before you write anything.** Merge the passes, drop duplicates, rank by severity across all of them, then apply the caps and write the verdict per [Output expectations](#output-expectations). Skip this and you ship N reviews stapled together.
+
+Skip the split under ~5 changed files. One pass reads that much without losing the thread.
 
 ## Evaluate the changes
 
@@ -92,10 +123,10 @@ For each changed file, read every `AGENTS.md` on the path from its directory up 
 
 ## Output expectations
 
-- **Lead the summary with the verdict on one line** — ship, fix blockers, or rework — before any context. Then 2–3 sentences: what the change does well, and the highest-severity concerns.
+- **Open with the verdict on one line** — ship, fix blockers, or rework. Nothing precedes it: no greeting, no "great work on this", no recap of what the PR does. The author wrote the diff and does not need it read back.
+- **Then at most three lines**, carrying only what the verdict rests on: the blocking concerns, any design-level concern that outgrew a finding, and the dropped-finding count. A strength earns a line only when it was the risk and it landed — "the migration path handles the null case, which was the hard part." Generic praise is padding; cut it.
 - List findings grouped by severity (**Blocker**, **Important**, **Nit**), each written to the shape above.
-- **Cap the review at ten findings**, highest severity first. Drop Nits first, then Importants, and name the drop in one summary line: "12 further Nits (naming, comment wording) not listed." A review nobody finishes fixes nothing, and a silent cut reads as full coverage.
-- Carry design-level concerns in the summary too, one line each — they are what a finding overflows into.
+- **Cap the review at ten findings and three Nits**, highest severity first. Drop Nits first, then Importants, and name the drop in one summary line: "12 further Nits (naming, comment wording) not listed." A review nobody finishes fixes nothing, and a silent cut reads as full coverage.
 - End with a **Test / verification gaps** section if the diff lacks coverage for changed behavior.
 
 ## Related guidance

--- a/.claude/skills/caic-review/references/large-diffs.md
+++ b/.claude/skills/caic-review/references/large-diffs.md
@@ -1,0 +1,47 @@
+# large-diffs.md — reviewing a diff too big to read evenly
+
+Load this when reading the whole diff at one depth would mean reading all of it shallowly: the file list scrolls past a screen, or you catch yourself skimming to keep moving. Rank the files first, then run the dimension passes from [caic-review](../SKILL.md) over whatever the ranking puts on top.
+
+No line count triggers this. A 600-line lockfile bump is not a large diff; four files rewriting the store is.
+
+## Rank before you read
+
+Sort the changed files by risk per line, then spend attention in that order.
+
+**Costs a glance, not a read**
+
+- Pure renames and moves. `git diff -M --stat` reports a similarity index; at 100% there is nothing to review but the new path.
+- `package-lock.json`. Review the `package.json` change that caused it.
+- Generated output, per the never-edit list in [AGENTS.md](../../../../AGENTS.md). None of it belongs in a diff, so finding some is a **Blocker** on sight and costs no reading at all.
+
+**Read in full**
+
+- `packages/ai-chat/src/types/**` — the public contract. A wrong line here ships to consumers and comes back only in a major.
+- `packages/ai-chat/src/chat/store/**` — reducers and state transitions, where a broken reference costs a re-render nobody asked for.
+- Any file whose directory carries its own `AGENTS.md`. That file exists because the area has rules that are easy to get wrong.
+- New files. There is no unchanged context to lean on — all of it is new logic.
+
+**Read the hunks, not the file**
+
+Everything else. Risk concentrates where the diff landed, and the surrounding code was reviewed once already.
+
+## Size is a finding
+
+A diff nobody can review well does not become reviewable by being reviewed anyway. When the change should have been several PRs, say so:
+
+- **Important** by default. Name the seams — which files would have made the second PR.
+- **Blocker** when the PR bundles unrelated work. That is scope creep, already a Blocker on its own; size is just how it surfaced.
+
+Mechanical bulk is not the same thing. A rename sweep across sixty files is one job, and it reviews fine once the ranking above drops it into the glance tier.
+
+## Say what you read
+
+A partial review that reads as a complete one is worse than no review. Close the summary with your coverage, alongside the dropped-finding count:
+
+> Read the store changes and public types in full. Skimmed 14 test-fixture updates and the lockfile.
+
+## Related guidance
+
+- [caic-review](../SKILL.md) — the rubric this triage feeds
+- [reviewing-a-pr.md](reviewing-a-pr.md) — base-branch resolution, which decides how large the diff even is
+- [Root AGENTS.md](../../../../AGENTS.md) — the generated-output list and the repo layout

--- a/.claude/skills/caic-review/references/large-diffs.md
+++ b/.claude/skills/caic-review/references/large-diffs.md
@@ -10,9 +10,9 @@ Sort the changed files by risk per line, then spend attention in that order.
 
 **Costs a glance, not a read**
 
-- Pure renames and moves. `git diff -M --stat` reports a similarity index; at 100% there is nothing to review but the new path.
+- Pure renames and moves. `git diff -M --summary` reports a similarity index; at 100% there is nothing to review but the new path.
 - `package-lock.json`. Review the `package.json` change that caused it.
-- Generated output, per the never-edit list in [AGENTS.md](../../../../AGENTS.md). None of it belongs in a diff, so finding some is a **Blocker** on sight and costs no reading at all.
+- Generated output this repo does not commit, per the never-edit list in [AGENTS.md](../../../../AGENTS.md) — an edit there is a **Blocker** on sight and costs no reading at all. The telemetry configs are the exception on that list: `packages/ai-chat/telemetry.yml` and `packages/ai-chat-components/telemetry.yml` are committed and regenerated, so they belong in the diff. Glance and move on.
 
 **Read in full**
 

--- a/.claude/skills/caic-review/references/reviewing-a-pr.md
+++ b/.claude/skills/caic-review/references/reviewing-a-pr.md
@@ -42,7 +42,7 @@ gh api --method POST repos/<owner>/<repo>/pulls/<pr>/reviews --input .github/pr-
 ```
 
 - **`event`** is `COMMENT` (feedback only), `APPROVE`, or `REQUEST_CHANGES`. Ask the user which — the review event is theirs, not yours. The verdict line still opens the body, per [Output expectations](../SKILL.md#output-expectations). GitHub rejects `APPROVE` and `REQUEST_CHANGES` on your own PR, so a self-authored PR can only take `COMMENT`.
-- **`line`** is the line number in the file as of `commit_id`, and it must fall inside the diff. `side: "RIGHT"` is the post-change file; use `"LEFT"` for a removed line. For a range, add `start_line` (and `start_side`).
+- **`line`** is the line number in the file as of `commit_id`, and it must fall inside the diff. `side: "RIGHT"` is the post-change file; use `"LEFT"` for a removed line. For a range, add `start_line` (and `start_side`). These fields carry the citation, so drop `file:line` from the comment body and keep the rest of the finding's order.
 - A comment outside the diff hunks returns 422. Put that finding in the summary `body` rather than forcing a line onto it.
 - A fix that replaces a line range ships as a fenced `suggestion` block in the comment body, so the author commits it from the PR page. The block replaces exactly the commented range — set `start_line` to match. A fix spanning files stays prose.
 

--- a/.claude/skills/caic-review/references/reviewing-a-pr.md
+++ b/.claude/skills/caic-review/references/reviewing-a-pr.md
@@ -44,6 +44,7 @@ gh api --method POST repos/<owner>/<repo>/pulls/<pr>/reviews --input .github/pr-
 - **`event`** is `COMMENT` (feedback only), `APPROVE`, or `REQUEST_CHANGES`. Ask the user which — the review event is theirs, not yours. The verdict line still opens the body, per [Output expectations](../SKILL.md#output-expectations). GitHub rejects `APPROVE` and `REQUEST_CHANGES` on your own PR, so a self-authored PR can only take `COMMENT`.
 - **`line`** is the line number in the file as of `commit_id`, and it must fall inside the diff. `side: "RIGHT"` is the post-change file; use `"LEFT"` for a removed line. For a range, add `start_line` (and `start_side`).
 - A comment outside the diff hunks returns 422. Put that finding in the summary `body` rather than forcing a line onto it.
+- A fix that replaces a line range ships as a fenced `suggestion` block in the comment body, so the author commits it from the PR page. The block replaces exactly the commented range — set `start_line` to match. A fix spanning files stays prose.
 
 ## Related guidance
 

--- a/.claude/skills/caic-review/references/reviewing-a-pr.md
+++ b/.claude/skills/caic-review/references/reviewing-a-pr.md
@@ -1,6 +1,6 @@
 # reviewing-a-pr.md — what changes when the target is a pull request
 
-Load this when the review target is a PR rather than your own working diff — someone else's branch, or your own PR up for review. A self-review posts nothing, so none of this applies to it.
+Load this when the review target is a PR rather than your own working diff — someone else's branch, or your own PR up for review. Both sections below need a PR number, so neither applies to a self-review; that path names its own range in [caic-review](../SKILL.md#scope-the-review-first).
 
 The rubric itself doesn't change: score the diff with [caic-review](../SKILL.md), then come back here to post.
 
@@ -41,7 +41,7 @@ Line comments beat a wall of prose: they land next to the code they're about. Bu
 gh api --method POST repos/<owner>/<repo>/pulls/<pr>/reviews --input .github/pr-drafts/review-<pr>.json
 ```
 
-- **`event`** is `COMMENT` (feedback only), `APPROVE`, or `REQUEST_CHANGES`. Ask the user which — the verdict is theirs, not yours. GitHub rejects `APPROVE` and `REQUEST_CHANGES` on your own PR, so a self-authored PR can only take `COMMENT`.
+- **`event`** is `COMMENT` (feedback only), `APPROVE`, or `REQUEST_CHANGES`. Ask the user which — the review event is theirs, not yours. The verdict line still opens the body, per [Output expectations](../SKILL.md#output-expectations). GitHub rejects `APPROVE` and `REQUEST_CHANGES` on your own PR, so a self-authored PR can only take `COMMENT`.
 - **`line`** is the line number in the file as of `commit_id`, and it must fall inside the diff. `side: "RIGHT"` is the post-change file; use `"LEFT"` for a removed line. For a range, add `start_line` (and `start_side`).
 - A comment outside the diff hunks returns 422. Put that finding in the summary `body` rather than forcing a line onto it.
 

--- a/.claude/skills/caic-review/references/reviewing-a-pr.md
+++ b/.claude/skills/caic-review/references/reviewing-a-pr.md
@@ -1,0 +1,53 @@
+# reviewing-a-pr.md — what changes when the target is a pull request
+
+Load this when the review target is a PR rather than your own working diff — someone else's branch, or your own PR up for review. A self-review posts nothing, so none of this applies to it.
+
+The rubric itself doesn't change: score the diff with [caic-review](../SKILL.md), then come back here to post.
+
+## Resolve the base branch before diffing
+
+Never assume `main`. A PR usually targets `upstream/main`, but long-running integration branches are common here, and diffing against the wrong base buries the review under unrelated commits.
+
+```bash
+gh pr view <pr> --json baseRefName,headRefName,headRefOid,isCrossRepository,url
+gh pr diff <pr>   # already scoped to the PR's real base
+```
+
+Use `gh pr diff`, or diff explicitly against the reported `baseRefName`. When the base is an integration branch rather than `main`, say so in the summary — it changes what is in scope and what counts as a regression.
+
+## Posting the review
+
+Line comments beat a wall of prose: they land next to the code they're about. Build the whole review as one payload and submit it once.
+
+**Draft first, submit second. Never run a `gh` command that writes to GitHub before the user has seen the exact payload and said go.** Write it to `.github/pr-drafts/review-<pr>.json` (git-ignored), show the summary and findings, then wait.
+
+```json
+{
+  "commit_id": "<headRefOid from gh pr view>",
+  "event": "COMMENT",
+  "body": "Fix blockers before merge. <assessment, highest-severity concerns, anything dropped>",
+  "comments": [
+    {
+      "path": "packages/ai-chat/src/foo.ts",
+      "line": 42,
+      "side": "RIGHT",
+      "body": "**Blocker** — the early return skips teardown, so the listener leaks on every close. Call `dispose()` before returning."
+    }
+  ]
+}
+```
+
+```bash
+gh api --method POST repos/<owner>/<repo>/pulls/<pr>/reviews --input .github/pr-drafts/review-<pr>.json
+```
+
+- **`event`** is `COMMENT` (feedback only), `APPROVE`, or `REQUEST_CHANGES`. Ask the user which — the verdict is theirs, not yours. GitHub rejects `APPROVE` and `REQUEST_CHANGES` on your own PR, so a self-authored PR can only take `COMMENT`.
+- **`line`** is the line number in the file as of `commit_id`, and it must fall inside the diff. `side: "RIGHT"` is the post-change file; use `"LEFT"` for a removed line. For a range, add `start_line` (and `start_side`).
+- A comment outside the diff hunks returns 422. Put that finding in the summary `body` rather than forcing a line onto it.
+
+## Related guidance
+
+- [caic-review](../SKILL.md) — the rubric that produces the findings posted here
+- [caic-pr](../../caic-pr/SKILL.md) — drafting the PR description, and opening the PR itself
+- [conventions.md](../../../../references/conventions.md) — commits, branches, PR titles
+- [Root AGENTS.md](../../../../AGENTS.md) — repo overview and pointer index


### PR DESCRIPTION
Closes #2131
Closes #2133

Reviews from `caic-review` were long, hedged, and padded with Nits nobody wanted. The rubric said what to look for and nothing about what a finding costs the person reading it. Gives a finding one shape and a bar it has to clear, splits the review into per-dimension passes, and adds a step whose only job is to kill a finding that is wrong.

- `.bob/skills/caic-review/SKILL.md` — 134 to 166 lines, most of it rewritten. The pass table under "Run one dimension at a time" is the load-bearing part: it routes by changed path, so a check with no row is a check that never runs.
- `.claude/skills/caic-review/**` — generated mirror, byte-identical. Review `.bob/` only.

#### Changelog

#### Major changes

**New**

- "How to write a finding": severity, defect, consequence, fix — in that order, with a worked pair at each severity.
- "What isn't a finding": what stays unsaid at every severity, led by anything a gate already decides.
- Per-dimension passes, selected from the changed paths. Synthesis owns dedup, ranking, caps, and the verdict.
- A refutation step before synthesis. Every Blocker and Important gets argued the other way; what survives ships.
- A spec-conformance pass for markdown that directs an agent — `AGENTS.md`, `references/`, skills. A prose pass can't see a defect in an instruction.
- `references/large-diffs.md` — rank files by risk before reading, treat an oversized diff as a finding, state coverage.
- `references/reviewing-a-pr.md` — base resolution, the review payload, and GitHub's suggestion block.

**Changed**

- The summary opens with a verdict, then at most three lines. No praise unless a named risk landed.
- Blockers are never dropped. Ten caps Important and Nit between them, at most three of those Nits.
- A finding's consequence names the input that reaches the defect, not the category.
- An objection may ship with a stated gap when no fix is nameable.
- A self-review gets the diff, the rubric, and what the work had to satisfy — never the author's reasoning.
- Untouched code the diff breaks is a regression, not someone else's problem.
- Asking for the one comment this repo wants — a non-obvious _why_ — is allowed again.

#### Minor changes

**New**

- A Blocker has to be read for, not inferred. An unread path gets named.
- A convention finding links the rule it breaks.
- Read-only gates run before the review is written. Builds stay off-limits — they race the watcher.

**Changed**

- `@carbon/ai-chat` specs live under `tests/<area>/spec/`. The old glob matched nothing.
- `git diff -M --summary`, not `--stat`. Only `--summary` prints a similarity index.
- Generated output is a Blocker on sight only where the repo doesn't commit it. The telemetry configs are committed and regenerated.
- The skills index names the two reference files `caic-review` now carries.

**Removed**

- "Keep a polite, constructive tone" — replaced by the `tone.md` binding.
- Two checks a gate already enforces: conventional-commit PR title, and the example-README Indexer contract.
- The `~5 changed files` threshold. Both triage triggers are behavioral instead.
- A duplicated over-engineering check that sent two passes at one defect.

