### PR TITLE
feat(components): add truncated text React wrapper

### DIFF
--- a/packages/ai-chat-components/src/components/truncated-text/__stories__/truncated-text-react.mdx
+++ b/packages/ai-chat-components/src/components/truncated-text/__stories__/truncated-text-react.mdx
@@ -1,0 +1,46 @@
+import { ArgTypes, Canvas, Meta } from '@storybook/addon-docs/blocks';
+import * as Stories from './truncated-text-react.stories';
+
+<Meta of={Stories} />
+
+# Truncated text
+
+[Source code](https://github.com/carbon-design-system/carbon-ai-chat/tree/main/packages/ai-chat-components/src/components/truncated-text) &nbsp;|&nbsp; [Feedback](https://github.com/carbon-design-system/carbon-ai-chat/issues)
+
+## Overview
+
+Use `<TruncatedText>` to clamp text to a limited number of lines and reveal overflow content.
+
+<Canvas of={Stories.Default} />
+
+## Customization
+
+### `type`
+
+Set `type` to `tooltip` to show overflowing text in a tooltip, or to `expand` to show an expand and collapse control.
+
+```jsx
+<TruncatedText
+  lines={2}
+  type="expand"
+  expandLabel="Show more"
+  collapseLabel="Show less"
+  value="Long text"
+/>
+```
+
+## Component API
+
+### `<TruncatedText>`
+
+<ArgTypes of={Stories.Default} />
+
+## JSX (via import)
+
+```jsx
+import { TruncatedText } from '@carbon/ai-chat-components/es/react/truncated-text.js';
+```
+
+## Feedback
+
+Open an issue at https://github.com/carbon-design-system/carbon-ai-chat/issues to provide feedback or request changes.

--- a/packages/ai-chat-components/src/components/truncated-text/__stories__/truncated-text-react.stories.jsx
+++ b/packages/ai-chat-components/src/components/truncated-text/__stories__/truncated-text-react.stories.jsx
@@ -1,0 +1,39 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/* eslint-disable */
+import React from 'react';
+import { TruncatedText } from '../../../react/truncated-text';
+import {
+  Default as DefaultWC,
+  Expand as ExpandWC,
+} from './truncated-text.stories';
+
+const renderTruncatedText = (args) => (
+  <div style={{ maxWidth: '20rem' }}>
+    <TruncatedText {...args} />
+  </div>
+);
+
+export default {
+  title: 'Components/Truncated text',
+  component: TruncatedText,
+};
+
+export const Default = {
+  argTypes: { ...DefaultWC.argTypes },
+  args: { ...DefaultWC.args },
+  render: renderTruncatedText,
+};
+
+export const Expand = {
+  argTypes: { ...ExpandWC.argTypes },
+  args: { ...ExpandWC.args },
+  render: renderTruncatedText,
+};

--- a/packages/ai-chat-components/src/components/truncated-text/__stories__/truncated-text.mdx
+++ b/packages/ai-chat-components/src/components/truncated-text/__stories__/truncated-text.mdx
@@ -1,0 +1,46 @@
+import { ArgTypes, Canvas, Meta } from '@storybook/addon-docs/blocks';
+import * as Stories from './truncated-text.stories';
+
+<Meta of={Stories} />
+
+# Truncated text
+
+[Source code](https://github.com/carbon-design-system/carbon-ai-chat/tree/main/packages/ai-chat-components/src/components/truncated-text) &nbsp;|&nbsp; [Feedback](https://github.com/carbon-design-system/carbon-ai-chat/issues)
+
+## Overview
+
+Use `cds-aichat-truncated-text` to clamp text to a limited number of lines and reveal overflow content.
+
+<Canvas of={Stories.Default} />
+
+## Customization
+
+### `type`
+
+Set `type` to `tooltip` to show overflowing text in a tooltip, or to `expand` to show an expand and collapse control.
+
+```html
+<cds-aichat-truncated-text
+  lines="2"
+  type="expand"
+  expand-label="Show more"
+  collapse-label="Show less"
+  value="Long text">
+</cds-aichat-truncated-text>
+```
+
+## Component API
+
+### `cds-aichat-truncated-text`
+
+<ArgTypes of="cds-aichat-truncated-text" />
+
+## JS (via import)
+
+```javascript
+import '@carbon/ai-chat-components/es/components/truncated-text/index.js';
+```
+
+## Feedback
+
+Open an issue at https://github.com/carbon-design-system/carbon-ai-chat/issues to provide feedback or request changes.

--- a/packages/ai-chat-components/src/components/truncated-text/__stories__/truncated-text.stories.js
+++ b/packages/ai-chat-components/src/components/truncated-text/__stories__/truncated-text.stories.js
@@ -1,0 +1,93 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import '../src/truncated-text';
+import { html } from 'lit';
+import { ifDefined } from 'lit/directives/if-defined.js';
+
+const argTypes = {
+  align: {
+    control: 'text',
+    description: 'Positions the tooltip relative to the truncated text.',
+  },
+  autoalign: {
+    control: 'boolean',
+    description: 'Automatically adjusts the tooltip alignment when needed.',
+  },
+  collapseLabel: {
+    control: 'text',
+    description: 'Label for the control that collapses expanded text.',
+  },
+  expandLabel: {
+    control: 'text',
+    description: 'Label for the control that expands truncated text.',
+  },
+  id: {
+    control: 'text',
+    description: 'Unique identifier for the truncated content.',
+  },
+  lines: {
+    control: { type: 'number', min: 0, step: 1 },
+    description: 'Maximum number of visible lines before truncation.',
+  },
+  type: {
+    control: 'select',
+    options: ['tooltip', 'expand'],
+    description: 'Shows overflow text in a tooltip or with an expand control.',
+  },
+  value: {
+    control: 'text',
+    description: 'Text to truncate.',
+  },
+};
+
+const renderTruncatedText = (args) => html`
+  <div style="max-width: 20rem;">
+    <cds-aichat-truncated-text
+      align=${ifDefined(args.align)}
+      ?autoalign=${args.autoalign}
+      collapse-label=${ifDefined(args.collapseLabel)}
+      expand-label=${ifDefined(args.expandLabel)}
+      id=${ifDefined(args.id)}
+      .lines=${args.lines}
+      type=${ifDefined(args.type)}
+      value=${ifDefined(args.value)}></cds-aichat-truncated-text>
+  </div>
+`;
+
+export default {
+  title: 'Components/Truncated text',
+  component: 'cds-aichat-truncated-text',
+};
+
+export const Default = {
+  args: {
+    align: 'top',
+    autoalign: false,
+    collapseLabel: 'Show less',
+    expandLabel: 'Show more',
+    id: 'truncated-text-default',
+    lines: 2,
+    type: 'tooltip',
+    value:
+      'This is a long piece of text that demonstrates how truncated text reveals overflow content in a tooltip.',
+  },
+  argTypes,
+  render: renderTruncatedText,
+};
+
+export const Expand = {
+  args: {
+    ...Default.args,
+    id: 'truncated-text-expand',
+    type: 'expand',
+  },
+  argTypes: { ...Default.argTypes },
+  render: renderTruncatedText,
+};

--- a/packages/ai-chat-components/src/react/truncated-text.ts
+++ b/packages/ai-chat-components/src/react/truncated-text.ts
@@ -1,0 +1,25 @@
+/**
+ * @license
+ *
+ * Copyright IBM Corp. 2026
+ *
+ * This source code is licensed under the Apache-2.0 license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import { createComponent } from '@lit/react';
+import React from 'react';
+
+import CDSAIChatTruncatedText from '../components/truncated-text/src/truncated-text.js';
+import { withWebComponentBridge } from './utils/withWebComponentBridge';
+
+const TruncatedText = withWebComponentBridge(
+  createComponent({
+    tagName: 'cds-aichat-truncated-text',
+    elementClass: CDSAIChatTruncatedText,
+    react: React,
+  })
+);
+
+export { TruncatedText };
+export default TruncatedText;


### PR DESCRIPTION
Closes #2274

Adds a React wrapper for truncated text.

#### Changelog

**New**

- React `TruncatedText` wrapper
- Lit and React stories for tooltip and expand modes

#### Testing / Reviewing

- `npm run test:react --workspace=@carbon/ai-chat-components`
- `npm run test:web-components --workspace=@carbon/ai-chat-components`
- `npm run build --workspace=@carbon/ai-chat-components`
- Check the React Storybook Default and Expand stories.