### PR TITLE
feat(examples): demonstrate a rejected upload in file-upload examples

### DIFF
--- a/examples/react/prompt-line-file-upload/README.md
+++ b/examples/react/prompt-line-file-upload/README.md
@@ -8,6 +8,7 @@
 - Simulating a 1-second upload with `AbortSignal` support and returning an `ExternalFileReference` wrapped in `StructuredData`.
 - The chat rendering each uploaded file as a chip in the user's own message bubble, from the `name` and `mime_type` on the returned reference.
 - Echoing attached file metadata back as a text message via `instance.messaging.addMessage` and `MessageResponseTypes.TEXT`, showing what the server receives.
+- Demonstrating the upload failure path: attaching a file whose name starts with "a" makes `onFileUpload` throw after the simulated delay, and the chat shows the attachment chip moving from uploading to errored with a description of what went wrong.
 - Documenting the optional `accept`, `maxFileSizeBytes`, and `maxFiles` config knobs (commented in source).
 
 ## When to use this pattern

--- a/examples/react/prompt-line-file-upload/src/customSendMessage.ts
+++ b/examples/react/prompt-line-file-upload/src/customSendMessage.ts
@@ -36,7 +36,9 @@ const WELCOME_TEXT = `Welcome! This example demonstrates file uploads in Carbon 
 
 Attach a file using the paperclip button in the input area, then send a message. The mock server will echo back the file metadata.
 
-You can attach multiple files at once before sending.`;
+You can attach multiple files at once before sending.
+
+Files whose name starts with "a" are rejected by the mock server — attach one to see the upload error state.`;
 
 // Replace with a real production implementation.
 async function customSendMessage(

--- a/examples/react/prompt-line-file-upload/src/mockOnFileUpload.ts
+++ b/examples/react/prompt-line-file-upload/src/mockOnFileUpload.ts
@@ -15,6 +15,9 @@
  * an `ExternalFileReference`, plus a companion responder that echoes
  * received file metadata back to the user.
  *
+ * Also demonstrates the failure path: throwing from `onFileUpload` marks the
+ * attachment as errored and blocks sending until the user removes it.
+ *
  * Returning `name` and `mime_type` on the reference is what lets the chat render
  * the attachment as a chip in the user's message bubble, and what lets that chip
  * come back if the conversation is restored from history.
@@ -43,7 +46,9 @@ import { uuid } from '@carbon/ai-chat-components/es/globals/utils/uuid.js';
  * Mock `UploadConfig.onFileUpload` handler.
  *
  * Simulates a 1-second server-side upload, then returns a {@link StructuredData}
- * containing an {@link ExternalFileReference} with the file's metadata.
+ * containing an {@link ExternalFileReference} with the file's metadata. Files
+ * whose name starts with "a" are rejected instead, so the example can show the
+ * errored-attachment state.
  *
  * In a real integration this function would POST the file to a backend and
  * return the server-assigned reference instead.
@@ -66,6 +71,16 @@ async function mockOnFileUpload(
       { once: true }
     );
   });
+
+  // Reject names starting with "a" so this example has a reproducible way to
+  // show an upload failing: the chip moves from uploading to errored and the
+  // prompt line blocks sending until the attachment is removed. The check runs
+  // after the delay above, not before it, so that transition stays visible.
+  if (file.name.toLowerCase().startsWith('a')) {
+    throw new Error(
+      'Files whose name starts with "a" are blocked by this server\'s content policy.'
+    );
+  }
 
   // A real backend returns its own server-assigned id; here we synthesise one client-side.
   const reference: ExternalFileReference = {

--- a/examples/web-components/prompt-line-file-upload/README.md
+++ b/examples/web-components/prompt-line-file-upload/README.md
@@ -9,6 +9,7 @@ Enables file attachments on `<cds-aichat-custom-element>` with a mock `onFileUpl
 - Respecting `AbortSignal` so removing a pending attachment cancels its in-flight upload.
 - The chat rendering each uploaded file as a chip in the user's own message bubble, from the `name` and `mime_type` on the returned reference.
 - Echoing file metadata (name, type, size, server id) back through `customSendMessage`, showing what the server receives.
+- Rejecting an upload by throwing from `onFileUpload`: any file whose name begins with "a" fails once the simulated delay elapses, leaving an errored attachment chip and a blocking error above the input until the file is removed.
 - Documenting optional upload guards (`accept`, `maxFileSizeBytes`, `maxFiles`) as commented configuration.
 
 ## When to use this pattern

