### PR TITLE
fix: bump engines.node to >=24.0.0 to match .nvmrc and dep floor

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "packages/*"
   ],
   "engines": {
-    "node": ">=22.0.0",
+    "node": ">=24.0.0",
     "npm": ">=10.0.0"
   },
   "scripts": {


### PR DESCRIPTION
Closes #1999 

`engines.node` in root `package.json` said `>=22.0.0`, but a transitive dep (`errorstacks@2.4.2` via `@web/test-runner → @web/browser-logs`) requires Node >=24. Meanwhile `.nvmrc` is already `24.18.1` and all CI jobs run on Node 24 — no job ever ran on 22. Bumped the floor to match reality.

#### Changelog

**Changed**

- Root `package.json` `engines.node` updated from `>=22.0.0` to `>=24.0.0`

#### Testing / Reviewing

Run `npm install` on Node 24 and confirm no engine-incompatibility warnings are emitted.
