### PR TITLE
feat(upload): move the upload-error title into the language pack

### DIFF
--- a/packages/ai-chat/src/chat/AppShell.tsx
+++ b/packages/ai-chat/src/chat/AppShell.tsx
@@ -461,10 +461,15 @@ function AppShell({
 
     const uploadError = fileWithError || pendingUploadWithError;
     if (uploadError) {
+      // The recovery instruction is appended unconditionally: a host's message
+      // says what went wrong, not how to get out of it.
+      const hostMessage =
+        'errorMessage' in uploadError ? uploadError.errorMessage : undefined;
       return {
-        title: 'File upload error',
-        description:
-          'errorMessage' in uploadError ? uploadError.errorMessage : undefined,
+        title: languagePack.fileSharing_uploadErrorTitle,
+        description: [hostMessage, languagePack.fileSharing_uploadErrorRecovery]
+          .filter(Boolean)
+          .join(' '),
         collapsible: false,
       };
     }
@@ -474,6 +479,8 @@ function AppShell({
   }, [
     inputFields.files,
     inputFields.pendingUploads,
+    languagePack.fileSharing_uploadErrorTitle,
+    languagePack.fileSharing_uploadErrorRecovery,
     publicConfig.input?.error,
   ]);
 

--- a/packages/ai-chat/src/chat/languages/en.json
+++ b/packages/ai-chat/src/chat/languages/en.json
@@ -192,6 +192,8 @@
   "fileSharing_removeButtonTitle": "Remove file",
   "fileSharing_statusUploading": "Uploading file",
   "fileSharing_uploadFailed": "There was an error uploading the file.",
+  "fileSharing_uploadErrorTitle": "File upload error",
+  "fileSharing_uploadErrorRecovery": "Remove the attachment and try again.",
   "fileSharing_agentMessageText": "File upload",
   "fileSharing_request": "The agent has requested you upload a file.",
   "fileSharing_ariaAnnounceFilesAdded": "{count, plural, one {File added.} other {{count, number} files added.}}",

--- a/packages/ai-chat/src/types/config/UploadConfig.ts
+++ b/packages/ai-chat/src/types/config/UploadConfig.ts
@@ -52,7 +52,14 @@ export interface UploadConfig {
    * removed before the message is sent.
    *
    * On failure: throw or return a rejected `Promise` — the widget marks the file as
-   * errored in the UI.
+   * errored in the UI. Your `Error`'s `message` becomes the description of that
+   * error, so write it as the reason the file was rejected.
+   *
+   * The chat owns the rest of the copy: the title above your message, and the
+   * instruction to remove the attachment and try again. Both come from the
+   * `fileSharing_uploadErrorTitle` and `fileSharing_uploadErrorRecovery` keys of
+   * {@link LanguagePack}, so don't repeat the recovery step in your own message.
+   * Reword either one through {@link PublicConfig.strings}.
    *
    * @param file - The `File` object selected by the user.
    * @param abortSignal - Fires if the user removes the pending upload before it


### PR DESCRIPTION
Closes #2105

The upload error's title was a hardcoded English literal in `AppShell`. No locale could translate it, no host could change it. A host that wrote its rejection in French still got "File upload error" above it.

The chat also never said how to recover. There is no retry — you remove the attachment and attach it again — and nothing on screen said so. That instruction is new copy in every locale.

#### Changelog

**New**

- `fileSharing_uploadErrorTitle` — the upload error's title.
- `fileSharing_uploadErrorRecovery` — tells the user to remove the attachment and try again. Renders on every failed upload.

**Changed**

- Upload-error title reads from the language pack. Both keys are overridable through `strings`.
- The error's announcement gains the recovery step and picks up the localized title.
- `UploadConfig.onFileUpload` JSDoc states the split. The host owns the description; the chat owns the title and the recovery step.

#### Testing / Reviewing

The demo's upload mock always resolves, so the failure path needs the example.

1. `npm run build --workspace=@carbon/ai-chat`
2. In `examples/react/prompt-line-file-upload/src/App.tsx`, swap `onFileUpload: mockOnFileUpload` for one that throws.

   ```ts
   onFileUpload: async () => {
     throw new Error('Le fichier a été refusé par le serveur.');
   },
   ```

3. `npm start --workspace=@carbon/ai-chat-examples-react-prompt-line-file-upload`. Attach any file.
   Expect "File upload error", the thrown message, then "Remove the attachment and try again."
4. Add to the same config, reload, attach again.

   ```ts
   strings: {
     fileSharing_uploadErrorTitle: 'Erreur de téléversement',
     fileSharing_uploadErrorRecovery: 'Supprimez la pièce jointe et réessayez.',
   },
   ```

   Expect both halves to change. The thrown message stays as written.

5. Remove the chip. The error clears and the input recovers, so the new copy is accurate.

One acceptance criterion on the issue cannot be met as written. "Changing the chat's locale changes both strings" — this package ships only `en.json`, and `config.locale` drives dayjs and `Intl` formatting, not strings. `buildLanguagePack` is `{...enLanguagePack, ...strings}`, with no locale input. Translation goes through `strings`, which step 4 covers. That holds for every key, not just these two. The issue also asked for a key-parity spec across the languages directory; with one file in it, such a spec cannot fail, so it isn't here.

No new tests here — the steps above are the verification. DoD gate is green: `npm run build` and `npm run test` on `@carbon/ai-chat` both exit 0, 111 suites and 1188 tests. No `docs/api/` drift.
