### PR TITLE
chore(deps): remove unused babel-preset-carbon

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,6 @@
         "@types/prop-types": "^15.7.15",
         "@types/react": "^19.2.2",
         "@types/react-dom": "^19.2.1",
-        "babel-preset-carbon": "^0.8.0",
         "chromatic": "^17.0.0",
         "commander": "^15.0.0",
         "concurrently": "^10.0.0",
@@ -5200,22 +5199,6 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "node_modules/@babel/plugin-proposal-export-default-from": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-export-default-from/-/plugin-proposal-export-default-from-7.29.7.tgz",
-      "integrity": "sha512-p+G5BNXDcy3bOXplhY4HybQ1GxH3i2Tppmdm/3epyRu2VgJJZuUlZ61MqRTg582Q7ZLBdP7fePYvsumSEkMxcQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
     "node_modules/@babel/plugin-proposal-private-property-in-object": {
       "version": "7.21.0-placeholder-for-preset-env.2",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
@@ -6164,22 +6147,6 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.29.7.tgz",
       "integrity": "sha512-bOMRLQuI0A5ZqHq3OWJ89/rXpJ/NJrbVhXiP4zwPGMs6kpcVsuTUNjwoE30K0Qm3mf48a/TnRYYD6vPNqcg6jA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.29.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-react-constant-elements": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-constant-elements/-/plugin-transform-react-constant-elements-7.29.7.tgz",
-      "integrity": "sha512-J0wGhKan+rIiE2OhfhRptySLrJ6SjQYM6b6N1FMlhyhCcw1Mig8vQjWchyB+bgHGDvaWo6Diu6CLRMra2uMtmg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -21414,16 +21381,6 @@
         "webpack": ">=5"
       }
     },
-    "node_modules/babel-plugin-dev-expression": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-dev-expression/-/babel-plugin-dev-expression-0.2.3.tgz",
-      "integrity": "sha512-rP5LK9QQTzCW61nVVzw88En1oK8t8gTsIeC6E61oelxNsU842yMjF0G1MxhvUpCkxCEIj7sE8/e5ieTheT//uw==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "@babel/core": "^7.0.0"
-      }
-    },
     "node_modules/babel-plugin-istanbul": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-8.0.0.tgz",
@@ -21497,24 +21454,6 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
-      }
-    },
-    "node_modules/babel-preset-carbon": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/babel-preset-carbon/-/babel-preset-carbon-0.8.0.tgz",
-      "integrity": "sha512-eHDI8jnmr35iVo1kDRa0ZakA5O9B3O5Is0xAuBtTJxd8pm0iFmPykdqrVu3FsexkbEW/pUCtljGRQ+ppDrqaJQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@babel/core": "^7.27.3",
-        "@babel/plugin-proposal-export-default-from": "^7.27.1",
-        "@babel/plugin-transform-class-properties": "^7.27.1",
-        "@babel/plugin-transform-export-namespace-from": "^7.27.1",
-        "@babel/plugin-transform-react-constant-elements": "^7.27.1",
-        "@babel/preset-env": "^7.27.2",
-        "@babel/preset-react": "^7.27.1",
-        "babel-plugin-dev-expression": "^0.2.3",
-        "browserslist-config-carbon": "^11.2.0"
       }
     },
     "node_modules/babel-preset-current-node-syntax": {
@@ -22130,13 +22069,6 @@
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
-    },
-    "node_modules/browserslist-config-carbon": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/browserslist-config-carbon/-/browserslist-config-carbon-11.2.0.tgz",
-      "integrity": "sha512-f/U/h4ZbdZVCpx3kaagLbKt51Y2rf2A0u1Ioyu7yvCf3hoxV3jeN7NliveEFSmcoHnb2JIJ82j5zIWOTHxInrg==",
-      "dev": true,
-      "license": "Apache-2.0"
     },
     "node_modules/bs-logger": {
       "version": "0.2.6",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     "@types/prop-types": "^15.7.15",
     "@types/react": "^19.2.2",
     "@types/react-dom": "^19.2.1",
-    "babel-preset-carbon": "^0.8.0",
     "chromatic": "^17.0.0",
     "commander": "^15.0.0",
     "concurrently": "^10.0.0",


### PR DESCRIPTION
Closes #

Drops `babel-preset-carbon`, a root devDependency nothing loads.

It has been declared since the initial `ai-chat` setup (#41) and referenced nowhere since. All three babel configs — `demo/.babelrc`, `packages/ai-chat/.babelrc`, `packages/ai-chat-components/babel.config.jest.cjs` — list `@babel/preset-*` directly.

Surfaced by the 0.9.0 renovate bump (#2253). That release moves the preset to `@babel/core ^8`, so npm nested a private 101-package Babel 8 tree under a preset no config references — about 1730 lines of lockfile for nothing. Removing is cheaper than carrying it. Babel 8 stays tracked under #1722.

#### Changelog

**Removed**

- `babel-preset-carbon` root devDependency.

#### Testing / Reviewing

No behavior to exercise — nothing imported the preset. Confirm it was dead and the tree still resolves:

1. `git grep babel-preset-carbon` — only hits are removed by this PR.
2. `npm ci` — resolves clean.
3. `npm run build && npm run ci-check`.

Run on this branch: build succeeded for 89 projects; `ci-check` passed for 7 — `ai-chat-components` 564 Chromium / 564 Firefox, demo Playwright 36.
