### PR TITLE
fix: chip color fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
         "text-readability": "^1.1.0"
       },
       "engines": {
-        "node": ">=22.0.0",
+        "node": ">=24.0.0",
         "npm": ">=10.0.0"
       }
     },
@@ -23762,16 +23762,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/conventional-commits-filter": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-6.0.1.tgz",
-      "integrity": "sha512-cs+LadpH7Kpw0M3k8wurk+sOVVDAENA0iK4OBOrkL94j5lEVYRJ4j3zd2bhY9qgzyrPqthdcYT3axzRN7AliMg==",
-      "extraneous": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=22"
       }
     },
     "node_modules/conventional-commits-parser": {

--- a/packages/ai-chat-components/src/components/prompt-line/src/tiptap/__tests__/render-token-chip.test.ts
+++ b/packages/ai-chat-components/src/components/prompt-line/src/tiptap/__tests__/render-token-chip.test.ts
@@ -1,0 +1,138 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { expect } from '@open-wc/testing';
+
+import { renderTokenChip } from '../render-token-chip.js';
+
+/**
+ * Returns all CSS text from the dynamic-css-var-sheet singleton, which uses
+ * either document.adoptedStyleSheets or a fallback <style> element.
+ */
+function getDynamicSheetCssText(): string {
+  // The dynamic-css-var-sheet adopts its singleton on the document. Collect
+  // all adopted stylesheets and also any <style> elements that may have been
+  // used as a fallback.
+  const fromAdopted = Array.from(document.adoptedStyleSheets ?? [])
+    .map((s) => {
+      try {
+        return Array.from(s.cssRules)
+          .map((r) => r.cssText)
+          .join('\n');
+      } catch {
+        return '';
+      }
+    })
+    .join('\n');
+
+  const fromStyle = Array.from(document.querySelectorAll('style'))
+    .map((el) => el.textContent ?? '')
+    .join('\n');
+
+  return `${fromAdopted}\n${fromStyle}`;
+}
+
+describe('renderTokenChip', function () {
+  afterEach(() => {
+    document
+      .querySelectorAll('.cds-aichat--token')
+      .forEach((el) => el.remove());
+  });
+
+  it('creates a span with class cds-aichat--token', () => {
+    const chip = renderTokenChip({
+      attrs: { label: 'Alice' },
+      type: 'mention',
+      context: 'composer',
+    });
+    expect(chip.tagName.toLowerCase()).to.equal('span');
+    expect(chip.classList.contains('cds-aichat--token')).to.be.true;
+  });
+
+  it('sets data-token-context="composer" for composer chips', () => {
+    const chip = renderTokenChip({
+      attrs: { label: 'Alice' },
+      type: 'mention',
+      context: 'composer',
+    });
+    expect(chip.getAttribute('data-token-context')).to.equal('composer');
+  });
+
+  it('sets data-token-context="historical" for historical chips', () => {
+    const chip = renderTokenChip({
+      attrs: { label: '/summarize', value: 'summarize', trigger: '/' },
+      type: 'command',
+      context: 'historical',
+    });
+    expect(chip.getAttribute('data-token-context')).to.equal('historical');
+  });
+
+  it('installs a chip color rule for composer chips with a static fallback', () => {
+    // Trigger rule installation by creating a chip.
+    renderTokenChip({
+      attrs: { label: 'Alice' },
+      type: 'mention',
+      context: 'composer',
+    });
+
+    const cssText = getDynamicSheetCssText();
+    // The rule must include a static fallback — bare var(--cds-tag-color-blue)
+    // without a fallback resolves to nothing in an unthemed host.
+    expect(cssText).to.match(/--cds-tag-color-blue,\s*#0043ce/i);
+  });
+
+  it('installs a chip color rule for historical chips with a static fallback', () => {
+    renderTokenChip({
+      attrs: { label: 'Alice' },
+      type: 'mention',
+      context: 'historical',
+    });
+
+    const cssText = getDynamicSheetCssText();
+    expect(cssText).to.match(/--cds-link-secondary,\s*#0043ce/i);
+  });
+
+  it('composer chip has a non-inherited color in an unthemed host', () => {
+    // No Carbon theme class on any ancestor — tokens are undefined.
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+
+    const chip = renderTokenChip({
+      attrs: { label: 'Alice' },
+      type: 'mention',
+      context: 'composer',
+    });
+    host.appendChild(chip);
+
+    const style = getComputedStyle(chip);
+    // #0043ce → rgb(0, 67, 206). The chip must not resolve to the inherited
+    // body text color.
+    expect(style.color).to.equal('rgb(0, 67, 206)');
+
+    host.remove();
+  });
+
+  it('historical chip has a non-inherited color in an unthemed host', () => {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+
+    const chip = renderTokenChip({
+      attrs: { label: 'Alice' },
+      type: 'mention',
+      context: 'historical',
+    });
+    host.appendChild(chip);
+
+    const style = getComputedStyle(chip);
+    // link-secondary white-theme fallback: #0043ce → rgb(0, 67, 206).
+    expect(style.color).to.equal('rgb(0, 67, 206)');
+
+    host.remove();
+  });
+});

--- a/packages/ai-chat-components/src/components/prompt-line/src/tiptap/render-token-chip.ts
+++ b/packages/ai-chat-components/src/components/prompt-line/src/tiptap/render-token-chip.ts
@@ -30,14 +30,14 @@ function ensureTokenStyleRules(): void {
   }
   setVarsForSelector('.cds-aichat--token', { 'white-space': 'normal' });
   setVarsForSelector('.cds-aichat--token[data-token-context="composer"]', {
-    color: 'var(--cds-tag-color-blue)',
+    color: 'var(--cds-tag-color-blue, #0043ce)',
   });
   setVarsForSelector(
     '.cds-aichat--token[data-token-context="composer"]::selection',
-    { 'background-color': 'var(--cds-tag-background-blue)' }
+    { 'background-color': 'var(--cds-tag-background-blue, #d0e2ff)' }
   );
   setVarsForSelector('.cds-aichat--token[data-token-context="historical"]', {
-    color: 'var(--cds-link-secondary)',
+    color: 'var(--cds-link-secondary, #0043ce)',
   });
   tokenStyleRulesInstalled = true;
 }


### PR DESCRIPTION
Closes #2157 

adds fallback for chip colors

#### Changelog

**New**

- `packages/ai-chat-components/src/components/prompt-line/src/tiptap/__tests__/render-token-chip.test.ts` adds tests for token chip functionality

**Changed**

- `packages/ai-chat-components/src/components/prompt-line/src/tiptap/render-token-chip.ts` adds fallback colors for chips

#### Testing / Reviewing

`npm run test` and review the colors are working appropriatly in the `examples/react/prompt-line-mentions-and-commands` example
