### PR TITLE
feat(types): render aliased type properties and guard entry parity

### DIFF
--- a/packages/ai-chat-components/src/components/prompt-line/src/tiptap/types.ts
+++ b/packages/ai-chat-components/src/components/prompt-line/src/tiptap/types.ts
@@ -116,7 +116,7 @@ export interface BaseSuggestionConfig {
   /**
    * When `true`, clicking a suggestion item fires `cds-aichat-autocomplete-select`
    * and inserts the item into the editor rather than sending immediately.
-   * Defaults to `false`. This property is ommitted in TriggerSuggestionConfig
+   * Defaults to `false`. This property is omitted in TriggerSuggestionConfig
    * since mentions and commands should always insert into the editor.
    */
   disableDirectSend?: boolean;

--- a/packages/ai-chat/AGENTS.md
+++ b/packages/ai-chat/AGENTS.md
@@ -52,6 +52,7 @@ From this package directory:
 
 ```bash
 npm run build      # rollup + typedoc
+npm run docs       # typedoc only — the fast docs loop, no rollup needed
 npm start          # rollup --watch + typedoc --watch + local doc server on :5001
 npm test           # jest with coverage
 npx jest path/to/file_spec.ts

--- a/packages/ai-chat/package.json
+++ b/packages/ai-chat/package.json
@@ -153,6 +153,7 @@
   },
   "scripts": {
     "build": "rollup -c ./tasks/rollup.aichat.js && typedoc",
+    "docs": "typedoc",
     "docs:api": "cross-env WRITE_API_INDEX=1 typedoc",
     "docs:api:check": "cross-env WRITE_API_INDEX=1 typedoc && git diff --exit-code -- docs/api",
     "postinstall": "ibmtelemetry --config=telemetry.yml",

--- a/packages/ai-chat/src/serverEntry.ts
+++ b/packages/ai-chat/src/serverEntry.ts
@@ -150,6 +150,7 @@ export type {
   BaseSuggestionConfig,
   TriggerSuggestionConfig,
   AutocompleteConfig,
+  StartersConfig,
   SuggestionItem,
   CustomListProps,
 } from './types/config/InputConfig';

--- a/packages/ai-chat/src/serverEntry.ts
+++ b/packages/ai-chat/src/serverEntry.ts
@@ -64,6 +64,10 @@ export { AutoScrollOptions } from './types/utilities/HasDoAutoScroll';
 export { LayoutCustomProperties } from './types/config/LayoutCustomProperties';
 
 export { CornersType } from './types/config/CornersType';
+export type {
+  PerCornerConfig,
+  ResolvedCornerConfig,
+} from './types/config/CornersType';
 
 export {
   BusEvent,
@@ -78,6 +82,7 @@ export {
   BusEventChatReady,
   BusEventChunkUserDefinedResponse,
   BusEventClosePanelButtonClicked,
+  BusEventCustomFooterSlot,
   BusEventCustomPanelClose,
   BusEventCustomPanelOpen,
   BusEventCustomPanelPreClose,
@@ -171,6 +176,11 @@ export {
 // rule. Raw `@tiptap/core` types are not re-exported — import those from
 // `@tiptap/core` directly. The Carbon suggestion-config types are exported
 // from `./types/config/InputConfig` alongside `InputConfig`.
+export type {
+  RenderInLightDomArgs,
+  RenderInLightDomResult,
+} from './types/utilities/inputUtils';
+
 export {
   carbonMention,
   carbonCommand,
@@ -233,6 +243,7 @@ export {
   EventInputData,
   FinalResponseChunk,
   GenericItem,
+  GenericItemCustomFooterSlotOptions,
   GenericItemMessageFeedbackCategories,
   GridItem,
   HorizontalCellAlignment,
@@ -310,8 +321,15 @@ export {
   ChatContainerPropsMarkdown,
   CustomMarkdownRenderers,
   MarkdownCustomRenderers,
+  MarkdownRendererChecklist,
+  MarkdownRendererChecklistItemArgs,
+  MarkdownRendererChecklistToggleArgs,
   MarkdownRendererCodeBlockArgs,
   MarkdownRendererCodeBlockData,
+  MarkdownRendererImageArgs,
+  MarkdownRendererImageResult,
+  MarkdownRendererLinkArgs,
+  MarkdownRendererLinkResult,
   MarkdownRendererTableArgs,
   MarkdownRendererTableData,
   RenderCustomMessageFooter,
@@ -323,6 +341,9 @@ export {
   WCMarkdown,
   WCRenderCustomMessageFooter,
   WCRenderUserDefinedResponse,
+  RenderUserDefinedInputNode,
+  RenderUserDefinedInputNodeState,
+  WCRenderUserDefinedInputNode,
 } from './types/component/ChatContainer';
 
 export type {

--- a/packages/ai-chat/src/types/AGENTS.md
+++ b/packages/ai-chat/src/types/AGENTS.md
@@ -16,7 +16,16 @@ Write for a consumer who has never seen the codebase.
 
 In scope: anything exported from [../aiChatEntry.tsx](../aiChatEntry.tsx) or [../serverEntry.ts](../serverEntry.ts), or transitively referenced (property type, generic arg, union member).
 
-Quick check: after a build, the rendered TypeDoc page for the symbol should exist under `dist/docs/carbon-tsdocs/` or the symbol name should appear in the rendered shape of something that does.
+Quick check: after a build, the symbol's rendered TypeDoc page under `dist/docs/carbon-tsdocs/` should list **its properties**, or the symbol name should appear in the rendered shape of something that does. A page that exists but renders no members is the failure mode this bar exists to catch — see [Object-shaped targets need `@interface`](#object-shaped-targets-need-interface).
+
+`npm run docs --workspace=@carbon/ai-chat` is the fast loop — TypeDoc only, no rollup, because the entry point is TS source:
+
+```bash
+npm run docs --workspace=@carbon/ai-chat
+grep -c 'tsd-index-heading' packages/ai-chat/dist/docs/carbon-tsdocs/interfaces/Type_reference.YourType.html
+```
+
+Don't reach for `npm run docs:api` to check this. It rewrites the committed [../../docs/api/](../../docs/api/), which is generated on a release or release candidate, not per PR.
 
 **Cross-package note**: many of these types are _declared_ in [@carbon/ai-chat-components](../../../ai-chat-components/) and surfaced here through a **local re-declaration**, not a transparent re-export. TypeDoc reads the JSDoc at the declaration site it sees — and the declaration site we want it to see is the local alias in this package, not the upstream source. The bar below therefore applies at the local declaration site you control. See [Cross-package re-exports](#cross-package-re-exports).
 
@@ -94,9 +103,30 @@ import type { AutocompleteConfig as _AutocompleteConfig } from '@carbon/ai-chat-
  * rendered.
  *
  * @category Config
+ * @interface
  */
 export type AutocompleteConfig = _AutocompleteConfig;
 ```
+
+#### Object-shaped targets need `@interface`
+
+Without it, the alias renders as a Type Alias page with **no properties**. TypeDoc documents the alias, not what it resolves to — so `trigger`, `items`, `onSelect` and the rest are absent from the docs site, the search index, and the MCP server, while the build still exits 0.
+
+`@interface` makes TypeDoc ask the type checker for the resolved member list, so `Omit<>` / `Pick<>` and inherited members all render flat, each carrying the upstream property's own JSDoc. Your prose and `@category` still win — they are read from the alias, not the target.
+
+Branch on the shape of the upstream target:
+
+| Upstream target | Local re-declaration |
+| --- | --- |
+| `interface` or object type | `export type X = _X;` **with `@interface`** |
+| union, function type, tuple | `export type X = _X;` — **no `@interface`** |
+| enum | `export const X = _X;` + `export type X = _X;` — **no `@interface`** |
+
+`@interface` on a union emits a `converting_union_as_interface` warning and keeps only the members common to every branch, so reach for it only when the target is object-shaped.
+
+The tag moves the generated page from `types/` to `interfaces/`. That is a one-time URL change per symbol; `{@link}` references update themselves.
+
+**Convert interlinked types together.** Property-level JSDoc is not parsed at all until properties exist, so a `{@link OtherType.someProp}` in an upstream comment only resolves once `OtherType` is also converted. Adding `@interface` to one half of a linked pair can turn a green build red under `validation.invalidLink`.
 
 For runtime values, use `export const`:
 
@@ -142,6 +172,7 @@ import type { TriggerSuggestionConfig } from '../../types/config/InputConfig'; /
 
 - **Unexported Carbon symbols in the public surface produce a TypeDoc warning.** If a Carbon type is referenced (even indirectly) by a public ai-chat type — as a property type, generic arg, or union member — but isn't re-exported from [../aiChatEntry.tsx](../aiChatEntry.tsx), `validation.notExported: true` in [../../typedoc.json](../../typedoc.json) warns. (Third-party types like `@tiptap/core`'s show as external references and are fine to import directly; see [Cross-linking](#cross-linking) for how to reference them in JSDoc.)
 - **`@category` values come from `categoryOrder`** in [../../typedoc.json](../../typedoc.json). A category outside that list lands in the `*` catchall.
+- **A missing `@interface` is build-green but caught by a test.** [tests/typedoc/spec/alias_members_spec.ts](../../tests/typedoc/spec/alias_members_spec.ts) parses this directory and fails on any `export type X = _X` alias missing the tag, with an allowlist for the targets that are genuinely not object-shaped. Add your exemption there, with a reason, or add the tag.
 
 ## Property-level JSDoc
 
@@ -232,11 +263,12 @@ import type { AutocompleteConfig as _AutocompleteConfig } from '@carbon/ai-chat-
  * rendered.
  *
  * @category Config
+ * @interface
  */
 export type AutocompleteConfig = _AutocompleteConfig;
 ```
 
-Why it works: the first sentence tells the reader where this type is reached from in the public API, so anyone landing on `AutocompleteConfig` in TypeDoc or the MCP index can jump straight to `InputConfig.autocomplete` to see it in context.
+Why it works: the first sentence tells the reader where this type is reached from in the public API, so anyone landing on `AutocompleteConfig` in TypeDoc or the MCP index can jump straight to `InputConfig.autocomplete` to see it in context. `@interface` is what makes the type's own properties render — see [Object-shaped targets need `@interface`](#object-shaped-targets-need-interface).
 
 ## Definition of done
 
@@ -244,8 +276,9 @@ When you change anything under [.](.) (or a type in `@carbon/ai-chat-components`
 
 1. `npm run build --workspace=@carbon/ai-chat` — rollup + TypeDoc. The build fails on `validation.invalidLink` errors.
 2. If you added a new public export, confirm it appears in both [../aiChatEntry.tsx](../aiChatEntry.tsx) and [../serverEntry.ts](../serverEntry.ts).
-3. If you added or changed a public instance method, confirm it carries at least one titled `@example` that meets [code-examples.md](../../references/code-examples.md) (review gate — not build-enforced).
-4. Semver: any change to a public type is a `feat` (additive) or a `fix!` / `BREAKING CHANGE` (non-additive). **Symbols still tagged [`@experimental`](#experimental) are the exception** — narrowing or removing one ships as a `feat`, because the tag is the notice that it could happen. A `!` bumps the major, and the majors are planned windows; don't open one to retract something we said was unstable. See [../../AGENTS.md](../../AGENTS.md) → _Authoring rules_ → _Public API changes_.
+3. If you added or changed a [cross-package re-export](#cross-package-re-exports), confirm its rendered page lists the type's properties — see the quick check under [Scope](#scope). Leave [../../docs/api/](../../docs/api/) alone; it is regenerated at release time.
+4. If you added or changed a public instance method, confirm it carries at least one titled `@example` that meets [code-examples.md](../../references/code-examples.md) (review gate — not build-enforced).
+5. Semver: any change to a public type is a `feat` (additive) or a `fix!` / `BREAKING CHANGE` (non-additive). **Symbols still tagged [`@experimental`](#experimental) are the exception** — narrowing or removing one ships as a `feat`, because the tag is the notice that it could happen. A `!` bumps the major, and the majors are planned windows; don't open one to retract something we said was unstable. See [../../AGENTS.md](../../AGENTS.md) → _Authoring rules_ → _Public API changes_.
 
 ## Related Guidance
 

--- a/packages/ai-chat/src/types/component/ChatContainer.ts
+++ b/packages/ai-chat/src/types/component/ChatContainer.ts
@@ -228,6 +228,7 @@ type RenderWriteableElementResponse = {
  * headers, rows, and streaming/loading flags.
  *
  * @category Messaging
+ * @interface
  */
 export type MarkdownRendererTableData = _MarkdownRendererTableData;
 
@@ -237,6 +238,7 @@ export type MarkdownRendererTableData = _MarkdownRendererTableData;
  * Carries the language, code text, and streaming flag.
  *
  * @category Messaging
+ * @interface
  */
 export type MarkdownRendererCodeBlockData = _MarkdownRendererCodeBlockData;
 
@@ -250,6 +252,7 @@ export type MarkdownRendererCodeBlockData = _MarkdownRendererCodeBlockData;
  * as opaque; its format is not part of the API.
  *
  * @category Messaging
+ * @interface
  */
 export type MarkdownRendererTableArgs = _MarkdownRendererTableArgs;
 
@@ -263,6 +266,7 @@ export type MarkdownRendererTableArgs = _MarkdownRendererTableArgs;
  * as opaque; its format is not part of the API.
  *
  * @category Messaging
+ * @interface
  */
 export type MarkdownRendererCodeBlockArgs = _MarkdownRendererCodeBlockArgs;
 
@@ -272,6 +276,7 @@ export type MarkdownRendererCodeBlockArgs = _MarkdownRendererCodeBlockArgs;
  * (href, title, text, attributes) plus the source markdown-it token.
  *
  * @category Messaging
+ * @interface
  */
 export type MarkdownRendererLinkArgs = _MarkdownRendererLinkArgs;
 
@@ -282,6 +287,7 @@ export type MarkdownRendererLinkArgs = _MarkdownRendererLinkArgs;
  * entirely. Supply `onClick` to intercept link clicks.
  *
  * @category Messaging
+ * @interface
  */
 export type MarkdownRendererLinkResult = _MarkdownRendererLinkResult;
 
@@ -291,6 +297,7 @@ export type MarkdownRendererLinkResult = _MarkdownRendererLinkResult;
  * (src, alt, title, attributes) plus the source markdown-it token.
  *
  * @category Messaging
+ * @interface
  */
 export type MarkdownRendererImageArgs = _MarkdownRendererImageArgs;
 
@@ -299,6 +306,7 @@ export type MarkdownRendererImageArgs = _MarkdownRendererImageArgs;
  * `attributes`). Return `null` to keep the defaults.
  *
  * @category Messaging
+ * @interface
  */
 export type MarkdownRendererImageResult = _MarkdownRendererImageResult;
 
@@ -307,6 +315,7 @@ export type MarkdownRendererImageResult = _MarkdownRendererImageResult;
  * an optional `getChecked` source-of-truth. See {@link MarkdownRendererChecklist}.
  *
  * @category Messaging
+ * @interface
  */
 export type MarkdownRendererChecklist = _MarkdownRendererChecklist;
 
@@ -315,6 +324,7 @@ export type MarkdownRendererChecklist = _MarkdownRendererChecklist;
  * `checklist.getChecked`.
  *
  * @category Messaging
+ * @interface
  */
 export type MarkdownRendererChecklistItemArgs =
   _MarkdownRendererChecklistItemArgs;
@@ -324,6 +334,7 @@ export type MarkdownRendererChecklistItemArgs =
  * (item identity + new checked state).
  *
  * @category Messaging
+ * @interface
  */
 export type MarkdownRendererChecklistToggleArgs =
   _MarkdownRendererChecklistToggleArgs;
@@ -337,6 +348,7 @@ export type MarkdownRendererChecklistToggleArgs =
  * than this baseline directly.
  *
  * @category Messaging
+ * @interface
  */
 export type MarkdownCustomRenderers = _MarkdownCustomRenderers;
 

--- a/packages/ai-chat/src/types/config/HeaderConfig.ts
+++ b/packages/ai-chat/src/types/config/HeaderConfig.ts
@@ -18,6 +18,7 @@ import type { ToolbarAction as _ToolbarAction } from '@carbon/ai-chat-components
  * rather than collapsing into the overflow menu when space is tight.
  *
  * @category Config
+ * @interface
  */
 export type ToolbarAction = _ToolbarAction;
 

--- a/packages/ai-chat/src/types/config/InputConfig.ts
+++ b/packages/ai-chat/src/types/config/InputConfig.ts
@@ -8,10 +8,11 @@
  */
 
 // Raw `@tiptap/core` types come from `@tiptap/core` directly. The Carbon
-// suggestion-config types are re-declared below (rather than imported from
-// the upstream symbols directly) so TypeDoc resolution stays pointed at our
-// JSDoc + `@category` placement; see [../AGENTS.md](../AGENTS.md) for the
-// cross-package re-export rule.
+// suggestion-config types are aliased below (rather than imported from the
+// upstream symbols directly) so TypeDoc resolution stays pointed at our
+// JSDoc + `@category` placement; `@interface` is what makes it render the
+// checker-resolved members rather than the bare alias. See
+// [../AGENTS.md](../AGENTS.md) for the cross-package re-export rule.
 import type { Extension } from '@tiptap/core';
 import type {
   BaseSuggestionConfig as _BaseSuggestionConfig,
@@ -26,9 +27,12 @@ import type { ToolbarAction } from './HeaderConfig';
 /**
  * Fields shared by every Carbon suggestion config (mention, command,
  * autocomplete). Provides the item source, debounce, minimum query length,
- * selection callback, and an optional custom list renderer.
+ * selection callback, an optional custom list renderer, and a
+ * `disableDirectSend` flag that inserts a clicked item into the editor
+ * instead of sending it straight to the assistant.
  *
  * @category Config
+ * @interface
  */
 export type BaseSuggestionConfig = _BaseSuggestionConfig;
 
@@ -43,6 +47,7 @@ export type BaseSuggestionConfig = _BaseSuggestionConfig;
  * {@link BaseSuggestionConfig}.
  *
  * @category Config
+ * @interface
  */
 export type TriggerSuggestionConfig = _TriggerSuggestionConfig;
 
@@ -52,6 +57,7 @@ export type TriggerSuggestionConfig = _TriggerSuggestionConfig;
  * rendered.
  *
  * @category Config
+ * @interface
  */
 export type AutocompleteConfig = _AutocompleteConfig;
 
@@ -61,29 +67,32 @@ export type AutocompleteConfig = _AutocompleteConfig;
  * replace the built-in suggestion list (e.g. to add a header above the items).
  *
  * @category Config
+ * @interface
  */
 export type StartersConfig = _StartersConfig;
 
 /**
  * Single list-item shape used by every Carbon suggestion surface
  * (mention, command, autocomplete, starters). Carries the id, label,
- * optional value override, optional description / avatar / icon, and a
+ * optional value override, optional description and avatar, and a
  * disabled flag. `showTriggerInChip` additionally controls, per item,
  * whether a mention/command selection renders with its trigger character —
  * chip-less surfaces (autocomplete, starters) ignore it.
  *
  * @category Config
+ * @interface
  */
 export type SuggestionItem = _SuggestionItem;
 
 /**
  * Props passed to a custom suggestion-list renderer (the `renderCustomList`
  * field on {@link BaseSuggestionConfig}). Includes the filtered
- * {@link SuggestionItem} array, the current `query`, and `onSelect` /
- * `onDismiss` callbacks.
+ * {@link SuggestionItem} array, the current `query`, and the `onSelect` /
+ * `onSend` / `onDismiss` callbacks.
  *
  * @category Config
  * @experimental
+ * @interface
  */
 export type CustomListProps = _CustomListProps;
 

--- a/packages/ai-chat/src/types/config/ServiceDeskConfig.ts
+++ b/packages/ai-chat/src/types/config/ServiceDeskConfig.ts
@@ -41,6 +41,7 @@ export type FileStatusValue = _FileStatusValue;
  * {@link FileStatusValue} and any error metadata.
  *
  * @category Service desk
+ * @interface
  */
 export type FileUpload = _FileUpload;
 

--- a/packages/ai-chat/src/types/utilities/inputUtils.ts
+++ b/packages/ai-chat/src/types/utilities/inputUtils.ts
@@ -200,8 +200,18 @@ export const renderTokenChip = _renderTokenChip;
  */
 export const renderInLightDom = _renderInLightDom;
 
-/** Args for {@link renderInLightDom}. @category Utilities */
+/**
+ * Args for {@link renderInLightDom}.
+ *
+ * @category Utilities
+ * @interface
+ */
 export type RenderInLightDomArgs = _RenderInLightDomArgs;
 
-/** Result of {@link renderInLightDom}. @category Utilities */
+/**
+ * Result of {@link renderInLightDom}.
+ *
+ * @category Utilities
+ * @interface
+ */
 export type RenderInLightDomResult = _RenderInLightDomResult;

--- a/packages/ai-chat/tests/config/spec/exports_compat_spec.ts
+++ b/packages/ai-chat/tests/config/spec/exports_compat_spec.ts
@@ -7,9 +7,30 @@
  *  @license
  */
 
-// This spec is intentionally focused on compile-time checks.
-// If any of the type assertions fail, ts-jest will surface a
-// compilation error and fail the test suite.
+/**
+ * Guards `src/aiChatEntry.tsx` and `src/serverEntry.ts` against drift.
+ *
+ * Two mechanisms live here because neither covers the other's ground.
+ *
+ * The compile-time assertions are built on `typeof import(...)`, which yields a
+ * module's *value* namespace. Types are erased from that namespace, so those
+ * assertions can compare the types of shared values — something a name diff
+ * cannot do — but they cannot see a type-only export at all.
+ *
+ * The runtime block diffs the *named exports* of the two entry files by
+ * parsing them, which covers types and values alike, in both directions.
+ * Diffing names rather than keying on the `type` keyword is deliberate: most
+ * public types in `aiChatEntry.tsx` ship in plain `export { ... }` blocks
+ * rather than `export type { ... }`, so a guard that looked for the keyword
+ * would still miss most of the public type surface.
+ *
+ * If any of the type assertions fail, ts-jest surfaces a compilation error and
+ * fails this whole file, runtime tests included.
+ */
+
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import ts from 'typescript';
 
 // Utility types for compile-time assertions
 type Equals<A, B> =
@@ -50,9 +71,167 @@ type _ServerHasNoComponents = AssertTrue<
   Equals<Extract<keyof ServerValues, ForbiddenComponentKeys>, never>
 >;
 
+const CLIENT_ENTRY = 'aiChatEntry.tsx';
+const SERVER_ENTRY = 'serverEntry.ts';
+
+/**
+ * Exported from `aiChatEntry.tsx` only, on purpose. `serverEntry.ts` is the
+ * SSR-safe surface, so it carries no React component values and no helper that
+ * touches the DOM or browser storage.
+ *
+ * Adding an entry is a deliberate, reviewable decision — an omission that is
+ * not recorded here fails the test below. The stale-entry test keeps the list
+ * from rotting once a name is exported from both entries or dropped entirely.
+ */
+const CLIENT_ONLY: Record<string, string> = {
+  ChatContainer: 'React component value.',
+  ChatCustomElement: 'React component value.',
+  ChatContainerProps: 'Props of a React component, so client-surface only.',
+  ChatCustomElementProps: 'Props of a React component, so client-surface only.',
+  readCarbonChatSession: 'Reads browser session storage.',
+  renderTokenChip: 'Renders into the DOM.',
+  renderInLightDom: 'Renders into the DOM.',
+};
+
+/**
+ * Exported from `serverEntry.ts` only, on purpose. Empty — every server export
+ * is also a client export today.
+ *
+ * `loadAllLazyDeps` is not an entry: both files export the name, the client as
+ * a type and the server as a value. That asymmetry is a value-side concern and
+ * is covered by `ServerOnlyAllowedKeys` above.
+ */
+const SERVER_ONLY: Record<string, string> = {};
+
+/**
+ * Every name an entry file exports. Both entries consist entirely of
+ * `export { ... } from '...'` and `export type { ... } from '...'`
+ * re-exports; any other exporting form throws rather than being skipped,
+ * because a form this cannot read would silently shrink the diff below.
+ */
+function readNamedExports(label: string, path: string): Set<string> {
+  const source = ts.createSourceFile(
+    path,
+    readFileSync(path, 'utf8'),
+    ts.ScriptTarget.Latest,
+    true,
+    path.endsWith('.tsx') ? ts.ScriptKind.TSX : ts.ScriptKind.TS
+  );
+
+  const names = new Set<string>();
+
+  source.forEachChild((node) => {
+    if (ts.isExportDeclaration(node)) {
+      if (!node.exportClause || !ts.isNamedExports(node.exportClause)) {
+        throw new Error(
+          `${label} uses a star re-export. This guard diffs named exports and ` +
+            `cannot enumerate names through one — re-export them explicitly.`
+        );
+      }
+      for (const element of node.exportClause.elements) {
+        names.add(element.name.text);
+      }
+      return;
+    }
+
+    const isExported =
+      ts.canHaveModifiers(node) &&
+      ts
+        .getModifiers(node)
+        ?.some((modifier) => modifier.kind === ts.SyntaxKind.ExportKeyword);
+
+    if (isExported || ts.isExportAssignment(node)) {
+      throw new Error(
+        `${label} declares an export locally. This guard only reads ` +
+          `re-export statements — declare the symbol in src/types/ and ` +
+          `re-export it here, or teach this parser the new form.`
+      );
+    }
+  });
+
+  return names;
+}
+
+const clientExports = readNamedExports(
+  CLIENT_ENTRY,
+  resolve(__dirname, '../../../src/aiChatEntry.tsx')
+);
+const serverExports = readNamedExports(
+  SERVER_ENTRY,
+  resolve(__dirname, '../../../src/serverEntry.ts')
+);
+
+/** `["X: exported from a, missing from b", ...]`, sorted and allowlist-filtered. */
+function missingFrom(
+  from: Set<string>,
+  to: Set<string>,
+  allowed: Record<string, string>,
+  fromLabel: string,
+  toLabel: string
+): string[] {
+  return [...from]
+    .filter((name) => !to.has(name) && !(name in allowed))
+    .sort()
+    .map(
+      (name) => `${name}: exported from ${fromLabel}, missing from ${toLabel}`
+    );
+}
+
+/** Allowlist entries that no longer describe a real asymmetry. */
+function staleEntries(
+  allowed: Record<string, string>,
+  present: Set<string>,
+  absent: Set<string>
+): string[] {
+  return Object.keys(allowed)
+    .filter((name) => absent.has(name) || !present.has(name))
+    .sort();
+}
+
 // Keep a minimal runtime test so Jest reports a passing spec when compilation succeeds.
 describe('API compatibility (server vs client)', () => {
   it('compiles with matching export surface', () => {
     expect(true).toBe(true);
+  });
+});
+
+describe('entry point export parity', () => {
+  it('reads both entry points', () => {
+    // A parser that quietly returned nothing would leave both diffs empty and
+    // this suite green, which is the failure mode the guard exists to stop.
+    expect(clientExports.size).toBeGreaterThan(200);
+    expect(serverExports.size).toBeGreaterThan(200);
+  });
+
+  it('exports every client symbol from the server entry', () => {
+    expect(
+      missingFrom(
+        clientExports,
+        serverExports,
+        CLIENT_ONLY,
+        CLIENT_ENTRY,
+        SERVER_ENTRY
+      )
+    ).toEqual([]);
+  });
+
+  it('exports every server symbol from the client entry', () => {
+    expect(
+      missingFrom(
+        serverExports,
+        clientExports,
+        SERVER_ONLY,
+        SERVER_ENTRY,
+        CLIENT_ENTRY
+      )
+    ).toEqual([]);
+  });
+
+  it('keeps the client-only allowlist free of stale entries', () => {
+    expect(staleEntries(CLIENT_ONLY, clientExports, serverExports)).toEqual([]);
+  });
+
+  it('keeps the server-only allowlist free of stale entries', () => {
+    expect(staleEntries(SERVER_ONLY, serverExports, clientExports)).toEqual([]);
   });
 });

--- a/packages/ai-chat/tests/typedoc/spec/alias_members_spec.ts
+++ b/packages/ai-chat/tests/typedoc/spec/alias_members_spec.ts
@@ -1,0 +1,151 @@
+/*
+ *  Copyright IBM Corp. 2026
+ *
+ *  This source code is licensed under the Apache-2.0 license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ *  @license
+ */
+
+/**
+ * Guards the cross-package re-export pattern documented in
+ * src/types/AGENTS.md.
+ *
+ * A public type surfaced as a bare `export type X = _X` alias of an upstream
+ * interface renders on the docs site with **no properties at all** — TypeDoc
+ * documents the alias, not what it resolves to. The same empty record then
+ * feeds the search index and the MCP server, so every property of that type is
+ * absent from all three surfaces while the build still exits 0.
+ *
+ * The fix is the `@interface` modifier tag, which makes TypeDoc emit the
+ * checker-resolved member list. Nothing else catches a missing one: the build
+ * passes, and the rendered page exists — it is just empty.
+ *
+ * Reads the TypeScript source rather than built or generated output, so it
+ * needs no docs build and stays correct between releases (docs/api/ is
+ * regenerated at release time, not per PR).
+ */
+
+import { readdirSync, readFileSync } from 'fs';
+import { join, relative, resolve } from 'path';
+import ts from 'typescript';
+
+/**
+ * Aliases that must NOT carry `@interface`, with the reason. `@interface`
+ * resolves the target's *properties*, so it is only correct for object-shaped
+ * targets. On a union TypeDoc warns (`converting_union_as_interface`) and emits
+ * only the members common to every branch.
+ *
+ * Adding an entry here is a deliberate, reviewable decision. The second test
+ * fails on stale entries, so this list cannot rot.
+ */
+const NOT_OBJECT_SHAPED: Record<string, string> = {
+  MarkdownItPlugin: 'union of markdown-it plugin function types and tuples',
+  FileStatusValue: 'enum — paired with `export const FileStatusValue`',
+  ChainOfThoughtStepStatus:
+    'enum — paired with `export const ChainOfThoughtStepStatus`',
+  CHAT_BUTTON_KIND: 'enum — paired with `export const CHAT_BUTTON_KIND`',
+  CHAT_BUTTON_SIZE: 'enum — paired with `export const CHAT_BUTTON_SIZE`',
+};
+
+const TYPES_ROOT = resolve(__dirname, '../../../src/types');
+
+function walk(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      return walk(full);
+    }
+    return entry.isFile() && full.endsWith('.ts') ? [full] : [];
+  });
+}
+
+interface Alias {
+  name: string;
+  target: string;
+  file: string;
+  hasInterfaceTag: boolean;
+}
+
+/** Every `export type X = _Y;` in src/types/, with its JSDoc tags resolved. */
+function collectAliases(): Alias[] {
+  const found: Alias[] = [];
+
+  for (const file of walk(TYPES_ROOT)) {
+    const source = ts.createSourceFile(
+      file,
+      readFileSync(file, 'utf8'),
+      ts.ScriptTarget.Latest,
+      true
+    );
+
+    for (const statement of source.statements) {
+      if (!ts.isTypeAliasDeclaration(statement)) {
+        continue;
+      }
+      const exported = statement.modifiers?.some(
+        (modifier) => modifier.kind === ts.SyntaxKind.ExportKeyword
+      );
+      if (!exported) {
+        continue;
+      }
+      // The cross-package form: `export type X = _X;` — a bare reference to an
+      // underscore-prefixed import alias of an upstream declaration.
+      if (
+        !ts.isTypeReferenceNode(statement.type) ||
+        !ts.isIdentifier(statement.type.typeName) ||
+        !statement.type.typeName.escapedText.toString().startsWith('_')
+      ) {
+        continue;
+      }
+
+      found.push({
+        name: statement.name.escapedText.toString(),
+        target: statement.type.typeName.escapedText.toString(),
+        file: relative(TYPES_ROOT, file),
+        hasInterfaceTag: ts
+          .getJSDocTags(statement)
+          .some((tag) => tag.tagName.escapedText === 'interface'),
+      });
+    }
+  }
+
+  return found;
+}
+
+const aliases = collectAliases();
+
+describe('cross-package type aliases render their properties', () => {
+  it('finds the aliases to check', () => {
+    // Guards the parser itself: a refactor that breaks collection would
+    // otherwise make every assertion below vacuously pass.
+    expect(aliases.length).toBeGreaterThan(20);
+  });
+
+  it('tags every object-shaped alias with @interface', () => {
+    const untagged = aliases
+      .filter((a) => !a.hasInterfaceTag && !(a.name in NOT_OBJECT_SHAPED))
+      .map((a) => `${a.name} (${a.file})`)
+      .sort();
+
+    expect(untagged).toEqual([]);
+  });
+
+  it('keeps the allowlist free of stale entries', () => {
+    const names = new Set(aliases.map((a) => a.name));
+    const stale = Object.keys(NOT_OBJECT_SHAPED)
+      .filter((name) => !names.has(name))
+      .sort();
+
+    expect(stale).toEqual([]);
+  });
+
+  it('does not tag an allowlisted alias', () => {
+    const contradictory = aliases
+      .filter((a) => a.name in NOT_OBJECT_SHAPED && a.hasInterfaceTag)
+      .map((a) => a.name)
+      .sort();
+
+    expect(contradictory).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #2141
Closes #2140

Public types declared as `export type X = _X` aliases rendered with no properties. TypeDoc documented the alias, not what it resolved to. The same empty record fed the search index and the MCP server.

Fixing that surfaced a second gap. A type exported from one entry point but not the other could ship unseen. The parity guard only ever looked at values.

- `packages/ai-chat/tests/config/spec/exports_compat_spec.ts` — two guards in one file now. The compile-time assertions still cover value types. The new runtime block parses both entry files and diffs their named exports. Star and locally-declared exports throw rather than being skipped.

#### Changelog

**New**

- 112 properties across 22 public types now render on the docs site, with their upstream JSDoc.
- 17 types now exported from `serverEntry.ts`, `StartersConfig` among them. They shipped from `aiChatEntry.tsx` only.
- `alias_members_spec.ts` — fails on a public alias missing `@interface`.
- Entry-point parity guard covers type-only exports, both directions. Client-only names sit in an allowlist with a stale-entry check.
- `npm run docs --workspace=@carbon/ai-chat` — TypeDoc-only build. Skips rollup, and leaves the release-generated `docs/api/` alone.

**Changed**

- 22 type pages move from `/docs/types/` to `/docs/interfaces/`.
- `src/types/AGENTS.md` prescribed the untagged alias form. Its worked example was a broken type.
- Three alias prose paragraphs contradicted the property lists they now sit above. Plus an "ommitted" typo upstream.

#### Testing / Reviewing

Docs output and type surface only — nothing to see in the demo.

1. `npm run build --workspace=@carbon/ai-chat`. Expect 0 errors.
2. Open `dist/docs/carbon-tsdocs/interfaces/Type_reference.TriggerSuggestionConfig.html`. Expect a properties index and a properties section, not a bare heading.
3. `npm run test --workspace=@carbon/ai-chat`.
4. Parity guard bites: drop a name from an `export type { ... }` block in `serverEntry.ts`. Rerun `exports_compat_spec.ts`. It names the symbol and the entry point missing it. Restore.
5. Alias guard bites: drop an `@interface` tag, run `npm run docs:api`, rerun `alias_members_spec.ts`. Restore both — `docs:api` rewrites committed files.