--- a/examples/web-components/prompt-line-file-upload/src/customSendMessage.ts
+++ b/examples/web-components/prompt-line-file-upload/src/customSendMessage.ts
@@ -38,7 +38,9 @@ const WELCOME_TEXT = `Welcome! This example demonstrates file uploads in Carbon 
 
 Attach a file using the paperclip button in the input area, then send a message. The mock server will echo back the file metadata.
 
-You can attach multiple files at once before sending.`;
+You can attach multiple files at once before sending.
+
+Files whose name starts with "a" are rejected by the mock server — attach one to see the upload error state.`;
 
 // Replace with a real production implementation that posts the user's
 // turn to your backend; this mock only inspects the request locally.

--- a/examples/web-components/prompt-line-file-upload/src/mockOnFileUpload.ts
+++ b/examples/web-components/prompt-line-file-upload/src/mockOnFileUpload.ts
@@ -18,6 +18,9 @@
  * next user turn, plus parsing those references back out of
  * `MessageRequest.input.structured_data` on the assistant side.
  *
+ * Also demonstrates the failure path: throwing from `onFileUpload` marks the
+ * attachment as errored and blocks sending until the user removes it.
+ *
  * Returning `name` and `mime_type` on the reference is what lets the chat render
  * the attachment as a chip in the user's message bubble, and what lets that chip
  * come back if the conversation is restored from history.
@@ -44,7 +47,9 @@ import { uuid } from '@carbon/ai-chat-components/es/globals/utils/uuid.js';
  * Mock `UploadConfig.onFileUpload` handler.
  *
  * Simulates a 1-second server-side upload, then returns a {@link StructuredData}
- * containing an {@link ExternalFileReference} with the file's metadata.
+ * containing an {@link ExternalFileReference} with the file's metadata. Files
+ * whose name starts with "a" are rejected instead, so the example can show the
+ * errored-attachment state.
  *
  * In a real integration this function would POST the file to a backend and
  * return the server-assigned reference instead.
@@ -70,6 +75,16 @@ async function mockOnFileUpload(
       { once: true }
     );
   });
+
+  // Reject names starting with "a" so this example has a reproducible way to
+  // show an upload failing: the chip moves from uploading to errored and the
+  // prompt line blocks sending until the attachment is removed. The check runs
+  // after the delay above, not before it, so that transition stays visible.
+  if (file.name.toLowerCase().startsWith('a')) {
+    throw new Error(
+      'Files whose name starts with "a" are blocked by this server\'s content policy.'
+    );
+  }
 
   // Shape required by the chat: `type: "reference"` + a stable `id` is
   // what `customSendMessage` uses to look the file back up on the next turn.


### PR DESCRIPTION
Closes #2108

<img width="710" height="279" alt="Screenshot 2026-08-28 at 9 35 38 AM" src="https://github.com/user-attachments/assets/ea32e644-63cd-4b11-98c0-7fb513cf7181" />



Both `prompt-line-file-upload` examples only showed the example on how it works but not what happens if the file upload fails. `onFileUpload`'s contract says "throw to reject", but nothing demonstrated what that produces — a host wiring a real endpoint had a template for success and none for failure.

Files whose name starts with "a" now fail. The check sits after the existing delay/abort race, not before it: throwing earlier would skip the in-flight state, and the uploading → errored transition is the point.

#### Changelog

**New**

- Upload failure path in both `prompt-line-file-upload` examples. Names starting with "a" throw from the mock `onFileUpload`.

**Changed**

- Welcome message and both example READMEs state the condition.

#### Testing / Reviewing

Not reachable from the demo site — run the example.

```bash
npm run build --workspace=@carbon/ai-chat-components
npm run build --workspace=@carbon/ai-chat
npm run start --workspace=@carbon/ai-chat-examples-react-prompt-line-file-upload
```

1. Welcome message states the "a" condition.
2. Attach `apple.txt`. Chip goes uploading → errored. Banner shows the rejection message plus the recovery step.
3. Type some text. Send stays disabled.
4. Remove the file. Banner clears, send re-enables.
5. Attach `avocado.txt` and `budget.csv` together. One errors, one succeeds, no extra handling.
6. Repeat on `@carbon/ai-chat-examples-web-components-prompt-line-file-upload`. Same condition, same message.
