### PR TITLE
fix: autocomplete item description color contrast

### DIFF
--- a/packages/ai-chat-components/src/components/prompt-line/autocomplete/src/autocomplete.scss
+++ b/packages/ai-chat-components/src/components/prompt-line/autocomplete/src/autocomplete.scss
@@ -116,7 +116,7 @@ $group-class: #{$item-class}-group;
 
     &--active,
     &--active:hover {
-      background: theme.$background-selected;
+      background: theme.$background-hover;
     }
 
     &--disabled {
@@ -170,7 +170,7 @@ $group-class: #{$item-class}-group;
   .#{$item-class}__description {
     @include type.type-style('helper-text-01');
 
-    color: theme.$text-helper;
+    color: theme.$text-secondary;
   }
 
   .#{$item-class}__send-icon {


### PR DESCRIPTION
Closes #2148

Fixes WCAG 2.1 AA — 1.4.3 violation where color contrast failed on the autocomplete item description against the background.

#### Changelog

**Changed**

- Changes background color when active from `$background-selected` to `theme.$background-hover`. The item is never "selected", there is only a default active option, so this is the more appropriate color token.
- Changes description text color from `$text-helper` to `$text-secondary`. Also needed to pass violation check.

#### Testing / Reviewing

- Go to storybook deploy preview -> Prompt Line -> Autocomplete -> With Categories
- Open story in isolation mode
- Run the IBM Equal Access Accessibility Checker (devtools)
- Ensure no WCAG violation "Text contrast of ... with its background is less than the WCAG AA minimum requirements for text of size 12px and weight of 400"
- Verify in white, g10, g90, and g100