### PR TITLE
feat(autocomplete): disabled items support

### DIFF
--- a/packages/ai-chat-components/src/components/prompt-line/autocomplete/__stories__/autocomplete-react.stories.jsx
+++ b/packages/ai-chat-components/src/components/prompt-line/autocomplete/__stories__/autocomplete-react.stories.jsx
@@ -14,6 +14,7 @@ import {
   Default as DefaultWC,
   WithHeader as WithHeaderWC,
   WithCategories as WithCategoriesWC,
+  WithDisabledItems as WithDisabledItemsWC,
   Detached as DetachedWC,
 } from './autocomplete.stories';
 import {
@@ -255,6 +256,50 @@ export const WithCategories = {
         <CDSAIChatAutocomplete
           groups={filteredGroups}
           inputText={query}
+          attached={args.attached ?? true}
+          disableDirectSend={args.disableDirectSend ?? false}
+          style={{ '--cds-aichat-autocomplete-max-height': '328px' }}
+          onSelect={(e) => action('cds-aichat-autocomplete-select')(e.detail)}
+          onSend={(e) => action('cds-aichat-autocomplete-send')(e.detail)}
+          onDismiss={() => action('cds-aichat-autocomplete-dismiss')()}
+        />
+      </Wrapper>
+    );
+  },
+};
+
+export const WithDisabledItems = {
+  render: (args) => {
+    const mixedItems = [
+      {
+        id: 'suggestion-1',
+        label: 'When is the best time to eat?',
+      },
+      {
+        id: 'suggestion-2',
+        label: 'When is the sun rising today?',
+        disabled: true,
+      },
+      {
+        id: 'suggestion-3',
+        label: 'When is the sun setting today?',
+      },
+      {
+        id: 'suggestion-4',
+        label: 'When is the start of Spring?',
+        disabled: true,
+      },
+      {
+        id: 'suggestion-5',
+        label: 'When is the next full moon?',
+      },
+    ];
+
+    return (
+      <Wrapper width="320px">
+        <CDSAIChatAutocomplete
+          items={mixedItems}
+          inputText={args.inputText || ''}
           attached={args.attached ?? true}
           disableDirectSend={args.disableDirectSend ?? false}
           style={{ '--cds-aichat-autocomplete-max-height': '328px' }}

--- a/packages/ai-chat-components/src/components/prompt-line/autocomplete/__stories__/autocomplete.stories.js
+++ b/packages/ai-chat-components/src/components/prompt-line/autocomplete/__stories__/autocomplete.stories.js
@@ -262,6 +262,54 @@ export const WithCategories = {
   },
 };
 
+export const WithDisabledItems = {
+  render: ({ inputText, disableDirectSend, attached }) => {
+    const mixedItems = [
+      {
+        id: 'suggestion-1',
+        label: 'When is the best time to eat?',
+      },
+      {
+        id: 'suggestion-2',
+        label: 'When is the sun rising today?',
+        disabled: true,
+      },
+      {
+        id: 'suggestion-3',
+        label: 'When is the sun setting today?',
+      },
+      {
+        id: 'suggestion-4',
+        label: 'When is the start of Spring?',
+        disabled: true,
+      },
+      {
+        id: 'suggestion-5',
+        label: 'When is the next full moon?',
+      },
+    ];
+
+    return html`
+      <div style="width: 320px;">
+        <cds-aichat-autocomplete
+          style="--cds-aichat-autocomplete-max-height: 328px;"
+          .items=${mixedItems}
+          ?attached=${attached}
+          ?disable-direct-send=${disableDirectSend}
+          input-text=${inputText}
+          @cds-aichat-autocomplete-select=${(e) =>
+            action('cds-aichat-autocomplete-select')(e.detail)}
+          @cds-aichat-autocomplete-send=${(e) =>
+            action('cds-aichat-autocomplete-send')(e.detail)}
+          @cds-aichat-autocomplete-dismiss=${() =>
+            action(
+              'cds-aichat-autocomplete-dismiss'
+            )()}></cds-aichat-autocomplete>
+      </div>
+    `;
+  },
+};
+
 export const Detached = {
   args: {
     attached: false,

--- a/packages/ai-chat-components/src/components/prompt-line/autocomplete/__tests__/autocomplete.test.ts
+++ b/packages/ai-chat-components/src/components/prompt-line/autocomplete/__tests__/autocomplete.test.ts
@@ -15,6 +15,8 @@ import type {
   SuggestionItem,
   SuggestionItemGroup,
 } from '../src/autocomplete.js';
+import { defaultAutocompleteI18n } from '../src/autocomplete.js';
+import prefix from '../../../../globals/settings.js';
 
 describe('cds-aichat-autocomplete', () => {
   const mockItems: SuggestionItem[] = [
@@ -731,6 +733,220 @@ describe('cds-aichat-autocomplete', () => {
       `);
 
       expect(el.disableDirectSend).to.be.true;
+    });
+  });
+
+  describe('disabled items', () => {
+    const disabledItem: SuggestionItem = {
+      id: 'disabled-1',
+      label: 'Disabled Option',
+      disabled: true,
+    };
+    const enabledItem: SuggestionItem = {
+      id: 'enabled-1',
+      label: 'Enabled Option',
+    };
+
+    it('should set aria-disabled correctly for disabled and enabled items', async () => {
+      const el = await fixture<AutocompleteElement>(html`
+        <cds-aichat-autocomplete
+          .items="${[disabledItem, enabledItem]}"></cds-aichat-autocomplete>
+      `);
+
+      const options = el.shadowRoot?.querySelectorAll('li[role="option"]');
+
+      expect(
+        (options?.[0] as HTMLElement)?.getAttribute('aria-disabled')
+      ).to.equal('true');
+      expect(
+        (options?.[1] as HTMLElement)?.getAttribute('aria-disabled')
+      ).to.equal('false');
+    });
+
+    it('should add the disabled class', async () => {
+      const el = await fixture<AutocompleteElement>(
+        html` <cds-aichat-autocomplete
+          .items="${[disabledItem]}"></cds-aichat-autocomplete>`
+      );
+
+      const options = el.shadowRoot?.querySelectorAll('li[role="option"]');
+      const disabledClass = `${prefix}-autocomplete-item--disabled`;
+
+      expect((options?.[0] as HTMLElement).classList.contains(disabledClass)).to
+        .be.true;
+    });
+
+    it('click on disabled item does not fire cds-aichat-autocomplete-send (disableDirectSend=false)', async () => {
+      const el = await fixture<AutocompleteElement>(html`
+        <cds-aichat-autocomplete
+          .items="${[disabledItem, enabledItem]}"></cds-aichat-autocomplete>
+      `);
+
+      let sendFired = false;
+      el.addEventListener('cds-aichat-autocomplete-send', () => {
+        sendFired = true;
+      });
+
+      const disabledOption = el.shadowRoot?.querySelector('li[role="option"]');
+      disabledOption?.dispatchEvent(
+        new MouseEvent('click', { bubbles: true, composed: true })
+      );
+      await el.updateComplete;
+
+      expect(sendFired).to.be.false;
+    });
+
+    it('click on disabled item does not fire cds-aichat-autocomplete-select (disableDirectSend=true)', async () => {
+      const el = await fixture<AutocompleteElement>(html`
+        <cds-aichat-autocomplete
+          .items="${[disabledItem, enabledItem]}"
+          .disableDirectSend="${true}"></cds-aichat-autocomplete>
+      `);
+
+      let selectFired = false;
+      el.addEventListener('cds-aichat-autocomplete-select', () => {
+        selectFired = true;
+      });
+
+      const disabledOption = el.shadowRoot?.querySelector('li[role="option"]');
+      disabledOption?.dispatchEvent(
+        new MouseEvent('click', { bubbles: true, composed: true })
+      );
+      await el.updateComplete;
+
+      expect(selectFired).to.be.false;
+    });
+
+    it('Enter on a disabled item does not fire send or select', async () => {
+      // Place the only-disabled item alone so _focusedIndex stays at 0 (no
+      // enabled item to skip to) and Enter has no valid target.
+      const el = await fixture<AutocompleteElement>(html`
+        <cds-aichat-autocomplete
+          .items="${[disabledItem]}"></cds-aichat-autocomplete>
+      `);
+
+      let sendFired = false;
+      let selectFired = false;
+      el.addEventListener('cds-aichat-autocomplete-send', () => {
+        sendFired = true;
+      });
+      el.addEventListener('cds-aichat-autocomplete-select', () => {
+        selectFired = true;
+      });
+
+      el.dispatchEvent(
+        new KeyboardEvent('keydown', {
+          key: 'Enter',
+          bubbles: true,
+          composed: true,
+        })
+      );
+      await el.updateComplete;
+
+      expect(sendFired).to.be.false;
+      expect(selectFired).to.be.false;
+    });
+
+    it('ArrowDown skips a disabled item and lands on the next enabled item', async () => {
+      // Layout: enabled(0) → disabled(1) → enabled(2)
+      const threeItems: SuggestionItem[] = [
+        enabledItem,
+        disabledItem,
+        { id: 'enabled-2', label: 'Enabled Option 2' },
+      ];
+      const el = await fixture<AutocompleteElement>(html`
+        <cds-aichat-autocomplete
+          .items="${threeItems}"></cds-aichat-autocomplete>
+      `);
+
+      // Focus starts at index 0 (first enabled). One ArrowDown should skip
+      // the disabled item at index 1 and land on index 2.
+      el.dispatchEvent(
+        new KeyboardEvent('keydown', {
+          key: 'ArrowDown',
+          bubbles: true,
+          composed: true,
+        })
+      );
+      await el.updateComplete;
+
+      const options = el.shadowRoot?.querySelectorAll('li[role="option"]');
+      expect(
+        (options?.[2] as HTMLElement)?.getAttribute('aria-selected')
+      ).to.equal('true');
+      expect(
+        (options?.[1] as HTMLElement)?.getAttribute('aria-selected')
+      ).to.equal('false');
+      expect(
+        (options?.[0] as HTMLElement)?.getAttribute('aria-selected')
+      ).to.equal('false');
+    });
+
+    it('ArrowDown stays put when no enabled item exists beyond current', async () => {
+      // Layout: enabled(0) → disabled(1). From 0, ArrowDown should not move.
+      const el = await fixture<AutocompleteElement>(html`
+        <cds-aichat-autocomplete
+          .items="${[enabledItem, disabledItem]}"></cds-aichat-autocomplete>
+      `);
+
+      el.dispatchEvent(
+        new KeyboardEvent('keydown', {
+          key: 'ArrowDown',
+          bubbles: true,
+          composed: true,
+        })
+      );
+      await el.updateComplete;
+
+      const options = el.shadowRoot?.querySelectorAll('li[role="option"]');
+      // Still on index 0 — no enabled item to land on.
+      expect(
+        (options?.[0] as HTMLElement)?.getAttribute('aria-selected')
+      ).to.equal('true');
+    });
+
+    it('initial focus skips a leading disabled item', async () => {
+      // Render with disabled first — _focusedIndex should initialise to the
+      // first enabled item, not index 0.
+      const el = await fixture<AutocompleteElement>(html`
+        <cds-aichat-autocomplete
+          .items="${[disabledItem, enabledItem]}"></cds-aichat-autocomplete>
+      `);
+
+      const options = el.shadowRoot?.querySelectorAll('li[role="option"]');
+      expect(
+        (options?.[1] as HTMLElement)?.getAttribute('aria-selected')
+      ).to.equal('true');
+      expect(
+        (options?.[0] as HTMLElement)?.getAttribute('aria-selected')
+      ).to.equal('false');
+    });
+
+    it('all-disabled list fires suggestionsAvailable with the correct count', async () => {
+      const allDisabledItems: SuggestionItem[] = [
+        { id: 'd1', label: 'Disabled A', disabled: true },
+        { id: 'd2', label: 'Disabled B', disabled: true },
+      ];
+
+      let announcedCount: number | null = null;
+      const trackingI18n = {
+        ...defaultAutocompleteI18n,
+        suggestionsAvailable: (count: number) => {
+          announcedCount = count;
+          return defaultAutocompleteI18n.suggestionsAvailable(count);
+        },
+      };
+
+      const el = await fixture<AutocompleteElement>(html`
+        <cds-aichat-autocomplete
+          .i18n="${trackingI18n}"></cds-aichat-autocomplete>
+      `);
+
+      // Setting items after mount triggers updated() → suggestionsAvailable
+      el.items = allDisabledItems;
+      await el.updateComplete;
+
+      expect(announcedCount).to.equal(2);
     });
   });
 });

--- a/packages/ai-chat-components/src/components/prompt-line/autocomplete/src/autocomplete.scss
+++ b/packages/ai-chat-components/src/components/prompt-line/autocomplete/src/autocomplete.scss
@@ -235,4 +235,3 @@ $group-class: #{$item-class}-group;
   --cds-aichat-border-radius-end-start: 0;
   --cds-aichat-border-radius-end-end: 0;
 }
-

--- a/packages/ai-chat-components/src/components/prompt-line/autocomplete/src/autocomplete.scss
+++ b/packages/ai-chat-components/src/components/prompt-line/autocomplete/src/autocomplete.scss
@@ -122,6 +122,26 @@ $group-class: #{$item-class}-group;
     &--active:hover {
       background: theme.$background-selected;
     }
+
+    &--disabled {
+      cursor: default;
+      pointer-events: none;
+
+      .#{$item-class}__label-remainder,
+      .#{$item-class}__label-typed {
+        color: theme.$text-disabled;
+      }
+
+      .#{$item-class}__description {
+        color: theme.$text-disabled;
+      }
+
+      // Override --active selector: send icon stays hidden even when
+      // the disabled item is keyboard-focused (--active class still present).
+      .#{$item-class}__send-icon svg {
+        fill: theme.$icon-disabled;
+      }
+    }
   }
 
   .#{$item-class}__content {
@@ -215,3 +235,4 @@ $group-class: #{$item-class}-group;
   --cds-aichat-border-radius-end-start: 0;
   --cds-aichat-border-radius-end-end: 0;
 }
+

--- a/packages/ai-chat-components/src/components/prompt-line/autocomplete/src/autocomplete.ts
+++ b/packages/ai-chat-components/src/components/prompt-line/autocomplete/src/autocomplete.ts
@@ -22,10 +22,7 @@ import type {
   SuggestionItem,
   SuggestionItemGroup,
 } from '../../src/tiptap/types.js';
-export type {
-  SuggestionItem,
-  SuggestionItemGroup,
-} from '../../src/tiptap/types.js';
+import { classMap } from 'lit/directives/class-map.js';
 
 const blockClass = `${prefix}-autocomplete`;
 const itemClass = `${blockClass}-item`;
@@ -243,8 +240,15 @@ class AutocompleteElement extends LitElement {
         this._openAnnounced = false;
         return;
       }
-      // Reset to first item and announce list opened (once per show).
-      this._focusedIndex = 0;
+      // Reset to first enabled item and announce list opened (once per show).
+      let firstEnabled = 0;
+      while (
+        firstEnabled < totalItems &&
+        this._getItemAtIndex(firstEnabled)?.disabled
+      ) {
+        firstEnabled++;
+      }
+      this._focusedIndex = firstEnabled < totalItems ? firstEnabled : 0;
       if (!this._openAnnounced) {
         this._openAnnounced = true;
         this._announcer.announce(this.i18n.suggestionsAvailable(totalItems));
@@ -283,6 +287,25 @@ class AutocompleteElement extends LitElement {
     return null;
   }
 
+  /**
+   * Move focus to the next enabled item in the given direction (+1 / -1),
+   * skipping over any disabled items. Mirrors the Carbon Dropdown `_navigate`
+   * pattern. Returns the resolved index, or the current index if no enabled
+   * item exists in that direction.
+   */
+  private _navigateTo(from: number, direction: 1 | -1): number {
+    const totalItems = this._getTotalItemCount();
+    let next = from + direction;
+    while (next >= 0 && next < totalItems) {
+      if (!this._getItemAtIndex(next)?.disabled) {
+        return next;
+      }
+      next += direction;
+    }
+    // No enabled item found in that direction — stay put.
+    return from;
+  }
+
   private _handleKeydown = (event: KeyboardEvent) => {
     const totalItems = this._getTotalItemCount();
     if (totalItems === 0) {
@@ -292,31 +315,43 @@ class AutocompleteElement extends LitElement {
     switch (event.key) {
       case 'ArrowDown':
         event.preventDefault();
-        this._focusedIndex = Math.min(this._focusedIndex + 1, totalItems - 1);
+        this._focusedIndex = this._navigateTo(this._focusedIndex, 1);
         this._scheduleMoveAnnouncement(this._focusedIndex, totalItems);
         this._scrollActiveItemIntoView();
         break;
 
       case 'ArrowUp':
         event.preventDefault();
-        this._focusedIndex = Math.max(this._focusedIndex - 1, 0);
+        this._focusedIndex = this._navigateTo(this._focusedIndex, -1);
         this._scheduleMoveAnnouncement(this._focusedIndex, totalItems);
         this._scrollActiveItemIntoView();
         break;
 
-      case 'Home':
+      case 'Home': {
         event.preventDefault();
-        this._focusedIndex = 0;
+        // Find first enabled item from the top.
+        let first = 0;
+        while (first < totalItems && this._getItemAtIndex(first)?.disabled) {
+          first++;
+        }
+        this._focusedIndex = first < totalItems ? first : this._focusedIndex;
         this._scheduleMoveAnnouncement(this._focusedIndex, totalItems);
         this._scrollActiveItemIntoView();
         break;
+      }
 
-      case 'End':
+      case 'End': {
         event.preventDefault();
-        this._focusedIndex = totalItems - 1;
+        // Find last enabled item from the bottom.
+        let last = totalItems - 1;
+        while (last >= 0 && this._getItemAtIndex(last)?.disabled) {
+          last--;
+        }
+        this._focusedIndex = last >= 0 ? last : this._focusedIndex;
         this._scheduleMoveAnnouncement(this._focusedIndex, totalItems);
         this._scrollActiveItemIntoView();
         break;
+      }
 
       case 'Escape':
         event.preventDefault();
@@ -413,6 +448,9 @@ class AutocompleteElement extends LitElement {
   }
 
   private _selectItem(item: SuggestionItem) {
+    if (item.disabled) {
+      return;
+    }
     this._announcer.announce(this.i18n.itemInserted(item.label));
     this.dispatchEvent(
       new CustomEvent<AutocompleteSelectEventDetail>(
@@ -438,12 +476,13 @@ class AutocompleteElement extends LitElement {
   }
 
   private _handleItemClick(index: number) {
-    if (!this.disableDirectSend) {
-      this._handleSend(index);
+    const item = this._getItemAtIndex(index);
+    if (!item || item.disabled) {
       return;
     }
-    const item = this._getItemAtIndex(index);
-    if (!item) {
+
+    if (!this.disableDirectSend) {
+      this._handleSend(index);
       return;
     }
     this._focusedIndex = index;
@@ -504,6 +543,7 @@ class AutocompleteElement extends LitElement {
   ) {
     const { typed, remainder } = this._getLabelParts(item);
     const isActive = index === this._focusedIndex;
+    const isDisabled = !!item.disabled;
     const id = `${item.id}--option`;
 
     return html`
@@ -516,7 +556,12 @@ class AutocompleteElement extends LitElement {
           }
         }}"
         aria-selected="${isActive ? 'true' : 'false'}"
-        class="${itemClass} ${isActive ? `${itemClass}--active` : ''}"
+        aria-disabled="${isDisabled ? 'true' : 'false'}"
+        class=${classMap({
+          [itemClass]: true,
+          [`${itemClass}--active`]: isActive,
+          [`${itemClass}--disabled`]: isDisabled,
+        })}
         id="${id}"
         role="option"
         tabindex="-1"
@@ -654,3 +699,7 @@ declare global {
 }
 
 export default AutocompleteElement;
+export type {
+  SuggestionItem,
+  SuggestionItemGroup,
+} from '../../src/tiptap/types.js';


### PR DESCRIPTION
Closes #2138 

<img width="389" height="264" alt="Screenshot 2026-08-17 at 2 00 56 PM" src="https://github.com/user-attachments/assets/89fcb4d7-441f-4d82-8e6d-53409ef5481d" />

Adds `disabled` support to `cds-aichat-autocomplete` suggestion items. Disabled items render with muted styles, are unreachable by keyboard navigation (skipped, matching Carbon Dropdown's `_navigate` pattern), and block click and Enter activation.

- `autocomplete.ts` — `_navigateTo` helper walks past disabled items in the direction of travel; `updated()` initial-focus also skips leading disabled items; guards in `_handleItemClick` and `_selectItem` block activation

#### Changelog

**New**

- `disabled?: boolean` on `SuggestionItem` — marks an item as non-interactive

**Changed**

- Arrow-key navigation skips disabled items (matches Carbon Dropdown behavior)
- Initial focus on list open lands on first enabled item, not first item
- Home/End keys land on first/last enabled item
- Click on a disabled item no longer fires `cds-aichat-autocomplete-send` or `cds-aichat-autocomplete-select`

#### Testing / Reviewing

Run the WTR suite:

```bash
npm run test:web-components --workspace=@carbon/ai-chat-components -- src/components/prompt-line/autocomplete/__tests__/autocomplete.test.ts
```

All tests in the `disabled items` describe block should pass, including:

- click suppressed (send and select paths)
- Enter suppressed
- ArrowDown skips disabled and lands on next enabled
- ArrowDown stays put when no enabled item exists beyond current
- initial focus skips a leading disabled item

Check the `WithDisabledItems` story in the Lit Storybook (`npm run storybook --workspace=@carbon/ai-chat-components`, port 6006) — disabled items should appear muted and arrow keys should skip over them.
