### PR TITLE
fix: set aria label on contenteditable element

### DIFF
--- a/packages/ai-chat-components/src/components/prompt-line/src/__tests__/prompt-line.test.ts
+++ b/packages/ai-chat-components/src/components/prompt-line/src/__tests__/prompt-line.test.ts
@@ -361,6 +361,28 @@ describe('<cds-aichat-prompt-line> staged extensions', function () {
   });
 });
 
+describe('<cds-aichat-prompt-line> accessible name', function () {
+  it('places aria-label on the focusable textarea in textarea mode', async () => {
+    const el = await makePromptLine({ ariaLabel: 'Ask a question' });
+    expect(getTextarea(el).getAttribute('aria-label')).to.equal(
+      'Ask a question'
+    );
+  });
+
+  it('places aria-label and role on the ProseMirror contenteditable in rich mode', async () => {
+    const el = await makePromptLine({
+      rich: true,
+      ariaLabel: 'Ask a question',
+    });
+    await waitForRich(el);
+    const pm = el.querySelector(
+      '[slot="editor"] [contenteditable]'
+    ) as HTMLElement;
+    expect(pm.getAttribute('aria-label')).to.equal('Ask a question');
+    expect(pm.getAttribute('role')).to.equal('textbox');
+  });
+});
+
 // Regression: long unbroken text does not widen textarea past its declared width.
 describe('<cds-aichat-prompt-line> long unbroken text wraps', function () {
   const LONG_URL = `https://example.com/x/${'a'.repeat(200)}`;

--- a/packages/ai-chat-components/src/components/prompt-line/src/prompt-line-rich-runtime.ts
+++ b/packages/ai-chat-components/src/components/prompt-line/src/prompt-line-rich-runtime.ts
@@ -88,6 +88,7 @@ class RichController implements PromptLineController {
    * loses its undo history for nothing.
    */
   private _installedExtensions: Extension[] = [];
+  private _ariaLabel = '';
   private _placeholder = '';
   private _testId = '';
   private _disabled = false;
@@ -100,17 +101,14 @@ class RichController implements PromptLineController {
   mount(host: HTMLElement, init: PromptLineControllerInit): void {
     this._host = host;
     this._extensions = init.extensions ?? [];
+    this._ariaLabel = init.ariaLabel;
     this._placeholder = init.placeholder;
     this._testId = init.testId;
     this._disabled = init.disabled;
 
-    host.setAttribute('role', 'textbox');
     host.setAttribute('aria-multiline', 'true');
     host.setAttribute('spellcheck', 'true');
     host.setAttribute('tabindex', '-1');
-    if (init.ariaLabel) {
-      host.setAttribute('aria-label', init.ariaLabel);
-    }
 
     // Pointer/touch before focus marks the next focus as mouse-driven so we
     // suppress the keyboard-focus outline.
@@ -247,14 +245,7 @@ class RichController implements PromptLineController {
   }
 
   setAriaLabel(ariaLabel: string): void {
-    if (!this._host) {
-      return;
-    }
-    if (ariaLabel) {
-      this._host.setAttribute('aria-label', ariaLabel);
-    } else {
-      this._host.removeAttribute('aria-label');
-    }
+    this._ariaLabel = ariaLabel;
   }
 
   setTestId(testId: string): void {
@@ -374,6 +365,15 @@ class RichController implements PromptLineController {
     return new Editor({
       element,
       extensions: [...baseExtensions, ...this._extensions],
+      editorProps: {
+        attributes: () => {
+          const attrs: Record<string, string> = { role: 'textbox' };
+          if (this._ariaLabel) {
+            attrs['aria-label'] = this._ariaLabel;
+          }
+          return attrs;
+        },
+      },
       content: content ?? undefined,
       autofocus: false,
       injectCSS: false,

--- a/packages/ai-chat-components/src/components/prompt-line/src/prompt-line-textarea-runtime.ts
+++ b/packages/ai-chat-components/src/components/prompt-line/src/prompt-line-textarea-runtime.ts
@@ -146,6 +146,7 @@ export class TextareaController implements PromptLineController {
     textarea.className = TA_FIELD_CLASS;
     textarea.classList.toggle(TA_PHONE_CLASS, IS_PHONE);
     textarea.setAttribute('rows', '1');
+    textarea.setAttribute('name', 'message');
     textarea.setAttribute('spellcheck', 'true');
     textarea.setAttribute('tabindex', '0');
     textarea.placeholder = init.placeholder;

--- a/packages/ai-chat-components/src/components/prompt-line/src/prompt-line.ts
+++ b/packages/ai-chat-components/src/components/prompt-line/src/prompt-line.ts
@@ -108,7 +108,7 @@ class PromptLineElement extends LitElement {
 
   /** Accessible label for the editing surface. */
   @property({ type: String, attribute: 'aria-label', reflect: true })
-  override ariaLabel = '';
+  override ariaLabel = 'Message';
 
   /** Test id, applied to the inner editable element. */
   @property({ type: String, attribute: 'test-id' })


### PR DESCRIPTION
Closes #2146

Sets `aria-label` and `role="textbox"` on Prompt Line div element with `contenteditable="true"` and not on its wrapper.

#### Changelog

**New**
- `prompt-line-rich-runtime.ts`: `setAriaLabel()` only sets value of private variable `_ariaLabel`, which is used to set `aria-label` on the textbox element via Tiptap's `editorProps.attributes`.
- Prompt line defaults to `'Message'` when `aria-label` is not set.
- Lite editor sets `'name'` attribute on `<textarea>` to remove browser warning "A form field element has neither an id nor a name attribute"
- Tests assert `aria-label` and `role` are appropriately set in both Lite and Rich editor.

#### Testing / Reviewing

- Verify new tests pass.
- Go to prompt line storybook deploy preview:
  - Run IBM Equal Access Accessibility Checker (devtools) in isolation mode for Command and mentions, Conversation starters, and Typeahead stories. Verify there is no violation "Form control with "textbox" role has no associated label".
  - Verify `role="textbox"` appears once per prompt line, on the div with `contenteditable="true"`.
  - Verify `aria-label` is set on the textbox element and its value is announced by a screen reader.