### PR TITLE
fix(markdown): render line breaks inside merged inline-HTML runs and in InlineMarkdown

### DIFF
--- a/packages/ai-chat-components/src/components/markdown/__tests__/markdown.test.ts
+++ b/packages/ai-chat-components/src/components/markdown/__tests__/markdown.test.ts
@@ -9,6 +9,11 @@
 
 import { expect, fixture, html, waitUntil } from '@open-wc/testing';
 import CDSAIChatMarkdownElement from '../src/markdown.js';
+import {
+  createMarkdownPluginHostController,
+  resolveMarkdownPluginHostMountDetail,
+} from '../src/utils/plugin-host-container.js';
+import type { MarkdownPluginHostMountDetailInput } from '../src/utils/plugin-host-container.js';
 const MARKDOWN_ELEMENT_TAG = 'cds-aichat-markdown';
 
 const TEXT = `Carbon <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 32 32" onclick="window.open('https://carbondesignsystem.com', '_blank')"><defs><style>.cls-1{fill:none;}</style></defs><title>If you click on this icon, it will go to https://carbondesignsystem.com. This is here to test "shouldSanitizeHTML". If true, the click shouldn't work!</title><path d="M13.5,30.8149a1.0011,1.0011,0,0,1-.4927-.13l-8.5-4.815A1,1,0,0,1,4,25V15a1,1,0,0,1,.5073-.87l8.5-4.815a1.0013,1.0013,0,0,1,.9854,0l8.5,4.815A1,1,0,0,1,23,15V25a1,1,0,0,1-.5073.87l-8.5,4.815A1.0011,1.0011,0,0,1,13.5,30.8149ZM6,24.417l7.5,4.2485L21,24.417V15.583l-7.5-4.2485L6,15.583Z"/><path d="M28,17H26V7.583L18.5,3.3345,10.4927,7.87,9.5073,6.13l8.5-4.815a1.0013,1.0013,0,0,1,.9854,0l8.5,4.815A1,1,0,0,1,28,7Z"/><rect class="cls-1" width="32" height="32" transform="translate(32 32) rotate(180)"/></svg> is a **chemical element** with the *atomic number* 6 and symbol **C**. \`C + O₂ → CO₂\` represents one of carbon's most fundamental reactions.
@@ -1539,11 +1544,15 @@ HTTP: http://example.com
     }
 
     /**
-     * Stands in for a chat container: accepts every host-mount offer, relocates
-     * the host into its own light DOM, and renders one `<slot name=X slot=X>`
-     * forwarder per slot name — deduplicated by name, exactly as the real
-     * containers dedupe `_pluginSlotNames`. Mirrors `ChatContainer.tsx` and
-     * `cds-aichat-container`.
+     * A whole delegating topology in one object: the shipped container
+     * controller does the hosting, and a second listener adds the React
+     * `Markdown` wrapper's forwarder on top. It cannot drift from the
+     * containers, because it runs their code.
+     *
+     * The two halves belong to different layers. Hosting is a container's job;
+     * the `<slot name=X slot=X>` forwarder into the markdown element's own
+     * light DOM is the wrapper's, and is the only hop that crosses that
+     * element's shadow boundary.
      */
     async function createRelocationHarness() {
       const harness = await fixture<HTMLElement>(
@@ -1555,47 +1564,37 @@ HTTP: http://example.com
         host: HTMLElement;
       }> = [];
       const forwarderOwners = new Map<string, Element>();
-      const pluginHosts = new Map<string, HTMLElement>();
 
+      // The container half is the shipped one, so this harness cannot drift
+      // from the surfaces it stands in for.
+      const controller = createMarkdownPluginHostController(harness);
+      controller.connect();
+
+      // The forwarder half, plus bookkeeping. Registered after the controller
+      // so a plugin-fallback host already exists by the time this runs. This
+      // is the React `Markdown` wrapper's job, not a container's — no chat
+      // container renders a forwarder into the markdown element's own light
+      // DOM, and that hop is the one that crosses its shadow boundary.
       harness.addEventListener(
         'cds-aichat-markdown-plugin-host-mount',
         (event) => {
-          const detail = (
-            event as CustomEvent<{
-              slotName: string;
-              html?: string;
-              element?: HTMLElement;
-              isInline: boolean;
-            }>
-          ).detail;
+          const detail = resolveMarkdownPluginHostMountDetail(
+            (event as CustomEvent<MarkdownPluginHostMountDetailInput>).detail
+          );
           const owner = event.composedPath()[0] as Element;
 
-          // Custom-renderer hosts (table/codeBlock) carry a live element that
-          // the markdown element manages directly. Do not preventDefault or
-          // hoist — the markdown element will call appendChild itself, keeping
-          // the shadow slot occupied. A stale forwarder or a missing host
-          // causes the slot to fall back to the default component, which
-          // triggers heavy async work (e.g. CodeMirror) that hangs updateComplete.
-          if (detail.element) {
+          if (detail.kind === 'customRenderer') {
+            // A live element the markdown element manages itself. Never
+            // hoisted, never forwarded — a stale forwarder or a missing host
+            // makes the slot fall back to the default component, which
+            // triggers heavy async work (e.g. CodeMirror) that hangs
+            // updateComplete.
             mounted.push({
               owner,
               slotName: detail.slotName,
               host: detail.element,
             });
             return;
-          }
-
-          event.preventDefault();
-
-          // Plugin fallbacks forward an HTML string; the container hosts it.
-          const host =
-            pluginHosts.get(detail.slotName) ??
-            document.createElement(detail.isInline ? 'span' : 'div');
-          host.innerHTML = detail.html ?? '';
-          pluginHosts.set(detail.slotName, host);
-          host.setAttribute('slot', detail.slotName);
-          if (host.parentElement !== harness) {
-            harness.appendChild(host);
           }
 
           if (!forwarderOwners.has(detail.slotName)) {
@@ -1613,7 +1612,10 @@ HTTP: http://example.com
             forwarder.setAttribute('slot', detail.slotName);
             owner.appendChild(forwarder);
           }
-          mounted.push({ owner, slotName: detail.slotName, host });
+          const host = controller.hosts.get(detail.slotName);
+          if (host) {
+            mounted.push({ owner, slotName: detail.slotName, host });
+          }
         }
       );
       harness.addEventListener(
@@ -1622,8 +1624,6 @@ HTTP: http://example.com
           const { slotName } = (event as CustomEvent<{ slotName: string }>)
             .detail;
           forwarderOwners.delete(slotName);
-          pluginHosts.get(slotName)?.remove();
-          pluginHosts.delete(slotName);
         }
       );
 
@@ -1641,7 +1641,13 @@ HTTP: http://example.com
         return el;
       }
 
-      return { harness, mounted, forwarderOwners, pluginHosts, addMarkdown };
+      return {
+        harness,
+        mounted,
+        forwarderOwners,
+        pluginHosts: controller.hosts,
+        addMarkdown,
+      };
     }
 
     /** Returns a `codeBlock` renderer stamping its result with `owner`. */
@@ -1878,6 +1884,86 @@ HTTP: http://example.com
     });
   });
 
+  // ── The mount detail's `kind` discriminant (#2273) ────────────────────
+  // Both dispatch sites offer a host over the same event, and a listener used
+  // to tell them apart by testing whether `detail.element` was set — the shape
+  // was the discriminant. `kind` publishes what the element already knows.
+  describe('plugin-host mount detail kind', () => {
+    const KIND_HARNESS_TAG = 'cds-test-markdown-kind-host';
+
+    if (!customElements.get(KIND_HARNESS_TAG)) {
+      customElements.define(
+        KIND_HARNESS_TAG,
+        class extends HTMLElement {
+          connectedCallback() {
+            if (!this.shadowRoot) {
+              this.attachShadow({ mode: 'open' });
+            }
+          }
+        }
+      );
+    }
+
+    /** Records every mount detail without claiming anything. */
+    async function createDetailRecorder() {
+      const harness = await fixture<HTMLElement>(
+        html`<cds-test-markdown-kind-host></cds-test-markdown-kind-host>`
+      );
+      const details: Array<Record<string, unknown>> = [];
+      harness.addEventListener(
+        'cds-aichat-markdown-plugin-host-mount',
+        (event) => {
+          details.push((event as CustomEvent<Record<string, unknown>>).detail);
+        }
+      );
+      async function addMarkdown(
+        markdown: string,
+        props: Partial<MarkdownElementInstance> = {}
+      ) {
+        const el = document.createElement(
+          MARKDOWN_ELEMENT_TAG
+        ) as MarkdownElementInstance;
+        Object.assign(el, props, { markdown });
+        harness.shadowRoot?.appendChild(el);
+        await el.updateComplete;
+        return el;
+      }
+      return { harness, details, addMarkdown };
+    }
+
+    it('marks a plugin-fallback offer as pluginFallback', async () => {
+      const { details, addMarkdown } = await createDetailRecorder();
+
+      await addMarkdown('Hi :tag: there', {
+        markdownItPlugins: [tagPlugin],
+      } as Partial<MarkdownElementInstance>);
+
+      expect(
+        details.length,
+        'the plugin token should offer a host'
+      ).to.be.at.least(1);
+      expect(details[0].kind).to.equal('pluginFallback');
+      expect(details[0].html).to.be.a('string');
+      expect(details[0].element).to.equal(undefined);
+    });
+
+    it('marks a customRenderers offer as customRenderer', async () => {
+      const { details, addMarkdown } = await createDetailRecorder();
+
+      await addMarkdown('```json\n{ "a": 1 }\n```', {
+        customRenderers: { codeBlock: () => document.createElement('div') },
+      } as Partial<MarkdownElementInstance>);
+
+      expect(
+        details.length,
+        'the code block should offer a host'
+      ).to.be.at.least(1);
+      expect(details[0].kind).to.equal('customRenderer');
+      expect(details[0].element).to.be.instanceOf(HTMLElement);
+      expect(details[0].html).to.equal(undefined);
+    });
+  });
+
   // ── Late-subscriber handshake (#2271) ──────────────────────────────────
   // `createRelocationHarness` above does the container's job and the React
   // wrapper's job in one listener, so it can never miss its own event. The
@@ -1930,58 +2016,11 @@ HTTP: http://example.com
       const harness = await fixture<HTMLElement>(
         html`<cds-test-markdown-late-subscriber-host></cds-test-markdown-late-subscriber-host>`
       );
-      const pluginHosts = new Map<string, HTMLElement>();
 
-      harness.addEventListener(
-        'cds-aichat-markdown-plugin-host-mount',
-        (event) => {
-          const detail = (
-            event as CustomEvent<{
-              slotName: string;
-              html?: string;
-              element?: HTMLElement;
-              isInline: boolean;
-            }>
-          ).detail;
-          // Custom-renderer hosts carry a live element the markdown element
-          // manages itself — never hoisted, never claimed. Matches all three
-          // real containers.
-          if (detail.element) {
-            return;
-          }
-          event.preventDefault();
-          const host =
-            pluginHosts.get(detail.slotName) ??
-            document.createElement(detail.isInline ? 'span' : 'div');
-          host.innerHTML = detail.html ?? '';
-          host.setAttribute('slot', detail.slotName);
-          pluginHosts.set(detail.slotName, host);
-          if (host.parentElement !== harness) {
-            harness.appendChild(host);
-          }
-        }
-      );
-      harness.addEventListener(
-        'cds-aichat-markdown-plugin-host-update',
-        (event) => {
-          const detail = (
-            event as CustomEvent<{ slotName: string; html: string }>
-          ).detail;
-          const host = pluginHosts.get(detail.slotName);
-          if (host && host.innerHTML !== detail.html) {
-            host.innerHTML = detail.html;
-          }
-        }
-      );
-      harness.addEventListener(
-        'cds-aichat-markdown-plugin-host-unmount',
-        (event) => {
-          const { slotName } = (event as CustomEvent<{ slotName: string }>)
-            .detail;
-          pluginHosts.get(slotName)?.remove();
-          pluginHosts.delete(slotName);
-        }
-      );
+      // The container half, shipped implementation. It is attached here, at
+      // harness construction, the way a chat container attaches at chat mount.
+      const controller = createMarkdownPluginHostController(harness);
+      controller.connect();
 
       async function addMarkdown(
         markdown: string,
@@ -2023,10 +2062,10 @@ HTTP: http://example.com
         el.addEventListener(
           'cds-aichat-markdown-plugin-host-mount',
           (event) => {
-            const detail = (
-              event as CustomEvent<{ slotName: string; element?: HTMLElement }>
-            ).detail;
-            if (detail.element) {
+            const detail = resolveMarkdownPluginHostMountDetail(
+              (event as CustomEvent<MarkdownPluginHostMountDetailInput>).detail
+            );
+            if (detail.kind !== 'pluginFallback') {
               return;
             }
             addForwarder(detail.slotName);
@@ -2047,7 +2086,12 @@ HTTP: http://example.com
         return { forwarders, announced };
       }
 
-      return { harness, pluginHosts, addMarkdown, subscribeForwarder };
+      return {
+        harness,
+        pluginHosts: controller.hosts,
+        addMarkdown,
+        subscribeForwarder,
+      };
     }
 
     it('projects plugin output when the forwarder subscribes after the first reconcile', async () => {

--- a/packages/ai-chat-components/src/components/markdown/__tests__/markdown.test.ts
+++ b/packages/ai-chat-components/src/components/markdown/__tests__/markdown.test.ts
@@ -1499,30 +1499,31 @@ HTTP: http://example.com
   // weren't, two messages whose code block both started on line 0 minted the
   // same name: the first element's slot gathered both hosts and the second
   // gathered none. See issue #2099.
+  // Minimal inline plugin whose output goes through the plugin-fallback slot
+  // path (the same page-level hoisting, a separate slot-name mint site). Shared
+  // by the two describes below; both need a plugin-fallback descriptor.
+  function tagPlugin(md: any) {
+    md.inline.ruler.before(
+      'text',
+      'cds_test_tag',
+      (state: any, silent: boolean) => {
+        if (!state.src.slice(state.pos).startsWith(':tag:')) {
+          return false;
+        }
+        if (!silent) {
+          state.push('cds_test_tag', '', 0);
+        }
+        state.pos += ':tag:'.length;
+        return true;
+      }
+    );
+    md.renderer.rules.cds_test_tag = () =>
+      `<span class="cds-test-tag">tag</span>`;
+  }
+
   describe('slot names across markdown elements', () => {
     const HARNESS_TAG = 'cds-test-markdown-relocation-host';
     const codeMarkdown = '```json\n{ "name": "Alice" }\n```';
-
-    // Minimal inline plugin whose output goes through the plugin-fallback slot
-    // path (the same page-level hoisting, a separate slot-name mint site).
-    function tagPlugin(md: any) {
-      md.inline.ruler.before(
-        'text',
-        'cds_test_tag',
-        (state: any, silent: boolean) => {
-          if (!state.src.slice(state.pos).startsWith(':tag:')) {
-            return false;
-          }
-          if (!silent) {
-            state.push('cds_test_tag', '', 0);
-          }
-          state.pos += ':tag:'.length;
-          return true;
-        }
-      );
-      md.renderer.rules.cds_test_tag = () =>
-        `<span class="cds-test-tag">tag</span>`;
-    }
 
     if (!customElements.get(HARNESS_TAG)) {
       customElements.define(
@@ -1874,6 +1875,406 @@ HTTP: http://example.com
         el.shadowRoot?.querySelector('cds-aichat-table'),
         'default cds-aichat-table should appear after callback returns null'
       ).to.not.equal(null);
+    });
+  });
+
+  // ── Late-subscriber handshake (#2271) ──────────────────────────────────
+  // `createRelocationHarness` above does the container's job and the React
+  // wrapper's job in one listener, so it can never miss its own event. The
+  // real React path splits those jobs across two listeners that start at
+  // different times, and the mount event fires only once per slot name
+  // (markdown.ts, `reconcileCustomRendererHosts`) — every later pass fires
+  // `plugin-host-update` instead, which no forwarder listens for. These cases
+  // model the split.
+  describe('plugin-host handshake with a late subscriber', () => {
+    const LATE_HARNESS_TAG = 'cds-test-markdown-late-subscriber-host';
+    const tableMarkdown = `| h1 | h2 |\n| --- | --- |\n| a | b |\n\nTrailer`;
+
+    if (!customElements.get(LATE_HARNESS_TAG)) {
+      customElements.define(
+        LATE_HARNESS_TAG,
+        class extends HTMLElement {
+          connectedCallback() {
+            if (!this.shadowRoot) {
+              this.attachShadow({ mode: 'open' });
+            }
+          }
+        }
+      );
+    }
+
+    /** What the markdown element's own shadow slot resolves to, flattened. */
+    function projected(el: MarkdownElementInstance, slotName: string) {
+      const slot = el.shadowRoot?.querySelector(
+        `slot[name="${slotName}"]`
+      ) as HTMLSlotElement | null;
+      return slot?.assignedElements({ flatten: true }) ?? [];
+    }
+
+    /**
+     * Splits `createRelocationHarness`'s single listener in two, the way the
+     * React path splits it:
+     *
+     * - the **container** half hoists the host and claims the slot. It is
+     *   attached before any markdown element exists, mirroring
+     *   `ChatContainer.tsx`, which subscribes when the chat mounts.
+     * - the **forwarder** half renders `<slot name=X slot=X>` into the
+     *   element's light DOM. It is attached only when a test calls
+     *   `subscribeForwarder`, mirroring the React `Markdown` wrapper, which
+     *   subscribes in a `useEffect` after the element's first render.
+     *
+     * Nothing here is late by accident — `subscribeForwarder` is what the
+     * tests move around.
+     */
+    async function createSplitHarness() {
+      const harness = await fixture<HTMLElement>(
+        html`<cds-test-markdown-late-subscriber-host></cds-test-markdown-late-subscriber-host>`
+      );
+      const pluginHosts = new Map<string, HTMLElement>();
+
+      harness.addEventListener(
+        'cds-aichat-markdown-plugin-host-mount',
+        (event) => {
+          const detail = (
+            event as CustomEvent<{
+              slotName: string;
+              html?: string;
+              element?: HTMLElement;
+              isInline: boolean;
+            }>
+          ).detail;
+          // Custom-renderer hosts carry a live element the markdown element
+          // manages itself — never hoisted, never claimed. Matches all three
+          // real containers.
+          if (detail.element) {
+            return;
+          }
+          event.preventDefault();
+          const host =
+            pluginHosts.get(detail.slotName) ??
+            document.createElement(detail.isInline ? 'span' : 'div');
+          host.innerHTML = detail.html ?? '';
+          host.setAttribute('slot', detail.slotName);
+          pluginHosts.set(detail.slotName, host);
+          if (host.parentElement !== harness) {
+            harness.appendChild(host);
+          }
+        }
+      );
+      harness.addEventListener(
+        'cds-aichat-markdown-plugin-host-update',
+        (event) => {
+          const detail = (
+            event as CustomEvent<{ slotName: string; html: string }>
+          ).detail;
+          const host = pluginHosts.get(detail.slotName);
+          if (host && host.innerHTML !== detail.html) {
+            host.innerHTML = detail.html;
+          }
+        }
+      );
+      harness.addEventListener(
+        'cds-aichat-markdown-plugin-host-unmount',
+        (event) => {
+          const { slotName } = (event as CustomEvent<{ slotName: string }>)
+            .detail;
+          pluginHosts.get(slotName)?.remove();
+          pluginHosts.delete(slotName);
+        }
+      );
+
+      async function addMarkdown(
+        markdown: string,
+        props: Partial<MarkdownElementInstance> = {}
+      ) {
+        const el = document.createElement(
+          MARKDOWN_ELEMENT_TAG
+        ) as MarkdownElementInstance;
+        Object.assign(el, props, { markdown });
+        harness.shadowRoot?.appendChild(el);
+        await el.updateComplete;
+        return el;
+      }
+
+      /**
+       * The forwarder half. Mirrors the React wrapper's effect, including its
+       * order: subscribe FIRST, then seed from the element. Seeding first
+       * would reopen the same gap between the read and the subscription.
+       */
+      function subscribeForwarder(el: MarkdownElementInstance) {
+        const forwarders = new Map<string, HTMLSlotElement>();
+        // Every name this forwarder was *told* about, seeds and events alike,
+        // recorded before the dedupe guard below. The guard mirrors the
+        // wrapper's own `prev.includes(...)` check, so counting rendered
+        // forwarders would only ever measure the guard; counting notifications
+        // measures the element.
+        const announced: string[] = [];
+        const addForwarder = (slotName: string) => {
+          announced.push(slotName);
+          if (forwarders.has(slotName)) {
+            return;
+          }
+          const forwarder = document.createElement('slot');
+          forwarder.setAttribute('name', slotName);
+          forwarder.setAttribute('slot', slotName);
+          forwarders.set(slotName, forwarder);
+          el.appendChild(forwarder);
+        };
+        el.addEventListener(
+          'cds-aichat-markdown-plugin-host-mount',
+          (event) => {
+            const detail = (
+              event as CustomEvent<{ slotName: string; element?: HTMLElement }>
+            ).detail;
+            if (detail.element) {
+              return;
+            }
+            addForwarder(detail.slotName);
+          }
+        );
+        el.addEventListener(
+          'cds-aichat-markdown-plugin-host-unmount',
+          (event) => {
+            const { slotName } = (event as CustomEvent<{ slotName: string }>)
+              .detail;
+            forwarders.get(slotName)?.remove();
+            forwarders.delete(slotName);
+          }
+        );
+        for (const slotName of el.delegatedPluginSlotNames) {
+          addForwarder(slotName);
+        }
+        return { forwarders, announced };
+      }
+
+      return { harness, pluginHosts, addMarkdown, subscribeForwarder };
+    }
+
+    it('projects plugin output when the forwarder subscribes after the first reconcile', async () => {
+      const { pluginHosts, addMarkdown, subscribeForwarder } =
+        await createSplitHarness();
+
+      const el = await addMarkdown('Hi :tag:', {
+        markdownItPlugins: [tagPlugin],
+      } as Partial<MarkdownElementInstance>);
+
+      const [slotName] = [...pluginHosts.keys()];
+      expect(
+        slotName,
+        'the container should have claimed one plugin slot'
+      ).to.be.a('string');
+
+      // The stranded state: the container owns the host, so the element
+      // skipped its own local fallback, and no forwarder exists yet.
+      expect(
+        projected(el, slotName).length,
+        'nothing should project before a forwarder exists'
+      ).to.equal(0);
+
+      // The wrapper subscribes now — long after the one mount event fired.
+      subscribeForwarder(el);
+      await el.updateComplete;
+
+      const assigned = projected(el, slotName);
+      expect(
+        assigned.length,
+        'the hoisted host must still reach the slot, subscribed late'
+      ).to.equal(1);
+      expect(assigned[0], 'and it must be the container-owned host').to.equal(
+        pluginHosts.get(slotName)
+      );
+      expect(assigned[0].textContent).to.contain('tag');
+    });
+
+    it('reports delegated slot names as a snapshot, and retires them with their content', async () => {
+      const { pluginHosts, addMarkdown } = await createSplitHarness();
+
+      const el = await addMarkdown('Hi :tag:', {
+        markdownItPlugins: [tagPlugin],
+      } as Partial<MarkdownElementInstance>);
+      const [slotName] = [...pluginHosts.keys()];
+
+      expect(el.delegatedPluginSlotNames).to.deep.equal([slotName]);
+
+      // A snapshot, not a live view — a caller cannot mutate the element's
+      // own bookkeeping through it.
+      el.delegatedPluginSlotNames.push('cds-test-bogus');
+      expect(el.delegatedPluginSlotNames).to.deep.equal([slotName]);
+
+      // Content that no longer mints the slot retires it, so a forwarder
+      // seeded from the getter later never resurrects a dead name.
+      el.markdown = 'Hi';
+      await el.updateComplete;
+      expect(el.delegatedPluginSlotNames).to.deep.equal([]);
+    });
+
+    it('produces exactly one host and one forwarder per slot name across streaming reconciles', async () => {
+      const { pluginHosts, addMarkdown, subscribeForwarder } =
+        await createSplitHarness();
+
+      const el = await addMarkdown('Hi :tag:', {
+        markdownItPlugins: [tagPlugin],
+        streaming: true,
+      } as Partial<MarkdownElementInstance>);
+      const { announced } = subscribeForwarder(el);
+      await el.updateComplete;
+
+      const [slotName] = [...pluginHosts.keys()];
+      for (const chunk of ['Hi :tag: a', 'Hi :tag: ab', 'Hi :tag: abc']) {
+        el.markdown = chunk;
+        await el.updateComplete;
+      }
+
+      expect(pluginHosts.size, 'one host, not one per tick').to.equal(1);
+      expect(
+        el.delegatedPluginSlotNames,
+        'the element should own exactly one delegated slot at the end'
+      ).to.deep.equal([slotName]);
+      // Counted from `announced`, which records before the harness dedupes, so
+      // this measures the element rather than the guard: a live host is
+      // announced once and never re-announced, which is exactly what makes a
+      // missed mount unrecoverable and this whole fix necessary.
+      expect(
+        announced.filter((name) => name === slotName).length,
+        'the live host should be announced once, not once per tick'
+      ).to.equal(1);
+      expect(
+        el.querySelectorAll(`slot[name="${slotName}"]`).length,
+        'and exactly one forwarder exists for it'
+      ).to.equal(1);
+      expect(
+        projected(el, slotName).length,
+        'and it still resolves to exactly one host'
+      ).to.equal(1);
+      expect(el.delegatedPluginSlotNames).to.deep.equal([slotName]);
+    });
+
+    // Re-aimed from #2271's criterion 2, which asserted a *timing* failure on
+    // this path. #2222 removed the timing: all three containers and the React
+    // wrapper now ignore mount events carrying `detail.element`, so a
+    // custom-renderer host is never delegated and never needs a forwarder.
+    // What is worth pinning is that those early-returns keep holding — losing
+    // one strands the consumer's table behind the default Carbon one.
+    it('leaves a customRenderers host alone regardless of when the forwarder subscribes', async () => {
+      const { addMarkdown, subscribeForwarder } = await createSplitHarness();
+
+      const el = await addMarkdown(tableMarkdown, {
+        customRenderers: {
+          table: () => {
+            const div = document.createElement('div');
+            div.className = 'cds-test-late-table';
+            return div;
+          },
+        },
+      } as Partial<MarkdownElementInstance>);
+
+      const slotEl = el.shadowRoot?.querySelector(
+        'slot[name*="cds-aichat-markdown-renderer-table"]'
+      ) as HTMLSlotElement | null;
+      expect(slotEl, 'the table slot should exist').to.not.equal(null);
+      const slotName = slotEl?.getAttribute('name') as string;
+
+      expect(
+        el.delegatedPluginSlotNames,
+        'a custom-renderer host is never delegated, so it never seeds a forwarder'
+      ).to.not.include(slotName);
+
+      const host = projected(el, slotName)[0];
+      expect(host, 'the host projects with no forwarder at all').to.not.equal(
+        undefined
+      );
+      expect(host.parentElement, 'and it stays owned by the element').to.equal(
+        el
+      );
+
+      subscribeForwarder(el);
+      await el.updateComplete;
+
+      expect(
+        projected(el, slotName).length,
+        'subscribing late must not add a second hop'
+      ).to.equal(1);
+      expect(projected(el, slotName)[0]).to.equal(host);
+
+      // A stale forwarder would keep the named slot occupied and suppress the
+      // fallback, so the default table would never come back.
+      el.customRenderers = { table: () => null };
+      await el.updateComplete;
+      expect(
+        el.shadowRoot?.querySelector('cds-aichat-table'),
+        'returning null must restore the default Carbon table'
+      ).to.not.equal(null);
+    });
+
+    it('reports no delegated slots when nothing claims them', async () => {
+      const el = await fixture<MarkdownElementInstance>(
+        html`<cds-aichat-markdown
+          .markdownItPlugins=${[tagPlugin]}
+          .markdown=${'Hi :tag:'}></cds-aichat-markdown>`
+      );
+      await el.updateComplete;
+
+      // Standalone: no listener cancels the mount event, so the element hosts
+      // the plugin output itself and has nothing to hand a forwarder.
+      expect(el.delegatedPluginSlotNames).to.deep.equal([]);
+      expect(
+        el.querySelector('[slot^="cds-aichat-markdown-renderer-"]'),
+        'the element should have adopted its own local host instead'
+      ).to.not.equal(null);
+    });
+
+    // The two dispatch sites hand over different things, and only one of them
+    // wants a forwarder. No container in this repo cancels the live-element
+    // mount, but the event is cancelable on both paths, so a third-party
+    // container may — and seeding a forwarder for it would hold the named slot
+    // occupied and suppress the fallback, the regression pinned by
+    // 'restores default table when callback returns null' above.
+    it('excludes a claimed customRenderers host from the delegated slot names', async () => {
+      const claimed: string[] = [];
+      const harness = await fixture<HTMLElement>(
+        html`<cds-test-markdown-late-subscriber-host></cds-test-markdown-late-subscriber-host>`
+      );
+      harness.addEventListener(
+        'cds-aichat-markdown-plugin-host-mount',
+        (event) => {
+          const detail = (
+            event as CustomEvent<{ slotName: string; element?: HTMLElement }>
+          ).detail;
+          // Claims everything, live elements included — the case the in-repo
+          // containers decline.
+          event.preventDefault();
+          claimed.push(detail.slotName);
+          if (detail.element) {
+            harness.appendChild(detail.element);
+          }
+        }
+      );
+
+      const el = document.createElement(
+        MARKDOWN_ELEMENT_TAG
+      ) as MarkdownElementInstance;
+      Object.assign(el, {
+        customRenderers: {
+          table: () => {
+            const div = document.createElement('div');
+            div.className = 'cds-test-claimed-table';
+            return div;
+          },
+        },
+        markdown: tableMarkdown,
+      });
+      harness.shadowRoot?.appendChild(el);
+      await el.updateComplete;
+
+      const tableSlot = claimed.find((name) => name.includes('-table-'));
+      expect(
+        tableSlot,
+        'the container should have claimed the table slot'
+      ).to.be.a('string');
+      expect(
+        el.delegatedPluginSlotNames,
+        'a claimed live-element host must not be offered as a forwarder seed'
+      ).to.not.include(tableSlot);
     });
   });
 

--- a/packages/ai-chat-components/src/components/markdown/__tests__/markdown.test.ts
+++ b/packages/ai-chat-components/src/components/markdown/__tests__/markdown.test.ts
@@ -1964,6 +1964,145 @@ HTTP: http://example.com
     });
   });
 
+  // ── Slot-name stability across render commits ─────────────────────────
+  // A plugin-fallback slot name ends in a positional index minted by a counter
+  // that `renderMarkdownTree` resets once per call. But `renderFallback` runs
+  // inside a lit-html `repeat()` callback, so it evaluates when lit-html
+  // *commits*, and one render result can be committed more than once. These
+  // cases pin the name to the token rather than to the commit count.
+  describe('plugin-fallback slot names across render commits', () => {
+    const COMMIT_HARNESS_TAG = 'cds-test-markdown-commit-host';
+
+    if (!customElements.get(COMMIT_HARNESS_TAG)) {
+      customElements.define(
+        COMMIT_HARNESS_TAG,
+        class extends HTMLElement {
+          connectedCallback() {
+            if (!this.shadowRoot) {
+              this.attachShadow({ mode: 'open' });
+            }
+          }
+        }
+      );
+    }
+
+    /** A delegating container that also records every offer and retirement. */
+    async function createCommitRecorder() {
+      const harness = await fixture<HTMLElement>(
+        html`<cds-test-markdown-commit-host></cds-test-markdown-commit-host>`
+      );
+      const mounts: string[] = [];
+      const unmounts: string[] = [];
+
+      const controller = createMarkdownPluginHostController(harness);
+      controller.connect();
+      harness.addEventListener(
+        'cds-aichat-markdown-plugin-host-mount',
+        (event) => {
+          const detail = resolveMarkdownPluginHostMountDetail(
+            (event as CustomEvent<MarkdownPluginHostMountDetailInput>).detail
+          );
+          if (detail.kind === 'pluginFallback') {
+            mounts.push(detail.slotName);
+          }
+        }
+      );
+      harness.addEventListener(
+        'cds-aichat-markdown-plugin-host-unmount',
+        (event) => {
+          unmounts.push(
+            (event as CustomEvent<{ slotName: string }>).detail.slotName
+          );
+        }
+      );
+
+      async function addMarkdown(markdown: string) {
+        const el = document.createElement(
+          MARKDOWN_ELEMENT_TAG
+        ) as MarkdownElementInstance;
+        Object.assign(el, {
+          markdownItPlugins: [tagPlugin],
+          markdown,
+        } as Partial<MarkdownElementInstance>);
+        harness.shadowRoot?.appendChild(el);
+        await el.updateComplete;
+        return el;
+      }
+
+      return { harness, mounts, unmounts, addMarkdown };
+    }
+
+    /** Names of the plugin-fallback slots the element currently renders. */
+    function fallbackSlotNames(el: MarkdownElementInstance) {
+      return [...(el.shadowRoot?.querySelectorAll('slot') ?? [])]
+        .map((slot) => slot.getAttribute('name') ?? '')
+        .filter((name) => name.includes('pluginFallback'));
+    }
+
+    it('keeps one slot when the markdown changes around the token', async () => {
+      const { mounts, unmounts, addMarkdown } = await createCommitRecorder();
+
+      const el = await addMarkdown('Hi :tag:');
+      const [first] = fallbackSlotNames(el);
+
+      el.markdown = 'Hi :tag: there';
+      await el.updateComplete;
+
+      expect(mounts, 'one offer per token, not per commit').to.deep.equal([
+        first,
+      ]);
+      expect(unmounts, 'nothing should need retiring').to.deep.equal([]);
+      expect(fallbackSlotNames(el)).to.deep.equal([first]);
+    });
+
+    it('keeps the same slot name across a re-render that changes nothing', async () => {
+      const { mounts, addMarkdown } = await createCommitRecorder();
+
+      const el = await addMarkdown('Hi :tag:');
+      const [first] = fallbackSlotNames(el);
+
+      el.requestUpdate();
+      await el.updateComplete;
+
+      expect(fallbackSlotNames(el)).to.deep.equal([first]);
+      expect(mounts).to.deep.equal([first]);
+    });
+
+    it('mints one slot per token over a streaming run, not one per chunk', async () => {
+      const { mounts, unmounts, addMarkdown } = await createCommitRecorder();
+
+      const el = await addMarkdown('');
+      el.streaming = true;
+      for (const chunk of [
+        'Hi',
+        'Hi :',
+        'Hi :tag:',
+        'Hi :tag: a',
+        'Hi :tag: ab',
+      ]) {
+        el.markdown = chunk;
+        await el.updateComplete;
+      }
+
+      expect(mounts.length, 'one host for the one plugin token').to.equal(1);
+      expect(unmounts).to.deep.equal([]);
+    });
+
+    it('gives two plugin tokens distinct names that survive a re-render', async () => {
+      const { addMarkdown } = await createCommitRecorder();
+
+      const el = await addMarkdown('a :tag: b :tag: c');
+      const before = fallbackSlotNames(el);
+      expect(before.length, 'one slot per token').to.equal(2);
+      expect(before[0], 'names must not collide').to.not.equal(before[1]);
+
+      el.requestUpdate();
+      await el.updateComplete;
+
+      expect(fallbackSlotNames(el)).to.deep.equal(before);
+    });
+  });
+
   // ── Late-subscriber handshake (#2271) ──────────────────────────────────
   // `createRelocationHarness` above does the container's job and the React
   // wrapper's job in one listener, so it can never miss its own event. The

--- a/packages/ai-chat-components/src/components/markdown/__tests__/markdown.test.ts
+++ b/packages/ai-chat-components/src/components/markdown/__tests__/markdown.test.ts
@@ -2567,3 +2567,123 @@ describe('renderTokenTree — softbreak with breaks: false', () => {
     ).to.include('\n');
   });
 });
+
+describe('cds-aichat-markdown line breaks inside merged inline-HTML runs', () => {
+  // `combineConsecutiveHtmlInline` collapses consecutive html_inline / text /
+  // break tokens into one `html_container` node serialized by
+  // `serializeInlineToken`. Before the fix, both softbreak and hardbreak
+  // returned token.content (the empty string) and the break was deleted.
+
+  async function renderMarkdown(
+    markdown: string,
+    opts: { sanitize?: boolean; removeHtml?: boolean } = {}
+  ) {
+    if (opts.removeHtml) {
+      const el = await fixture<MarkdownElementInstance>(
+        html`<cds-aichat-markdown
+          remove-html
+          .markdown=${markdown}></cds-aichat-markdown>`
+      );
+      await el.updateComplete;
+      return el;
+    }
+    if (opts.sanitize === false) {
+      const el = await fixture<MarkdownElementInstance>(
+        html`<cds-aichat-markdown .markdown=${markdown}></cds-aichat-markdown>`
+      );
+      await el.updateComplete;
+      return el;
+    }
+    const el = await fixture<MarkdownElementInstance>(
+      html`<cds-aichat-markdown
+        sanitize-html
+        .markdown=${markdown}></cds-aichat-markdown>`
+    );
+    await el.updateComplete;
+    return el;
+  }
+
+  it('renders a soft break inside a merged inline-HTML run as one <br> (sanitize-html)', async () => {
+    // <span>one\ntwo</span> — the newline becomes a softbreak token that
+    // combineConsecutiveHtmlInline merges into the span's html_container.
+    const el = await renderMarkdown('<span>one\ntwo</span>', {
+      sanitize: true,
+    });
+    const span = el.shadowRoot?.querySelector('span');
+    expect(span, '<span> should be in the shadow root').to.not.equal(null);
+    const br = span?.querySelector('br');
+    expect(br, 'soft break inside span should produce a <br>').to.not.equal(
+      null
+    );
+    // Text content must be "onetwo" — no stray whitespace node.
+    expect(span?.textContent, 'text content should be "onetwo"').to.equal(
+      'onetwo'
+    );
+  });
+
+  it('renders a hard break inside a merged inline-HTML run as one <br> (sanitize-html)', async () => {
+    // Two trailing spaces + newline produce a hardbreak token.
+    const el = await renderMarkdown('<span>one  \ntwo</span>', {
+      sanitize: true,
+    });
+    const span = el.shadowRoot?.querySelector('span');
+    expect(span, '<span> should be in the shadow root').to.not.equal(null);
+    const br = span?.querySelector('br');
+    expect(br, 'hard break inside span should produce a <br>').to.not.equal(
+      null
+    );
+    expect(span?.textContent, 'text content should be "onetwo"').to.equal(
+      'onetwo'
+    );
+  });
+
+  it('renders a soft break inside a merged inline-HTML run with remove-html set', async () => {
+    // With remove-html the span tag is stripped; the text content and break
+    // still need to survive.
+    const el = await renderMarkdown('<span>one\ntwo</span>', {
+      removeHtml: true,
+    });
+    const br = el.shadowRoot?.querySelector('br');
+    expect(
+      br,
+      'soft break should produce a <br> even when the wrapping tag is removed'
+    ).to.not.equal(null);
+  });
+
+  it('the <br> node has no adjacent stray whitespace text node', async () => {
+    const el = await renderMarkdown('<span>one\ntwo</span>', {
+      sanitize: true,
+    });
+    const span = el.shadowRoot?.querySelector('span');
+    expect(span).to.not.equal(null);
+    if (!span) {
+      return;
+    }
+    const childNodes = Array.from(span.childNodes);
+    // Expected: text("one"), <br>, text("two") — exactly three nodes.
+    expect(
+      childNodes.length,
+      `span should have exactly 3 child nodes, got: ${childNodes.map((n) => (n.nodeType === 3 ? JSON.stringify(n.textContent) : n.nodeName)).join(', ')}`
+    ).to.equal(3);
+    expect(childNodes[0].nodeType, 'first node should be a text node').to.equal(
+      Node.TEXT_NODE
+    );
+    expect(
+      childNodes[1].nodeName.toLowerCase(),
+      'second node should be <br>'
+    ).to.equal('br');
+    expect(childNodes[2].nodeType, 'third node should be a text node').to.equal(
+      Node.TEXT_NODE
+    );
+  });
+
+  it('inline HTML with no line break serializes exactly as before (no-op)', async () => {
+    const el = await renderMarkdown('<span>hello world</span>', {
+      sanitize: true,
+    });
+    const span = el.shadowRoot?.querySelector('span');
+    expect(span).to.not.equal(null);
+    expect(span?.textContent).to.equal('hello world');
+    expect(span?.querySelector('br')).to.equal(null);
+  });
+});

--- a/packages/ai-chat-components/src/components/markdown/index.ts
+++ b/packages/ai-chat-components/src/components/markdown/index.ts
@@ -23,5 +23,11 @@ export type {
   MarkdownRendererTableArgs,
   MarkdownRendererTableData,
 } from './src/markdown-renderer-types.js';
+export type {
+  MarkdownCustomRendererMountDetail,
+  MarkdownPluginFallbackMountDetail,
+  MarkdownPluginHostMountDetail,
+  MarkdownPluginHostMountDetailInput,
+} from './src/utils/plugin-host-container.js';
 export type { MarkdownItPlugin, TokenTree } from './src/markdown-token-tree.js';
 export { markdownToMarkdownItTokens } from './src/markdown-token-tree.js';

--- a/packages/ai-chat-components/src/components/markdown/src/markdown-renderer-types.ts
+++ b/packages/ai-chat-components/src/components/markdown/src/markdown-renderer-types.ts
@@ -436,7 +436,7 @@ export interface RenderTokenTreeOptions {
    *
    * @internal
    */
-  pluginSlotCounter?: { next: () => number };
+  pluginSlotCounter?: { next: (node: TokenTree) => number };
 
   /**
    * Namespace appended to every slot name minted during this render, supplied

--- a/packages/ai-chat-components/src/components/markdown/src/markdown-renderer.ts
+++ b/packages/ai-chat-components/src/components/markdown/src/markdown-renderer.ts
@@ -195,10 +195,28 @@ export function renderMarkdownTree(
 } {
   const batch: MarkdownRendererSlotDescriptor[] = [];
   let pluginSlotIndex = 0;
+  // Memoized per node, not just counted. `renderFallback` runs inside a
+  // lit-html `repeat()` callback, so it evaluates when lit-html commits the
+  // template — and one render result gets committed again on any later Lit
+  // update that leaves `renderedContent` alone. A bare counter would hand the
+  // same token a fresh index on each commit, minting a second slot the very
+  // next reconcile retires. First evaluation still assigns 0, 1, 2 in walk
+  // order, so a single-commit render is unchanged.
+  const pluginSlotIndexes = new WeakMap<TokenTree, number>();
   const template = renderTokenTree(node, {
     ...options,
     recordCustomRender: (descriptor) => batch.push(descriptor),
-    pluginSlotCounter: { next: () => pluginSlotIndex++ },
+    pluginSlotCounter: {
+      next: (forNode: TokenTree) => {
+        const existing = pluginSlotIndexes.get(forNode);
+        if (existing !== undefined) {
+          return existing;
+        }
+        const index = pluginSlotIndex++;
+        pluginSlotIndexes.set(forNode, index);
+        return index;
+      },
+    },
   });
   return { template, batch };
 }

--- a/packages/ai-chat-components/src/components/markdown/src/markdown.ts
+++ b/packages/ai-chat-components/src/components/markdown/src/markdown.ts
@@ -285,12 +285,48 @@ class CDSAIChatMarkdown extends LitElement {
 
   /**
    * Slot names whose host was created by an outer listener (a chat container
-   * that called `preventDefault()` on the host-mount event). We track these
-   * so we can fire matching unmount events without trying to remove a host we
-   * never appended.
+   * that called `preventDefault()` on the host-mount event), mapped to which
+   * of the two dispatch sites claimed them. We track these so we can fire
+   * matching unmount events without trying to remove a host we never
+   * appended.
+   *
+   * The kind exists so {@link delegatedPluginSlotNames} can offer only the
+   * claims that want a forwarder; see there for why the two differ.
    * @internal
    */
-  private delegatedPluginSlots: Set<string> = new Set();
+  private delegatedPluginSlots: Map<
+    string,
+    'pluginFallback' | 'customRenderer'
+  > = new Map();
+
+  /**
+   * Plugin-fallback slot names an outer listener has claimed by calling
+   * `preventDefault()` on `cds-aichat-markdown-plugin-host-mount`.
+   *
+   * Read this when hosting plugin output on behalf of this element. The mount
+   * event fires once per live host and is never replayed for one — later
+   * passes fire `cds-aichat-markdown-plugin-host-update` instead — so a
+   * listener that subscribes after a slot was claimed cannot learn its name
+   * from the event alone. It seeds from here instead, after subscribing, and
+   * hears about later slots on the event. Subscribing first and reading second
+   * is the order that leaves no gap.
+   *
+   * Plugin-fallback claims only. A claim on a mount event carrying
+   * `detail.element` is a `customRenderers` host, whose content this element
+   * keeps writing to — forwarding one would hold the named slot occupied and
+   * suppress its fallback when the callback later returns `null`. Those names
+   * are tracked for their unmount events but never offered here.
+   *
+   * A snapshot, not a live view: mutating the returned array changes nothing,
+   * and it goes stale as content changes, so re-read rather than cache. Empty
+   * when no listener has claimed a plugin-fallback slot — including standalone
+   * usage, where this element hosts plugin output in its own light DOM.
+   */
+  get delegatedPluginSlotNames(): string[] {
+    return [...this.delegatedPluginSlots]
+      .filter(([, kind]) => kind === 'pluginFallback')
+      .map(([slotName]) => slotName);
+  }
 
   /**
    * The markdown-it instance produced by the most recent parse. Forwarded into
@@ -387,7 +423,7 @@ class CDSAIChatMarkdown extends LitElement {
     }
     this.slotHosts.clear();
     // Ask any delegating chat container to drop its hosts too.
-    for (const slotName of this.delegatedPluginSlots) {
+    for (const slotName of this.delegatedPluginSlots.keys()) {
       this.dispatchEvent(
         new CustomEvent('cds-aichat-markdown-plugin-host-unmount', {
           bubbles: true,
@@ -814,7 +850,10 @@ class CDSAIChatMarkdown extends LitElement {
           );
           this.dispatchEvent(mountEvent);
           if (mountEvent.defaultPrevented) {
-            this.delegatedPluginSlots.add(descriptor.slotName);
+            this.delegatedPluginSlots.set(
+              descriptor.slotName,
+              'pluginFallback'
+            );
           }
         } else if (alreadyDelegated) {
           // The chain owns this slot; push HTML updates through a second
@@ -914,7 +953,7 @@ class CDSAIChatMarkdown extends LitElement {
         );
         this.dispatchEvent(mountEvent);
         if (mountEvent.defaultPrevented) {
-          this.delegatedPluginSlots.add(descriptor.slotName);
+          this.delegatedPluginSlots.set(descriptor.slotName, 'customRenderer');
         } else {
           this.appendChild(host);
         }
@@ -933,7 +972,7 @@ class CDSAIChatMarkdown extends LitElement {
 
     // Tell any delegating chat container to drop hosts whose descriptor
     // disappeared (e.g. a streaming chunk removed a math node).
-    for (const slotName of this.delegatedPluginSlots) {
+    for (const slotName of this.delegatedPluginSlots.keys()) {
       if (!wanted.has(slotName)) {
         this.dispatchEvent(
           new CustomEvent('cds-aichat-markdown-plugin-host-unmount', {

--- a/packages/ai-chat-components/src/components/markdown/src/markdown.ts
+++ b/packages/ai-chat-components/src/components/markdown/src/markdown.ts
@@ -23,6 +23,10 @@ import {
   type MarkdownItPlugin,
   type TokenTree,
 } from './markdown-token-tree.js';
+import type {
+  MarkdownCustomRendererMountDetail,
+  MarkdownPluginFallbackMountDetail,
+} from './utils/plugin-host-container.js';
 import {
   renderMarkdownTree,
   type MarkdownCustomRenderers,
@@ -311,11 +315,11 @@ class CDSAIChatMarkdown extends LitElement {
    * hears about later slots on the event. Subscribing first and reading second
    * is the order that leaves no gap.
    *
-   * Plugin-fallback claims only. A claim on a mount event carrying
-   * `detail.element` is a `customRenderers` host, whose content this element
-   * keeps writing to — forwarding one would hold the named slot occupied and
-   * suppress its fallback when the callback later returns `null`. Those names
-   * are tracked for their unmount events but never offered here.
+   * Plugin-fallback claims only. A claim on a mount event whose detail is
+   * `kind: 'customRenderer'` is a `customRenderers` host, whose content this
+   * element keeps writing to — forwarding one would hold the named slot
+   * occupied and suppress its fallback when the callback later returns `null`.
+   * Those names are tracked for their unmount events but never offered here.
    *
    * A snapshot, not a live view: mutating the returned array changes nothing,
    * and it goes stale as content changes, so re-read rather than cache. Empty
@@ -842,10 +846,11 @@ class CDSAIChatMarkdown extends LitElement {
               composed: true,
               cancelable: true,
               detail: {
+                kind: 'pluginFallback',
                 slotName: descriptor.slotName,
                 html: descriptor.html,
                 isInline: descriptor.isInline,
-              },
+              } satisfies MarkdownPluginFallbackMountDetail,
             }
           );
           this.dispatchEvent(mountEvent);
@@ -945,10 +950,11 @@ class CDSAIChatMarkdown extends LitElement {
             composed: true,
             cancelable: true,
             detail: {
+              kind: 'customRenderer',
               slotName: descriptor.slotName,
               element: host,
               isInline: false,
-            },
+            } satisfies MarkdownCustomRendererMountDetail,
           }
         );
         this.dispatchEvent(mountEvent);

--- a/packages/ai-chat-components/src/components/markdown/src/utils/html-helpers.ts
+++ b/packages/ai-chat-components/src/components/markdown/src/utils/html-helpers.ts
@@ -349,11 +349,20 @@ function serializeInlineToken(tokenTree: TokenTree): string {
   const token = tokenTree.token;
   const type = token.type ?? '';
 
+  // Break tokens carry no content — return the HTML void element directly so
+  // the merged node renders a visible line break instead of the empty string.
+  // Not `'<br />\n'` — the trailing newline would add a stray whitespace text
+  // node as the run's sibling. The merged node keeps `type: 'html_container'`
+  // and still routes through sanitizeHtmlContent → unsafeHTML; DOMPurify's
+  // default allow-list keeps <br>, so the element survives both sanitize-html
+  // and remove-html modes.
+  if (type === 'softbreak' || type === 'hardbreak') {
+    return '<br />';
+  }
+
   if (
     type === 'text' ||
     type === 'code_inline' ||
-    type === 'softbreak' ||
-    type === 'hardbreak' ||
     type === 'entity' ||
     type === 'html_inline'
   ) {

--- a/packages/ai-chat-components/src/components/markdown/src/utils/plugin-fallback.ts
+++ b/packages/ai-chat-components/src/components/markdown/src/utils/plugin-fallback.ts
@@ -225,7 +225,7 @@ export function renderFallback(
     }
   }
 
-  const index = options.pluginSlotCounter?.next() ?? 0;
+  const index = options.pluginSlotCounter?.next(node) ?? 0;
   const slotName = withInstanceNamespace(
     `${PLUGIN_FALLBACK_SLOT_PREFIX}-${index}`,
     options

--- a/packages/ai-chat-components/src/components/markdown/src/utils/plugin-host-container.ts
+++ b/packages/ai-chat-components/src/components/markdown/src/utils/plugin-host-container.ts
@@ -1,0 +1,241 @@
+/*
+ *  Copyright IBM Corp. 2026
+ *
+ *  This source code is licensed under the Apache-2.0 license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ *  @license
+ */
+
+/**
+ * The container half of the plugin-host protocol.
+ *
+ * `<cds-aichat-markdown>` offers a host for plugin output to whichever chat
+ * element is outermost, over three composed events — `-mount`, `-update` and
+ * `-unmount`. Accepting the offer means calling `preventDefault()` on the
+ * mount event and putting the host somewhere consumer-loaded CSS can reach it,
+ * which the markdown element's own light DOM is not: it sits inside the chat's
+ * shadow root.
+ *
+ * A container supplies only the element hosts are appended to, and whatever
+ * policy the framework cannot infer.
+ */
+
+/** Mount detail for plugin output the element hands over as an HTML string. */
+export interface MarkdownPluginFallbackMountDetail {
+  kind: 'pluginFallback';
+  slotName: string;
+  html: string;
+  isInline: boolean;
+}
+
+/**
+ * Mount detail for a `customRenderers` host. It carries a live element whose
+ * content the markdown element keeps writing to, so a listener must not claim
+ * it: the element hosts it itself, and a claim would strand the named slot.
+ */
+export interface MarkdownCustomRendererMountDetail {
+  kind: 'customRenderer';
+  slotName: string;
+  element: HTMLElement;
+  isInline: boolean;
+}
+
+/**
+ * The `cds-aichat-markdown-plugin-host-mount` detail, discriminated on `kind`.
+ *
+ * Narrow on `kind`, never on which of `html` / `element` is present — the two
+ * members deliberately declare only their own fields, so reading the wrong one
+ * is a compile error rather than a silent `undefined`.
+ */
+export type MarkdownPluginHostMountDetail =
+  MarkdownPluginFallbackMountDetail | MarkdownCustomRendererMountDetail;
+
+/**
+ * A mount detail as it arrives on the wire, `kind` included or not.
+ *
+ * `kind` is newer than the events themselves, and `@carbon/ai-chat` depends on
+ * this package through a caret range, so a listener can still receive the
+ * original shape from an older build. Pass anything you receive through
+ * {@link resolveMarkdownPluginHostMountDetail} and narrow on the result.
+ */
+export type MarkdownPluginHostMountDetailInput =
+  | MarkdownPluginHostMountDetail
+  | Omit<MarkdownPluginFallbackMountDetail, 'kind'>
+  | Omit<MarkdownCustomRendererMountDetail, 'kind'>;
+
+/**
+ * Fills in `kind` for a detail emitted before the field existed.
+ *
+ * The one place the payload's shape is still consulted, and only when there is
+ * nothing else to go on. Delete it once the floor on `@carbon/ai-chat-components`
+ * rises past the release that added `kind`.
+ */
+export function resolveMarkdownPluginHostMountDetail(
+  detail: MarkdownPluginHostMountDetailInput
+): MarkdownPluginHostMountDetail {
+  if ('kind' in detail) {
+    return detail;
+  }
+  return 'element' in detail
+    ? { ...detail, kind: 'customRenderer' }
+    : { ...detail, kind: 'pluginFallback' };
+}
+
+export interface MarkdownPluginHostControllerOptions {
+  /**
+   * Called with a fresh array whenever the set of slot names this surface
+   * should forward inward changes. Surfaces that render no forwarder of their
+   * own — the React `ChatContainer`, whose single hop comes from the React
+   * `Markdown` wrapper — omit it.
+   *
+   * Plugin-fallback names only, and including names this surface declined to
+   * host: a container nested inside an outer chat element still has to forward
+   * the slot the outer one is hosting.
+   */
+  onSlotNamesChange?: (slotNames: string[]) => void;
+
+  /**
+   * Return `true` to forward the slot without hosting it, because an outer
+   * chat element will. Omitted by surfaces that are always outermost.
+   */
+  shouldDefer?: (event: Event) => boolean;
+}
+
+export interface MarkdownPluginHostController {
+  /** Subscribes to the three events. Safe to call again without disconnecting. */
+  connect(): void;
+  /** Unsubscribes and releases every host. Leaves forwarded slot names alone. */
+  disconnect(): void;
+  readonly hosts: ReadonlyMap<string, HTMLElement>;
+}
+
+const MOUNT = 'cds-aichat-markdown-plugin-host-mount';
+const UPDATE = 'cds-aichat-markdown-plugin-host-update';
+const UNMOUNT = 'cds-aichat-markdown-plugin-host-unmount';
+
+/**
+ * Answers the plugin-host offer on `target`'s behalf, hosting accepted offers
+ * as slot-attributed children of `target`.
+ *
+ * `target` is both the listener and the host parent because in every chat
+ * surface they are the same element — the offer is claimed by whichever chat
+ * element is outermost, and that is the element whose light DOM is page DOM.
+ *
+ * Not part of this package's advertised surface: it is deliberately absent from
+ * `components/markdown/index.ts`, where only the detail types above are
+ * exported. It is not marked with the internal JSDoc tag either — this package
+ * compiles with `stripInternal`, which would drop the declaration from the
+ * emitted `.d.ts`, and every caller lives in the sibling package and resolves
+ * its types through exactly that file. (Do not write that tag's name anywhere
+ * in this comment: `stripInternal` matches the string, not just a real tag.)
+ */
+export function createMarkdownPluginHostController(
+  target: HTMLElement,
+  options: MarkdownPluginHostControllerOptions = {}
+): MarkdownPluginHostController {
+  const { onSlotNamesChange, shouldDefer } = options;
+  // Keyed by slot name alone: the markdown element namespaces every name it
+  // mints per element (see `./slot-names.js`), so two messages rendering the
+  // same markdown can't collide here.
+  const hosts = new Map<string, HTMLElement>();
+  let slotNames: string[] = [];
+
+  // Built once, not per `connect()`: a Lit `connectedCallback` can fire again
+  // without an intervening disconnect, and fresh closures would register a
+  // second time and handle every mount twice.
+  const handleMount = (event: Event) => {
+    const raw = (
+      event as CustomEvent<MarkdownPluginHostMountDetailInput | undefined>
+    ).detail;
+    if (!raw?.slotName) {
+      return;
+    }
+    const detail = resolveMarkdownPluginHostMountDetail(raw);
+    if (detail.kind === 'customRenderer') {
+      // The markdown element manages this host itself. Neither claim it nor
+      // forward its name — a forwarder would hold the named slot occupied and
+      // suppress the fallback the renderer falls back to when it returns null.
+      return;
+    }
+
+    // Track before deferring: a container nested inside an outer chat element
+    // hosts nothing but still has to forward the slot inward.
+    if (!slotNames.includes(detail.slotName)) {
+      slotNames = [...slotNames, detail.slotName];
+      onSlotNamesChange?.(slotNames);
+    }
+    if (shouldDefer?.(event)) {
+      return;
+    }
+
+    event.preventDefault();
+    let host = hosts.get(detail.slotName);
+    if (!host) {
+      host = document.createElement(detail.isInline ? 'span' : 'div');
+      host.setAttribute('slot', detail.slotName);
+      // Match `.cds-aichat-markdown-stack > *:not(:first-child)` spacing;
+      // shadow CSS doesn't reach a host in page light DOM, so apply it inline.
+      // Inline output flows with text and gets no extra spacing.
+      if (!detail.isInline) {
+        host.style.marginBlockStart = '1rem';
+      }
+      hosts.set(detail.slotName, host);
+      target.appendChild(host);
+    }
+    if (host.innerHTML !== detail.html) {
+      host.innerHTML = detail.html;
+    }
+  };
+
+  const handleUpdate = (event: Event) => {
+    const detail = (
+      event as CustomEvent<{ slotName: string; html: string } | undefined>
+    ).detail;
+    if (!detail?.slotName) {
+      return;
+    }
+    const host = hosts.get(detail.slotName);
+    if (host && host.innerHTML !== detail.html) {
+      host.innerHTML = detail.html;
+    }
+  };
+
+  const handleUnmount = (event: Event) => {
+    const detail = (event as CustomEvent<{ slotName: string } | undefined>)
+      .detail;
+    if (!detail?.slotName) {
+      return;
+    }
+    if (slotNames.includes(detail.slotName)) {
+      slotNames = slotNames.filter((name) => name !== detail.slotName);
+      onSlotNamesChange?.(slotNames);
+    }
+    const host = hosts.get(detail.slotName);
+    if (host) {
+      host.remove();
+      hosts.delete(detail.slotName);
+    }
+  };
+
+  return {
+    hosts,
+    connect() {
+      target.addEventListener(MOUNT, handleMount);
+      target.addEventListener(UPDATE, handleUpdate);
+      target.addEventListener(UNMOUNT, handleUnmount);
+    },
+    disconnect() {
+      target.removeEventListener(MOUNT, handleMount);
+      target.removeEventListener(UPDATE, handleUpdate);
+      target.removeEventListener(UNMOUNT, handleUnmount);
+      for (const host of hosts.values()) {
+        host.remove();
+      }
+      hosts.clear();
+      // Slot names deliberately survive: a reconnect re-hosts from the events
+      // that follow, and clearing here would make the next mount replace the
+      // consumer's list rather than extend it.
+    },
+  };
+}

--- a/packages/ai-chat-components/src/react/__tests__/jest.setup.ts
+++ b/packages/ai-chat-components/src/react/__tests__/jest.setup.ts
@@ -7,6 +7,12 @@
  *  @license
  */
 
+// React 19 only suppresses its "not configured to support act(...)" warning
+// when the environment declares itself. Set for the whole React suite, since
+// every wrapper spec drives renders through `act`.
+(globalThis as unknown as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
 beforeEach(() => {
   // Mock DOMParser for icon transformation tests
   if (typeof DOMParser === 'undefined') {

--- a/packages/ai-chat-components/src/react/__tests__/markdown.test.ts
+++ b/packages/ai-chat-components/src/react/__tests__/markdown.test.ts
@@ -1,0 +1,155 @@
+/*
+ *  Copyright IBM Corp. 2025, 2026
+ *
+ *  This source code is licensed under the Apache-2.0 license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ *  @license
+ */
+
+import { act, createElement } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+/** Slot names the stubbed element reports as already delegated. */
+let mockDelegatedSlotNames: string[] = [];
+
+// The real `<cds-aichat-markdown>` drags the decorated Lit component tree
+// through Babel, which this suite has no transform for — and none of it is
+// under test here. The wrapper's contract with the element is two event names
+// and one getter, so the stub implements exactly that. The element's side of
+// the same contract (which names the getter reports, and that `customRenderers`
+// claims are excluded from them) is proved against the real element in a real
+// browser: see `describe('plugin-host handshake with a late subscriber')` in
+// `src/components/markdown/__tests__/markdown.test.ts`.
+jest.mock('../../components/markdown/src/markdown', () => {
+  // `globalThis.` qualified because jest.mock factories may not close over
+  // out-of-scope identifiers.
+  class MarkdownStub extends globalThis.HTMLElement {
+    get delegatedPluginSlotNames(): string[] {
+      return [...mockDelegatedSlotNames];
+    }
+  }
+  if (!globalThis.customElements.get('cds-aichat-markdown')) {
+    globalThis.customElements.define('cds-aichat-markdown', MarkdownStub);
+  }
+  return { __esModule: true, default: MarkdownStub };
+});
+
+import Markdown from '../markdown';
+
+/**
+ * The wrapper's half of the late-subscriber handshake (#2271).
+ *
+ * `cds-aichat-markdown-plugin-host-mount` fires once per live host and is
+ * never replayed. The wrapper subscribes in a passive effect, so a slot
+ * claimed before that effect ran would never get the `<slot>` forwarder its
+ * hoisted host needs — and that forwarder is the only thing crossing the
+ * element's shadow boundary. The wrapper therefore seeds from
+ * `delegatedPluginSlotNames` after subscribing.
+ */
+describe('<Markdown> plugin slot forwarders', () => {
+  let container: HTMLElement;
+  let root: Root;
+
+  beforeEach(() => {
+    mockDelegatedSlotNames = [];
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  function renderMarkdown() {
+    // `createElement` rather than JSX: this package's TS build compiles the
+    // test suites too, under the automatic JSX runtime, so a JSX file here
+    // needs a `React` import the build then rejects as unused.
+    act(() => {
+      root.render(createElement(Markdown, { markdown: 'Hi' }));
+    });
+    const element = container.querySelector('cds-aichat-markdown');
+    expect(element).not.toBeNull();
+    return element as HTMLElement;
+  }
+
+  /** Forwarders the wrapper rendered into the element's light DOM. */
+  function forwarderNames(element: HTMLElement) {
+    return Array.from(element.querySelectorAll('slot')).map((slot) =>
+      slot.getAttribute('name')
+    );
+  }
+
+  function dispatchMount(
+    element: HTMLElement,
+    detail: { slotName: string; element?: HTMLElement }
+  ) {
+    act(() => {
+      element.dispatchEvent(
+        new CustomEvent('cds-aichat-markdown-plugin-host-mount', {
+          bubbles: true,
+          composed: true,
+          cancelable: true,
+          detail: { isInline: false, ...detail },
+        })
+      );
+    });
+  }
+
+  it('renders a forwarder for a slot claimed before it subscribed', () => {
+    mockDelegatedSlotNames = ['cds-test-slot-a'];
+
+    const element = renderMarkdown();
+
+    // The mount event for this slot fired before the effect existed. Without
+    // the seed there is nothing to render a forwarder from, and the hoisted
+    // host stays stranded outside the shadow slot for good.
+    expect(forwarderNames(element)).toEqual(['cds-test-slot-a']);
+    // `name` gathers the hoisted host out of the container's light DOM;
+    // `slot` assigns the forwarder itself into the element's shadow slot.
+    // Both halves are load-bearing.
+    expect(element.querySelector('slot')?.getAttribute('slot')).toBe(
+      'cds-test-slot-a'
+    );
+  });
+
+  it('renders no forwarder when nothing was claimed', () => {
+    expect(forwarderNames(renderMarkdown())).toEqual([]);
+  });
+
+  it('still hears mount events that arrive after it subscribed', () => {
+    const element = renderMarkdown();
+
+    dispatchMount(element, { slotName: 'cds-test-slot-b' });
+
+    expect(forwarderNames(element)).toEqual(['cds-test-slot-b']);
+  });
+
+  it('renders one forwarder when a slot is both seeded and announced', () => {
+    mockDelegatedSlotNames = ['cds-test-slot-c'];
+    const element = renderMarkdown();
+
+    // A container re-announcing a slot the seed already covered. Also the
+    // shape React StrictMode produces, where the effect subscribes twice and
+    // therefore seeds twice.
+    dispatchMount(element, { slotName: 'cds-test-slot-c' });
+
+    expect(forwarderNames(element)).toEqual(['cds-test-slot-c']);
+  });
+
+  it('never forwards a customRenderers host', () => {
+    const element = renderMarkdown();
+
+    // A live-element mount is a `customRenderers` host the element keeps
+    // writing to. Forwarding it would hold the named slot occupied and
+    // suppress its fallback once the callback returns null.
+    dispatchMount(element, {
+      slotName: 'cds-test-slot-d',
+      element: document.createElement('div'),
+    });
+
+    expect(forwarderNames(element)).toEqual([]);
+  });
+});

--- a/packages/ai-chat-components/src/react/markdown.tsx
+++ b/packages/ai-chat-components/src/react/markdown.tsx
@@ -205,6 +205,21 @@ const Markdown = forwardRef<CDSAIChatMarkdown, MarkdownProps>(function Markdown(
       'cds-aichat-markdown-plugin-host-unmount',
       handleUnmount
     );
+    // Then catch up on anything claimed before this effect ran. The mount
+    // event fires once per live host and is never replayed for one, and this
+    // effect is passive — it runs after the commit that created the element,
+    // by which time Lit has already flushed its first update in a microtask.
+    // A plugin token present in that first render therefore dispatches its
+    // one mount event before `handleMount` exists: the container claims the
+    // host, the element skips its own local fallback, and without this seed
+    // no forwarder is ever rendered for it. Seeding after subscribing, not
+    // before, is what leaves no gap between the read and the subscription.
+    setPluginSlotNames((prev) => {
+      const missed = node.delegatedPluginSlotNames.filter(
+        (slotName) => !prev.includes(slotName)
+      );
+      return missed.length ? [...prev, ...missed] : prev;
+    });
     return () => {
       node.removeEventListener(
         'cds-aichat-markdown-plugin-host-mount',

--- a/packages/ai-chat-components/src/react/markdown.tsx
+++ b/packages/ai-chat-components/src/react/markdown.tsx
@@ -22,6 +22,10 @@ import { createPortal, flushSync } from 'react-dom';
 
 // Export the actual class for the component that will *directly* be wrapped with React.
 import CDSAIChatMarkdown from '../components/markdown/src/markdown.js';
+import {
+  type MarkdownPluginHostMountDetailInput,
+  resolveMarkdownPluginHostMountDetail,
+} from '../components/markdown/src/utils/plugin-host-container.js';
 import type {
   MarkdownCustomRenderers,
   MarkdownRendererCodeBlockArgs,
@@ -167,17 +171,18 @@ const Markdown = forwardRef<CDSAIChatMarkdown, MarkdownProps>(function Markdown(
       return undefined;
     }
     const handleMount = (event: Event) => {
-      const detail = (
-        event as CustomEvent<{ slotName: string; element?: HTMLElement }>
+      const raw = (
+        event as CustomEvent<MarkdownPluginHostMountDetailInput | undefined>
       ).detail;
-      if (!detail?.slotName) {
+      if (!raw?.slotName) {
         return;
       }
-      // Consumer-renderer hosts (table/codeBlock) forward a live element that
+      const detail = resolveMarkdownPluginHostMountDetail(raw);
+      // Consumer-renderer hosts (table/codeBlock) carry a live element that
       // is adopted directly by the markdown element's own reconcile. They do
       // not need a <slot> forwarder here — adding one would suppress the
       // slot's fallback content if the callback later returns null.
-      if (detail.element) {
+      if (detail.kind !== 'pluginFallback') {
         return;
       }
       setPluginSlotNames((prev) =>

--- a/packages/ai-chat/src/chat/components/helpers/InlineMarkdown/InlineMarkdown.tsx
+++ b/packages/ai-chat/src/chat/components/helpers/InlineMarkdown/InlineMarkdown.tsx
@@ -81,9 +81,6 @@ function renderInlineTokenList(tokens: Token[] | null): ReactNode {
         break;
 
       case 'softbreak':
-        pushChild(<Fragment key={nextKey()}> </Fragment>);
-        break;
-
       case 'hardbreak':
         pushChild(<br key={nextKey()} />);
         break;

--- a/packages/ai-chat/src/react/ChatContainer.tsx
+++ b/packages/ai-chat/src/react/ChatContainer.tsx
@@ -22,6 +22,7 @@ import { createPortal } from 'react-dom';
 import ChatAppEntry from '../chat/ChatAppEntry';
 import { carbonElement } from '@carbon/ai-chat-components/es/globals/decorators/index.js';
 import { ChatContainerProps } from '../types/component/ChatContainer';
+import { createMarkdownPluginHostController } from '@carbon/ai-chat-components/es/components/markdown/src/utils/plugin-host-container.js';
 import { ChatInstance } from '../types/instance/ChatInstance';
 import { BusEventType } from '../types/events/eventBusTypes';
 import {
@@ -210,112 +211,18 @@ function ChatContainer(
    * Plugin-fallback slot hosts (e.g. KaTeX rendered by a markdown-it plugin)
    * need to live in the page light DOM so a consumer-loaded stylesheet can
    * reach them — the markdown element's own light DOM sits inside this
-   * wrapper's shadow root, where global CSS doesn't apply. The markdown
-   * element bubbles a composed `cds-aichat-markdown-plugin-host-mount` event
-   * for each new plugin slot; we accept the offer (`preventDefault()`),
-   * create the host as a slot-attributed child of the wrapper (= page light
-   * DOM, since this is the outermost chat element on the React path), and
-   * tear it down when the matching unmount event fires.
+   * wrapper's shadow root, where global CSS doesn't apply. The wrapper is the
+   * outermost chat element on the React path, so it is the one that claims the
+   * offer. Nothing forwards a slot name here: the React `Markdown` wrapper in
+   * `@carbon/ai-chat-components` supplies the single hop this topology needs.
    */
   useEffect(() => {
     if (!wrapper) {
       return undefined;
     }
-    // Keyed by slot name alone: the markdown element namespaces every name it
-    // mints per element (see `markdown/src/utils/slot-names.ts` in
-    // `@carbon/ai-chat-components`), so two messages rendering the same
-    // markdown can't collide here.
-    const hosts = new Map<string, HTMLElement>();
-    const handleMount = (event: Event) => {
-      const detail = (
-        event as CustomEvent<{
-          slotName: string;
-          html?: string;
-          element?: HTMLElement;
-          isInline: boolean;
-        }>
-      ).detail;
-      if (!detail?.slotName) {
-        return;
-      }
-      // Custom-renderer hosts (table/codeBlock) forward a live element that
-      // the markdown element manages directly — do not preventDefault or hoist,
-      // or the named slot loses its host and falls back to the default Carbon
-      // component. Plugin fallbacks forward an HTML string instead.
-      if (detail.element) {
-        return;
-      }
-      event.preventDefault();
-      let host = hosts.get(detail.slotName);
-      if (!host) {
-        host = document.createElement(detail.isInline ? 'span' : 'div');
-        host.setAttribute('slot', detail.slotName);
-        // Match the spacing applied to direct children of
-        // `.cds-aichat-markdown-stack`; shadow CSS doesn't reach this host
-        // (we mounted it in page light DOM), so apply it inline. Inline
-        // plugin output flows with text and gets no extra spacing.
-        if (!detail.isInline) {
-          host.style.marginBlockStart = '1rem';
-        }
-        hosts.set(detail.slotName, host);
-        wrapper.appendChild(host);
-      }
-      if (host.innerHTML !== (detail.html ?? '')) {
-        host.innerHTML = detail.html ?? '';
-      }
-    };
-    const handleUpdate = (event: Event) => {
-      const detail = (event as CustomEvent<{ slotName: string; html: string }>)
-        .detail;
-      if (!detail?.slotName) {
-        return;
-      }
-      const host = hosts.get(detail.slotName);
-      if (host && host.innerHTML !== detail.html) {
-        host.innerHTML = detail.html;
-      }
-    };
-    const handleUnmount = (event: Event) => {
-      const detail = (event as CustomEvent<{ slotName: string }>).detail;
-      if (!detail?.slotName) {
-        return;
-      }
-      const host = hosts.get(detail.slotName);
-      if (host) {
-        host.remove();
-        hosts.delete(detail.slotName);
-      }
-    };
-    wrapper.addEventListener(
-      'cds-aichat-markdown-plugin-host-mount',
-      handleMount
-    );
-    wrapper.addEventListener(
-      'cds-aichat-markdown-plugin-host-update',
-      handleUpdate
-    );
-    wrapper.addEventListener(
-      'cds-aichat-markdown-plugin-host-unmount',
-      handleUnmount
-    );
-    return () => {
-      wrapper.removeEventListener(
-        'cds-aichat-markdown-plugin-host-mount',
-        handleMount
-      );
-      wrapper.removeEventListener(
-        'cds-aichat-markdown-plugin-host-update',
-        handleUpdate
-      );
-      wrapper.removeEventListener(
-        'cds-aichat-markdown-plugin-host-unmount',
-        handleUnmount
-      );
-      for (const host of hosts.values()) {
-        host.remove();
-      }
-      hosts.clear();
-    };
+    const controller = createMarkdownPluginHostController(wrapper);
+    controller.connect();
+    return () => controller.disconnect();
   }, [wrapper]);
 
   const onBeforeRenderOverride = useCallback(

--- a/packages/ai-chat/src/web-components/cds-aichat-container/index.ts
+++ b/packages/ai-chat/src/web-components/cds-aichat-container/index.ts
@@ -17,6 +17,7 @@ import { html } from 'lit';
 import { property, state } from 'lit/decorators.js';
 
 import { carbonElement } from '@carbon/ai-chat-components/es/globals/decorators/index.js';
+import { createMarkdownPluginHostController } from '@carbon/ai-chat-components/es/components/markdown/src/utils/plugin-host-container.js';
 import { PublicConfig } from '../../types/config/PublicConfig';
 import { FlattenedConfigElement } from '../shared/FlattenedConfigElement';
 import { ChatInstance } from '../../types/instance/ChatInstance';
@@ -161,18 +162,6 @@ class ChatContainer extends FlattenedConfigElement {
    */
   @state()
   _pluginSlotNames: string[] = [];
-
-  /**
-   * Page-level host elements created for plugin-output slots, keyed by slot
-   * name. Created in this element's outer light DOM so consumer-loaded
-   * stylesheets (e.g. KaTeX) reach the rendered HTML normally.
-   *
-   * Keying by slot name alone is safe because the markdown element namespaces
-   * every name it mints per element (see `markdown/src/utils/slot-names.ts` in
-   * `@carbon/ai-chat-components`), so two messages rendering the same markdown
-   * can't collide here.
-   */
-  private _pluginHosts: Map<string, HTMLElement> = new Map();
 
   /**
    * The chat instance.
@@ -446,117 +435,27 @@ class ChatContainer extends FlattenedConfigElement {
     return false;
   }
 
-  private handlePluginHostMount = (event: Event) => {
-    const detail = (
-      event as CustomEvent<{
-        slotName: string;
-        html?: string;
-        element?: HTMLElement;
-        isInline: boolean;
-      }>
-    ).detail;
-    if (!detail?.slotName) {
-      return;
-    }
-    // Track the slot regardless of who owns hosting so our render forwarder
-    // projects the page-level content into cds-aichat-internal's slot.
-    if (!this._pluginSlotNames.includes(detail.slotName)) {
-      this._pluginSlotNames = [...this._pluginSlotNames, detail.slotName];
-    }
-    if (this.hasOuterChatHandler(event)) {
-      // An outer chat element will create the page-level host; just forward.
-      // This applies to the live-element path too: appending here would land
-      // the node in this element's light DOM (inside the outer chat element's
-      // shadow root), where global CSS still wouldn't reach it.
-      return;
-    }
-    // Custom-renderer hosts (table/codeBlock) forward a live element that
-    // the markdown element manages directly — do not preventDefault or hoist,
-    // or the named slot loses its host and falls back to the default Carbon
-    // component. Plugin fallbacks forward an HTML string instead.
-    if (detail.element) {
-      return;
-    }
-    event.preventDefault();
-    let host = this._pluginHosts.get(detail.slotName);
-    if (!host) {
-      host = document.createElement(detail.isInline ? 'span' : 'div');
-      host.setAttribute('slot', detail.slotName);
-      // Match `.cds-aichat-markdown-stack > *:not(:first-child)` spacing;
-      // shadow CSS doesn't reach this host (it lives in this element's
-      // outer light DOM), so apply it inline. Inline output flows with
-      // text and gets no extra spacing.
-      if (!detail.isInline) {
-        host.style.marginBlockStart = '1rem';
-      }
-      this._pluginHosts.set(detail.slotName, host);
-      this.appendChild(host);
-    }
-    if (host.innerHTML !== (detail.html ?? '')) {
-      host.innerHTML = detail.html ?? '';
-    }
-  };
-
-  private handlePluginHostUpdate = (event: Event) => {
-    const detail = (event as CustomEvent<{ slotName: string; html: string }>)
-      .detail;
-    if (!detail?.slotName) {
-      return;
-    }
-    const host = this._pluginHosts.get(detail.slotName);
-    if (host && host.innerHTML !== detail.html) {
-      host.innerHTML = detail.html;
-    }
-  };
-
-  private handlePluginHostUnmount = (event: Event) => {
-    const detail = (event as CustomEvent<{ slotName: string }>).detail;
-    if (!detail?.slotName) {
-      return;
-    }
-    this._pluginSlotNames = this._pluginSlotNames.filter(
-      (n) => n !== detail.slotName
-    );
-    const host = this._pluginHosts.get(detail.slotName);
-    if (host) {
-      host.remove();
-      this._pluginHosts.delete(detail.slotName);
-    }
-  };
+  /**
+   * The container half of the plugin-host protocol. Hosts land in this
+   * element's own light DOM — page DOM when this element is outermost — so a
+   * consumer-loaded stylesheet reaches the plugin output; the markdown
+   * element's own light DOM sits inside the chat's shadow root, where it
+   * cannot.
+   */
+  private pluginHostController = createMarkdownPluginHostController(this, {
+    onSlotNamesChange: (slotNames) => {
+      this._pluginSlotNames = slotNames;
+    },
+    shouldDefer: (event) => this.hasOuterChatHandler(event),
+  });
 
   connectedCallback() {
     super.connectedCallback();
-    this.addEventListener(
-      'cds-aichat-markdown-plugin-host-mount',
-      this.handlePluginHostMount
-    );
-    this.addEventListener(
-      'cds-aichat-markdown-plugin-host-update',
-      this.handlePluginHostUpdate
-    );
-    this.addEventListener(
-      'cds-aichat-markdown-plugin-host-unmount',
-      this.handlePluginHostUnmount
-    );
+    this.pluginHostController.connect();
   }
 
   disconnectedCallback() {
-    this.removeEventListener(
-      'cds-aichat-markdown-plugin-host-mount',
-      this.handlePluginHostMount
-    );
-    this.removeEventListener(
-      'cds-aichat-markdown-plugin-host-update',
-      this.handlePluginHostUpdate
-    );
-    this.removeEventListener(
-      'cds-aichat-markdown-plugin-host-unmount',
-      this.handlePluginHostUnmount
-    );
-    for (const host of this._pluginHosts.values()) {
-      host.remove();
-    }
-    this._pluginHosts.clear();
+    this.pluginHostController.disconnect();
     super.disconnectedCallback();
   }
 

--- a/packages/ai-chat/src/web-components/cds-aichat-custom-element/index.ts
+++ b/packages/ai-chat/src/web-components/cds-aichat-custom-element/index.ts
@@ -18,6 +18,7 @@ import { html } from 'lit';
 import { property, state } from 'lit/decorators.js';
 
 import { carbonElement } from '@carbon/ai-chat-components/es/globals/decorators/index.js';
+import { createMarkdownPluginHostController } from '@carbon/ai-chat-components/es/components/markdown/src/utils/plugin-host-container.js';
 import { PublicConfig } from '../../types/config/PublicConfig';
 import { FlattenedConfigElement } from '../shared/FlattenedConfigElement';
 import { ChatInstance } from '../../types/instance/ChatInstance';
@@ -199,18 +200,6 @@ class ChatCustomElement extends FlattenedConfigElement {
   @state()
   private _pluginSlotNames: string[] = [];
 
-  /**
-   * Page-level host elements created for plugin-output slots, keyed by slot
-   * name. Created in this element's outer light DOM so consumer-loaded
-   * stylesheets (e.g. KaTeX) reach the rendered HTML normally.
-   *
-   * Keying by slot name alone is safe because the markdown element namespaces
-   * every name it mints per element (see `markdown/src/utils/slot-names.ts` in
-   * `@carbon/ai-chat-components`), so two messages rendering the same markdown
-   * can't collide here.
-   */
-  private _pluginHosts: Map<string, HTMLElement> = new Map();
-
   @state()
   private _instance!: ChatInstance;
 
@@ -238,111 +227,26 @@ class ChatCustomElement extends FlattenedConfigElement {
     }
   };
 
-  private handlePluginHostMount = (event: Event) => {
-    const detail = (
-      event as CustomEvent<{
-        slotName: string;
-        html?: string;
-        element?: HTMLElement;
-        isInline: boolean;
-      }>
-    ).detail;
-    if (!detail?.slotName) {
-      return;
-    }
-    if (!this._pluginSlotNames.includes(detail.slotName)) {
-      this._pluginSlotNames = [...this._pluginSlotNames, detail.slotName];
-    }
-    // cds-aichat-custom-element is always the outermost chat element in its
-    // shadow chain; there is no further chat ancestor to defer to. Take
-    // hosting unconditionally.
-    // Custom-renderer hosts (table/codeBlock) forward a live element that
-    // the markdown element manages directly — do not preventDefault or hoist,
-    // or the named slot loses its host and falls back to the default Carbon
-    // component. Plugin fallbacks forward an HTML string instead.
-    if (detail.element) {
-      return;
-    }
-    event.preventDefault();
-    let host = this._pluginHosts.get(detail.slotName);
-    if (!host) {
-      host = document.createElement(detail.isInline ? 'span' : 'div');
-      host.setAttribute('slot', detail.slotName);
-      // Match `.cds-aichat-markdown-stack > *:not(:first-child)` spacing;
-      // shadow CSS doesn't reach this host (it lives in this element's
-      // outer light DOM), so apply it inline. Inline output flows with
-      // text and gets no extra spacing.
-      if (!detail.isInline) {
-        host.style.marginBlockStart = '1rem';
-      }
-      this._pluginHosts.set(detail.slotName, host);
-      this.appendChild(host);
-    }
-    if (host.innerHTML !== (detail.html ?? '')) {
-      host.innerHTML = detail.html ?? '';
-    }
-  };
-
-  private handlePluginHostUpdate = (event: Event) => {
-    const detail = (event as CustomEvent<{ slotName: string; html: string }>)
-      .detail;
-    if (!detail?.slotName) {
-      return;
-    }
-    const host = this._pluginHosts.get(detail.slotName);
-    if (host && host.innerHTML !== detail.html) {
-      host.innerHTML = detail.html;
-    }
-  };
-
-  private handlePluginHostUnmount = (event: Event) => {
-    const detail = (event as CustomEvent<{ slotName: string }>).detail;
-    if (!detail?.slotName) {
-      return;
-    }
-    this._pluginSlotNames = this._pluginSlotNames.filter(
-      (n) => n !== detail.slotName
-    );
-    const host = this._pluginHosts.get(detail.slotName);
-    if (host) {
-      host.remove();
-      this._pluginHosts.delete(detail.slotName);
-    }
-  };
+  /**
+   * The container half of the plugin-host protocol. Hosts land in this
+   * element's own light DOM — page DOM, since a `cds-aichat-custom-element` is
+   * always the outermost chat element in its shadow chain — so a
+   * consumer-loaded stylesheet reaches the plugin output. There is no outer
+   * chat ancestor to defer to, so this surface takes hosting unconditionally.
+   */
+  private pluginHostController = createMarkdownPluginHostController(this, {
+    onSlotNamesChange: (slotNames) => {
+      this._pluginSlotNames = slotNames;
+    },
+  });
 
   connectedCallback() {
     super.connectedCallback();
-    this.addEventListener(
-      'cds-aichat-markdown-plugin-host-mount',
-      this.handlePluginHostMount
-    );
-    this.addEventListener(
-      'cds-aichat-markdown-plugin-host-update',
-      this.handlePluginHostUpdate
-    );
-    this.addEventListener(
-      'cds-aichat-markdown-plugin-host-unmount',
-      this.handlePluginHostUnmount
-    );
+    this.pluginHostController.connect();
   }
 
   disconnectedCallback() {
-    this.removeEventListener(
-      'cds-aichat-markdown-plugin-host-mount',
-      this.handlePluginHostMount
-    );
-    this.removeEventListener(
-      'cds-aichat-markdown-plugin-host-update',
-      this.handlePluginHostUpdate
-    );
-    this.removeEventListener(
-      'cds-aichat-markdown-plugin-host-unmount',
-      this.handlePluginHostUnmount
-    );
-    for (const host of this._pluginHosts.values()) {
-      host.remove();
-    }
-    this._pluginHosts.clear();
+    this.pluginHostController.disconnect();
     super.disconnectedCallback();
   }
 

--- a/packages/ai-chat/tests/components/spec/messageRichUserContentChipSpacing_spec.tsx
+++ b/packages/ai-chat/tests/components/spec/messageRichUserContentChipSpacing_spec.tsx
@@ -68,6 +68,22 @@ function messageWith(content: JSONContent): MessageRequest {
   } as unknown as MessageRequest;
 }
 
+/** Count <br> elements inside every <p> in the rendered bubble. */
+function brCount(content: JSONContent): number {
+  const { container } = render(
+    <StoreProvider store={makeStore()}>
+      <MessageRichUserContent
+        content={content}
+        message={messageWith(content)}
+      />
+    </StoreProvider>
+  );
+  return Array.from(container.querySelectorAll('p')).reduce(
+    (n, p) => n + p.querySelectorAll('br').length,
+    0
+  );
+}
+
 /** Return the text content of every <p> in the rendered bubble, joined. */
 function renderedText(content: JSONContent): string {
   const { container } = render(
@@ -222,5 +238,34 @@ describe('MessageRichUserContent chip spacing (issue #2155)', () => {
       ],
     };
     expect(renderedText(content)).toBe('run deploy now');
+  });
+
+  it('a Shift+Enter in a chip paragraph renders a <br>, same as in a plain paragraph (issue #2272)', () => {
+    // A `hardBreak` TipTap node encodes Shift+Enter. The chip-bearing path
+    // routes through renderInlineMarkdown (inline walker); the all-textual path
+    // goes through MarkdownWithDefaults (mocked here as a passthrough).
+    // Both should produce a <br> so the same message renders identically
+    // regardless of whether it contains a chip.
+
+    // Chip path: text → hardBreak → text, with a chip before the text.
+    const withChip: JSONContent = {
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            { type: 'mention', attrs: { id: 'u1', label: 'Alice' } },
+            { type: 'text', text: ' line one' },
+            { type: 'hardBreak' },
+            { type: 'text', text: 'line two' },
+          ],
+        },
+      ],
+    };
+
+    // No-chip path (all-textual): same text content, no chip.
+    // MarkdownWithDefaults is mocked to a passthrough, so we check br count
+    // on the chip path only — that is the path this fix touches.
+    expect(brCount(withChip)).toBe(1);
   });
 });

--- a/packages/ai-chat/tests/utils/spec/inlineMarkdown_spec.tsx
+++ b/packages/ai-chat/tests/utils/spec/inlineMarkdown_spec.tsx
@@ -61,6 +61,21 @@ describe('renderInlineMarkdown', () => {
     expect(a?.textContent).toBe('docs');
   });
 
+  it('renders a soft break (single newline) as <br>', () => {
+    const { container } = renderInline('one\ntwo');
+    const root = container.querySelector('[data-testid=root]');
+    expect(root?.querySelector('br')).not.toBeNull();
+    // textContent collapses inline; just verify both words survive.
+    expect(root?.textContent).toContain('one');
+    expect(root?.textContent).toContain('two');
+  });
+
+  it('renders a hard break (two trailing spaces + newline) as <br>', () => {
+    const { container } = renderInline('one  \ntwo');
+    const root = container.querySelector('[data-testid=root]');
+    expect(root?.querySelector('br')).not.toBeNull();
+  });
+
   it('strips raw HTML (removeHTML=true at tokenize time)', () => {
     // Malicious-ish input: an inline <img> tag with onerror. With HTML disabled
     // in the tokenizer, the parser keeps the raw `<` text but does not produce

--- a/packages/ai-chat/tests/web-components/spec/pluginHostParity_spec.tsx
+++ b/packages/ai-chat/tests/web-components/spec/pluginHostParity_spec.tsx
@@ -1,0 +1,458 @@
+/*
+ *  Copyright IBM Corp. 2026
+ *
+ *  This source code is licensed under the Apache-2.0 license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ *  @license
+ */
+
+/**
+ * Three-container parity for the plugin-host protocol.
+ *
+ * `<cds-aichat-markdown>` offers plugin-fallback and custom-renderer hosts to
+ * an ancestor chat container over three composed events. The container half is
+ * implemented once per surface — React `ChatContainer`, `cds-aichat-container`
+ * and `cds-aichat-custom-element` — and nothing has ever checked that the three
+ * agree. This spec drives all three with one identical event sequence and
+ * compares the resulting host DOM.
+ *
+ * The events are synthesized rather than produced by a real markdown element:
+ * jsdom never upgrades `<cds-aichat-markdown>`, and the subject under test is
+ * the listener, not the dispatcher. The details below are the ones
+ * `reconcileCustomRendererHosts` actually dispatches — see
+ * `packages/ai-chat-components/src/components/markdown/src/markdown.ts`.
+ */
+
+import type {
+  MarkdownPluginHostMountDetail,
+  MarkdownPluginHostMountDetailInput,
+} from '@carbon/ai-chat-components/es/components/markdown/index.js';
+import { waitFor } from '@testing-library/react';
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+
+import '../../../src/web-components/cds-aichat-container';
+import '../../../src/web-components/cds-aichat-custom-element';
+import { ChatContainer } from '../../../src/react/ChatContainer';
+import { createBaseConfig, createBaseTestProps } from '../../test_helpers';
+
+// `cds-aichat-custom-element` spreads `root.adoptedStyleSheets` in its
+// `createRenderRoot` to append its hide-sheet, and jsdom's ShadowRoot has no
+// such property, so connecting it throws before any listener is wired. Same
+// class of environment gap as the `CSSStyleSheet` stub in `tests/setup.ts`,
+// kept local because this is the first spec to connect that element.
+const adopted = new WeakMap<ShadowRoot, unknown[]>();
+if (!('adoptedStyleSheets' in ShadowRoot.prototype)) {
+  Object.defineProperty(ShadowRoot.prototype, 'adoptedStyleSheets', {
+    configurable: true,
+    get(this: ShadowRoot) {
+      return adopted.get(this) ?? [];
+    },
+    set(this: ShadowRoot, sheets: unknown[]) {
+      adopted.set(this, sheets);
+    },
+  });
+}
+
+const MOUNT = 'cds-aichat-markdown-plugin-host-mount';
+const UPDATE = 'cds-aichat-markdown-plugin-host-update';
+const UNMOUNT = 'cds-aichat-markdown-plugin-host-unmount';
+
+/**
+ * Dispatches a mount offer the way the markdown element does. Typed against
+ * the union the components package publishes, so a detail that drifts from the
+ * shipped shape is a compile error rather than a passing test.
+ */
+function mountEvent(detail: MarkdownPluginHostMountDetailInput) {
+  return new CustomEvent(MOUNT, {
+    bubbles: true,
+    composed: true,
+    cancelable: true,
+    detail,
+  });
+}
+
+/** The kinded details every non-legacy case below is built from. */
+function fallbackDetail(
+  slotName: string,
+  html: string,
+  isInline: boolean
+): MarkdownPluginHostMountDetail {
+  return { kind: 'pluginFallback', slotName, html, isInline };
+}
+
+function rendererDetail(
+  slotName: string,
+  element: HTMLElement
+): MarkdownPluginHostMountDetail {
+  return { kind: 'customRenderer', slotName, element, isInline: false };
+}
+
+function plainEvent(type: string, detail: Record<string, unknown>) {
+  return new CustomEvent(type, { bubbles: true, composed: true, detail });
+}
+
+/**
+ * One container surface, reduced to what the protocol needs: the element that
+ * both listens and receives hosts, plus the element to dispatch from (the same
+ * node except where a nested topology is under test).
+ */
+interface Subject {
+  name: string;
+  /** Listener target and host parent. */
+  host: HTMLElement;
+  /** Node the markdown element would have dispatched from. */
+  source: HTMLElement;
+  /** Awaits a render pass, where the surface has one. */
+  settle: () => Promise<void>;
+}
+
+const subjects: Subject[] = [];
+let containerElement: HTMLElement;
+let customElement: HTMLElement;
+
+/** Boots every surface once — each boot is seconds, not milliseconds. */
+beforeAll(async () => {
+  containerElement = document.createElement('cds-aichat-container');
+  (containerElement as unknown as { config: unknown }).config =
+    createBaseConfig();
+  document.body.appendChild(containerElement);
+
+  customElement = document.createElement('cds-aichat-custom-element');
+  (customElement as unknown as { config: unknown }).config = createBaseConfig();
+  document.body.appendChild(customElement);
+
+  // A plain root rather than `@testing-library/react`'s `render`: its automatic
+  // cleanup unmounts between cases, and unmounting tears down the very effect
+  // that owns the listeners under test. Every surface here is booted once.
+  const reactMount = document.createElement('div');
+  document.body.appendChild(reactMount);
+  createRoot(reactMount).render(
+    React.createElement(ChatContainer, createBaseTestProps() as never)
+  );
+
+  let reactWrapper: HTMLElement | undefined;
+  // Wait for the listeners themselves, not for the element: they are attached
+  // by an effect keyed on the wrapper, which is set only after the shadow-ready
+  // handshake resolves. A probe offer is the only thing that proves they exist.
+  await waitFor(
+    () => {
+      const found = reactMount.querySelector<HTMLElement>('cds-aichat-react');
+      expect(found).not.toBeNull();
+      const probe = mountEvent(fallbackDetail('boot-probe', '', false));
+      found?.dispatchEvent(probe);
+      expect(probe.defaultPrevented).toBe(true);
+      reactWrapper = found ?? undefined;
+    },
+    { timeout: 8000 }
+  );
+  if (!reactWrapper) {
+    throw new Error('ChatContainer never produced a cds-aichat-react wrapper');
+  }
+  const wrapper = reactWrapper;
+  wrapper.dispatchEvent(plainEvent(UNMOUNT, { slotName: 'boot-probe' }));
+
+  subjects.push(
+    {
+      name: 'ChatContainer',
+      host: wrapper,
+      source: wrapper,
+      settle: async () => undefined,
+    },
+    {
+      name: 'cds-aichat-container',
+      host: containerElement,
+      source: containerElement,
+      settle: async () => {
+        await (containerElement as unknown as { updateComplete: Promise<void> })
+          .updateComplete;
+      },
+    },
+    {
+      name: 'cds-aichat-custom-element',
+      host: customElement,
+      source: customElement,
+      settle: async () => {
+        await (customElement as unknown as { updateComplete: Promise<void> })
+          .updateComplete;
+      },
+    }
+  );
+}, 30000);
+
+/**
+ * Runs `probe` against every surface and keys the results by name, so a single
+ * assertion covers all three. An `expect` inside the loop instead would abort
+ * at the first failing surface and leave the others unmeasured — which is the
+ * comparison this spec exists to make.
+ */
+async function acrossSubjects<T>(
+  probe: (subject: Subject) => Promise<T>
+): Promise<Record<string, T>> {
+  const results: Record<string, T> = {};
+  for (const subject of subjects) {
+    results[subject.name] = await probe(subject);
+  }
+  return results;
+}
+
+/** Builds the expectation every surface has to match. */
+function sameForAll<T>(value: (subject: Subject) => T): Record<string, T> {
+  return Object.fromEntries(subjects.map((s) => [s.name, value(s)]));
+}
+
+/** Slot names a surface forwards inward, or null where it forwards none. */
+function forwardedNames(subject: Subject): string[] | null {
+  return (
+    (subject.host as unknown as { _pluginSlotNames?: string[] })
+      ._pluginSlotNames ?? null
+  );
+}
+
+/** The host a container appended for `slotName`, if it appended one. */
+function hostFor(subject: Subject, slotName: string) {
+  // `:not(slot)` because a nested container's own forwarders are
+  // `<slot name=X slot=X>` light-DOM children carrying the same attribute.
+  return subject.host.querySelector<HTMLElement>(
+    `[slot="${slotName}"]:not(slot)`
+  );
+}
+
+describe('plugin-host protocol: all three containers agree', () => {
+  it.each([
+    ['block', false, 'DIV', '1rem'],
+    ['inline', true, 'SPAN', ''],
+  ])(
+    'hosts a %s plugin-fallback mount identically',
+    async (label, isInline, tagName, spacing) => {
+      const results = await acrossSubjects(async (subject) => {
+        const slotName = `parity-fallback-${label}-${subject.name}`;
+        const event = mountEvent(
+          fallbackDetail(slotName, '<i>x</i>', isInline)
+        );
+        subject.source.dispatchEvent(event);
+        await subject.settle();
+        const host = hostFor(subject, slotName);
+        return {
+          claimed: event.defaultPrevented,
+          tagName: host?.tagName,
+          slot: host?.getAttribute('slot'),
+          spacing: host?.style.marginBlockStart,
+          html: host?.innerHTML,
+        };
+      });
+
+      expect(results).toEqual(
+        sameForAll((subject) => ({
+          claimed: true,
+          tagName,
+          slot: `parity-fallback-${label}-${subject.name}`,
+          spacing,
+          html: '<i>x</i>',
+        }))
+      );
+    }
+  );
+
+  it('declines a custom-renderer mount identically', async () => {
+    const results = await acrossSubjects(async (subject) => {
+      const slotName = `parity-renderer-${subject.name}`;
+      const live = document.createElement('div');
+      live.setAttribute('slot', slotName);
+      const event = mountEvent(rendererDetail(slotName, live));
+      subject.source.dispatchEvent(event);
+      await subject.settle();
+      return {
+        claimed: event.defaultPrevented,
+        hosted: hostFor(subject, slotName) !== null,
+      };
+    });
+
+    expect(results).toEqual(
+      sameForAll(() => ({ claimed: false, hosted: false }))
+    );
+  });
+
+  it('rewrites host content in place on update', async () => {
+    const results = await acrossSubjects(async (subject) => {
+      const slotName = `parity-update-${subject.name}`;
+      subject.source.dispatchEvent(
+        mountEvent(fallbackDetail(slotName, '<i>one</i>', false))
+      );
+      await subject.settle();
+      const host = hostFor(subject, slotName);
+
+      subject.source.dispatchEvent(
+        plainEvent(UPDATE, { slotName, html: '<i>two</i>' })
+      );
+      await subject.settle();
+
+      return {
+        sameNode: hostFor(subject, slotName) === host,
+        html: host?.innerHTML,
+      };
+    });
+
+    expect(results).toEqual(
+      sameForAll(() => ({ sameNode: true, html: '<i>two</i>' }))
+    );
+  });
+
+  it('removes the host and drops the slot name on unmount', async () => {
+    const results = await acrossSubjects(async (subject) => {
+      const slotName = `parity-unmount-${subject.name}`;
+      subject.source.dispatchEvent(
+        mountEvent(fallbackDetail(slotName, '<i>x</i>', false))
+      );
+      await subject.settle();
+      const hostedBefore = hostFor(subject, slotName) !== null;
+      const forwardedBefore = forwardedNames(subject)?.includes(slotName);
+
+      subject.source.dispatchEvent(plainEvent(UNMOUNT, { slotName }));
+      await subject.settle();
+
+      return {
+        hostedBefore,
+        // `undefined` on a surface that forwards nothing, which is
+        // `ChatContainer` — the React `Markdown` wrapper owns its only hop.
+        forwardedBefore,
+        hostedAfter: hostFor(subject, slotName) !== null,
+        forwardedAfter: forwardedNames(subject)?.includes(slotName),
+      };
+    });
+
+    expect(results).toEqual(
+      sameForAll((subject) => ({
+        hostedBefore: true,
+        forwardedBefore: forwardedNames(subject) === null ? undefined : true,
+        hostedAfter: false,
+        forwardedAfter: forwardedNames(subject) === null ? undefined : false,
+      }))
+    );
+  });
+
+  it('ignores a mount with no slot name', async () => {
+    for (const subject of subjects) {
+      const before = subject.host.childElementCount;
+      // Deliberately malformed: the union requires `slotName`, so the cast is
+      // what lets the case exist at all — and it is exactly the payload the
+      // no-op lock says must be ignored.
+      const event = mountEvent({
+        kind: 'pluginFallback',
+        html: '<i>x</i>',
+        isInline: false,
+      } as unknown as MarkdownPluginHostMountDetailInput);
+      subject.source.dispatchEvent(event);
+      await subject.settle();
+
+      expect(event.defaultPrevented).toBe(false);
+      expect(subject.host.childElementCount).toBe(before);
+    }
+  });
+
+  /**
+   * The components dependency is a caret range, so an older build can still
+   * emit the pre-`kind` shape. It has to keep hosting.
+   */
+  it('hosts a legacy mount detail that carries no kind', async () => {
+    for (const subject of subjects) {
+      const slotName = `parity-legacy-${subject.name}`;
+      subject.source.dispatchEvent(
+        mountEvent({ slotName, html: '<i>legacy</i>', isInline: false })
+      );
+      await subject.settle();
+
+      const host = hostFor(subject, slotName);
+      expect(host?.tagName).toBe('DIV');
+      expect(host?.innerHTML).toBe('<i>legacy</i>');
+    }
+  });
+
+  it('declines a legacy custom-renderer mount that carries no kind', async () => {
+    for (const subject of subjects) {
+      const slotName = `parity-legacy-renderer-${subject.name}`;
+      const live = document.createElement('div');
+      const event = mountEvent({ slotName, element: live, isInline: false });
+      subject.source.dispatchEvent(event);
+      await subject.settle();
+
+      expect(event.defaultPrevented).toBe(false);
+      expect(hostFor(subject, slotName)).toBeNull();
+    }
+  });
+});
+
+describe('plugin-host protocol: forwarder slot names', () => {
+  it('forwards a plugin-fallback slot name', async () => {
+    for (const subject of subjects) {
+      const slotName = `forward-fallback-${subject.name}`;
+      subject.source.dispatchEvent(
+        mountEvent({
+          kind: 'pluginFallback',
+          slotName,
+          html: '<i>x</i>',
+          isInline: false,
+        })
+      );
+      await subject.settle();
+
+      const names = forwardedNames(subject);
+      if (names === null) {
+        // ChatContainer renders no forwarder; the React Markdown wrapper
+        // supplies the only hop on that topology.
+        continue;
+      }
+      expect(names).toContain(slotName);
+    }
+  });
+
+  /**
+   * A custom-renderer host is never delegated, so a forwarder for its name
+   * gathers nothing and its `slot=` half terminates against no matching
+   * `<slot name=…>` one hop in. Tracking it anyway is the one place the three
+   * surfaces disagree today.
+   */
+  it('does not forward a custom-renderer slot name', async () => {
+    for (const subject of subjects) {
+      const slotName = `forward-renderer-${subject.name}`;
+      const live = document.createElement('div');
+      subject.source.dispatchEvent(mountEvent(rendererDetail(slotName, live)));
+      await subject.settle();
+
+      const names = forwardedNames(subject);
+      if (names === null) {
+        continue;
+      }
+      expect(names).not.toContain(slotName);
+    }
+  });
+});
+
+describe('plugin-host protocol: nested topology', () => {
+  it('cds-aichat-container declines when an outer chat element is present', async () => {
+    const inner = customElement.shadowRoot?.querySelector<HTMLElement>(
+      'cds-aichat-container'
+    );
+    if (!inner) {
+      throw new Error('cds-aichat-custom-element rendered no inner container');
+    }
+
+    const slotName = 'nested-fallback';
+    const event = mountEvent(fallbackDetail(slotName, '<i>x</i>', false));
+    inner.dispatchEvent(event);
+    await (inner as unknown as { updateComplete: Promise<void> })
+      .updateComplete;
+    await (customElement as unknown as { updateComplete: Promise<void> })
+      .updateComplete;
+
+    // The inner container forwards but does not host; the outer element hosts.
+    expect(inner.querySelector(`[slot="${slotName}"]:not(slot)`)).toBeNull();
+    expect(
+      (inner as unknown as { _pluginSlotNames: string[] })._pluginSlotNames
+    ).toContain(slotName);
+    expect(
+      customElement.querySelector(`[slot="${slotName}"]:not(slot)`)
+    ).not.toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #2270
Closes #2272
Closes #2271
Closes #2273

Five changes to the line-break and plugin-host story. One per commit, each green and revertable alone.

The first two are two-line fixes with their proofs. Commits 3-5 are the ones to read closely:

- `packages/ai-chat-components/src/components/markdown/src/markdown.ts` — `delegatedPluginSlots` becomes a kinded `Map`, and a new public `delegatedPluginSlotNames` getter reads only one of the two kinds. The kind split is the load-bearing part; see the getter's JSDoc for why.
- `packages/ai-chat-components/src/react/markdown.tsx` — six lines inside the existing subscribe effect. Order matters: attach both listeners, *then* seed.

#### Commit map

1. **`fix(markdown): render line breaks inside merged inline-HTML runs`** — `serializeInlineToken` returned `token.content ?? ''` for `softbreak` and `hardbreak`. Break tokens carry no content. So a break inside a merged inline-HTML run — `<span>one\ntwo</span>` — was deleted, not rendered. Returns `'<br />'` now, not `'<br />\n'`; the trailing newline adds a stray whitespace text node that a spec pins.
2. **`fix(markdown): treat a soft break as a line break in InlineMarkdown`** — `renderInlineMarkdown` rendered `softbreak` as a space. `hardbreak` already produced `<br />`. Under `breaks: true` a soft break *is* a line break, so the two paths disagreed. The same message rendered as one line or two, depending only on whether it held a chip. The `softbreak` case now falls through to `hardbreak`.
3. **`fix(markdown): seed plugin slot forwarders from the element`** — the late-subscriber fix. Detail below.
4. **`refactor(markdown): consolidate the plugin-host container protocol`** — the container half of the protocol was written five times. One helper now, plus a real discriminant on the mount detail. Detail below.
5. **`fix(markdown): mint a plugin-fallback slot name once per token`** — the defect commit 3 turned up, root-caused and fixed. Detail below.

#### The late-subscriber fix

`cds-aichat-markdown-plugin-host-mount` fires once per live host and is never replayed for one — later passes fire `plugin-host-update` instead. Two listeners depend on that single event and start listening at different times:

| Listener | Attaches | Job |
| --- | --- | --- |
| Chat container | chat mount | `preventDefault()`, hoist the host into page light DOM |
| React `Markdown` wrapper | the element's first passive-effect flush | render the `<slot name=X slot=X>` forwarder |

That forwarder is the only thing crossing `<cds-aichat-markdown>`'s own shadow boundary. That holds on **every** container topology; the web-component containers supply outer hops only.

Miss the one event and the slot is stranded for good. The container owns the host. The element skips its own local fallback. No forwarder ever appears, so plugin-fallback output shows nothing at all.

The wrapper now seeds from a getter on the element instead of relying on having caught the event. No event added, none re-fired, no container changed.

#### The consolidation (#2273)

The container half of the plugin-host protocol existed five times: `ChatContainer.tsx`, `cds-aichat-container`, `cds-aichat-custom-element`, and two harnesses in `markdown.test.ts` whose docstrings claim to mirror them. `handleUpdate` was line-for-line identical in all three containers. Nothing enforced the mirror, and a divergence between containers renders content under one surface and silently drops it under another — a plugin-fallback host is emitted into an empty `<slot>`, so a lost host looks like nothing at all.

`createMarkdownPluginHostController` in `@carbon/ai-chat-components` is the single implementation. A caller supplies the element hosts are appended to, plus the two policies the framework cannot infer: where forwarded slot names go, and whether an outer chat element will host instead. Net −430 lines across the three containers.

Each copy also decided which of two payloads it had received by testing whether `detail.element` was set — the shape was the discriminant. The mount detail now carries `kind`, and the union behind it is exported. The union members declare only their own fields, so reading `detail.html` inside a `customRenderer` branch is `TS2339` rather than a silent `undefined`. Details from before the field existed still host: one shim fills `kind` in at the protocol boundary, and everything downstream switches on it.

**One deliberate behavior change.** Both web-component containers tracked `customRenderer` slot names and rendered an outer forwarder for them; the React wrapper and `ChatContainer` did not. Those forwarders are inert — a `customRenderer` host is never delegated, so the element hosts it in its own light DOM, the outer forwarder gathers nothing, and its `slot=` half terminates against a `<slot name=X>` the wrapper declines to render. The controller keeps the wrapper's rule. That closes a hazard for third-party containers, where a claimed live-element mount plus a forwarder would hold the named slot occupied and suppress the fallback a `null`-returning callback depends on. It also changes the observable contents of `_pluginSlotNames`, which on `cds-aichat-container` is not declared `private`.

#### The slot-counter fix (commit 5)

Found while testing commit 3; root cause is not what it first looked like.

`renderFallback` does not run while `renderMarkdownTree` walks the tree. It runs inside a lit-html `repeat()` directive callback, so it evaluates when lit-html **commits** the template. `render()` returns the stored `renderedContent`, and any later Lit update inside the render throttle re-commits that same `TemplateResult`, re-running the repeat callback against the same counter closure. One render result committed twice advanced the counter twice and pushed two descriptors for one token, so a delegating container built and tore down a spurious host per commit.

Two corrections to how this was first described: it is **not** streaming-specific — a bare `requestUpdate()` on a settled element reproduces it, and a stream only hits it often because every chunk is another commit — and `table`/`codeBlock` names were never affected, because `slotNameFor` derives those from `token.map` and the parent's `currentIndex`, which is idempotent under re-commit.

The index is now memoized per tree node rather than counting evaluations. First evaluation still assigns 0, 1, 2 in walk order, so a render committed once is byte-identical to before.

#### Changelog

**New**

- `CDSAIChatMarkdown.delegatedPluginSlotNames` — read-only getter. Lists the plugin-fallback slot names an outer listener has claimed. For anyone implementing the hosting half of the protocol: a late subscriber can recover the names it missed.
- `MarkdownPluginHostMountDetail` and `MarkdownPluginHostMountDetailInput`, exported from `@carbon/ai-chat-components/es/components/markdown/index.js`. The `cds-aichat-markdown-plugin-host-mount` detail, discriminated on a new `kind` field, plus the shape as it arrives on the wire from a build predating that field. Additive: every listener reads named properties off a bare `Event` cast, so a new field cannot break one.

**Changed**

- A single `\n` inside inline HTML renders as `<br>` instead of vanishing.
- `InlineMarkdown` renders a soft break as `<br />`, matching the block renderer. A message with a chip and one without now render the same.
- Plugin-fallback output reaches its slot regardless of when the forwarder's listener subscribed.
- `cds-aichat-container` and `cds-aichat-custom-element` no longer render an outer `<slot>` forwarder for a `customRenderers` slot name. Those forwarders were inert; see above.
- A plugin-fallback token produces one slot host for as long as it exists, rather than one per lit-html commit. Anyone counting `cds-aichat-markdown-plugin-host-mount` events sees fewer; anyone keyed by slot name sees no difference, because the extra host was always retired immediately.

**Removed**

- A plugin overriding `md.renderer.rules.softbreak` no longer takes effect. `softbreak` was never in `PLUGIN_DELEGABLE_TOKEN_TYPES`, so it only ever reached output through the unknown-token fallback — never a supported extension point.

#### Testing / Reviewing

Build first — workspace deps resolve through built artifacts:

```bash
npm run build --workspace=@carbon/ai-chat-components
npm run build --workspace=@carbon/ai-chat
```

Automated:

```bash
npm run test --workspace=@carbon/ai-chat-components   # 581 WTR × 3 browsers, 24 Jest
npm run test --workspace=@carbon/ai-chat
npm run lint && npm run lint:license
```

Manual — commit 1. Paste into the Storybook markdown story: `<span>**Summary**\nUse the Assets application.</span>`. Before, the newline disappears and the words merge; after, the lines are separate.

Manual — commit 2. Type a message with Shift+Enter, then mention someone so the paragraph routes through the chip path. Before, the break collapses to a space; after, it matches the same text without the chip.

Commit 3 is covered by `describe('plugin-host handshake with a late subscriber')` in `markdown.test.ts`, plus the new React-wrapper spec. Reproducing it by hand is awkward. You need a `markdownItPlugins` plugin emitting an unknown token, inside a chat container, on the first paint. The tests model that split directly.

Commit 4 is covered by `packages/ai-chat/tests/web-components/spec/pluginHostParity_spec.tsx` — the first test anywhere to load these handlers, since `grep -rn "plugin-host" packages/ai-chat/tests` was empty. It drives all three containers with one event sequence and compares the resulting host DOM. Ten of its eleven cases were written against the old handlers and pass unchanged; the forwarder case failed for both web-component containers before the change and passes after. Deleting a branch from any one handler turns the spec red — worth re-running that yourself if you want to trust it.

Commit 5 is covered by `describe('plugin-fallback slot names across render commits')`. All four cases fail before it in all three browsers.

#### Reviewer notes

Three things worth knowing, none of them blocking:

- **Criterion 2 on #2271 was re-aimed.** It asserted a *timing* failure for `customRenderers` hosts. #2222 removed that timing. All three containers and the wrapper now ignore mount events carrying `detail.element`, so such a host is never delegated. Re-aimed at the live question instead: does the seed leak a `customRenderers` slot name into the forwarder list? It doesn't, and a test fails if that changes.
- **Criterion 5 on #2271 is descoped to #2273.** Three-container parity is #2273's whole purpose. This commit changes no container. That leaves the invariant unproven until #2273 lands; recorded on both issues.
- **Criterion 5 on #2271 is met here, one commit later than planned.** Commit 3 descoped three-container parity to #2273 because it changed no container. `pluginHostParity_spec.tsx` is that proof.
- **Four of #2273's criteria needed correcting**, all recorded on the issue: its "package entry" does not exist (`@carbon/ai-chat-components` publishes no `"."` export, so the markdown barrel is the entry); its wrong-branch compile check names `@carbon/ai-chat`, but the helper lives in the components package, so the error surfaces in that build; and its "an unmount drops its slot name" half is provable across two containers, not three, because `ChatContainer` keeps no slot-name list and renders no forwarder.
- **The refactor is behavior-preserving except where it says otherwise.** The `customRenderer` forwarder change is the one exception and it has its own failing-first test. Everything else is pinned by cases written against the old handlers and left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
