### PR TITLE
fix(input): localize max-char-count error title and announcement

### DIFF
--- a/packages/ai-chat/src/chat/components/input/Input.tsx
+++ b/packages/ai-chat/src/chat/components/input/Input.tsx
@@ -545,17 +545,19 @@ function Input(props: InputProps, ref: Ref<InputFunctions>) {
    */
   const renderErrorMessage = () => {
     if (overMaxLength) {
+      const errorTitle = intl.formatMessage({
+        id: 'input_maxCharCountExceededTitle',
+      });
       const errorText = intl.formatMessage(
         { id: 'input_maxCharCountExceeded' },
         { max: maxInputChars, current: rawInputValue.length }
       );
       return (
         <div slot="field-messaging">
-          <AnnounceOnMount
-            announceOnce={`Error: Max character count exceeded. ${errorText}`}>
+          <AnnounceOnMount announceOnce={`${errorTitle}. ${errorText}`}>
             <ErrorMessage
               fullscreen={chatWidthBreakpoint === ChatWidthBreakpoint.WIDE}
-              title="Error: Max character count exceeded"
+              title={errorTitle}
               description={errorText}
               collapsible={true}
             />

--- a/packages/ai-chat/src/chat/languages/en.json
+++ b/packages/ai-chat/src/chat/languages/en.json
@@ -38,6 +38,7 @@
   "input_sendingMessage": "Sending message...",
   "input_keyboardShortcutAnnouncement": "Press {key} to toggle focus between the message list and input field.",
   "input_maxCharCountExceeded": "Maximum character count of {max} exceeded. {current} characters, currently.",
+  "input_maxCharCountExceededTitle": "Error: Max character count exceeded",
   "window_title": "Chat window",
   "window_ariaChatRegion": "Chat",
   "window_ariaChatRegionNamespace": "Chat {namespace}",


### PR DESCRIPTION
Closes #2162

The over-max-length error's title and announcement were English literals. A translated `languagePack` still showed an English heading. Both now come from the language pack.

#### Changelog

**New**

- `input_maxCharCountExceededTitle` language-pack key for the over-max-length error title.

**Changed**

- Over-max-length error title and live-region announcement now read from the language pack.

#### Testing / Reviewing

1. In `examples/react/theme-plex-override`, add a `strings` override for the two keys below.
   ```
   input_maxCharCountExceededTitle
   input_maxCharCountExceeded
   ```
2. Type past the character limit (10,000 by default).
3. Check the error banner title and the screen-reader announcement. Both should show the override text, not "Error: Max character count exceeded".
