### PR TITLE
cherry-pick: #2180, #2181, #2193, #2192 to v1.19.0

### DIFF
--- a/packages/ai-chat-components/src/components/prompt-line/autocomplete/__stories__/autocomplete-react.stories.jsx
+++ b/packages/ai-chat-components/src/components/prompt-line/autocomplete/__stories__/autocomplete-react.stories.jsx
@@ -14,6 +14,7 @@ import {
   Default as DefaultWC,
   WithHeader as WithHeaderWC,
   WithCategories as WithCategoriesWC,
+  WithDisabledItems as WithDisabledItemsWC,
   Detached as DetachedWC,
 } from './autocomplete.stories';
 import {
@@ -255,6 +256,50 @@ export const WithCategories = {
         <CDSAIChatAutocomplete
           groups={filteredGroups}
           inputText={query}
+          attached={args.attached ?? true}
+          disableDirectSend={args.disableDirectSend ?? false}
+          style={{ '--cds-aichat-autocomplete-max-height': '328px' }}
+          onSelect={(e) => action('cds-aichat-autocomplete-select')(e.detail)}
+          onSend={(e) => action('cds-aichat-autocomplete-send')(e.detail)}
+          onDismiss={() => action('cds-aichat-autocomplete-dismiss')()}
+        />
+      </Wrapper>
+    );
+  },
+};
+
+export const WithDisabledItems = {
+  render: (args) => {
+    const mixedItems = [
+      {
+        id: 'suggestion-1',
+        label: 'When is the best time to eat?',
+      },
+      {
+        id: 'suggestion-2',
+        label: 'When is the sun rising today?',
+        disabled: true,
+      },
+      {
+        id: 'suggestion-3',
+        label: 'When is the sun setting today?',
+      },
+      {
+        id: 'suggestion-4',
+        label: 'When is the start of Spring?',
+        disabled: true,
+      },
+      {
+        id: 'suggestion-5',
+        label: 'When is the next full moon?',
+      },
+    ];
+
+    return (
+      <Wrapper width="320px">
+        <CDSAIChatAutocomplete
+          items={mixedItems}
+          inputText={args.inputText || ''}
           attached={args.attached ?? true}
           disableDirectSend={args.disableDirectSend ?? false}
           style={{ '--cds-aichat-autocomplete-max-height': '328px' }}

--- a/packages/ai-chat-components/src/components/prompt-line/autocomplete/__stories__/autocomplete.stories.js
+++ b/packages/ai-chat-components/src/components/prompt-line/autocomplete/__stories__/autocomplete.stories.js
@@ -262,6 +262,54 @@ export const WithCategories = {
   },
 };
 
+export const WithDisabledItems = {
+  render: ({ inputText, disableDirectSend, attached }) => {
+    const mixedItems = [
+      {
+        id: 'suggestion-1',
+        label: 'When is the best time to eat?',
+      },
+      {
+        id: 'suggestion-2',
+        label: 'When is the sun rising today?',
+        disabled: true,
+      },
+      {
+        id: 'suggestion-3',
+        label: 'When is the sun setting today?',
+      },
+      {
+        id: 'suggestion-4',
+        label: 'When is the start of Spring?',
+        disabled: true,
+      },
+      {
+        id: 'suggestion-5',
+        label: 'When is the next full moon?',
+      },
+    ];
+
+    return html`
+      <div style="width: 320px;">
+        <cds-aichat-autocomplete
+          style="--cds-aichat-autocomplete-max-height: 328px;"
+          .items=${mixedItems}
+          ?attached=${attached}
+          ?disable-direct-send=${disableDirectSend}
+          input-text=${inputText}
+          @cds-aichat-autocomplete-select=${(e) =>
+            action('cds-aichat-autocomplete-select')(e.detail)}
+          @cds-aichat-autocomplete-send=${(e) =>
+            action('cds-aichat-autocomplete-send')(e.detail)}
+          @cds-aichat-autocomplete-dismiss=${() =>
+            action(
+              'cds-aichat-autocomplete-dismiss'
+            )()}></cds-aichat-autocomplete>
+      </div>
+    `;
+  },
+};
+
 export const Detached = {
   args: {
     attached: false,

--- a/packages/ai-chat-components/src/components/prompt-line/autocomplete/__tests__/autocomplete.test.ts
+++ b/packages/ai-chat-components/src/components/prompt-line/autocomplete/__tests__/autocomplete.test.ts
@@ -15,6 +15,8 @@ import type {
   SuggestionItem,
   SuggestionItemGroup,
 } from '../src/autocomplete.js';
+import { defaultAutocompleteI18n } from '../src/autocomplete.js';
+import prefix from '../../../../globals/settings.js';
 
 describe('cds-aichat-autocomplete', () => {
   const mockItems: SuggestionItem[] = [
@@ -731,6 +733,220 @@ describe('cds-aichat-autocomplete', () => {
       `);
 
       expect(el.disableDirectSend).to.be.true;
+    });
+  });
+
+  describe('disabled items', () => {
+    const disabledItem: SuggestionItem = {
+      id: 'disabled-1',
+      label: 'Disabled Option',
+      disabled: true,
+    };
+    const enabledItem: SuggestionItem = {
+      id: 'enabled-1',
+      label: 'Enabled Option',
+    };
+
+    it('should set aria-disabled correctly for disabled and enabled items', async () => {
+      const el = await fixture<AutocompleteElement>(html`
+        <cds-aichat-autocomplete
+          .items="${[disabledItem, enabledItem]}"></cds-aichat-autocomplete>
+      `);
+
+      const options = el.shadowRoot?.querySelectorAll('li[role="option"]');
+
+      expect(
+        (options?.[0] as HTMLElement)?.getAttribute('aria-disabled')
+      ).to.equal('true');
+      expect(
+        (options?.[1] as HTMLElement)?.getAttribute('aria-disabled')
+      ).to.equal('false');
+    });
+
+    it('should add the disabled class', async () => {
+      const el = await fixture<AutocompleteElement>(
+        html` <cds-aichat-autocomplete
+          .items="${[disabledItem]}"></cds-aichat-autocomplete>`
+      );
+
+      const options = el.shadowRoot?.querySelectorAll('li[role="option"]');
+      const disabledClass = `${prefix}-autocomplete-item--disabled`;
+
+      expect((options?.[0] as HTMLElement).classList.contains(disabledClass)).to
+        .be.true;
+    });
+
+    it('click on disabled item does not fire cds-aichat-autocomplete-send (disableDirectSend=false)', async () => {
+      const el = await fixture<AutocompleteElement>(html`
+        <cds-aichat-autocomplete
+          .items="${[disabledItem, enabledItem]}"></cds-aichat-autocomplete>
+      `);
+
+      let sendFired = false;
+      el.addEventListener('cds-aichat-autocomplete-send', () => {
+        sendFired = true;
+      });
+
+      const disabledOption = el.shadowRoot?.querySelector('li[role="option"]');
+      disabledOption?.dispatchEvent(
+        new MouseEvent('click', { bubbles: true, composed: true })
+      );
+      await el.updateComplete;
+
+      expect(sendFired).to.be.false;
+    });
+
+    it('click on disabled item does not fire cds-aichat-autocomplete-select (disableDirectSend=true)', async () => {
+      const el = await fixture<AutocompleteElement>(html`
+        <cds-aichat-autocomplete
+          .items="${[disabledItem, enabledItem]}"
+          .disableDirectSend="${true}"></cds-aichat-autocomplete>
+      `);
+
+      let selectFired = false;
+      el.addEventListener('cds-aichat-autocomplete-select', () => {
+        selectFired = true;
+      });
+
+      const disabledOption = el.shadowRoot?.querySelector('li[role="option"]');
+      disabledOption?.dispatchEvent(
+        new MouseEvent('click', { bubbles: true, composed: true })
+      );
+      await el.updateComplete;
+
+      expect(selectFired).to.be.false;
+    });
+
+    it('Enter on a disabled item does not fire send or select', async () => {
+      // Place the only-disabled item alone so _focusedIndex stays at 0 (no
+      // enabled item to skip to) and Enter has no valid target.
+      const el = await fixture<AutocompleteElement>(html`
+        <cds-aichat-autocomplete
+          .items="${[disabledItem]}"></cds-aichat-autocomplete>
+      `);
+
+      let sendFired = false;
+      let selectFired = false;
+      el.addEventListener('cds-aichat-autocomplete-send', () => {
+        sendFired = true;
+      });
+      el.addEventListener('cds-aichat-autocomplete-select', () => {
+        selectFired = true;
+      });
+
+      el.dispatchEvent(
+        new KeyboardEvent('keydown', {
+          key: 'Enter',
+          bubbles: true,
+          composed: true,
+        })
+      );
+      await el.updateComplete;
+
+      expect(sendFired).to.be.false;
+      expect(selectFired).to.be.false;
+    });
+
+    it('ArrowDown skips a disabled item and lands on the next enabled item', async () => {
+      // Layout: enabled(0) → disabled(1) → enabled(2)
+      const threeItems: SuggestionItem[] = [
+        enabledItem,
+        disabledItem,
+        { id: 'enabled-2', label: 'Enabled Option 2' },
+      ];
+      const el = await fixture<AutocompleteElement>(html`
+        <cds-aichat-autocomplete
+          .items="${threeItems}"></cds-aichat-autocomplete>
+      `);
+
+      // Focus starts at index 0 (first enabled). One ArrowDown should skip
+      // the disabled item at index 1 and land on index 2.
+      el.dispatchEvent(
+        new KeyboardEvent('keydown', {
+          key: 'ArrowDown',
+          bubbles: true,
+          composed: true,
+        })
+      );
+      await el.updateComplete;
+
+      const options = el.shadowRoot?.querySelectorAll('li[role="option"]');
+      expect(
+        (options?.[2] as HTMLElement)?.getAttribute('aria-selected')
+      ).to.equal('true');
+      expect(
+        (options?.[1] as HTMLElement)?.getAttribute('aria-selected')
+      ).to.equal('false');
+      expect(
+        (options?.[0] as HTMLElement)?.getAttribute('aria-selected')
+      ).to.equal('false');
+    });
+
+    it('ArrowDown stays put when no enabled item exists beyond current', async () => {
+      // Layout: enabled(0) → disabled(1). From 0, ArrowDown should not move.
+      const el = await fixture<AutocompleteElement>(html`
+        <cds-aichat-autocomplete
+          .items="${[enabledItem, disabledItem]}"></cds-aichat-autocomplete>
+      `);
+
+      el.dispatchEvent(
+        new KeyboardEvent('keydown', {
+          key: 'ArrowDown',
+          bubbles: true,
+          composed: true,
+        })
+      );
+      await el.updateComplete;
+
+      const options = el.shadowRoot?.querySelectorAll('li[role="option"]');
+      // Still on index 0 — no enabled item to land on.
+      expect(
+        (options?.[0] as HTMLElement)?.getAttribute('aria-selected')
+      ).to.equal('true');
+    });
+
+    it('initial focus skips a leading disabled item', async () => {
+      // Render with disabled first — _focusedIndex should initialise to the
+      // first enabled item, not index 0.
+      const el = await fixture<AutocompleteElement>(html`
+        <cds-aichat-autocomplete
+          .items="${[disabledItem, enabledItem]}"></cds-aichat-autocomplete>
+      `);
+
+      const options = el.shadowRoot?.querySelectorAll('li[role="option"]');
+      expect(
+        (options?.[1] as HTMLElement)?.getAttribute('aria-selected')
+      ).to.equal('true');
+      expect(
+        (options?.[0] as HTMLElement)?.getAttribute('aria-selected')
+      ).to.equal('false');
+    });
+
+    it('all-disabled list fires suggestionsAvailable with the correct count', async () => {
+      const allDisabledItems: SuggestionItem[] = [
+        { id: 'd1', label: 'Disabled A', disabled: true },
+        { id: 'd2', label: 'Disabled B', disabled: true },
+      ];
+
+      let announcedCount: number | null = null;
+      const trackingI18n = {
+        ...defaultAutocompleteI18n,
+        suggestionsAvailable: (count: number) => {
+          announcedCount = count;
+          return defaultAutocompleteI18n.suggestionsAvailable(count);
+        },
+      };
+
+      const el = await fixture<AutocompleteElement>(html`
+        <cds-aichat-autocomplete
+          .i18n="${trackingI18n}"></cds-aichat-autocomplete>
+      `);
+
+      // Setting items after mount triggers updated() → suggestionsAvailable
+      el.items = allDisabledItems;
+      await el.updateComplete;
+
+      expect(announcedCount).to.equal(2);
     });
   });
 });

--- a/packages/ai-chat-components/src/components/prompt-line/autocomplete/src/autocomplete.scss
+++ b/packages/ai-chat-components/src/components/prompt-line/autocomplete/src/autocomplete.scss
@@ -122,6 +122,26 @@ $group-class: #{$item-class}-group;
     &--active:hover {
       background: theme.$background-selected;
     }
+
+    &--disabled {
+      cursor: default;
+      pointer-events: none;
+
+      .#{$item-class}__label-remainder,
+      .#{$item-class}__label-typed {
+        color: theme.$text-disabled;
+      }
+
+      .#{$item-class}__description {
+        color: theme.$text-disabled;
+      }
+
+      // Override --active selector: send icon stays hidden even when
+      // the disabled item is keyboard-focused (--active class still present).
+      .#{$item-class}__send-icon svg {
+        fill: theme.$icon-disabled;
+      }
+    }
   }
 
   .#{$item-class}__content {

--- a/packages/ai-chat-components/src/components/prompt-line/autocomplete/src/autocomplete.ts
+++ b/packages/ai-chat-components/src/components/prompt-line/autocomplete/src/autocomplete.ts
@@ -22,10 +22,7 @@ import type {
   SuggestionItem,
   SuggestionItemGroup,
 } from '../../src/tiptap/types.js';
-export type {
-  SuggestionItem,
-  SuggestionItemGroup,
-} from '../../src/tiptap/types.js';
+import { classMap } from 'lit/directives/class-map.js';
 
 const blockClass = `${prefix}-autocomplete`;
 const itemClass = `${blockClass}-item`;
@@ -243,8 +240,15 @@ class AutocompleteElement extends LitElement {
         this._openAnnounced = false;
         return;
       }
-      // Reset to first item and announce list opened (once per show).
-      this._focusedIndex = 0;
+      // Reset to first enabled item and announce list opened (once per show).
+      let firstEnabled = 0;
+      while (
+        firstEnabled < totalItems &&
+        this._getItemAtIndex(firstEnabled)?.disabled
+      ) {
+        firstEnabled++;
+      }
+      this._focusedIndex = firstEnabled < totalItems ? firstEnabled : 0;
       if (!this._openAnnounced) {
         this._openAnnounced = true;
         this._announcer.announce(this.i18n.suggestionsAvailable(totalItems));
@@ -283,6 +287,25 @@ class AutocompleteElement extends LitElement {
     return null;
   }
 
+  /**
+   * Move focus to the next enabled item in the given direction (+1 / -1),
+   * skipping over any disabled items. Mirrors the Carbon Dropdown `_navigate`
+   * pattern. Returns the resolved index, or the current index if no enabled
+   * item exists in that direction.
+   */
+  private _navigateTo(from: number, direction: 1 | -1): number {
+    const totalItems = this._getTotalItemCount();
+    let next = from + direction;
+    while (next >= 0 && next < totalItems) {
+      if (!this._getItemAtIndex(next)?.disabled) {
+        return next;
+      }
+      next += direction;
+    }
+    // No enabled item found in that direction — stay put.
+    return from;
+  }
+
   private _handleKeydown = (event: KeyboardEvent) => {
     const totalItems = this._getTotalItemCount();
     if (totalItems === 0) {
@@ -292,31 +315,43 @@ class AutocompleteElement extends LitElement {
     switch (event.key) {
       case 'ArrowDown':
         event.preventDefault();
-        this._focusedIndex = Math.min(this._focusedIndex + 1, totalItems - 1);
+        this._focusedIndex = this._navigateTo(this._focusedIndex, 1);
         this._scheduleMoveAnnouncement(this._focusedIndex, totalItems);
         this._scrollActiveItemIntoView();
         break;
 
       case 'ArrowUp':
         event.preventDefault();
-        this._focusedIndex = Math.max(this._focusedIndex - 1, 0);
+        this._focusedIndex = this._navigateTo(this._focusedIndex, -1);
         this._scheduleMoveAnnouncement(this._focusedIndex, totalItems);
         this._scrollActiveItemIntoView();
         break;
 
-      case 'Home':
+      case 'Home': {
         event.preventDefault();
-        this._focusedIndex = 0;
+        // Find first enabled item from the top.
+        let first = 0;
+        while (first < totalItems && this._getItemAtIndex(first)?.disabled) {
+          first++;
+        }
+        this._focusedIndex = first < totalItems ? first : this._focusedIndex;
         this._scheduleMoveAnnouncement(this._focusedIndex, totalItems);
         this._scrollActiveItemIntoView();
         break;
+      }
 
-      case 'End':
+      case 'End': {
         event.preventDefault();
-        this._focusedIndex = totalItems - 1;
+        // Find last enabled item from the bottom.
+        let last = totalItems - 1;
+        while (last >= 0 && this._getItemAtIndex(last)?.disabled) {
+          last--;
+        }
+        this._focusedIndex = last >= 0 ? last : this._focusedIndex;
         this._scheduleMoveAnnouncement(this._focusedIndex, totalItems);
         this._scrollActiveItemIntoView();
         break;
+      }
 
       case 'Escape':
         event.preventDefault();
@@ -413,6 +448,9 @@ class AutocompleteElement extends LitElement {
   }
 
   private _selectItem(item: SuggestionItem) {
+    if (item.disabled) {
+      return;
+    }
     this._announcer.announce(this.i18n.itemInserted(item.label));
     this.dispatchEvent(
       new CustomEvent<AutocompleteSelectEventDetail>(
@@ -438,12 +476,13 @@ class AutocompleteElement extends LitElement {
   }
 
   private _handleItemClick(index: number) {
-    if (!this.disableDirectSend) {
-      this._handleSend(index);
+    const item = this._getItemAtIndex(index);
+    if (!item || item.disabled) {
       return;
     }
-    const item = this._getItemAtIndex(index);
-    if (!item) {
+
+    if (!this.disableDirectSend) {
+      this._handleSend(index);
       return;
     }
     this._focusedIndex = index;
@@ -504,6 +543,7 @@ class AutocompleteElement extends LitElement {
   ) {
     const { typed, remainder } = this._getLabelParts(item);
     const isActive = index === this._focusedIndex;
+    const isDisabled = !!item.disabled;
     const id = `${item.id}--option`;
 
     return html`
@@ -516,7 +556,12 @@ class AutocompleteElement extends LitElement {
           }
         }}"
         aria-selected="${isActive ? 'true' : 'false'}"
-        class="${itemClass} ${isActive ? `${itemClass}--active` : ''}"
+        aria-disabled="${isDisabled ? 'true' : 'false'}"
+        class=${classMap({
+          [itemClass]: true,
+          [`${itemClass}--active`]: isActive,
+          [`${itemClass}--disabled`]: isDisabled,
+        })}
         id="${id}"
         role="option"
         tabindex="-1"
@@ -654,3 +699,7 @@ declare global {
 }
 
 export default AutocompleteElement;
+export type {
+  SuggestionItem,
+  SuggestionItemGroup,
+} from '../../src/tiptap/types.js';

--- a/packages/ai-chat-components/src/components/prompt-line/src/tiptap/carbon-autocomplete.ts
+++ b/packages/ai-chat-components/src/components/prompt-line/src/tiptap/carbon-autocomplete.ts
@@ -34,11 +34,10 @@ export function carbonAutocomplete(
   config: AutocompleteConfig,
   excludeTriggers: ExcludedTrigger[] = []
 ): Extension {
-  const name = config.name ?? 'autocomplete';
-  const pluginKey = new PluginKey(`carbonAutocompleteSuggestion_${name}`);
+  const pluginKey = new PluginKey('carbonAutocompleteSuggestion');
 
   return Extension.create({
-    name: `carbon${capitalize(name)}`,
+    name: 'carbonAutocomplete',
 
     addProseMirrorPlugins() {
       const editor = this.editor;
@@ -151,8 +150,4 @@ async function resolveItems(
   return config.items.filter((item) =>
     item.label.toLowerCase().includes(lower)
   );
-}
-
-function capitalize(value: string): string {
-  return value.charAt(0).toUpperCase() + value.slice(1);
 }

--- a/packages/ai-chat-components/src/components/prompt-line/src/tiptap/carbon-mention.ts
+++ b/packages/ai-chat-components/src/components/prompt-line/src/tiptap/carbon-mention.ts
@@ -28,9 +28,8 @@
  * Either default can be overridden per-config (`TriggerSuggestionConfig.
  * showTriggerInChip`) or per-item (`SuggestionItem.showTriggerInChip`, which
  * wins when set — e.g. a single `@` picker mixing people and agents).
- * Hosts compose multiple instances cleanly by passing distinct `name`
- * values — the factory threads the name through `Mention.extend({ name })`
- * to sidestep the [Tiptap stacking caveat](https://github.com/ueberdosis/tiptap/issues/2219).
+ * Each chat supports one mention trigger and one command trigger, because
+ * Tiptap resolves extensions by name.
  */
 
 import type { Editor, Range } from '@tiptap/core';
@@ -52,7 +51,7 @@ function buildTriggerExtension(
   config: TriggerSuggestionConfig,
   build: BuildOptions
 ) {
-  const name = config.name ?? build.defaultName;
+  const name = build.defaultName;
   const pluginKey = new PluginKey(`${build.defaultPluginKeyName}_${name}`);
 
   return Mention.extend({

--- a/packages/ai-chat-components/src/components/prompt-line/src/tiptap/types.ts
+++ b/packages/ai-chat-components/src/components/prompt-line/src/tiptap/types.ts
@@ -142,15 +142,6 @@ export interface TriggerSuggestionConfig extends Omit<
    *  anywhere. Defaults to "anywhere". */
   triggerPosition?: 'start' | 'anywhere';
 
-  /**
-   * Override the schema-node name. Threaded through `Mention.extend({ name })`
-   * inside the carbon factory to sidestep Tiptap's last-named-wins stacking
-   * caveat when multiple triggers coexist.
-   *
-   * Defaults: `"mention"` (carbonMention) / `"command"` (carbonCommand).
-   */
-  name?: string;
-
   /** Replace the visual element rendered inside the token chip. */
   renderCustomToken?: (item: SuggestionItem) => HTMLElement | ReactNode;
 
@@ -182,11 +173,11 @@ export interface TriggerSuggestionConfig extends Omit<
 
 /**
  * Live autocomplete config. Selection inserts plain text (no token chip).
+ *
+ * Note: only one autocomplete config per editor is supported, because Tiptap
+ * resolves extensions by name.
  */
-export interface AutocompleteConfig extends BaseSuggestionConfig {
-  /** Override the suggestion plugin key name. Defaults to `"autocomplete"`. */
-  name?: string;
-}
+export type AutocompleteConfig = BaseSuggestionConfig;
 
 /**
  * Configuration for starter prompts — shown when the editor is empty and

--- a/packages/ai-chat/src/chat/components/input/Input.tsx
+++ b/packages/ai-chat/src/chat/components/input/Input.tsx
@@ -545,17 +545,19 @@ function Input(props: InputProps, ref: Ref<InputFunctions>) {
    */
   const renderErrorMessage = () => {
     if (overMaxLength) {
+      const errorTitle = intl.formatMessage({
+        id: 'input_maxCharCountExceededTitle',
+      });
       const errorText = intl.formatMessage(
         { id: 'input_maxCharCountExceeded' },
         { max: maxInputChars, current: rawInputValue.length }
       );
       return (
         <div slot="field-messaging">
-          <AnnounceOnMount
-            announceOnce={`Error: Max character count exceeded. ${errorText}`}>
+          <AnnounceOnMount announceOnce={`${errorTitle}. ${errorText}`}>
             <ErrorMessage
               fullscreen={chatWidthBreakpoint === ChatWidthBreakpoint.WIDE}
-              title="Error: Max character count exceeded"
+              title={errorTitle}
               description={errorText}
               collapsible={true}
             />

--- a/packages/ai-chat/src/chat/components/input/useInputValueSync.ts
+++ b/packages/ai-chat/src/chat/components/input/useInputValueSync.ts
@@ -183,7 +183,7 @@ function useInputValueSync({
    * by @lit/react's native-event scheduling. See issue #1382.
    */
   const sendCurrentValue = () => {
-    const text = rawInputValueRef.current;
+    const text = rawInputValueRef.current.trim();
     // Re-evaluate from the ref at call time: callers like the starter and
     // autocomplete-item send paths seed the ref synchronously before calling
     // here, so using the closure-captured `hasValidInput` (derived from

--- a/packages/ai-chat/src/chat/languages/en.json
+++ b/packages/ai-chat/src/chat/languages/en.json
@@ -38,6 +38,7 @@
   "input_sendingMessage": "Sending message...",
   "input_keyboardShortcutAnnouncement": "Press {key} to toggle focus between the message list and input field.",
   "input_maxCharCountExceeded": "Maximum character count of {max} exceeded. {current} characters, currently.",
+  "input_maxCharCountExceededTitle": "Error: Max character count exceeded",
   "window_title": "Chat window",
   "window_ariaChatRegion": "Chat",
   "window_ariaChatRegionNamespace": "Chat {namespace}",

--- a/packages/ai-chat/src/types/config/InputConfig.ts
+++ b/packages/ai-chat/src/types/config/InputConfig.ts
@@ -39,12 +39,13 @@ export type BaseSuggestionConfig = _BaseSuggestionConfig;
 /**
  * Trigger-character-driven suggestion config consumed by
  * {@link InputConfig.mention} and {@link InputConfig.command}. Adds the
- * trigger character, an optional `triggerPosition`, an optional schema-node
- * `name` override, a custom-token renderer, an `onRemove` callback (the
- * mirror of `onSelect`, fired when a token is deleted), and a
- * `showTriggerInChip` default (whether selected items render as
- * `/summarize` or a bare `summarize`, overridable per item) on top of
+ * trigger character, an optional `triggerPosition`, a custom-token renderer,
+ * an `onRemove` callback (the mirror of `onSelect`, fired when a token is
+ * deleted), and a `showTriggerInChip` default (whether selected items render
+ * as `/summarize` or a bare `summarize`, overridable per item) on top of
  * {@link BaseSuggestionConfig}.
+ *
+ * Each chat supports one mention trigger and one command trigger.
  *
  * @category Config
  * @interface

--- a/packages/ai-chat/src/types/utilities/inputUtils.ts
+++ b/packages/ai-chat/src/types/utilities/inputUtils.ts
@@ -49,8 +49,8 @@ import type {
  * Tiptap extension factory for `@`-style mention triggers. Wraps
  * `@tiptap/extension-mention` with Carbon-specific chip rendering, extended
  * schema attributes (`value`, `data`), and direct
- * `cds-aichat-trigger-change` dispatch. Pass distinct `name` values when
- * composing multiple instances.
+ * `cds-aichat-trigger-change` dispatch. Each chat supports one mention
+ * trigger.
  *
  * @function
  * @category Utilities

--- a/packages/ai-chat/tests/components/spec/inputSendTrim_spec.tsx
+++ b/packages/ai-chat/tests/components/spec/inputSendTrim_spec.tsx
@@ -1,0 +1,186 @@
+/*
+ *  Copyright IBM Corp. 2026
+ *
+ *  This source code is licensed under the Apache-2.0 license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ *  @license
+ */
+
+/**
+ * Regression: the text handed to onSendInput must be trimmed, matching the
+ * 1.18 behaviour.
+ *
+ * sendCurrentValue() reads rawInputValueRef.current and passes it to
+ * onSendInput. The fix adds a .trim() at that read so leading/trailing
+ * whitespace (and Shift+Enter trailing newlines) never reach the host.
+ *
+ * Tested by capturing the onChange / onSendIntent props that Input.tsx
+ * passes to the mock PromptLine element, calling them directly in the test,
+ * and asserting onSendInput receives the trimmed value.
+ */
+
+import React from 'react';
+import { render, act, waitFor } from '@testing-library/react';
+
+import { StoreProvider } from '../../../src/chat/providers/StoreProvider';
+import { ServiceManagerContext } from '../../../src/chat/contexts/ServiceManagerContext';
+import { IntlProvider } from '../../../src/chat/providers/IntlProvider';
+import { AriaAnnouncerContext } from '../../../src/chat/contexts/AriaAnnouncerContext';
+import { createIntl } from '../../../src/chat/utils/i18n';
+import {
+  makeConfigStore,
+  setupAfterEach,
+  setupBeforeEach,
+} from '../../test_helpers';
+
+const testIntl = createIntl({ locale: 'en', messages: {} });
+
+// ---------------------------------------------------------------------------
+// Capture the onChange / onSendIntent props wired to PromptLine by Input.tsx
+// ---------------------------------------------------------------------------
+
+type MockPromptLineProps = {
+  onChange?: (event: CustomEvent<{ rawValue: string }>) => void;
+  onSendIntent?: (event: CustomEvent) => void;
+  [key: string]: unknown;
+};
+let capturedOnChange: MockPromptLineProps['onChange'] | undefined;
+let capturedOnSendIntent: MockPromptLineProps['onSendIntent'] | undefined;
+const clearContentSpy = jest.fn();
+
+jest.mock('@carbon/ai-chat-components/es/react/prompt-line-shell.js', () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }): React.ReactElement =>
+    React.createElement('div', null, children),
+}));
+
+jest.mock('@carbon/ai-chat-components/es/react/prompt-line.js', () => {
+  const MockPromptLine = React.forwardRef(
+    (
+      props: MockPromptLineProps,
+      ref: React.Ref<unknown>
+    ): React.ReactElement => {
+      // Capture the callbacks on every render so we always have the latest.
+      capturedOnChange = props.onChange;
+      capturedOnSendIntent = props.onSendIntent;
+      React.useImperativeHandle(ref, () => ({ clearContent: clearContentSpy }));
+      return React.createElement('div', null);
+    }
+  );
+  MockPromptLine.displayName = 'MockPromptLine';
+  return { __esModule: true, default: MockPromptLine };
+});
+
+jest.mock(
+  '@carbon/ai-chat-components/es/react/hooks/useChatAutocomplete.js',
+  () => ({
+    __esModule: true,
+    useChatAutocomplete: (): {
+      onTriggerChange: () => void;
+      autocompleteContent: null;
+    } => ({
+      onTriggerChange: () => {},
+      autocompleteContent: null,
+    }),
+  })
+);
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function renderInput(onSendInput: jest.Mock) {
+  const { Input: InputExport } =
+    await import('../../../src/chat/components/input/Input');
+
+  const store = makeConfigStore({});
+  const serviceManager = {
+    store,
+    setInputFunctionsRef: jest.fn(),
+  } as any;
+
+  render(
+    React.createElement(
+      StoreProvider,
+      { store },
+      React.createElement(
+        IntlProvider,
+        { intl: testIntl },
+        React.createElement(
+          AriaAnnouncerContext.Provider,
+          { value: jest.fn() },
+          React.createElement(
+            ServiceManagerContext.Provider,
+            { value: serviceManager },
+            React.createElement(InputExport, {
+              disableInput: false,
+              isInputVisible: true,
+              disableSend: false,
+              onSendInput,
+            })
+          )
+        )
+      )
+    )
+  );
+
+  await waitFor(() => expect(capturedOnSendIntent).toBeDefined());
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('sendCurrentValue trims leading/trailing whitespace', () => {
+  beforeEach(() => {
+    setupBeforeEach();
+    clearContentSpy.mockClear();
+    capturedOnChange = undefined;
+    capturedOnSendIntent = undefined;
+  });
+  afterEach(setupAfterEach);
+
+  it('trims surrounding spaces before calling onSendInput', async () => {
+    const onSendInput = jest.fn();
+    await renderInput(onSendInput);
+
+    act(() => {
+      // Seed the ref with a padded value via the onChange callback.
+      capturedOnChange?.(
+        new CustomEvent('change', {
+          detail: { rawValue: '   padded message   ' },
+        }) as CustomEvent<{ rawValue: string }>
+      );
+    });
+
+    act(() => {
+      // Fire the send intent — routes through handlePromptSendIntent →
+      // sendCurrentValue → onSendInput with the trimmed value.
+      capturedOnSendIntent?.(new CustomEvent('send-intent'));
+    });
+
+    expect(onSendInput).toHaveBeenCalledTimes(1);
+    expect(onSendInput).toHaveBeenCalledWith('padded message', undefined);
+  });
+
+  it('strips a trailing newline left by Shift+Enter', async () => {
+    const onSendInput = jest.fn();
+    await renderInput(onSendInput);
+
+    act(() => {
+      capturedOnChange?.(
+        new CustomEvent('change', {
+          detail: { rawValue: 'hello\n' },
+        }) as CustomEvent<{ rawValue: string }>
+      );
+    });
+
+    act(() => {
+      capturedOnSendIntent?.(new CustomEvent('send-intent'));
+    });
+
+    expect(onSendInput).toHaveBeenCalledTimes(1);
+    expect(onSendInput).toHaveBeenCalledWith('hello', undefined);
+  });
+});


### PR DESCRIPTION
Cherry-picks for release/v1.19.0:
- #2180 feat(autocomplete): disabled items support
- #2181 fix(input): trim sent message text
- #2193 fix(input): localize max-char-count error
- #2192 feat(prompt-line): remove name from suggestion configs