### PR TITLE
fix(prompt-line): storybook follow-ups

### DIFF
--- a/packages/ai-chat-components/references/component-authoring.md
+++ b/packages/ai-chat-components/references/component-authoring.md
@@ -20,6 +20,34 @@ component-name/
 
 Shared pieces: [../src/components/shared/](../src/components/shared/); design tokens / utilities: [../src/globals/](../src/globals/); test helpers: [../src/testing/](../src/testing/); ambient types: [../src/typings/](../src/typings/).
 
+### Nested sub-component directories
+
+When a component grows a logically independent child element that can be used standalone (e.g. [`prompt-line/autocomplete/`](../src/components/prompt-line/autocomplete/)), that child lives as a **sibling directory** next to `src/` and `__stories__/` rather than as another file under `src/`:
+
+```
+component-name/
+  index.ts              # re-exports parent elements AND the sub-component's public API
+  src/                  # parent element implementation (unchanged)
+  __stories__/          # parent stories (unchanged)
+  __tests__/            # parent tests (unchanged)
+  sub-component/
+    index.ts            # sub-component's own public entry
+    src/
+      sub-component.ts
+      sub-component.scss
+    __stories__/        # stories specific to the sub-component
+    __tests__/
+      sub-component.test.ts
+```
+
+Rules for this pattern:
+
+- **Use it when** the child element has meaningful standalone use and its own story set. A helper element that only ever exists inside the parent belongs in `src/` instead.
+- **Both `index.ts` files matter.** The parent's `index.ts` re-exports the sub-component so consumers have one import path; the sub-component's own `index.ts` exists so it can also be imported directly.
+- **Types may flow upward.** If the sub-component's types are shared with the parent (e.g. `SuggestionItem` defined in `src/tiptap/types.ts` and re-used by `autocomplete/src/autocomplete.ts`), import from the parent rather than duplicating them.
+- **Stories are scoped to the sub-component directory.** The sub-component's `__stories__/` produces its own Storybook group; the parent's `__stories__/` does not need to duplicate those stories.
+- **Tests mirror the same split.** `__tests__/` directories exist at both levels; tests for the sub-component's element live under `sub-component/__tests__/`, not alongside the parent's tests.
+
 **Experimental components** use a `preview-*` prefix and a `Preview/` story title. Their APIs may change without a deprecation window and are not recommended for production; they graduate to the main directory (and `Components/` group) when stable.
 
 ## Generated artifacts — never hand-edit

--- a/packages/ai-chat-components/references/component-authoring.md
+++ b/packages/ai-chat-components/references/component-authoring.md
@@ -44,7 +44,7 @@ Rules for this pattern:
 
 - **Use it when** the child element has meaningful standalone use and its own story set. A helper element that only ever exists inside the parent belongs in `src/` instead.
 - **Both `index.ts` files matter.** The parent's `index.ts` re-exports the sub-component so consumers have one import path; the sub-component's own `index.ts` exists so it can also be imported directly.
-- **Types may flow upward.** If the sub-component's types are shared with the parent (e.g. `SuggestionItem` defined in `src/tiptap/types.ts` and re-used by `autocomplete/src/autocomplete.ts`), import from the parent rather than duplicating them.
+- **Types may flow upward.** If the sub-component's types are shared with the parent (e.g. `SuggestionItem` defined in `src/components/prompt-line/src/tiptap/types.ts` and re-used by `autocomplete/src/autocomplete.ts`), import from the parent rather than duplicating them.
 - **Stories are scoped to the sub-component directory.** The sub-component's `__stories__/` produces its own Storybook group; the parent's `__stories__/` does not need to duplicate those stories.
 - **Tests mirror the same split.** `__tests__/` directories exist at both levels; tests for the sub-component's element live under `sub-component/__tests__/`, not alongside the parent's tests.
 

--- a/packages/ai-chat-components/src/components/prompt-line/__stories__/prompt-line-react.stories.jsx
+++ b/packages/ai-chat-components/src/components/prompt-line/__stories__/prompt-line-react.stories.jsx
@@ -823,7 +823,7 @@ const _disableMeta = Object.fromEntries(
   Object.keys(WCMeta.argTypes).map((k) => [k, { table: { disable: true } }])
 );
 
