### PR TITLE
fix(shared): defer dynamic sheet rewrites out of the teardown window

### DIFF
--- a/packages/ai-chat-components/src/components/shared/__tests__/dynamic-css-var-sheet.test.ts
+++ b/packages/ai-chat-components/src/components/shared/__tests__/dynamic-css-var-sheet.test.ts
@@ -1,0 +1,111 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { expect } from '@open-wc/testing';
+
+import {
+  setVarsForSelector,
+  clearSelector,
+  clearVarsForSelector,
+} from '../dynamic-css-var-sheet.js';
+
+/**
+ * Reads every rule the shared sheet has published onto the document. The module
+ * adopts its singleton on `document`, so a selector is "live" as soon as it
+ * appears here.
+ */
+function documentCssText(): string {
+  return Array.from(document.adoptedStyleSheets ?? [])
+    .map((sheet) => {
+      try {
+        return Array.from(sheet.cssRules)
+          .map((rule) => rule.cssText)
+          .join('\n');
+      } catch {
+        return '';
+      }
+    })
+    .join('\n');
+}
+
+describe('dynamic-css-var-sheet', function () {
+  // Unique per test so a leaked rule can never satisfy a later assertion.
+  let selector: string;
+  let counter = 0;
+
+  beforeEach(() => {
+    selector = `.dcvs-test-${++counter}`;
+  });
+
+  afterEach(async () => {
+    clearSelector(selector);
+    await Promise.resolve();
+  });
+
+  it('publishes a rule synchronously', () => {
+    setVarsForSelector(selector, { color: 'rgb(255, 0, 0)' });
+    expect(documentCssText()).to.contain(selector);
+  });
+
+  // Regression guard for #2201. Components call the clear helpers from
+  // `disconnectedCallback`, which WebKit runs while draining the custom-element
+  // reaction queue inside `Element.remove()`. Mutating an adopted sheet in that
+  // window segfaults the WebKit renderer, so the write must land after it.
+  it('defers clearSelector past the synchronous teardown window', async () => {
+    setVarsForSelector(selector, { color: 'rgb(255, 0, 0)' });
+    expect(documentCssText()).to.contain(selector);
+
+    clearSelector(selector);
+    expect(
+      documentCssText(),
+      'sheet must not be mutated inside disconnectedCallback'
+    ).to.contain(selector);
+
+    await Promise.resolve();
+    expect(documentCssText()).to.not.contain(selector);
+  });
+
+  it('defers clearVarsForSelector past the synchronous teardown window', async () => {
+    setVarsForSelector(selector, { color: 'rgb(255, 0, 0)' });
+    expect(documentCssText()).to.contain(selector);
+
+    clearVarsForSelector(selector, ['color']);
+    expect(
+      documentCssText(),
+      'sheet must not be mutated inside disconnectedCallback'
+    ).to.contain(selector);
+
+    await Promise.resolve();
+    expect(documentCssText()).to.not.contain(selector);
+  });
+
+  it('coalesces repeated clears into a single flush', async () => {
+    const other = `${selector}-other`;
+    setVarsForSelector(selector, { color: 'rgb(255, 0, 0)' });
+    setVarsForSelector(other, { color: 'rgb(0, 0, 255)' });
+
+    clearSelector(selector);
+    clearSelector(other);
+    await Promise.resolve();
+
+    const css = documentCssText();
+    expect(css).to.not.contain(selector);
+    expect(css).to.not.contain(other);
+  });
+
+  it('keeps a re-set selector alive when a clear is already pending', async () => {
+    setVarsForSelector(selector, { color: 'rgb(255, 0, 0)' });
+    clearSelector(selector);
+    // A component re-connecting before the flush must win over the queued clear.
+    setVarsForSelector(selector, { color: 'rgb(0, 128, 0)' });
+
+    await Promise.resolve();
+    expect(documentCssText()).to.contain(selector);
+  });
+});

