### PR TITLE
fix(prompt-line): autocomplete send clear input

### DIFF
--- a/packages/ai-chat/src/chat/components/input/Input.tsx
+++ b/packages/ai-chat/src/chat/components/input/Input.tsx
@@ -504,7 +504,9 @@ function Input(props: InputProps, ref: Ref<InputFunctions>) {
       sendCurrentValue();
     },
     onSendItem: (text) => {
-      onSendInput(text);
+      setRawInputValue(text);
+      rawInputValueRef.current = text;
+      sendCurrentValue();
     },
   });
 

--- a/packages/ai-chat/src/chat/components/input/useInputValueSync.ts
+++ b/packages/ai-chat/src/chat/components/input/useInputValueSync.ts
@@ -139,9 +139,10 @@ function useInputValueSync({
     hasErrorProp ||
     hasInFlightUpload(pendingUploads);
 
-  // The single predicate behind both the Send control's enabled state and the send
-  // path itself. They disagreed before, which is why the button could light up on a
-  // file-only input and then do nothing when pressed.
+  // Drives the Send control's enabled state (React render path). The send
+  // function itself re-evaluates from the ref so it stays correct even when
+  // called synchronously after seeding the ref (e.g. starter / autocomplete
+  // item send) before React has re-rendered with the new state value.
   const hasValidInput = hasSendableInput(rawInputValue, pendingUploads);
 
   /**
@@ -183,7 +184,11 @@ function useInputValueSync({
    */
   const sendCurrentValue = () => {
     const text = rawInputValueRef.current;
-    if (!hasValidInput) {
+    // Re-evaluate from the ref at call time: callers like the starter and
+    // autocomplete-item send paths seed the ref synchronously before calling
+    // here, so using the closure-captured `hasValidInput` (derived from
+    // `rawInputValue` state) would race the React re-render and bail early.
+    if (!hasSendableInput(text, pendingUploads)) {
       return;
     }
     if (effectiveDisableSend) {

--- a/packages/ai-chat/tests/components/spec/inputAutocompleteSend_spec.tsx
+++ b/packages/ai-chat/tests/components/spec/inputAutocompleteSend_spec.tsx
@@ -1,0 +1,166 @@
+/*
+ *  Copyright IBM Corp. 2026
+ *
+ *  This source code is licensed under the Apache-2.0 license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ *  @license
+ */
+
+/**
+ * Regression: calling onSend from a renderCustomList callback must result in
+ * the message being sent and the input being cleared.
+ *
+ * The regression path is:
+ *   props.onSend(text)          — from renderCustomList
+ *   → handleSend (useChatAutocomplete)
+ *   → onSendItem (Input.tsx)
+ *   → setRawInputValue(text) + rawInputValueRef.current = text
+ *   → sendCurrentValue()       — reads ref, not stale state
+ *   → onSendInput(text)        — fires customSendMessage
+ *   → setRawInputValue('')     — clears the field
+ *
+ * Tested by capturing the onSendItem callback that Input.tsx passes into
+ * useChatAutocomplete, calling it, and asserting that clearContent() was
+ * called on the prompt-line element — the imperative clear inside
+ * sendCurrentValue(). The pre-fix regression called onSendInput(text) directly
+ * from onSendItem, bypassing sendCurrentValue() entirely, so clearContent()
+ * was never reached.
+ */
+
+import React from 'react';
+import { render, act, waitFor } from '@testing-library/react';
+
+import { StoreProvider } from '../../../src/chat/providers/StoreProvider';
+import { ServiceManagerContext } from '../../../src/chat/contexts/ServiceManagerContext';
+import { IntlProvider } from '../../../src/chat/providers/IntlProvider';
+import { AriaAnnouncerContext } from '../../../src/chat/contexts/AriaAnnouncerContext';
+import { createIntl } from '../../../src/chat/utils/i18n';
+import {
+  makeConfigStore,
+  setupAfterEach,
+  setupBeforeEach,
+} from '../../test_helpers';
+
+const testIntl = createIntl({ locale: 'en', messages: {} });
+
+// ---------------------------------------------------------------------------
+// Mock all heavy Lit web components so Input renders without a real DOM/Tiptap
+// ---------------------------------------------------------------------------
+
+jest.mock('@carbon/ai-chat-components/es/react/prompt-line-shell.js', () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }): React.ReactElement =>
+    React.createElement(
+      'div',
+      { 'data-testid': 'prompt-line-shell' },
+      children
+    ),
+}));
+// clearContent is the imperative clear called by sendCurrentValue() after send.
+// If the regression is present (onSendItem calls onSendInput directly), this
+// spy is never reached.
+const clearContentSpy = jest.fn();
+jest.mock('@carbon/ai-chat-components/es/react/prompt-line.js', () => {
+  const MockPromptLine = React.forwardRef(
+    (_props: unknown, ref: React.Ref<unknown>): React.ReactElement => {
+      React.useImperativeHandle(ref, () => ({ clearContent: clearContentSpy }));
+      return React.createElement('div', { 'data-testid': 'prompt-line' });
+    }
+  );
+  MockPromptLine.displayName = 'MockPromptLine';
+  return { __esModule: true, default: MockPromptLine };
+});
+jest.mock('@carbon/ai-chat-components/es/react/input-send-control.js', () => ({
+  __esModule: true,
+  default: (): null => null,
+}));
+jest.mock('@carbon/ai-chat-components/es/react/file-uploads.js', () => ({
+  __esModule: true,
+  default: (): null => null,
+}));
+jest.mock('@carbon/ai-chat-components/es/react/error-message.js', () => ({
+  __esModule: true,
+  default: (): null => null,
+}));
+
+// ---------------------------------------------------------------------------
+// Spy on useChatAutocomplete to capture the onSendItem wired by Input.tsx
+// ---------------------------------------------------------------------------
+
+let capturedOnSendItem: ((text: string) => void) | undefined;
+
+jest.mock(
+  '@carbon/ai-chat-components/es/react/hooks/useChatAutocomplete.js',
+  () => ({
+    __esModule: true,
+    useChatAutocomplete: (options: {
+      onSendItem?: (text: string) => void;
+    }): { onTriggerChange: () => void; autocompleteContent: null } => {
+      capturedOnSendItem = options.onSendItem;
+      return { onTriggerChange: () => {}, autocompleteContent: null };
+    },
+  })
+);
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('input autocomplete send regression', () => {
+  beforeEach(() => {
+    setupBeforeEach();
+    clearContentSpy.mockClear();
+  });
+  afterEach(setupAfterEach);
+
+  it('onSendItem routes through sendCurrentValue and clears the input', async () => {
+    const { Input: InputExport } =
+      await import('../../../src/chat/components/input/Input');
+
+    const store = makeConfigStore({});
+    const onSendInput = jest.fn();
+    const serviceManager = {
+      store,
+      setInputFunctionsRef: jest.fn(),
+    } as any;
+
+    capturedOnSendItem = undefined;
+
+    render(
+      React.createElement(
+        StoreProvider,
+        { store },
+        React.createElement(
+          IntlProvider,
+          { intl: testIntl },
+          React.createElement(
+            AriaAnnouncerContext.Provider,
+            { value: jest.fn() },
+            React.createElement(
+              ServiceManagerContext.Provider,
+              { value: serviceManager },
+              React.createElement(InputExport, {
+                disableInput: false,
+                isInputVisible: true,
+                disableSend: false,
+                onSendInput,
+              })
+            )
+          )
+        )
+      )
+    );
+
+    await waitFor(() => expect(capturedOnSendItem).toBeDefined());
+
+    act(() => {
+      capturedOnSendItem?.('hello from autocomplete');
+    });
+
+    expect(onSendInput).toHaveBeenCalledTimes(1);
+    // clearContent() is called inside sendCurrentValue() — the imperative clear.
+    // If onSendItem bypasses sendCurrentValue() (the regression), this is never called.
+    expect(clearContentSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/ai-chat/tests/components/spec/inputAutocompleteSend_spec.tsx
+++ b/packages/ai-chat/tests/components/spec/inputAutocompleteSend_spec.tsx
@@ -51,11 +51,7 @@ const testIntl = createIntl({ locale: 'en', messages: {} });
 jest.mock('@carbon/ai-chat-components/es/react/prompt-line-shell.js', () => ({
   __esModule: true,
   default: ({ children }: { children: React.ReactNode }): React.ReactElement =>
-    React.createElement(
-      'div',
-      { 'data-testid': 'prompt-line-shell' },
-      children
-    ),
+    React.createElement('div', null, children),
 }));
 // clearContent is the imperative clear called by sendCurrentValue() after send.
 // If the regression is present (onSendItem calls onSendInput directly), this
@@ -65,24 +61,12 @@ jest.mock('@carbon/ai-chat-components/es/react/prompt-line.js', () => {
   const MockPromptLine = React.forwardRef(
     (_props: unknown, ref: React.Ref<unknown>): React.ReactElement => {
       React.useImperativeHandle(ref, () => ({ clearContent: clearContentSpy }));
-      return React.createElement('div', { 'data-testid': 'prompt-line' });
+      return React.createElement('div', null);
     }
   );
   MockPromptLine.displayName = 'MockPromptLine';
   return { __esModule: true, default: MockPromptLine };
 });
-jest.mock('@carbon/ai-chat-components/es/react/input-send-control.js', () => ({
-  __esModule: true,
-  default: (): null => null,
-}));
-jest.mock('@carbon/ai-chat-components/es/react/file-uploads.js', () => ({
-  __esModule: true,
-  default: (): null => null,
-}));
-jest.mock('@carbon/ai-chat-components/es/react/error-message.js', () => ({
-  __esModule: true,
-  default: (): null => null,
-}));
 
 // ---------------------------------------------------------------------------
 // Spy on useChatAutocomplete to capture the onSendItem wired by Input.tsx


### PR DESCRIPTION
Closes #2154

Autocomplete item send bypassed `sendCurrentValue()` and called `onSendInput(text)` directly, so the input was never cleared and `clearContent()` was never reached. Fixed by seeding the ref synchronously in `onSendItem` and routing through `sendCurrentValue()`, which re-evaluates from the ref at call time rather than stale React state.

**Changed**
- `Input.tsx`: `onSendItem` follows "canonical" send path that clears input
- `useInputValueSync.ts`: `sendCurrentValue` now calls `hasSendableInput(text, pendingUploads)` from the ref, not the closure-captured `hasValidInput`; comment updated to explain why both exist

**New**
- Added regression test to ensure `onSendItem` routes through `sendCurrentValue()` and clears the input

#### Testing / Reviewing

1. Go to demo deploy preview
2. Chat configuration -> Input -> Enable autocomplete suggestions
3. Type enough to trigger an autocomplete suggestion. Click or keyboard-select an item
4. Confirm that message is sent and the input field is cleared