### PR TITLE
docs(adr): point discussion links at live RFC discussions

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Carbon AI Chat is an **open source** project at IBM. We pride ourselves on open 
 
 This project is made possible not just by the Carbon team, but by community members who’ve generously contributed their time to give back.
 
-Decisions that change public API or break an integration are written up as [architecture decision records](../docs/adr/README.md) before the code lands. Each one merges while it is still open for comment, with a tracking issue and a date. If a decision is wrong for how you use this library, that is where to say so.
+Decisions that change public API or break an integration are written up as [architecture decision records](../docs/adr/README.md) before the code lands. Each one merges while it is still open for comment, with an [RFC discussion](https://github.com/carbon-design-system/carbon-ai-chat/discussions/categories/rfc-discussions) and a date. If a decision is wrong for how you use this library, that is where to say so.
 
 ## Code of conduct
 

--- a/docs/adr/0002-core-react-wrapper-headless-sdk-split.md
+++ b/docs/adr/0002-core-react-wrapper-headless-sdk-split.md
@@ -6,7 +6,7 @@ deciders: '@carbon-design-system/carbon-ai-chat-developers'
 consulted:
 informed:
 epic: https://github.com/carbon-design-system/carbon-ai-chat/issues/2030
-discussion: https://github.com/carbon-design-system/carbon-ai-chat/issues/2110
+discussion: https://github.com/carbon-design-system/carbon-ai-chat/discussions/2208
 supersedes:
 superseded-by:
 ---

--- a/docs/adr/0003-instance-lifetime-belongs-to-the-acquire.md
+++ b/docs/adr/0003-instance-lifetime-belongs-to-the-acquire.md
@@ -6,7 +6,7 @@ deciders: '@carbon-design-system/carbon-ai-chat-developers'
 consulted:
 informed:
 epic: https://github.com/carbon-design-system/carbon-ai-chat/issues/2030
-discussion: https://github.com/carbon-design-system/carbon-ai-chat/issues/2111
+discussion: https://github.com/carbon-design-system/carbon-ai-chat/discussions/2209
 supersedes:
 superseded-by:
 ---

--- a/docs/adr/0004-per-field-scoped-stores.md
+++ b/docs/adr/0004-per-field-scoped-stores.md
@@ -6,7 +6,7 @@ deciders: '@carbon-design-system/carbon-ai-chat-developers'
 consulted:
 informed:
 epic: https://github.com/carbon-design-system/carbon-ai-chat/issues/2030
-discussion: https://github.com/carbon-design-system/carbon-ai-chat/issues/2112
+discussion: https://github.com/carbon-design-system/carbon-ai-chat/discussions/2210
 supersedes:
 superseded-by:
 ---

--- a/docs/adr/0005-chat-instance-survives-as-the-composition.md
+++ b/docs/adr/0005-chat-instance-survives-as-the-composition.md
@@ -6,7 +6,7 @@ deciders: '@carbon-design-system/carbon-ai-chat-developers'
 consulted:
 informed:
 epic: https://github.com/carbon-design-system/carbon-ai-chat/issues/2030
-discussion: https://github.com/carbon-design-system/carbon-ai-chat/issues/2113
+discussion: https://github.com/carbon-design-system/carbon-ai-chat/discussions/2211
 supersedes:
 superseded-by:
 ---

--- a/docs/adr/0007-one-store-pipeline-behind-both-delivery-apis.md
+++ b/docs/adr/0007-one-store-pipeline-behind-both-delivery-apis.md
@@ -6,7 +6,7 @@ deciders: '@carbon-design-system/carbon-ai-chat-developers'
 consulted:
 informed:
 epic: https://github.com/carbon-design-system/carbon-ai-chat/issues/2031
-discussion: https://github.com/carbon-design-system/carbon-ai-chat/issues/2114
+discussion: https://github.com/carbon-design-system/carbon-ai-chat/discussions/2212
 supersedes:
 superseded-by:
 ---

--- a/docs/adr/0009-conversation-verbs-on-instance-messaging.md
+++ b/docs/adr/0009-conversation-verbs-on-instance-messaging.md
@@ -6,7 +6,7 @@ deciders: '@carbon-design-system/carbon-ai-chat-developers'
 consulted:
 informed:
 epic: https://github.com/carbon-design-system/carbon-ai-chat/issues/2031
-discussion: https://github.com/carbon-design-system/carbon-ai-chat/issues/2115
+discussion: https://github.com/carbon-design-system/carbon-ai-chat/discussions/2213
 supersedes:
 superseded-by:
 ---

--- a/docs/adr/0023-sdk-prefixed-seam-types.md
+++ b/docs/adr/0023-sdk-prefixed-seam-types.md
@@ -6,7 +6,7 @@ deciders: '@carbon-design-system/carbon-ai-chat-developers'
 consulted:
 informed:
 epic: https://github.com/carbon-design-system/carbon-ai-chat/issues/2030
-discussion: https://github.com/carbon-design-system/carbon-ai-chat/issues/2116
+discussion: https://github.com/carbon-design-system/carbon-ai-chat/discussions/2214
 supersedes:
 superseded-by:
 ---

--- a/docs/adr/0025-the-sdk-entry-point-shape.md
+++ b/docs/adr/0025-the-sdk-entry-point-shape.md
@@ -6,7 +6,7 @@ deciders: '@carbon-design-system/carbon-ai-chat-developers'
 consulted:
 informed:
 epic: https://github.com/carbon-design-system/carbon-ai-chat/issues/2030
-discussion: https://github.com/carbon-design-system/carbon-ai-chat/issues/2117
+discussion: https://github.com/carbon-design-system/carbon-ai-chat/discussions/2215
 supersedes:
 superseded-by:
 ---

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -34,20 +34,20 @@ Status runs `proposed` → `accepted` or `rejected`. An accepted ADR that a late
 
 ## How an ADR gets decided
 
-GitHub Discussions is off for this repo, and review comments on a merged PR stop being findable. So the comment venue is a tracking issue, and the ADR itself merges early.
+Review comments on a merged PR stop being findable, so the comment venue is a [GitHub Discussion](https://github.com/carbon-design-system/carbon-ai-chat/discussions) in the **RFC Discussions** category, and the ADR itself merges early.
 
 1. **Draft it.** Copy [template.md](template.md), fill it in, claim a number. Drafts go in `.github/adr-drafts/`, which is git-ignored.
 2. **Pick the window.** Set `comments-by` to the earliest date this decision should be ratified. Ten working days is the recommended minimum; a decision with a wide blast radius, or one that lands over a holiday, deserves longer.
 3. **Open the PR**, titled `docs: ADR-NNNN <title>`.
-4. **File the tracking issue**, titled `Comment on ADR-NNNN: <title>`, and put its number in the ADR's `discussion` field. That issue is where the discussion happens, and it stays open until the ADR is decided.
+4. **Open the RFC discussion**, titled `[RFC]: <title>`, in the **RFC Discussions** category, and put its URL in the ADR's `discussion` field. That discussion is where the feedback happens, and it stays open until the ADR is decided.
 5. **Merge it.** Merge once the ADR reads clearly, not once everyone agrees. Status stays `proposed`, so nothing is settled — but the ADR is on `main` where people can find it, and it stops collecting rebases.
-6. **Accept or reject it**, on or after `comments-by`. Someone on `@carbon-design-system/carbon-ai-chat-developers` sets the status in a follow-up PR and closes the tracking issue.
+6. **Accept or reject it**, on or after `comments-by`. Someone on `@carbon-design-system/carbon-ai-chat-developers` sets the status in a follow-up PR and closes the discussion.
 
 > **Note**: Silence is not agreement. A window closing does not accept an ADR — someone has to. `comments-by` is the earliest date that decision can be made, not a timer that makes it for you. Until a person sets the status, the ADR is still `proposed` and the decision is still open.
 
 An objection pushes `comments-by` out. It does not reject the ADR. Rejection is its own outcome and needs the same write-up as acceptance — the next person to have the idea deserves to know it was already tried.
 
-**Find the undecided ones through the open tracking issues**, not by reading frontmatter. That is what they are for: an open `Comment on ADR-NNNN` issue is an ADR nobody has ratified yet.
+**Find the undecided ones through the open RFC discussions**, not by reading frontmatter. That is what they are for: an open discussion in the [RFC Discussions category](https://github.com/carbon-design-system/carbon-ai-chat/discussions/categories/rfc-discussions) is an ADR nobody has ratified yet.
 
 ## What happens to your comment
 
@@ -95,4 +95,4 @@ Generated from the records themselves — run `npm run sync:adrs` after adding o
 
 <!-- adr-index:end -->
 
-Every `proposed` row has an open tracking issue behind it. `is:issue is:open in:title "Comment on ADR"` is the same list, with the discussion attached.
+Every `proposed` row has an open RFC discussion behind it. The [Discussions tab, filtered to RFC Discussions](https://github.com/carbon-design-system/carbon-ai-chat/discussions/categories/rfc-discussions), is the same list, with the discussion attached.


### PR DESCRIPTION
## Summary

RFC feedback for proposed ADRs now happens in [GitHub Discussions](https://github.com/carbon-design-system/carbon-ai-chat/discussions/categories/rfc-discussions) (category **RFC Discussions**) instead of the placeholder tracking-issue workflow. This PR:

- Updates the `discussion:` frontmatter field in the 8 proposed ADRs to point at the real discussion thread instead of a placeholder `.../issues/NNNN` link.
- Updates `docs/adr/README.md` and `.github/CONTRIBUTING.md` to describe GitHub Discussions as the RFC feedback venue, replacing the old "GitHub Discussions is off for this repo" / tracking-issue language.

## Discussion links

| ADR | Title | Before (placeholder) | After (real discussion) |
| --- | --- | --- | --- |
| [0002](docs/adr/0002-core-react-wrapper-headless-sdk-split.md) | The core, React wrapper, and headless SDK ship from one package | `.../issues/2110` | [discussions/2208](https://github.com/carbon-design-system/carbon-ai-chat/discussions/2208) |
| [0003](docs/adr/0003-instance-lifetime-belongs-to-the-acquire.md) | Instance lifetime belongs to the acquire, not the host mount | `.../issues/2111` | [discussions/2209](https://github.com/carbon-design-system/carbon-ai-chat/discussions/2209) |
| [0004](docs/adr/0004-per-field-scoped-stores.md) | Chat state is read through per-field scoped stores | `.../issues/2112` | [discussions/2210](https://github.com/carbon-design-system/carbon-ai-chat/discussions/2210) |
| [0005](docs/adr/0005-chat-instance-survives-as-the-composition.md) | `ChatInstance` survives the split as the composition of both halves | `.../issues/2113` | [discussions/2211](https://github.com/carbon-design-system/carbon-ai-chat/discussions/2211) |
| [0007](docs/adr/0007-one-store-pipeline-behind-both-delivery-apis.md) | Both message-delivery APIs run on one store pipeline | `.../issues/2114` | [discussions/2212](https://github.com/carbon-design-system/carbon-ai-chat/discussions/2212) |
| [0009](docs/adr/0009-conversation-verbs-on-instance-messaging.md) | Every conversation verb is reached through `instance.messaging` | `.../issues/2115` | [discussions/2213](https://github.com/carbon-design-system/carbon-ai-chat/discussions/2213) |
| [0023](docs/adr/0023-sdk-prefixed-seam-types.md) | Callbacks survive the split unchanged through a parameterized config | `.../issues/2116` | [discussions/2214](https://github.com/carbon-design-system/carbon-ai-chat/discussions/2214) |
| [0025](docs/adr/0025-the-sdk-entry-point-shape.md) | The SDK is acquired, and lifecycle lives on what the acquire returns | `.../issues/2117` | [discussions/2215](https://github.com/carbon-design-system/carbon-ai-chat/discussions/2215) |

ADR-0001 is out of scope — it's already `accepted` and had no RFC discussion.

## Test plan

- [x] `node tools/validate-adrs.js` passes (0 errors)
- [x] Each discussion link resolved by matching the ADR title against the "RFC Discussions" category via the Discussions GraphQL API
- [ ] Reviewer spot-checks a couple of the discussion links resolve to the matching ADR