### PR TITLE
fix(prompt-line): set mentionSuggestionChar on tiptap mentions extension

### DIFF
--- a/packages/ai-chat-components/src/components/prompt-line/src/tiptap/__tests__/carbon-mention-remove.test.ts
+++ b/packages/ai-chat-components/src/components/prompt-line/src/tiptap/__tests__/carbon-mention-remove.test.ts
@@ -13,7 +13,7 @@ import DocumentNode from '@tiptap/extension-document';
 import ParagraphNode from '@tiptap/extension-paragraph';
 import TextNode from '@tiptap/extension-text';
 
-import { carbonMention } from '../carbon-mention.js';
+import { carbonCommand, carbonMention } from '../carbon-mention.js';
 import { setHostOriginMeta } from '../origin-meta.js';
 import type { SuggestionItem, TriggerSuggestionConfig } from '../types.js';
 
@@ -22,7 +22,17 @@ const ITEMS: SuggestionItem[] = [
   { id: 'u2', label: 'Bob' },
 ];
 
-function makeEditor(overrides: Partial<TriggerSuggestionConfig> = {}) {
+const DEFAULT_TRIGGER: Record<'mention' | 'command', string> = {
+  mention: '@',
+  command: '/',
+};
+
+function makeEditor(
+  type: 'mention' | 'command' = 'mention',
+  overrides: Partial<TriggerSuggestionConfig> = {},
+  trigger = DEFAULT_TRIGGER[type]
+) {
+  const factory = type === 'command' ? carbonCommand : carbonMention;
   const mount = document.createElement('div');
   document.body.appendChild(mount);
   const editor = new Editor({
@@ -31,7 +41,7 @@ function makeEditor(overrides: Partial<TriggerSuggestionConfig> = {}) {
       DocumentNode,
       ParagraphNode,
       TextNode,
-      carbonMention({ trigger: '@', items: ITEMS, ...overrides }),
+      factory({ trigger, items: ITEMS, ...overrides }),
     ],
     content: '',
   });
@@ -47,7 +57,13 @@ function makeEditor(overrides: Partial<TriggerSuggestionConfig> = {}) {
 /** Insert an atomic mention node carrying the given attrs at the cursor. */
 function insertMention(
   editor: Editor,
-  attrs: { id: string; label: string; value?: string; data?: unknown }
+  attrs: {
+    id: string;
+    label: string;
+    value?: string;
+    data?: unknown;
+    mentionSuggestionChar?: string;
+  }
 ) {
   editor.commands.insertContent({
     type: 'mention',
@@ -55,11 +71,11 @@ function insertMention(
   });
 }
 
-/** Document positions of every mention node, in order. */
-function mentionPositions(editor: Editor): number[] {
+/** Document positions of every token node of the given type, in order. */
+function tokenPositions(editor: Editor, type: 'mention' | 'command'): number[] {
   const positions: number[] = [];
   editor.state.doc.descendants((node, pos) => {
-    if (node.type.name === 'mention') {
+    if (node.type.name === type) {
       positions.push(pos);
     }
   });
@@ -77,14 +93,14 @@ function deleteMentionAt(editor: Editor, pos: number) {
 describe('tiptap/carbon-mention onRemove', function () {
   it('fires once with the reconstructed item when a mention is deleted', () => {
     const removed: SuggestionItem[] = [];
-    const { editor, cleanup } = makeEditor({
+    const { editor, cleanup } = makeEditor('mention', {
       onRemove: (item) => removed.push(item),
     });
 
     insertMention(editor, { id: 'u1', label: 'Alice', value: '@alice' });
     expect(removed).to.have.lengthOf(0);
 
-    deleteMentionAt(editor, mentionPositions(editor)[0]);
+    deleteMentionAt(editor, tokenPositions(editor, 'mention')[0]);
 
     expect(removed).to.have.lengthOf(1);
     expect(removed[0].id).to.equal('u1');
@@ -95,7 +111,7 @@ describe('tiptap/carbon-mention onRemove', function () {
 
   it('carries custom fields stashed in attrs.data back onto the item', () => {
     const removed: SuggestionItem[] = [];
-    const { editor, cleanup } = makeEditor({
+    const { editor, cleanup } = makeEditor('mention', {
       onRemove: (item) => removed.push(item),
     });
 
@@ -104,7 +120,7 @@ describe('tiptap/carbon-mention onRemove', function () {
       label: 'Alice',
       data: { team: 'design' },
     });
-    deleteMentionAt(editor, mentionPositions(editor)[0]);
+    deleteMentionAt(editor, tokenPositions(editor, 'mention')[0]);
 
     expect(removed).to.have.lengthOf(1);
     expect((removed[0] as Record<string, unknown>).team).to.equal('design');
@@ -113,7 +129,7 @@ describe('tiptap/carbon-mention onRemove', function () {
 
   it('fires once per removed instance for duplicate ids (multiset diff)', () => {
     const removed: SuggestionItem[] = [];
-    const { editor, cleanup } = makeEditor({
+    const { editor, cleanup } = makeEditor('mention', {
       onRemove: (item) => removed.push(item),
     });
 
@@ -123,25 +139,25 @@ describe('tiptap/carbon-mention onRemove', function () {
     insertMention(editor, { id: 'u1', label: 'Alice' });
 
     // Delete just one of the two — exactly one onRemove.
-    const positions = mentionPositions(editor);
+    const positions = tokenPositions(editor, 'mention');
     expect(positions).to.have.lengthOf(2);
     deleteMentionAt(editor, positions[positions.length - 1]);
     expect(removed).to.have.lengthOf(1);
 
     // Delete the survivor — one more.
-    deleteMentionAt(editor, mentionPositions(editor)[0]);
+    deleteMentionAt(editor, tokenPositions(editor, 'mention')[0]);
     expect(removed).to.have.lengthOf(2);
     cleanup();
   });
 
   it('does NOT fire for host-origin (programmatic) removals', () => {
     const removed: SuggestionItem[] = [];
-    const { editor, cleanup } = makeEditor({
+    const { editor, cleanup } = makeEditor('mention', {
       onRemove: (item) => removed.push(item),
     });
 
     insertMention(editor, { id: 'u1', label: 'Alice' });
-    const pos = mentionPositions(editor)[0];
+    const pos = tokenPositions(editor, 'mention')[0];
 
     const tr = editor.state.tr.delete(pos, pos + 1);
     setHostOriginMeta(tr);
@@ -152,14 +168,57 @@ describe('tiptap/carbon-mention onRemove', function () {
   });
 
   it('does not throw when no onRemove is configured', () => {
-    const { editor, cleanup } = makeEditor();
+    const { editor, cleanup } = makeEditor('mention');
 
     insertMention(editor, { id: 'u1', label: 'Alice' });
     expect(() =>
-      deleteMentionAt(editor, mentionPositions(editor)[0])
+      deleteMentionAt(editor, tokenPositions(editor, 'mention')[0])
     ).to.not.throw();
 
-    expect(mentionPositions(editor)).to.have.lengthOf(0);
+    expect(tokenPositions(editor, 'mention')).to.have.lengthOf(0);
+    cleanup();
+  });
+
+  it('Backspace leaves the correct trigger char for carbonMention with custom trigger', () => {
+    const { editor, cleanup } = makeEditor('mention', {}, '*');
+
+    insertMention(editor, {
+      id: 'u1',
+      label: 'Alice',
+      mentionSuggestionChar: '*',
+    });
+
+    // Place cursor immediately after the chip so Backspace targets it.
+    const pos = tokenPositions(editor, 'mention')[0];
+    editor.commands.setTextSelection(pos + 1);
+
+    editor.commands.keyboardShortcut('Backspace');
+
+    // The chip should be gone and replaced with the trigger character.
+    expect(tokenPositions(editor, 'mention')).to.have.lengthOf(0);
+    expect(editor.state.doc.textContent).to.equal('*');
+    cleanup();
+  });
+});
+
+describe('tiptap/carbon-command Backspace', function () {
+  it('Backspace leaves "/" when using the default command trigger', () => {
+    const { editor, cleanup } = makeEditor('command', {}, '/');
+
+    editor.commands.insertContent({
+      type: 'command',
+      attrs: { id: 'c1', label: 'summarize', value: null, data: null },
+    });
+
+    // Place cursor immediately after the chip so Backspace targets it.
+    const pos = tokenPositions(editor, 'command')[0];
+    editor.commands.setTextSelection(pos + 1);
+
+    editor.commands.keyboardShortcut('Backspace');
+
+    // The chip should be gone and "/" left behind.
+    expect(tokenPositions(editor, 'command')).to.have.lengthOf(0);
+    expect(editor.state.doc.textContent).to.equal('/');
     cleanup();
   });
 });

--- a/packages/ai-chat-components/src/components/prompt-line/src/tiptap/carbon-mention.ts
+++ b/packages/ai-chat-components/src/components/prompt-line/src/tiptap/carbon-mention.ts
@@ -61,6 +61,7 @@ function buildTriggerExtension(
       const parent = (this.parent?.() ?? {}) as Record<string, unknown>;
       return {
         ...parent,
+        mentionSuggestionChar: { default: config.trigger },
         value: { default: null },
         data: { default: null },
         trigger: { default: null },


### PR DESCRIPTION
Closes #2232

The Tiptap mentions extension leaves behind the value of `mentionSuggestionChar` when a mention is deleted with Backspace. We never override the default value `'@'`, so every mention/command leaves that behind on Backspace. This PR change manually sets `mentionSuggestionChar` with the value of `config.trigger`.

#### Changelog

**New**
- `buildTriggerExtension()` manually sets the value of `mentionSuggestionChar` with `config.trigger`.
- Two regression tests. Check that (1) the correct character is left behind on backspace when a mention has a non-default trigger (`'*'`), and (2) the default command leaves behind `'/'` on Backspace.

**Changed**
- `carbon-mention-remove.test.ts`: `makeEditor()` takes in a `type` so it can use either a `carbonCommand` or `carbonMention` in the test editor. Similarly, `mentionPositions()` is renamed to `tokenPositions()` and also extended to support commands.

#### Testing / Reviewing

- Verify new regression tests pass
- Go to demo deploy preview -> Chat configuration -> Enable @mentions AND Enable /commands.
- Enter an @ mention into the prompt line, then press Backspace to delete it. An "@" should be left behind.
- Enter a / command into the prompt line, then press Backspace to delete it. A "/" should be left behind.