### PR TITLE
fix(prompt-line): useChatAutocomplete calls onMount on correct host element

### DIFF
--- a/packages/ai-chat-components/src/react/hooks/useChatAutocomplete.tsx
+++ b/packages/ai-chat-components/src/react/hooks/useChatAutocomplete.tsx
@@ -355,8 +355,6 @@ function CustomReactNodePortal({
     chatWrapper.appendChild(hostEl);
 
     setHostElement(hostEl);
-    onMount?.(hostEl);
-
     return () => {
       onMount?.(null);
       if (onMousedown) {
@@ -371,6 +369,21 @@ function CustomReactNodePortal({
     // those updates in place.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  // After the portal content is committed into hostElement, hand the first
+  // child element to the controller. This is typically a custom element (e.g.
+  // <cds-aichat-autocomplete>) whose properties (anchorElement, keydown
+  // forwarding) only work on the element itself — not on the plain <div>
+  // wrapper that createPortal renders into. Custom elements are defined
+  // synchronously at module load, so by the time useEffect fires (post-paint)
+  // the element is fully upgraded and its properties are available.
+  React.useEffect(() => {
+    if (!hostElement) {
+      return;
+    }
+    const child = hostElement.firstElementChild as HTMLElement | null;
+    onMount?.(child ?? hostElement);
+  }, [hostElement, onMount]);
 
   return (
     <div slot={slot} ref={containerRef}>


### PR DESCRIPTION
Closes #2194 

Fixes two bugs surfaced in the React prompt line conversation starters example. The cause of both is in the `useChatAutocomplete` React hook when `onMount()` gets called on the wrapper `<div>` element instead of its child element.

#### Changelog

**Changed**
- `packages/ai-chat-components/src/react/hooks/useChatAutocomplete.tsx`: `onMount()` is called inside a `useEffect()` to delay until the portal content is committed into hostElement. `onMount` is then called on the child element (the actual autocomplete component) of `hostElement` if it exists.

#### Testing / Reviewing

1. `npm run start --workspace=@carbon/ai-chat-examples-react-prompt-line-conversation-starters`
2. Click outside of the prompt line, then click inside the text area to trigger the conversation starters. Verify the prompt suggestions appear as expected.
3. Verify arrow keys work to navigate starters.
4. Ensure there are no regressions with sending items or dismissing autocomplete.