-export const PromptLineAPI = {
+const PromptLineAPI = {
   tags: ['!dev'],
   name: 'PromptLine',
   argTypes: {
@@ -875,7 +875,7 @@ export const PromptLineAPI = {
   ),
 };
 
-export const PromptLineShellAPI = {
+const PromptLineShellAPI = {
   tags: ['!dev'],
   name: 'PromptLineShell',
   argTypes: {
@@ -919,7 +919,7 @@ export const PromptLineShellAPI = {
   ),
 };
 
-export const CDSAIChatInputSendControlAPI = {
+const CDSAIChatInputSendControlAPI = {
   tags: ['!dev'],
   name: 'CDSAIChatInputSendControl',
   argTypes: {
@@ -978,7 +978,7 @@ export const CDSAIChatInputSendControlAPI = {
   ),
 };
 
-export const CDSAIChatAutocompleteAPI = {
+const CDSAIChatAutocompleteAPI = {
   tags: ['!dev'],
   name: 'CDSAIChatAutocomplete',
   argTypes: {
@@ -1025,7 +1025,7 @@ export const CDSAIChatAutocompleteAPI = {
   ),
 };
 
-export const CDSAIChatFileUploadsAPI = {
+const CDSAIChatFileUploadsAPI = {
   tags: ['!dev'],
   name: 'CDSAIChatFileUploads',
   argTypes: {
@@ -1093,7 +1093,7 @@ export const CDSAIChatFileUploadsAPI = {
   },
 };
 
-export const CDSAIChatErrorMessageAPI = {
+const CDSAIChatErrorMessageAPI = {
   tags: ['!dev'],
   name: 'CDSAIChatErrorMessage',
   argTypes: {
@@ -1142,30 +1142,36 @@ export const CDSAIChatErrorMessageAPI = {
 
 export const PromptLineArgTypes = {
   tags: ['!dev'],
+  parameters: { chromatic: { disable: true } },
   argTypes: PromptLineAPI.argTypes,
 };
 
 export const PromptLineShellArgTypes = {
   tags: ['!dev'],
+  parameters: { chromatic: { disable: true } },
   argTypes: PromptLineShellAPI.argTypes,
 };
 
 export const CDSAIChatInputSendControlArgTypes = {
   tags: ['!dev'],
+  parameters: { chromatic: { disable: true } },
   argTypes: CDSAIChatInputSendControlAPI.argTypes,
 };
 
 export const CDSAIChatAutocompleteArgTypes = {
   tags: ['!dev'],
+  parameters: { chromatic: { disable: true } },
   argTypes: CDSAIChatAutocompleteAPI.argTypes,
 };
 
 export const CDSAIChatFileUploadsArgTypes = {
   tags: ['!dev'],
+  parameters: { chromatic: { disable: true } },
   argTypes: CDSAIChatFileUploadsAPI.argTypes,
 };
 
 export const CDSAIChatErrorMessageArgTypes = {
   tags: ['!dev'],
+  parameters: { chromatic: { disable: true } },
   argTypes: CDSAIChatErrorMessageAPI.argTypes,
 };

--- a/packages/ai-chat-components/src/components/prompt-line/__stories__/prompt-line-react.stories.jsx
+++ b/packages/ai-chat-components/src/components/prompt-line/__stories__/prompt-line-react.stories.jsx
@@ -211,8 +211,13 @@ export default {
   component: PromptLine,
   argTypes: {
     ...WCMeta.argTypes,
+    expanded: {
+      control: 'boolean',
+      description:
+        'Whether the shell uses the expanded layout (full-width editor row with inline actions beneath it).',
+    },
   },
-  args: { ...WCMeta.args },
+  args: { ...WCMeta.args, expanded: false },
 };
 
 // ---------------------------------------------------------------------------
@@ -228,68 +233,7 @@ export const Default = {
     placeholder,
     disabled,
     rounded,
-    hasError,
-    errorTitle,
-    errorDescription,
-    errorCollapsible,
-    errorFullscreen,
-  }) => {
-    const [hasValidInput, setHasValidInput] = useState(false);
-
-    const onChange = useCallback((e) => {
-      setHasValidInput(e.detail.rawValue.length > 0);
-      action('cds-aichat-prompt-change')(e.detail);
-    }, []);
-
-    return (
-      <Wrapper>
-        <PromptLineShell
-          rounded={rounded}
-          disabled={disabled}
-          hasError={hasError}>
-          {hasError && errorTitle && (
-            <CDSAIChatErrorMessage
-              slot="field-messaging"
-              title={errorTitle}
-              description={errorDescription}
-              collapsible={errorCollapsible}
-              fullscreen={errorFullscreen}
-            />
-          )}
-          <PromptLine
-            slot="editor"
-            placeholder={placeholder}
-            disabled={disabled}
-            onChange={onChange}
-            onSendIntent={(e) =>
-              action('cds-aichat-prompt-send-intent')(e.detail)
-            }
-          />
-          <CDSAIChatInputSendControl
-            slot="send-control"
-            disabled={disabled}
-            hasValidInput={hasValidInput}
-            onSend={() => action('cds-aichat-input-send')()}
-          />
-        </PromptLineShell>
-      </Wrapper>
-    );
-  },
-};
-
-// ---------------------------------------------------------------------------
-// Expanded — full-width editor row + 10 dummy action buttons beneath it
-// ---------------------------------------------------------------------------
-
-export const Expanded = {
-  argTypes: {
-    attached: { table: { disable: true } },
-    disableDirectSend: { table: { disable: true } },
-  },
-  render: ({
-    placeholder,
-    disabled,
-    rounded,
+    expanded,
     hasError,
     errorTitle,
     errorDescription,
@@ -309,7 +253,7 @@ export const Expanded = {
           rounded={rounded}
           disabled={disabled}
           hasError={hasError}
-          expanded>
+          expanded={expanded}>
           {hasError && errorTitle && (
             <CDSAIChatErrorMessage
               slot="field-messaging"
@@ -324,8 +268,13 @@ export const Expanded = {
             placeholder={placeholder}
             disabled={disabled}
             onChange={onChange}
+            onSendIntent={(e) =>
+              action('cds-aichat-prompt-send-intent')(e.detail)
+            }
           />
-          <InlineActions actions={dummyActions} disabled={disabled} />
+          {expanded && (
+            <InlineActions actions={dummyActions} disabled={disabled} />
+          )}
           <CDSAIChatInputSendControl
             slot="send-control"
             disabled={disabled}
@@ -336,6 +285,15 @@ export const Expanded = {
       </Wrapper>
     );
   },
+};
+
+// ---------------------------------------------------------------------------
+// Expanded — full-width editor row + 10 dummy action buttons beneath it
+// ---------------------------------------------------------------------------
+
+export const Expanded = {
+  args: { ...Default.args, expanded: true },
+  render: Default.render,
 };
 
 // ---------------------------------------------------------------------------

--- a/packages/ai-chat-components/src/components/prompt-line/__stories__/prompt-line-react.stories.jsx
+++ b/packages/ai-chat-components/src/components/prompt-line/__stories__/prompt-line-react.stories.jsx
@@ -309,6 +309,7 @@ const CommandsAndMentionsStory = ({
   errorDescription,
   errorCollapsible,
   errorFullscreen,
+  attached,
 }) => {
   const [hasValidInput, setHasValidInput] = useState(false);
   const promptLineRef = useRef(null);
@@ -349,7 +350,7 @@ const CommandsAndMentionsStory = ({
     mention,
     command,
     promptLineRef,
-    attached: false,
+    attached,
   });
 
   const onChange = useCallback((e) => {

--- a/packages/ai-chat-components/src/components/prompt-line/__stories__/prompt-line-react.stories.jsx
+++ b/packages/ai-chat-components/src/components/prompt-line/__stories__/prompt-line-react.stories.jsx
@@ -950,7 +950,7 @@ const CDSAIChatAutocompleteAPI = {
     attached: {
       control: 'boolean',
       description:
-        'When `true`, suppresses bottom corner rounding (use when overlaying the input).',
+        'When `true`, suppresses bottom corner rounding. Use in float and sidebar layouts when there is no gap between autocomplete and input bar.',
       table: { category: '' },
     },
     disableDirectSend: {

--- a/packages/ai-chat-components/src/components/prompt-line/__stories__/prompt-line-react.stories.jsx
+++ b/packages/ai-chat-components/src/components/prompt-line/__stories__/prompt-line-react.stories.jsx
@@ -405,6 +405,9 @@ const CommandsAndMentionsStory = ({
 };
 
 export const CommandsAndMentions = {
+  argTypes: {
+    disableDirectSend: { table: { disable: true } },
+  },
   name: 'Commands and mentions',
   render: (args) => <CommandsAndMentionsStory {...args} />,
 };

--- a/packages/ai-chat-components/src/components/prompt-line/__stories__/prompt-line-react.stories.jsx
+++ b/packages/ai-chat-components/src/components/prompt-line/__stories__/prompt-line-react.stories.jsx
@@ -292,6 +292,10 @@ export const Default = {
 // ---------------------------------------------------------------------------
 
 export const Expanded = {
+  argTypes: {
+    attached: { table: { disable: true } },
+    disableDirectSend: { table: { disable: true } },
+  },
   args: { ...Default.args, expanded: true },
   render: Default.render,
 };

--- a/packages/ai-chat-components/src/components/prompt-line/__stories__/prompt-line.stories.js
+++ b/packages/ai-chat-components/src/components/prompt-line/__stories__/prompt-line.stories.js
@@ -873,7 +873,7 @@ export default {
     attached: {
       control: 'boolean',
       description:
-        'Whether the autocomplete popover is visually attached to the input — removes bottom-corner rounding (Typeahead only).',
+        'When `true`, suppresses bottom corner rounding. Use in float and sidebar layouts when there is no gap between autocomplete and input bar.',
       table: { category: 'Autocomplete' },
     },
   },

--- a/packages/ai-chat-components/src/components/prompt-line/__stories__/prompt-line.stories.js
+++ b/packages/ai-chat-components/src/components/prompt-line/__stories__/prompt-line.stories.js
@@ -975,6 +975,10 @@ export const Default = {
 // ---------------------------------------------------------------------------
 
 export const Expanded = {
+  argTypes: {
+    disableDirectSend: { table: { disable: true } },
+    attached: { table: { disable: true } },
+  },
   args: { ...Default.args, expanded: true },
   render: Default.render,
 };

--- a/packages/ai-chat-components/src/components/prompt-line/__stories__/prompt-line.stories.js
+++ b/packages/ai-chat-components/src/components/prompt-line/__stories__/prompt-line.stories.js
@@ -984,6 +984,9 @@ export const Expanded = {
 // ---------------------------------------------------------------------------
 
 export const CommandsAndMentions = {
+  argTypes: {
+    disableDirectSend: { table: { disable: true } },
+  },
   name: 'Commands and mentions',
   render: ({
     placeholder,

--- a/packages/ai-chat-components/src/components/prompt-line/__stories__/prompt-line.stories.js
+++ b/packages/ai-chat-components/src/components/prompt-line/__stories__/prompt-line.stories.js
@@ -808,6 +808,11 @@ export default {
       control: 'boolean',
       description: 'Whether the shell has rounded corners.',
     },
+    expanded: {
+      control: 'boolean',
+      description:
+        'Whether the shell uses the expanded layout (full-width editor row with inline actions beneath it).',
+    },
     hasError: {
       control: 'boolean',
       description: 'Whether the shell is in an error state.',
@@ -846,6 +851,7 @@ export default {
     placeholder: 'Type something...',
     disabled: false,
     rounded: true,
+    expanded: false,
     hasError: false,
     errorTitle: 'Something went wrong.',
     errorDescription: '',
@@ -869,75 +875,7 @@ export const Default = {
     placeholder,
     disabled,
     rounded,
-    hasError,
-    errorTitle,
-    errorDescription,
-    errorCollapsible,
-    errorFullscreen,
-  }) => {
-    let sendControlEl = null;
-
-    const onPromptChange = (e) => {
-      if (sendControlEl) {
-        sendControlEl.hasValidInput = e.detail.rawValue.length > 0;
-      }
-      action('cds-aichat-prompt-change')(e.detail);
-    };
-
-    return html`
-      <style>
-        ${styles}
-      </style>
-      <div class="prompt-line-story-wrapper">
-        <cds-aichat-prompt-line-shell
-          ?rounded=${rounded}
-          ?disabled=${disabled}
-          ?has-error=${hasError}>
-          ${
-            hasError && errorTitle
-              ? html`<cds-aichat-error-message
-                  slot="field-messaging"
-                  title=${errorTitle}
-                  description=${errorDescription}
-                  ?collapsible=${errorCollapsible}
-                  ?fullscreen=${errorFullscreen}></cds-aichat-error-message>`
-              : null
-          }
-          <cds-aichat-prompt-line
-            slot="editor"
-            placeholder=${placeholder}
-            ?disabled=${disabled}
-            @cds-aichat-prompt-change=${onPromptChange}
-            @cds-aichat-prompt-send-intent=${(e) =>
-              action('cds-aichat-prompt-send-intent')(
-                e.detail
-              )}></cds-aichat-prompt-line>
-          <cds-aichat-input-send-control
-            slot="send-control"
-            ?disabled=${disabled}
-            @cds-aichat-input-send=${() => action('cds-aichat-input-send')()}
-            ${ref((el) => {
-              sendControlEl = el ?? null;
-            })}></cds-aichat-input-send-control>
-        </cds-aichat-prompt-line-shell>
-      </div>
-    `;
-  },
-};
-
-// ---------------------------------------------------------------------------
-// Expanded — full-width editor row + 10 dummy action buttons beneath it
-// ---------------------------------------------------------------------------
-
-export const Expanded = {
-  argTypes: {
-    disableDirectSend: { table: { disable: true } },
-    attached: { table: { disable: true } },
-  },
-  render: ({
-    placeholder,
-    disabled,
-    rounded,
+    expanded,
     hasError,
     errorTitle,
     errorDescription,
@@ -962,7 +900,7 @@ export const Expanded = {
           ?rounded=${rounded}
           ?disabled=${disabled}
           ?has-error=${hasError}
-          expanded>
+          ?expanded=${expanded}>
           ${
             hasError && errorTitle
               ? html`<cds-aichat-error-message
@@ -977,10 +915,18 @@ export const Expanded = {
             slot="editor"
             placeholder=${placeholder}
             ?disabled=${disabled}
-            @cds-aichat-prompt-change=${onPromptChange}></cds-aichat-prompt-line>
-          <prompt-line-story-inline-actions
-            .actions=${dummyActions}
-            ?disabled=${disabled}></prompt-line-story-inline-actions>
+            @cds-aichat-prompt-change=${onPromptChange}
+            @cds-aichat-prompt-send-intent=${(e) =>
+              action('cds-aichat-prompt-send-intent')(
+                e.detail
+              )}></cds-aichat-prompt-line>
+          ${
+            expanded
+              ? html`<prompt-line-story-inline-actions
+                  .actions=${dummyActions}
+                  ?disabled=${disabled}></prompt-line-story-inline-actions>`
+              : null
+          }
           <cds-aichat-input-send-control
             slot="send-control"
             ?disabled=${disabled}
@@ -992,6 +938,15 @@ export const Expanded = {
       </div>
     `;
   },
+};
+
+// ---------------------------------------------------------------------------
+// Expanded — full-width editor row + 10 dummy action buttons beneath it
+// ---------------------------------------------------------------------------
+
+export const Expanded = {
+  args: { ...Default.args, expanded: true },
+  render: Default.render,
 };
 
 // ---------------------------------------------------------------------------

--- a/packages/ai-chat-components/src/components/prompt-line/__stories__/prompt-line.stories.js
+++ b/packages/ai-chat-components/src/components/prompt-line/__stories__/prompt-line.stories.js
@@ -528,6 +528,7 @@ class PromptLineCommandsAndMentionsStory extends LitElement {
     errorDescription: {},
     errorCollapsible: { type: Boolean },
     errorFullscreen: { type: Boolean },
+    attached: { type: Boolean },
   };
 
   constructor() {
@@ -540,6 +541,7 @@ class PromptLineCommandsAndMentionsStory extends LitElement {
     this.errorDescription = '';
     this.errorCollapsible = false;
     this.errorFullscreen = true;
+    this.attached = false;
     this._sendControlRef = createRef();
     this._mentionConfig = {
       trigger: '@',
@@ -569,6 +571,34 @@ class PromptLineCommandsAndMentionsStory extends LitElement {
 
   createRenderRoot() {
     return this;
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    this._autocompleteObserver = new MutationObserver(() => {
+      this._pushAttached();
+    });
+    this._autocompleteObserver.observe(this, {
+      childList: true,
+      subtree: true,
+    });
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    this._autocompleteObserver?.disconnect();
+    this._autocompleteObserver = null;
+  }
+
+  updated() {
+    this._pushAttached();
+  }
+
+  _pushAttached() {
+    const autocompleteEl = this.querySelector('cds-aichat-autocomplete');
+    if (autocompleteEl) {
+      autocompleteEl.attached = this.attached;
+    }
   }
 
   _onPromptChange(e) {
@@ -964,6 +994,7 @@ export const CommandsAndMentions = {
     errorDescription,
     errorCollapsible,
     errorFullscreen,
+    attached,
   }) => {
     const el = document.createElement(
       'prompt-line-story-commands-and-mentions'
@@ -976,6 +1007,7 @@ export const CommandsAndMentions = {
     el.errorDescription = errorDescription;
     el.errorCollapsible = errorCollapsible;
     el.errorFullscreen = errorFullscreen;
+    el.attached = attached;
     return el;
   },
 };

--- a/packages/ai-chat-components/src/components/prompt-line/autocomplete/__tests__/autocomplete.test.ts
+++ b/packages/ai-chat-components/src/components/prompt-line/autocomplete/__tests__/autocomplete.test.ts
@@ -460,6 +460,40 @@ describe('cds-aichat-autocomplete', () => {
 
       expect(dismissEventFired).to.be.true;
     });
+
+    it('should not emit dismiss event when anchor element inside a shadow root is clicked', async () => {
+      const el = await fixture<AutocompleteElement>(html`
+        <cds-aichat-autocomplete
+          .items="${mockItems}"></cds-aichat-autocomplete>
+      `);
+
+      const host = document.createElement('div');
+      document.body.appendChild(host);
+      const root = host.attachShadow({ mode: 'open' });
+      const anchor = document.createElement('div');
+      anchor.innerHTML = '<span id="deep">editor text</span>';
+      root.appendChild(anchor);
+      el.anchorElement = anchor;
+
+      root
+        .querySelector('#deep')!
+        .dispatchEvent(
+          new MouseEvent('click', { bubbles: true, composed: true })
+        );
+
+      let dismissEventFired = false;
+      el.addEventListener('cds-aichat-autocomplete-dismiss', () => {
+        dismissEventFired = true;
+      });
+
+      anchor.dispatchEvent(
+        new MouseEvent('click', { bubbles: true, composed: true })
+      );
+
+      await el.updateComplete;
+
+      expect(dismissEventFired).to.be.false;
+    });
   });
 
   describe('keyboard navigation', () => {

--- a/packages/ai-chat-components/src/components/prompt-line/autocomplete/__tests__/autocomplete.test.ts
+++ b/packages/ai-chat-components/src/components/prompt-line/autocomplete/__tests__/autocomplete.test.ts
@@ -475,16 +475,16 @@ describe('cds-aichat-autocomplete', () => {
       root.appendChild(anchor);
       el.anchorElement = anchor;
 
+      let dismissEventFired = false;
+      el.addEventListener('cds-aichat-autocomplete-dismiss', () => {
+        dismissEventFired = true;
+      });
+
       root
         .querySelector('#deep')!
         .dispatchEvent(
           new MouseEvent('click', { bubbles: true, composed: true })
         );
-
-      let dismissEventFired = false;
-      el.addEventListener('cds-aichat-autocomplete-dismiss', () => {
-        dismissEventFired = true;
-      });
 
       anchor.dispatchEvent(
         new MouseEvent('click', { bubbles: true, composed: true })

--- a/packages/ai-chat-components/src/components/prompt-line/autocomplete/src/autocomplete.ts
+++ b/packages/ai-chat-components/src/components/prompt-line/autocomplete/src/autocomplete.ts
@@ -417,17 +417,11 @@ class AutocompleteElement extends LitElement {
     // Use composedPath() instead of event.target so clicks originating inside
     // a shadow root are visible.
     const path = event.composedPath();
-    const isNode = (t: EventTarget): t is Node => t instanceof Node;
-    // Check if click is on autocomplete itself
-    if (path.filter(isNode).some((n) => this.contains(n))) {
+
+    if (path.includes(this)) {
       return;
     }
-    // Check if click is on anchor element
-    const { anchorElement } = this;
-    if (
-      anchorElement &&
-      path.filter(isNode).some((n) => anchorElement.contains(n))
-    ) {
+    if (this.anchorElement && path.includes(this.anchorElement)) {
       return;
     }
     this._dismiss();

--- a/packages/ai-chat-components/src/components/prompt-line/src/__tests__/autocomplete-controller.test.ts
+++ b/packages/ai-chat-components/src/components/prompt-line/src/__tests__/autocomplete-controller.test.ts
@@ -15,8 +15,13 @@
  */
 
 import { expect } from '@open-wc/testing';
+import { Editor } from '@tiptap/core';
+import DocumentNode from '@tiptap/extension-document';
+import ParagraphNode from '@tiptap/extension-paragraph';
+import TextNode from '@tiptap/extension-text';
 
 import { AutocompleteController } from '../autocomplete-controller.js';
+import { carbonStarterTrigger } from '../tiptap/carbon-starter-trigger.js';
 import {
   dispatchTriggerChange,
   resetTriggerChangeState,
@@ -808,6 +813,111 @@ describe('AutocompleteController', () => {
       await flush();
       // The mention config has no renderCustomList, so it must be undefined.
       expect(last.renderCustomList).to.equal(undefined);
+    });
+  });
+
+  describe('Escape / dismiss does not re-open the starter overlay', () => {
+    function makeEditorWithController(items = STARTERS.items) {
+      const mount = document.createElement('div');
+      // Must be in the document and have layout for focus() to work.
+      mount.style.cssText = 'position:fixed;top:0;left:0;width:1px;height:1px;';
+      document.body.appendChild(mount);
+
+      const editor = new Editor({
+        element: mount,
+        extensions: [
+          DocumentNode,
+          ParagraphNode,
+          TextNode,
+          carbonStarterTrigger(items),
+        ],
+        content: '',
+      });
+
+      const editorEvents: (TriggerChangeEventDetail | null)[] = [];
+      editor.view.dom.addEventListener('cds-aichat-trigger-change', (e) => {
+        editorEvents.push(
+          (e as CustomEvent<TriggerChangeEventDetail | null>).detail
+        );
+      });
+
+      const states: Array<{ trigger: TriggerChangeEventDetail | null }> = [];
+      const controller = new AutocompleteController({
+        starters: STARTERS,
+        onChange: (state) => {
+          states.push({ trigger: state.trigger });
+        },
+      });
+
+      // Wire the real editor into the controller through a minimal promptLine
+      // stub — `getEditor()` must expose `view.dom` (for resetTriggerChangeState)
+      // and the Tiptap `Editor` satisfies that interface.
+      const promptLine = { getEditor: () => editor as any };
+      controller.setPromptLine(promptLine as any);
+
+      // Feed trigger-change events from the real editor into the controller.
+      editor.view.dom.addEventListener('cds-aichat-trigger-change', (e) => {
+        controller.handleTriggerChangeEvent(
+          e as CustomEvent<TriggerChangeEventDetail | null>
+        );
+      });
+
+      return {
+        editor,
+        mount,
+        controller,
+        states,
+        editorEvents,
+        cleanup: () => {
+          controller.destroy();
+          editor.destroy();
+          mount.remove();
+        },
+      };
+    }
+
+    it('dismiss() leaves trigger null and emits no further starter detail', async () => {
+      const { editor, controller, states, editorEvents, cleanup } =
+        makeEditorWithController();
+      try {
+        // Focus the real editor — carbonStarterTrigger.onFocus fires synchronously
+        // and the controller receives the starter detail via the DOM listener.
+        editor.view.dom.focus();
+        await flush();
+
+        const lastStateBeforeDismiss = states[states.length - 1];
+        expect(lastStateBeforeDismiss?.trigger?.type).to.equal('starter');
+
+        // Snapshot the event count before dismissing.
+        const editorEventCountBeforeDismiss = editorEvents.length;
+        states.length = 0;
+
+        // Simulate what happens when the overlay's Escape handler calls dismiss().
+        controller.dismiss();
+
+        // Controller state must be null immediately.
+        expect(states[states.length - 1]?.trigger).to.equal(null);
+
+        // Allow any microtask / macrotask queue to drain.
+        await new Promise<void>((resolve) => setTimeout(resolve));
+
+        // The real editor is still focused and still empty — but no new
+        // starter detail should have been dispatched by the extension.  The
+        // coalescing state was reset by dismiss(), so if the extension fired
+        // again it would appear in editorEvents.
+        const newStarterEvents = editorEvents
+          .slice(editorEventCountBeforeDismiss)
+          .filter((d) => d?.type === 'starter');
+        expect(newStarterEvents).to.have.lengthOf(0);
+
+        // And the controller must not have re-opened the overlay.
+        const reopenedStates = states.filter(
+          (s) => s.trigger?.type === 'starter'
+        );
+        expect(reopenedStates).to.have.lengthOf(0);
+      } finally {
+        cleanup();
+      }
     });
   });
 

--- a/packages/ai-chat-components/src/components/prompt-line/src/autocomplete-controller.ts
+++ b/packages/ai-chat-components/src/components/prompt-line/src/autocomplete-controller.ts
@@ -150,10 +150,9 @@ export class AutocompleteController {
       const prevIsOn = this._starters?.isOn !== false;
       const isOn = next.starters?.isOn !== false;
       this._starters = next.starters;
-      // isOn toggled: push the new value into the Tiptap extension storage and
-      // fire a no-op transaction so onTransaction → maybeEmit re-evaluates.
-      // Focus state is unchanged — the list appears on the next focus if the
-      // editor is not currently focused, or immediately if it is.
+      // isOn toggled: push the new value into the Tiptap extension storage.
+      // onTransaction is gated on editor.isFocused, so re-evaluation happens
+      // immediately when the editor is focused, and on the next focus otherwise.
       if (prevIsOn !== isOn) {
         writeStarterStorage(this._promptLine?.getEditor(), { isOn });
       }

--- a/packages/ai-chat-components/src/components/prompt-line/src/tiptap/carbon-starter-trigger.ts
+++ b/packages/ai-chat-components/src/components/prompt-line/src/tiptap/carbon-starter-trigger.ts
@@ -103,10 +103,9 @@ export function carbonStarterTrigger(
   });
 }
 
-function maybeEmit(editor: Editor, forceClear = false): void {
+function maybeEmit(editor: Editor): void {
   const storage = readStarterStorage(editor);
   const isActive =
-    !forceClear &&
     storage?.isOn !== false &&
     (storage?.items.length ?? 0) > 0 &&
     editor.isEditable &&

--- a/packages/ai-chat-components/src/react/hooks/useChatAutocomplete.tsx
+++ b/packages/ai-chat-components/src/react/hooks/useChatAutocomplete.tsx
@@ -194,9 +194,12 @@ export function useChatAutocomplete(
 
   // Prevent mousedown on the autocomplete container from stealing focus from
   // the editor.
-  const handleContainerMousedown = React.useCallback((e: React.MouseEvent) => {
-    e.preventDefault();
-  }, []);
+  const handleContainerMousedown = React.useCallback(
+    (e: Event | React.MouseEvent) => {
+      e.preventDefault();
+    },
+    []
+  );
 
   const autocompleteContent = React.useMemo<ReactNode>(() => {
     if (!state.trigger || state.items.length === 0) {
@@ -228,7 +231,7 @@ export function useChatAutocomplete(
           slot="autocomplete-content"
           node={result as ReactNode}
           onMount={setListElement}
-          onMousedown={(e) => e.preventDefault()}
+          onMousedown={handleContainerMousedown}
         />
       );
     }


### PR DESCRIPTION
Closes #2065

Adds regression tests for two bugs that were fixed in #2022:
1) Escape key failed to dismiss the Prompt Line autocomplete overlay when using conversation starters
2) `_handleClickOutside` didn't detect clicks on an anchor inside a shadow root

Also fixes a series of small cleanup items (listed in #2065) related to the Prompt Line storybook.

#### Changelog

**New**

- `autocomplete.test.ts`: Regression test. Clicking an autocomplete anchor element inside a shadow root should not trigger the autocomplete to close.
- `autocomplete-controller.test.ts`: Regression test. Conversation starters should not re-open immediately after pressing Escape on an empty editor.

**Changed**

- `component-authoring.md`: Documents nested sub-component directory pattern.
- `prompt-line.stories.js`: Removes duplicate code by composing "Expanded" prompt line story from "Default".  In "Commands and mentions" story, disables `disableDirectSend` control as it has no effect on mentions/commands and makes `attached` control functional.
- `prompt-line-react.stories.jsx`: Applies the same fixes as the WC stories. Also makes the *API objects module-local consts and adds `parameters: { chromatic: { disable: true } }` to the `*ArgTypes` exports that must stay exported for `<ArgTypes of={…}>`. This stops Chromatic from taking blank snapshots of these exports.
- `autocomplete.ts`: Simplifies checks in `_handleClickOutside()`.
- `autocomplete-controller.ts`: Updates outdated comment.
- `carbon-starter-trigger.ts`: Removes `forceClear` parameter from `maybeEmit()` (dead code).
- `useChatAutocomplete.tsx`: Use `handleContainerMousedown` as mousedown handler for `CustomElementHost` and `CustomReactNodePortal`.

#### Testing / Reviewing
- Ensure both new regression tests pass. Already verified that they fail prior to #2022 commit.
- Go to Storybook deploy preview -> Prompt Line -> Commands and mentions. Verify toggling the `attached` control works.