### PR TITLE
fix(prompt-line): preserve keyboard focus state across rich editor upgrade

### DIFF
--- a/packages/ai-chat-components/src/components/prompt-line/src/__tests__/prompt-line-editor-stability.test.ts
+++ b/packages/ai-chat-components/src/components/prompt-line/src/__tests__/prompt-line-editor-stability.test.ts
@@ -13,12 +13,11 @@
  * its undo history mid-typing.
  */
 
-import { expect, fixture, html, nextFrame } from '@open-wc/testing';
+import { expect, fixture, html, nextFrame, oneEvent } from '@open-wc/testing';
 import { Extension } from '@tiptap/core';
 
 import '../prompt-line.js';
 import type PromptLineElement from '../prompt-line.js';
-import { PM_KEYBOARD_FOCUS_CLASS } from '../prompt-line-rich-runtime.js';
 import { buildCarbonExtensions } from '../tiptap/build-extensions.js';
 import {
   readStarterStorage,
@@ -294,30 +293,65 @@ describe('<cds-aichat-prompt-line> editor stability', function () {
     expect(el.getEditor()).to.not.equal(editor);
   });
 
-  it('keeps the keyboard-focus ring across a recreate', async () => {
-    // The class lives on `view.dom`, which a recreate replaces, so it has to be
-    // read off the outgoing editor before the swap.
+  it('preserves keyboard-focus state across a recreate', async () => {
     const el = await makeRichPromptLine(
       buildCarbonExtensions({ mention: { trigger: '@', items: PEOPLE } })
     );
-    // Focus the editable node directly, the way tabbing in does. `el.focus()`
-    // would set the mouse-focus flag and suppress the ring by design.
+    // Focus directly (no preceding pointer event) so the rich controller latches
+    // keyboard origin. Await a frame so Tiptap registers isFocused before the
+    // recreate reads it.
+    const preFocus = oneEvent(
+      el,
+      'cds-aichat-prompt-focus'
+    ) as Promise<CustomEvent>;
     el.getEditor()!.view.dom.focus();
     await nextFrame();
-    expect(
-      el.getEditor()!.view.dom.classList.contains(PM_KEYBOARD_FOCUS_CLASS)
-    ).to.equal(true);
+    expect((await preFocus).detail.keyboard).to.equal(true);
 
+    // Trigger a recreate while the editor is focused; the new editor should
+    // report keyboard focus, not silently reset to mouse.
+    const postFocus = oneEvent(
+      el,
+      'cds-aichat-prompt-focus'
+    ) as Promise<CustomEvent>;
     await setExtensions(
       el,
       buildCarbonExtensions({ mention: { trigger: '#', items: PEOPLE } })
     );
     await nextFrame();
-
     expect(el.getEditor()!.isFocused).to.equal(true);
-    expect(
-      el.getEditor()!.view.dom.classList.contains(PM_KEYBOARD_FOCUS_CLASS)
-    ).to.equal(true);
+    expect((await postFocus).detail.keyboard).to.equal(true);
+  });
+
+  it('preserves mouse-focus state (no ring) across a recreate', async () => {
+    const el = await makeRichPromptLine(
+      buildCarbonExtensions({ mention: { trigger: '@', items: PEOPLE } })
+    );
+    // Simulate a pointer-driven focus: dispatch mousedown before focusing so
+    // the controller latches mouse origin.
+    const preFocus = oneEvent(
+      el,
+      'cds-aichat-prompt-focus'
+    ) as Promise<CustomEvent>;
+    el.getEditor()!.view.dom.dispatchEvent(
+      new MouseEvent('mousedown', { bubbles: true })
+    );
+    el.getEditor()!.view.dom.focus();
+    await nextFrame();
+    expect((await preFocus).detail.keyboard).to.equal(false);
+
+    // Trigger a recreate; the new editor should still report mouse focus.
+    const postFocus = oneEvent(
+      el,
+      'cds-aichat-prompt-focus'
+    ) as Promise<CustomEvent>;
+    await setExtensions(
+      el,
+      buildCarbonExtensions({ mention: { trigger: '#', items: PEOPLE } })
+    );
+    await nextFrame();
+    expect(el.getEditor()!.isFocused).to.equal(true);
+    expect((await postFocus).detail.keyboard).to.equal(false);
   });
 
   it('keeps the editor when the host reverts the config mid-composition', async () => {

--- a/packages/ai-chat-components/src/components/prompt-line/src/__tests__/prompt-line.test.ts
+++ b/packages/ai-chat-components/src/components/prompt-line/src/__tests__/prompt-line.test.ts
@@ -301,6 +301,28 @@ describe('<cds-aichat-prompt-line> (rich upgrade)', function () {
     expect(removed).to.have.lengthOf(0);
     expect(el.getEditor()!.getText()).to.equal('');
   });
+
+  it('preserves keyboard-focus state across the upgrade', async () => {
+    const el = await makePromptLine();
+
+    // Establish keyboard focus on the textarea (no preceding pointer event).
+    const preFocus = oneEvent(
+      el,
+      'cds-aichat-prompt-focus'
+    ) as Promise<CustomEvent>;
+    getTextarea(el).focus();
+    expect((await preFocus).detail.keyboard).to.equal(true);
+
+    // The upgrade calls rich.focus() internally. Capture that re-focus event
+    // and assert the keyboard flag is preserved — not silently dropped.
+    const postFocus = oneEvent(
+      el,
+      'cds-aichat-prompt-focus'
+    ) as Promise<CustomEvent>;
+    el.rich = true;
+    await waitForRich(el);
+    expect((await postFocus).detail.keyboard).to.equal(true);
+  });
 });
 
 describe('<cds-aichat-prompt-line> ensureEditor()', function () {

--- a/packages/ai-chat-components/src/components/prompt-line/src/prompt-line-constants.ts
+++ b/packages/ai-chat-components/src/components/prompt-line/src/prompt-line-constants.ts
@@ -10,7 +10,7 @@
 /**
  * Max block size the prompt line grows to before it caps and shows a vertical
  * scrollbar. Shared by both editing surfaces — the lite `<textarea>`
- * ([./prompt-line-controller.ts]) and the rich Tiptap content node
+ * ([./prompt-line-textarea-runtime.ts]) and the rich Tiptap content node
  * ([./tiptap/editor-styles.ts]) — so the two modes cap at the same height and
  * the textarea→rich swap stays imperceptible. Keep them reading this one
  * constant so they can't drift.

--- a/packages/ai-chat-components/src/components/prompt-line/src/prompt-line-controller.ts
+++ b/packages/ai-chat-components/src/components/prompt-line/src/prompt-line-controller.ts
@@ -8,26 +8,10 @@
  */
 
 /**
- * Editing-surface controller contract for `<cds-aichat-prompt-line>`.
+ * Shared types for the prompt-line controller abstraction.
  *
- * The prompt-line shell ([./prompt-line.ts]) delegates all editing behavior to
- * a `PromptLineController`. Two implementations exist:
- *
- * - `TextareaController` ([./prompt-line-textarea-runtime.ts]) — a Tiptap-free
- *   `<textarea>`. It is the default and keeps the shell's static import graph
- *   free of `@tiptap/*`.
- * - The rich controller ([./prompt-line-rich-runtime.ts]) — a Tiptap `Editor`,
- *   reached only through a dynamic `import()` so Tiptap lands in its own lazy
- *   chunk.
- *
- * Both controllers emit the **same** `cds-aichat-prompt-*` events with the
- * same detail shapes, so the React wrapper and `@carbon/ai-chat`'s `Input`
- * handlers are identical regardless of mode. The shell can swap a
- * `TextareaController` for the rich controller in place (text, caret, and
- * focus transfer losslessly because the textarea holds plain text).
- *
- * `Editor` / `JSONContent` are **type-only** imports here — erased at compile,
- * so this module carries no Tiptap runtime.
+ * `Editor` / `JSONContent` / `Extension` are **type-only** imports here —
+ * erased at compile, so this module carries no Tiptap runtime.
  */
 
 import type { Editor, Extension, JSONContent } from '@tiptap/core';
@@ -61,8 +45,23 @@ export interface PromptLineControllerInit {
 }
 
 /**
- * The surface the shell drives. Both the textarea and the rich editor satisfy
- * it, so the shell never branches on mode beyond construction.
+ * The editing-surface controller abstraction for `<cds-aichat-prompt-line>`.
+ *
+ * The prompt-line shell ([./prompt-line.ts]) delegates all editing behavior to
+ * a `PromptLineController`. Two implementations exist:
+ *
+ * - `TextareaController` (./prompt-line-textarea.ts) — a Tiptap-free `<textarea>`.
+ *   It is the default and keeps the shell's static import graph free of `@tiptap/*`.
+ * - The rich controller ([./prompt-line-rich-runtime.ts]) — a Tiptap `Editor`,
+ *   reached only through a dynamic `import()` so Tiptap lands in its own lazy
+ *   chunk.
+ *
+ * Both controllers emit the **same** `cds-aichat-prompt-*` events with the
+ * same detail shapes, so the React wrapper and `@carbon/ai-chat`'s `Input`
+ * handlers are identical regardless of mode. The shell can swap a
+ * `TextareaController` for the rich controller in place (text, caret, focus,
+ * and keyboard-focus state transfer losslessly because the textarea holds plain
+ * text and both controllers share the same focus-tracking contract).
  */
 export interface PromptLineController {
   /** Mount the editing surface into the (already-slotted) light-DOM host. */
@@ -79,7 +78,9 @@ export interface PromptLineController {
   /** Live Tiptap editor, or `null` in textarea mode. */
   getEditor(): Editor | null;
 
-  focus(): void;
+  /** Accepts `keyboardFocus`, which when true specifies that a focus ring should be visible around the prompt line text area */
+  focus(keyboardFocus: boolean): void;
+
   blur(): void;
   hasFocus(): boolean;
 
@@ -112,4 +113,7 @@ export interface PromptLineController {
 
   undo(): boolean;
   redo(): boolean;
+
+  /** Whether the most recent focus event was driven by keyboard (not pointer/touch-driven). */
+  getKeyboardFocus(): boolean;
 }

--- a/packages/ai-chat-components/src/components/prompt-line/src/prompt-line-controller.ts
+++ b/packages/ai-chat-components/src/components/prompt-line/src/prompt-line-controller.ts
@@ -50,8 +50,9 @@ export interface PromptLineControllerInit {
  * The prompt-line shell ([./prompt-line.ts]) delegates all editing behavior to
  * a `PromptLineController`. Two implementations exist:
  *
- * - `TextareaController` (./prompt-line-textarea.ts) — a Tiptap-free `<textarea>`.
- *   It is the default and keeps the shell's static import graph free of `@tiptap/*`.
+ * - `TextareaController` (./prompt-line-textarea-runtime.ts) — a Tiptap-free
+ *   `<textarea>`. It is the default and keeps the shell's static import graph
+ *   free of `@tiptap/*`.
  * - The rich controller ([./prompt-line-rich-runtime.ts]) — a Tiptap `Editor`,
  *   reached only through a dynamic `import()` so Tiptap lands in its own lazy
  *   chunk.

--- a/packages/ai-chat-components/src/components/prompt-line/src/prompt-line-mouse-focus.ts
+++ b/packages/ai-chat-components/src/components/prompt-line/src/prompt-line-mouse-focus.ts
@@ -1,0 +1,77 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Shared mouse-focus tracking used by both `TextareaController` and
+ * `RichController`. Pointer/touch events before focus mark it as mouse-driven
+ * so the keyboard-focus outline is suppressed.
+ *
+ * Subclasses should:
+ *  - call `this._attachMouseFocusListeners(host)` in `mount()`
+ *  - call `this._detachMouseFocusListeners(host)` in `destroy()`
+ *  - call `this._consumeMouseFocus()` when the focus event fires to get the
+ *    `wasMouseFocus` boolean and latch it into `_lastFocusFromMouse`
+ *  - call `this._setNextFocusOrigin(keyboardFocus)` in `focus(keyboardFocus)` before delegating
+ */
+export abstract class MouseFocusController {
+  protected _focusFromMouse = false;
+  protected _lastFocusFromMouse = false;
+  /**
+   * Set by `focus(keyboardFocus)` to pin the keyboard value for the next focus
+   * event, bypassing pointer-event tracking. Takes priority over
+   * `_focusFromMouse` so a programmatic focus call cannot be clobbered by a
+   * synthetic pointer event fired during the same `.focus()` call (observed in
+   * Chromium/Firefox headless).
+   */
+  private _nextFocusOriginKeyboard: boolean | null = null;
+
+  protected readonly _setMouseFlag = (): void => {
+    this._focusFromMouse = true;
+  };
+
+  /** Pins the keyboard value for the next focus event. Call this in
+   * `focus(keyboardFocus)` before delegating to the native `.focus()`. */
+  protected _setNextFocusOrigin(keyboard: boolean): void {
+    this._nextFocusOriginKeyboard = keyboard;
+  }
+
+  /**
+   * Called at the start of the focus event. Consumes `_focusFromMouse` (or the
+   * pinned origin set by `_setNextFocusOrigin()`), latches the result into
+   * `_lastFocusFromMouse`, and returns whether focus was mouse-driven.
+   */
+  protected _consumeMouseFocus(): boolean {
+    let wasMouseFocus: boolean;
+    if (this._nextFocusOriginKeyboard !== null) {
+      wasMouseFocus = !this._nextFocusOriginKeyboard;
+      this._nextFocusOriginKeyboard = null;
+    } else {
+      wasMouseFocus = this._focusFromMouse;
+    }
+    this._focusFromMouse = false;
+    this._lastFocusFromMouse = wasMouseFocus;
+    return wasMouseFocus;
+  }
+
+  getKeyboardFocus(): boolean {
+    return !this._lastFocusFromMouse;
+  }
+
+  protected _attachMouseFocusListeners(host: HTMLElement): void {
+    host.addEventListener('pointerdown', this._setMouseFlag);
+    host.addEventListener('mousedown', this._setMouseFlag);
+    host.addEventListener('touchstart', this._setMouseFlag);
+  }
+
+  protected _detachMouseFocusListeners(host: HTMLElement): void {
+    host.removeEventListener('pointerdown', this._setMouseFlag);
+    host.removeEventListener('mousedown', this._setMouseFlag);
+    host.removeEventListener('touchstart', this._setMouseFlag);
+  }
+}

--- a/packages/ai-chat-components/src/components/prompt-line/src/prompt-line-rich-runtime.ts
+++ b/packages/ai-chat-components/src/components/prompt-line/src/prompt-line-rich-runtime.ts
@@ -34,7 +34,7 @@ import TextNode from '@tiptap/extension-text';
 import { UndoRedo } from '@tiptap/extensions';
 
 import { IS_PHONE } from '../../../globals/utils/browser-utils.js';
-import { setVarsForSelector } from '../../shared/dynamic-css-var-sheet.js';
+import { MouseFocusController } from './prompt-line-mouse-focus.js';
 import type {
   PromptLineController,
   PromptLineControllerInit,
@@ -56,24 +56,14 @@ import type { StartersConfig } from './tiptap/types.js';
 import { textToDoc } from './tiptap/json-utils.js';
 import { setHostOriginMeta } from './tiptap/origin-meta.js';
 
-/** Exported so tests assert the ring without retyping the literal. */
-export const PM_KEYBOARD_FOCUS_CLASS =
-  'cds-aichat--input-pm-content--keyboard-focus';
-
-let keyboardFocusRuleInstalled = false;
-function ensureKeyboardFocusRule(): void {
-  if (keyboardFocusRuleInstalled) {
-    return;
-  }
-  setVarsForSelector(`.${PM_KEYBOARD_FOCUS_CLASS}`, { outline: 'revert' });
-  keyboardFocusRuleInstalled = true;
-}
-
 /**
  * Tiptap-backed prompt-line controller. Mirrors the editor lifecycle the
  * element owned before the textarea/rich split.
  */
-class RichController implements PromptLineController {
+class RichController
+  extends MouseFocusController
+  implements PromptLineController
+{
   private _editor: Editor | null = null;
   private _host: HTMLElement | null = null;
   private _extensions: Extension[] = [];
@@ -91,8 +81,8 @@ class RichController implements PromptLineController {
   private _placeholder = '';
   private _testId = '';
   private _disabled = false;
-  private _focusFromMouse = false;
   private _isComposing = false;
+  private _hadFocus = false;
   /** Set when a recreate is withheld during an IME composition. */
   private _pendingRecreate = false;
   private _pendingRecreateTimer: ReturnType<typeof setTimeout> | null = null;
@@ -114,11 +104,7 @@ class RichController implements PromptLineController {
 
     // Pointer/touch before focus marks the next focus as mouse-driven so we
     // suppress the keyboard-focus outline.
-    host.addEventListener('pointerdown', this._setMouseFlag);
-    host.addEventListener('mousedown', this._setMouseFlag);
-    host.addEventListener('touchstart', this._setMouseFlag);
-
-    ensureKeyboardFocusRule();
+    this._attachMouseFocusListeners(host);
 
     // Prefer a structured `content` seed (mentions / custom nodes); otherwise
     // rebuild a doc from the plain-text value (lossless from the textarea).
@@ -133,15 +119,14 @@ class RichController implements PromptLineController {
   destroy(): void {
     const host = this._host;
     if (host) {
-      host.removeEventListener('pointerdown', this._setMouseFlag);
-      host.removeEventListener('mousedown', this._setMouseFlag);
-      host.removeEventListener('touchstart', this._setMouseFlag);
+      this._detachMouseFocusListeners(host);
     }
     if (this._pendingRecreateTimer) {
       clearTimeout(this._pendingRecreateTimer);
       this._pendingRecreateTimer = null;
     }
     this._isComposing = false;
+    this._hadFocus = false;
     this._pendingRecreate = false;
     this._editor?.destroy();
     this._editor = null;
@@ -204,8 +189,8 @@ class RichController implements PromptLineController {
     return this._editor;
   }
 
-  focus(): void {
-    this._focusFromMouse = true;
+  focus(keyboardFocus: boolean): void {
+    this._setNextFocusOrigin(keyboardFocus);
     this._editor?.commands.focus();
   }
 
@@ -318,10 +303,6 @@ class RichController implements PromptLineController {
   // Internals
   // -------------------------------------------------------------------------
 
-  private _setMouseFlag = (): void => {
-    this._focusFromMouse = true;
-  };
-
   private _flushPendingRecreate(): void {
     // A fresh composition may have started while the flush was queued; its own
     // compositionend re-queues this. A detached host means the element's own
@@ -382,15 +363,11 @@ class RichController implements PromptLineController {
 
   private _wireEditorEvents(editor: Editor): void {
     editor.on('focus', () => {
-      const wasMouseFocus = this._focusFromMouse;
-      this._focusFromMouse = false;
-      if (!wasMouseFocus) {
-        editor.view.dom.classList.add(PM_KEYBOARD_FOCUS_CLASS);
-      }
+      this._hadFocus = true;
+      const wasMouseFocus = this._consumeMouseFocus();
       this._dispatch('cds-aichat-prompt-focus', { keyboard: !wasMouseFocus });
     });
     editor.on('blur', () => {
-      editor.view.dom.classList.remove(PM_KEYBOARD_FOCUS_CLASS);
       this._dispatch('cds-aichat-prompt-blur');
     });
     // Forward keydown for hosts wanting raw-key access. ValueSync /
@@ -417,10 +394,8 @@ class RichController implements PromptLineController {
           to: this._editor.state.selection.to,
         }
       : null;
-    const wasFocused = this._editor?.isFocused ?? false;
-    const wasKeyboardFocus =
-      this._editor?.view.dom.classList.contains(PM_KEYBOARD_FOCUS_CLASS) ??
-      false;
+    const wasFocused = this._hadFocus;
+    const wasKeyboardFocus = this.getKeyboardFocus();
     this._editor?.destroy();
     this._editor = this._createEditor(host, previousJson);
     this._wireEditorEvents(this._editor);
@@ -435,8 +410,7 @@ class RichController implements PromptLineController {
     }
 
     if (wasFocused) {
-      this._focusFromMouse = !wasKeyboardFocus;
-      this._editor.commands.focus();
+      this.focus(wasKeyboardFocus);
     }
   }
 

--- a/packages/ai-chat-components/src/components/prompt-line/src/prompt-line-shell.scss
+++ b/packages/ai-chat-components/src/components/prompt-line/src/prompt-line-shell.scss
@@ -301,12 +301,14 @@
   outline-offset: calc(-1 * button.$button-border-width);
 }
 
-// Focus outline for expanded state — only on text area, and only when focus
-// arrived via keyboard navigation. `prompt-line-shell` listens for
-// `cds-aichat-prompt-focus` and reads `event.detail.keyboard`; the rich runtime
-// sets that flag when no pointer/touch event preceded the focus. The shell
-// toggles `--keyboard-focus` on the shadow-DOM text-area node, which this rule
-// targets directly.
+// Focus outline for expanded state — both on text area and rich text, and only
+// when focus arrived via keyboard navigation. `prompt-line-shell` listens for
+// `cds-aichat-prompt-focus` and reads `event.detail.keyboard`; both the textarea
+// and rich controllers set that flag — true when no pointer/touch event preceded
+// the focus, or when a programmatic `focus(keyboardFocus)` call explicitly
+// requests it (e.g. `_swapToRich` preserving focus state across the upgrade).
+// The shell toggles `--keyboard-focus` on the shadow-DOM text-area node, which
+// this rule targets directly.
 .#{$prefix}--input-container--expanded
   .#{$prefix}--input-text-area--keyboard-focus {
   outline-color: theme.$focus;

--- a/packages/ai-chat-components/src/components/prompt-line/src/prompt-line-textarea-runtime.ts
+++ b/packages/ai-chat-components/src/components/prompt-line/src/prompt-line-textarea-runtime.ts
@@ -8,14 +8,25 @@
  */
 
 /**
- * `<textarea>`-backed implementation of `PromptLineController`. Tiptap-free;
- * emits the same `cds-aichat-prompt-*` events as the rich editor. Auto-grows
- * via a hidden mirror, capped at `PROMPT_LINE_MAX_BLOCK_SIZE` with the field
- * scrolling past it — the same cap the rich contenteditable applies (see
- * ./tiptap/editor-styles.ts), so the textarea→rich swap is imperceptible.
+ * Textarea runtime for `<cds-aichat-prompt-line>`'s default (non-rich) mode.
+ * This module is **statically imported** by the prompt-line shell
+ * ([./prompt-line.ts]), so it is always part of the initial bundle — but it
+ * carries **no `@tiptap/*` runtime**. The only Tiptap symbols used here are
+ * type imports erased at compile time.
  *
- * Named to mirror `prompt-line-rich-runtime.ts`: each file is one
- * implementation of `PromptLineController`.
+ * `TextareaController` implements {@link PromptLineController} backed by a
+ * native `<textarea>`. It mirrors the typography and sizing of the Tiptap
+ * editor exactly (auto-grow via a CSS grid mirror, Carbon `body-01` tokens,
+ * the same `max-block-size` cap) so the textarea→editor swap triggered by
+ * the rich-mode loader ([./prompt-line-rich-loader.ts]) is visually
+ * imperceptible. State — plain text, caret position, and keyboard-focus
+ * tracking — transfers losslessly to the rich controller because the textarea
+ * is always the plain-text source of truth. The same `cds-aichat-prompt-*`
+ * events are emitted, keeping the React wrapper and `Input` handlers
+ * mode-agnostic.
+ *
+ * `Editor` / `JSONContent` are **type-only** imports here — erased at compile,
+ * so this module carries no Tiptap runtime.
  */
 
 import type { Editor, Extension, JSONContent } from '@tiptap/core';
@@ -29,6 +40,7 @@ import {
   PROMPT_LINE_MAX_BLOCK_SIZE,
   TYPING_TIMEOUT_MS,
 } from './prompt-line-constants.js';
+import { MouseFocusController } from './prompt-line-mouse-focus.js';
 import type {
   PromptLineController,
   PromptLineControllerInit,
@@ -122,12 +134,14 @@ function ensureTextareaStyleRules(): void {
  * the rich contenteditable applies (see ./tiptap/editor-styles.ts), so the
  * textarea→rich swap is imperceptible.
  */
-export class TextareaController implements PromptLineController {
+export class TextareaController
+  extends MouseFocusController
+  implements PromptLineController
+{
   private _wrap: HTMLDivElement | null = null;
   private _textarea: HTMLTextAreaElement | null = null;
   private _mirror: HTMLDivElement | null = null;
   private _host: HTMLElement | null = null;
-  private _focusFromMouse = false;
 
   private _isTyping = false;
   private _typingTimer: ReturnType<typeof setTimeout> | null = null;
@@ -179,9 +193,7 @@ export class TextareaController implements PromptLineController {
 
     // Pointer/touch before focus marks the next focus as mouse-driven so we
     // suppress the keyboard-focus outline.
-    host.addEventListener('pointerdown', this._setMouseFlag);
-    host.addEventListener('mousedown', this._setMouseFlag);
-    host.addEventListener('touchstart', this._setMouseFlag);
+    this._attachMouseFocusListeners(host);
 
     this._syncMirror();
   }
@@ -197,9 +209,7 @@ export class TextareaController implements PromptLineController {
     }
     const host = this._host;
     if (host) {
-      host.removeEventListener('pointerdown', this._setMouseFlag);
-      host.removeEventListener('mousedown', this._setMouseFlag);
-      host.removeEventListener('touchstart', this._setMouseFlag);
+      this._detachMouseFocusListeners(host);
     }
     this._wrap?.remove();
     this._wrap = null;
@@ -249,8 +259,8 @@ export class TextareaController implements PromptLineController {
     return null;
   }
 
-  focus(): void {
-    this._focusFromMouse = true;
+  focus(keyboardFocus: boolean): void {
+    this._setNextFocusOrigin(keyboardFocus);
     this._textarea?.focus();
   }
 
@@ -387,13 +397,8 @@ export class TextareaController implements PromptLineController {
     }
   };
 
-  private _setMouseFlag = (): void => {
-    this._focusFromMouse = true;
-  };
-
   private _onFocus = (): void => {
-    const wasMouseFocus = this._focusFromMouse;
-    this._focusFromMouse = false;
+    const wasMouseFocus = this._consumeMouseFocus();
     this._dispatch('cds-aichat-prompt-focus', { keyboard: !wasMouseFocus });
   };
 

--- a/packages/ai-chat-components/src/components/prompt-line/src/prompt-line.ts
+++ b/packages/ai-chat-components/src/components/prompt-line/src/prompt-line.ts
@@ -299,7 +299,7 @@ class PromptLineElement extends LitElement {
 
     if (this.autofocus) {
       // Defer so consumer listeners are attached first.
-      Promise.resolve().then(() => this._controller?.focus());
+      Promise.resolve().then(() => this._controller?.focus(false));
     }
   }
 
@@ -359,7 +359,7 @@ class PromptLineElement extends LitElement {
   }
 
   override focus(): void {
-    this._controller?.focus();
+    this._controller?.focus(false);
   }
 
   override blur(): void {
@@ -544,6 +544,7 @@ class PromptLineElement extends LitElement {
     const value = previous.getValue();
     const selection = previous.getSelection();
     const hadFocus = previous.hasFocus();
+    const hadKeyboardFocus = previous.getKeyboardFocus();
 
     previous.destroy();
     this._controller = rich;
@@ -559,7 +560,7 @@ class PromptLineElement extends LitElement {
       to: textOffsetToDocPos(value, selection.to),
     });
     if (hadFocus) {
-      rich.focus();
+      rich.focus(hadKeyboardFocus);
     }
     this._settleRichReady();
   }


### PR DESCRIPTION
Closes #2187

Fixes bug where the prompt line keyboard-focus state wasn't preserved across the upgrade from lite to rich editor. The keyboard-focus state determines whether the blue focus outline should appear around the prompt line editor/text area. When focus is not keyboard-triggered (i.e. via Mouse), the outline is not visible.

#### Changelog

**New**
- `prompt-line.test.ts`: Tests the keyboard-focus flag is preserved across the upgrade from lite editor to rich.
- `prompt-line-editor-stability.test.ts`: Test that both keyboard-focus and non-keyboard-focus (mouse) states are preserved across a rebuild.

**Changed**
- `TextareaController` and `RichController` previously held their own logic for managing the keyboard-focus state (both tracked via a `_focusFromMouse`). These changes remove this duplication by moving the mouse-focus tracking to an abstract class, `MouseFocusController`, which is implemented by both `TextareaController` and `RichController`.
- Re-organized files to a cleaner split:
  - `prompt-line-rich-runtime.ts`: Serves same purpose as before. Implements class `RichController`, the rich editing-surface controller.
  - `prompt-line-textarea-runtime.ts`: Implements the class `TextareaController`, the default editing-surface controller.
  - `prompt-line-types.ts`: Shared types for the prompt-line. Previously lived inside `packages/ai-chat-components/src/components/prompt-line/src/prompt-line-controller.ts` along with the `TextareaController` implementation.
  - `prompt-line-mouse-focus.ts`: Shared mouse-focus tracking used by `TextareaController` and `RichController`.
- `PromptLineController.focus()` accepts `keyboardFocus`, which when true specifies that a focus ring should be visible around the prompt line text area. When a lite editor is upgraded to rich in `_swapToRich()`, the keyboard-focus state is preserved by passing the previous value into `PromptLineController.focus()`.
- Updated imports according to file changes.

**Removed**

- #2187 references logic that applies `outline: 'revert'` to the rich editor in `ensureKeyboardFocusRule()`, which disagrees with how the lite editor handles keyboard focus. This is effectively dead code that has no visual impact. The actual outline styles exist in `prompt-line-shell.scss` and are driven by the class `cds-aichat--input-text-area--keyboard-focus`. This PR removes this dead code and a corresponding test (`prompt-line-editor-stability.test.ts`).

#### Testing / Reviewing

1. Verify new test passes
2. Go to demo deploy preview -> Chat Configuration -> Input -> Enable expanded layout
3. Verify no regressions in focusing input via mouse (no focus outline) or via keyboard (blue focus outline appears)
4. Set "Enable autocomplete suggestions" to true to switch prompt line to rich mode
5. Repeat Step 3 to verify no regressions in rich editor