--- a/packages/ai-chat-components/src/components/shared/dynamic-css-var-sheet.ts
+++ b/packages/ai-chat-components/src/components/shared/dynamic-css-var-sheet.ts
@@ -106,6 +106,29 @@ function rewrite(): void {
 }
 
 /**
+ * Flush a rewrite on a microtask rather than inline.
+ *
+ * The teardown helpers below run from component `disconnectedCallback`s, which
+ * WebKit invokes while draining the custom-element reaction queue inside
+ * `Element.remove()`. Mutating an adopted sheet in that window segfaults WebKit
+ * in `Style::Invalidator::invalidateHostAndSlottedStyleIfNeeded`: it walks every
+ * style scope adopting the sheet and dereferences a shadow-root host that isn't
+ * valid mid-removal (#2201). Deferring past the removal sidesteps the window,
+ * and is unobservable — nothing reads the sheet back after a rule is cleared.
+ */
+let teardownFlushScheduled = false;
+function rewriteAfterTeardown(): void {
+  if (teardownFlushScheduled) {
+    return;
+  }
+  teardownFlushScheduled = true;
+  queueMicrotask(() => {
+    teardownFlushScheduled = false;
+    rewrite();
+  });
+}
+
+/**
  * Adopt the shared dynamic stylesheet on a root so its rules apply within
  * that tree. Idempotent per root: subsequent calls for the same root are a
  * no-op so we don't spuriously create a fallback `<style>` element on top of
@@ -174,7 +197,7 @@ function clearSelector(selector: string): void {
   if (!declarationsBySelector.delete(selector)) {
     return;
   }
-  rewrite();
+  rewriteAfterTeardown();
 }
 
 /**
@@ -198,7 +221,7 @@ function clearVarsForSelector(selector: string, props: string[]): void {
   if (existing.size === 0) {
     declarationsBySelector.delete(selector);
   }
-  rewrite();
+  rewriteAfterTeardown();
 }
 
 export { adoptOnRoot, setVarsForSelector, clearSelector, clearVarsForSelector };


### PR DESCRIPTION
Closes #2201

WebKit's renderer crashed partway through the `@carbon/ai-chat-components` suite. It took ~18 tests with it and still reported `0 failed`, so `ci-check` could never come back clean locally.

The cause was ours, not the runner. Four components clear their rules from `disconnectedCallback`. That put `replaceSync` inside WebKit's custom-element reaction queue during `Element.remove()`, where it walks the shared sheet's style scopes and hits a shadow-root host that is not valid mid-removal. All 31 local crash reports were identical: `SIGSEGV` at `0x1c` in `Style::Invalidator::invalidateHostAndSlottedStyleIfNeeded`.

- `src/components/shared/dynamic-css-var-sheet.ts` — the clear helpers flush on a microtask now. `setVarsForSelector` stays synchronous on purpose: `history-panel-item` measures right after a write.

#### Changelog

**New**

- First tests for `dynamic-css-var-sheet`.

**Changed**

- `clearSelector` and `clearVarsForSelector` flush on a microtask, not inline.

#### Testing / Reviewing

No visual change — the fix is on the teardown path. Proof is the suite plus the absence of crash logs.

```bash
npm run test --workspace=@carbon/ai-chat-components
```

- WebKit reports 511 passed / 0 failed, matching Chromium and Firefox. Ran three times in a row on macOS/arm64.
- No new files in `~/Library/Logs/DiagnosticReports/com.apple.WebKit.WebContent.Development-*.ips`.

To see the old crash: point both clear helpers back at `rewrite()`, rebuild, run the suite. Needs all three browsers — WebKit alone never reproduces it.

Two notes for the reviewer:

- Whether real Safari crashes on this path is still unverified. The path is a chat component leaving the DOM, which is ordinary consumer behaviour. If it does, this is a user-facing crash fix, not test cleanup.
- Any `chat-button` failures on a first run are a stale `es/` build, not this change. Nx replays a cached build and the tests import from `es/`. Rebuild and they clear.
