### PR TITLE
fix(markdown): restore consumer CSS and fix line breaks

### DIFF
--- a/demo/TEST_PLAN.md
+++ b/demo/TEST_PLAN.md
@@ -86,6 +86,14 @@ We should be looking for what here can can automate, and as we do, we can remove
 - [ ] **user_defined (stream)**
 - [ ] **video**
 
+#### Markdown custom renderers
+
+Deep-link only — there is no sidebar switcher. Append `markdownCustomRenderers` to the `settings` query param, e.g. `/?settings={"framework":"web-component","layout":"fullscreen","markdownCustomRenderers":"true"}`, then send **table**.
+
+- [ ] The table renders as the demo's own "Custom table: N columns, M rows" node instead of the Carbon table, in all four container shapes (react/web-component × float/fullscreen).
+- [ ] That node is a child of the outermost chat element in the page's light DOM, not of the markdown element inside the shadow root — check in devtools, and confirm a rule typed into the page's own stylesheet reaches it.
+- [ ] Send **table (stream)** and confirm one node is reused as chunks arrive, rather than a new one per chunk.
+
 ### Track 3: Mobile & Non-Chrome Browser Support
 
 **Focus:** Smoke testing across browsers, emphasis on mobile.

--- a/demo/TEST_PLAN.md
+++ b/demo/TEST_PLAN.md
@@ -88,10 +88,10 @@ We should be looking for what here can can automate, and as we do, we can remove
 
 #### Markdown custom renderers
 
-Deep-link only — there is no sidebar switcher. Append `markdownCustomRenderers` to the `settings` query param, e.g. `/?settings={"framework":"web-component","layout":"fullscreen","markdownCustomRenderers":"true"}`, then send **table**.
+Set **Chat Configuration → Markdown → Table rendering** to `customRenderers.table` in the sidebar (or deep-link it: append `markdownCustomRenderers` to the `settings` query param), then send **table**.
 
 - [ ] The table renders as the demo's own "Custom table: N columns, M rows" node instead of the Carbon table, in all four container shapes (react/web-component × float/fullscreen).
-- [ ] That node is a child of the outermost chat element in the page's light DOM, not of the markdown element inside the shadow root — check in devtools, and confirm a rule typed into the page's own stylesheet reaches it.
+- [ ] That node is a child of the outermost chat element, not of the markdown element inside the shadow root — check in devtools. The tree that element sits in differs by shape: the document for the React ones, `<demo-app>`'s shadow root for the web-component ones. Add a rule to that root and confirm it reaches the node.
 - [ ] Send **table (stream)** and confirm one node is reused as chunks arrive, rather than a new one per chunk.
 
 ### Track 3: Mobile & Non-Chrome Browser Support

--- a/demo/src/framework/demo-body.tsx
+++ b/demo/src/framework/demo-body.tsx
@@ -38,6 +38,7 @@ import './demo-chat-version-switcher';
 import './demo-keyboard-shortcut-switcher';
 import '@carbon/web-components/es/components/button/index.js';
 import './demo-chat-avatar-switcher';
+import './demo-markdown-custom-renderers-switcher';
 
 const { defaultConfig, defaultSettings } = getSettings();
 
@@ -86,6 +87,7 @@ export class DemoBody extends LitElement {
     demo-chat-theme-switcher,
     demo-homescreen-switcher,
     demo-writeable-elements-switcher,
+    demo-markdown-custom-renderers-switcher,
     demo-direction-switcher,
     demo-chat-version-switcher {
       display: block;
@@ -594,6 +596,16 @@ export class DemoBody extends LitElement {
                       </div>
                       <demo-writeable-elements-switcher
                         .settings=${this.settings}></demo-writeable-elements-switcher>
+                    </div>
+                    <div
+                      class="config-section"
+                      role="group"
+                      aria-labelledby="markdown-heading">
+                      <div class="config-section__title" id="markdown-heading">
+                        Markdown
+                      </div>
+                      <demo-markdown-custom-renderers-switcher
+                        .settings=${this.settings}></demo-markdown-custom-renderers-switcher>
                     </div>
                   </cds-accordion-item>
                   <cds-accordion-item title="Chat Configuration">

--- a/demo/src/framework/demo-markdown-custom-renderers-switcher.ts
+++ b/demo/src/framework/demo-markdown-custom-renderers-switcher.ts
@@ -1,0 +1,51 @@
+/*
+ *  Copyright IBM Corp. 2026
+ *
+ *  This source code is licensed under the Apache-2.0 license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ *  @license
+ */
+
+import '@carbon/web-components/es/components/dropdown/index.js';
+
+import { html, LitElement } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+
+import { Settings } from './types';
+
+@customElement('demo-markdown-custom-renderers-switcher')
+export class DemoMarkdownCustomRenderersSwitcher extends LitElement {
+  @property({ type: Object })
+  accessor settings!: Settings;
+
+  dropdownSelected = (event: Event) => {
+    const customEvent = event as CustomEvent;
+    this.dispatchEvent(
+      new CustomEvent('settings-changed', {
+        detail: {
+          ...this.settings,
+          markdownCustomRenderers: customEvent.detail.item.value,
+        },
+        bubbles: true,
+        composed: true,
+      })
+    );
+  };
+
+  render() {
+    return html`<cds-dropdown
+      value="${this.settings.markdownCustomRenderers ?? 'false'}"
+      title-text="Table rendering"
+      @cds-dropdown-selected=${this.dropdownSelected}>
+      <cds-dropdown-item value="false">Carbon table</cds-dropdown-item>
+      <cds-dropdown-item value="true">customRenderers.table</cds-dropdown-item>
+    </cds-dropdown>`;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'demo-markdown-custom-renderers-switcher': DemoMarkdownCustomRenderersSwitcher;
+  }
+}

--- a/demo/src/framework/types.ts
+++ b/demo/src/framework/types.ts
@@ -12,6 +12,14 @@ interface Settings {
   layout: 'float' | 'sidebar' | 'fullscreen';
   writeableElements: 'true' | 'false';
   hideDefaultAiLabelContent?: 'true' | 'false';
+  /**
+   * Renders markdown tables through `markdown.customRenderers.table` instead
+   * of the built-in Carbon table. Deep-link only — there is no sidebar
+   * switcher, because the reason it exists is a Playwright case that proves a
+   * page stylesheet reaches the node the callback returns, and that only holds
+   * while the node sits in page light DOM.
+   */
+  markdownCustomRenderers?: 'true' | 'false';
   direction: 'default' | 'ltr' | 'rtl';
   showHeader?: boolean;
   showMenuOptions?: boolean;

--- a/demo/src/framework/types.ts
+++ b/demo/src/framework/types.ts
@@ -14,10 +14,9 @@ interface Settings {
   hideDefaultAiLabelContent?: 'true' | 'false';
   /**
    * Renders markdown tables through `markdown.customRenderers.table` instead
-   * of the built-in Carbon table. Deep-link only — there is no sidebar
-   * switcher, because the reason it exists is a Playwright case that proves a
-   * page stylesheet reaches the node the callback returns, and that only holds
-   * while the node sits in page light DOM.
+   * of the built-in Carbon table. Exists for the Playwright case that proves a
+   * page stylesheet reaches the node the callback returns, which only holds
+   * while that node sits in the chat element's own light DOM.
    */
   markdownCustomRenderers?: 'true' | 'false';
   direction: 'default' | 'ltr' | 'rtl';

--- a/demo/src/react/DemoApp.tsx
+++ b/demo/src/react/DemoApp.tsx
@@ -24,6 +24,7 @@ import {
   ChatCustomElement,
   ChatInstance,
   FeedbackInteractionType,
+  MarkdownRendererTableArgs,
   PublicConfig,
   RenderUserDefinedState,
   RenderCustomMessageFooter,
@@ -50,6 +51,21 @@ const sleep = (milliseconds: number) =>
 
 const serviceDeskFactory = (parameters: ServiceDeskFactoryParameters) =>
   Promise.resolve(new MockServiceDesk(parameters) as ServiceDesk);
+
+/**
+ * Stand-in for a consumer's own table component. The class is the only hook a
+ * page stylesheet has: the chat's own CSS lives in a shadow root, so a page
+ * rule that lands on this node proves the chat put it in page light DOM.
+ */
+function renderCustomTable({ headers, rows }: MarkdownRendererTableArgs) {
+  return (
+    <div
+      className="demo-markdown-custom-table"
+      data-testid="demo_markdown_custom_table">
+      {`Custom table: ${headers.length} columns, ${rows.length} rows`}
+    </div>
+  );
+}
 
 interface AppProps {
   config: PublicConfig;
@@ -417,10 +433,21 @@ function DemoApp({ config, settings, onChatInstanceReady }: AppProps) {
     hideDefaultAiLabelContent: true,
   };
 
+  // Memoized because `markdown` is compared by reference: a fresh literal each
+  // render would rebuild every custom-renderer host on every parent update.
+  const markdownConfig = useMemo(
+    () =>
+      settings.markdownCustomRenderers === 'true'
+        ? { ...config.markdown, customRenderers: { table: renderCustomTable } }
+        : config.markdown,
+    [config.markdown, settings.markdownCustomRenderers]
+  );
+
   return settings.layout === 'float' ? (
     <ChatContainer
       {...config}
       header={headerConfig}
+      markdown={markdownConfig}
       onBeforeRender={onBeforeRender}
       renderUserDefinedResponse={renderUserDefinedResponse}
       renderCustomMessageFooter={renderCustomMessageFooter}
@@ -432,6 +459,7 @@ function DemoApp({ config, settings, onChatInstanceReady }: AppProps) {
       <ChatCustomElement
         {...config}
         header={headerConfig}
+        markdown={markdownConfig}
         className={className as string}
         onViewPreChange={onViewPreChange}
         onViewChange={onViewChange}

--- a/demo/src/web-components/demo-app.ts
+++ b/demo/src/web-components/demo-app.ts
@@ -25,12 +25,14 @@ import {
   BusEventViewPreChange,
   ChatInstance,
   GenericItem,
+  MarkdownRendererTableArgs,
   PublicConfig,
   RenderUserDefinedState,
   ServiceDesk,
   ServiceDeskFactoryParameters,
   UserDefinedItem,
   ViewType,
+  WCMarkdown,
 } from '@carbon/ai-chat';
 // Raw CSS text of the shipped sidebar layout. demo-app keeps its shadow DOM, so
 // the compiled stylesheet is imported as a string (webpack `?raw` loader) and
@@ -152,6 +154,20 @@ export class DemoApp extends LitElement {
    */
   private _userDefinedElements = new Set<HTMLElement>();
 
+  /**
+   * One node per table slot, kept so the callback returns the same reference
+   * across renders — a streaming table re-invokes it on every chunk, and a new
+   * element each time would tear the consumer's subtree down and rebuild it.
+   */
+  private _customTableNodes = new Map<string, HTMLElement>();
+
+  /**
+   * Rebuilt in `willUpdate` rather than per render: `.markdown` is compared by
+   * reference, and the parent-state timer re-renders this element every 1.5s,
+   * so a fresh literal would restart the chat's markdown config on every tick.
+   */
+  private _markdownConfig?: WCMarkdown;
+
   private _interval?: ReturnType<typeof setInterval>;
 
   protected firstUpdated(_changedProperties: PropertyValues): void {
@@ -166,6 +182,40 @@ export class DemoApp extends LitElement {
     this._interval = setInterval(() => {
       this.valueFromParent = Date.now().toString();
     }, 1500);
+  }
+
+  /**
+   * Stand-in for a consumer's own table component. The class is the only hook
+   * a page stylesheet has: the chat's own CSS lives in a shadow root, so a
+   * page rule that lands on this node proves the chat put it in page light
+   * DOM.
+   */
+  private renderCustomTable = ({
+    headers,
+    rows,
+    slotName,
+  }: MarkdownRendererTableArgs) => {
+    let node = this._customTableNodes.get(slotName);
+    if (!node) {
+      node = document.createElement('div');
+      node.className = 'demo-markdown-custom-table';
+      node.dataset.testid = 'demo_markdown_custom_table';
+      this._customTableNodes.set(slotName, node);
+    }
+    node.textContent = `Custom table: ${headers.length} columns, ${rows.length} rows`;
+    return node;
+  };
+
+  protected willUpdate(changedProperties: PropertyValues): void {
+    if (changedProperties.has('config') || changedProperties.has('settings')) {
+      this._markdownConfig =
+        this.settings.markdownCustomRenderers === 'true'
+          ? {
+              ...this.config.markdown,
+              customRenderers: { table: this.renderCustomTable },
+            }
+          : this.config.markdown;
+    }
   }
 
   protected updated(changedProperties: PropertyValues): void {
@@ -494,6 +544,7 @@ export class DemoApp extends LitElement {
                 hideDefaultAiLabelContent: true,
               }}
               .layout=${this.config.layout}
+              .markdown=${this._markdownConfig}
               .messaging=${this.config.messaging}
               .isReadonly=${this.config.isReadonly ?? undefined}
               .persistFeedback=${this.config.persistFeedback ?? undefined}
@@ -535,6 +586,7 @@ export class DemoApp extends LitElement {
                 hideDefaultAiLabelContent: true,
               }}
               .layout=${this.config.layout}
+              .markdown=${this._markdownConfig}
               .messaging=${this.config.messaging}
               .isReadonly=${this.config.isReadonly ?? undefined}
               .persistFeedback=${this.config.persistFeedback ?? undefined}
@@ -577,6 +629,7 @@ export class DemoApp extends LitElement {
                 hideDefaultAiLabelContent: true,
               }}
               .layout=${this.config.layout}
+              .markdown=${this._markdownConfig}
               .messaging=${this.config.messaging}
               .isReadonly=${this.config.isReadonly ?? undefined}
               .assistantName=${this.config.assistantName}

--- a/demo/tests/markdown-custom-renderers.spec.ts
+++ b/demo/tests/markdown-custom-renderers.spec.ts
@@ -1,0 +1,141 @@
+/*
+ *  Copyright IBM Corp. 2026
+ *
+ *  This source code is licensed under the Apache-2.0 license found in the
+ *  LICENSE file in the root directory of this source tree.
+ */
+
+import { PageObjectId } from '@carbon/ai-chat/server';
+import { test, expect } from '@playwright/test';
+
+import {
+  destroyChatSession,
+  openChatViaLauncher,
+  sendChatMessage,
+  waitForChatReady,
+} from './utils';
+
+// Import types for window.chatInstance without emitting runtime code
+import type {} from '../types/window';
+
+/**
+ * A `customRenderers.table` result has to end up somewhere a consumer's own
+ * stylesheet can reach, which means out of the chat's shadow DOM and into the
+ * tree the consumer put the chat element in — the markdown element's own light
+ * DOM sits several chat-owned boundaries below that, where a consumer rule
+ * stops. No unit harness can see this: jsdom does not flatten slots and has no
+ * cascade, and the property is about where in the consumer's page the node
+ * lives, not what the element rendered.
+ *
+ * That tree is not always the document. This demo renders its web-component
+ * surfaces inside `<demo-app>`'s shadow root, so there the consumer's
+ * stylesheet is one that lives in that shadow root — a boundary the host page
+ * owns and the chat must not cross. Each case therefore anchors on the
+ * outermost chat element's own root rather than on `document`, which is also
+ * what keeps the assertion honest: an implementation that hoisted hosts to
+ * `document.body` instead of to the chat element would fail it.
+ *
+ * The four demo container shapes stack a different number of *chat* shadow
+ * boundaries between the markdown element and that root, so each one is a
+ * different chance for the chain to break.
+ */
+const TOPOLOGIES = [
+  {
+    framework: 'react',
+    layout: 'float',
+    surface: 'React ChatContainer',
+    chatElement: 'cds-aichat-react',
+  },
+  {
+    framework: 'react',
+    layout: 'fullscreen',
+    surface: 'React ChatCustomElement',
+    chatElement: 'cds-aichat-react',
+  },
+  {
+    framework: 'web-component',
+    layout: 'float',
+    surface: 'cds-aichat-container',
+    chatElement: 'cds-aichat-container',
+  },
+  {
+    framework: 'web-component',
+    layout: 'fullscreen',
+    surface: 'cds-aichat-custom-element',
+    chatElement: 'cds-aichat-custom-element',
+  },
+] as const;
+
+// Distinctive enough that a match cannot be a Carbon default, and set by
+// nothing else on the page.
+const PAGE_RULE_COLOR = 'rgb(255, 0, 255)';
+
+test.beforeEach(async ({ page }) => {
+  // Block analytics script BEFORE navigation to avoid cookie consent issues
+  await page.route(/.*ibm-common\.js$/, (route) => route.abort());
+});
+
+test.afterEach(async ({ page }) => {
+  await destroyChatSession(page);
+});
+
+for (const { framework, layout, surface, chatElement } of TOPOLOGIES) {
+  test(`a page stylesheet reaches the customRenderers.table node (${surface})`, async ({
+    page,
+  }) => {
+    test.slow();
+
+    const settings = encodeURIComponent(
+      JSON.stringify({ framework, layout, markdownCustomRenderers: 'true' })
+    );
+    await page.goto(`/?settings=${settings}`);
+    await page.waitForLoadState('domcontentloaded');
+    await page.waitForFunction(() => Boolean(window.chatInstance), {
+      timeout: 10000,
+    });
+
+    // The consumer's stylesheet, added to the tree the chat element itself
+    // sits in, so it reaches nothing inside the chat's shadow roots — and
+    // added before the table renders, so the node is never briefly unstyled
+    // for reasons of ordering.
+    const chat = page.locator(chatElement);
+    await expect(chat).toBeAttached({ timeout: 10000 });
+    await chat.evaluate((element, color) => {
+      const root = element.getRootNode();
+      const style = document.createElement('style');
+      style.textContent = `.demo-markdown-custom-table { background-color: ${color}; }`;
+      (root instanceof Document ? root.head : (root as ShadowRoot)).appendChild(
+        style
+      );
+    }, PAGE_RULE_COLOR);
+
+    await openChatViaLauncher(page);
+    await waitForChatReady(page, { panelTestId: PageObjectId.MAIN_PANEL });
+
+    await sendChatMessage(page, 'table');
+
+    const customTable = page.getByTestId('demo_markdown_custom_table').first();
+    await expect(customTable).toBeVisible({ timeout: 15000 });
+
+    // Asserted first because it names the cause: when the chat leaves the host
+    // in its own shadow root, the computed-style assertion below fails with
+    // nothing to say about why. A root holding the chat element is the
+    // consumer's tree; a root holding none is one of the chat's own.
+    await expect
+      .poll(() =>
+        customTable.evaluate(
+          (node, tag) =>
+            (node.getRootNode() as Document | ShadowRoot).querySelector(tag) !==
+            null,
+          chatElement
+        )
+      )
+      .toBe(true);
+
+    await expect
+      .poll(() =>
+        customTable.evaluate((node) => getComputedStyle(node).backgroundColor)
+      )
+      .toBe(PAGE_RULE_COLOR);
+  });
+}

--- a/packages/ai-chat-components/src/components/markdown/__tests__/markdown.test.ts
+++ b/packages/ai-chat-components/src/components/markdown/__tests__/markdown.test.ts
@@ -1581,21 +1581,72 @@ HTTP: http://example.com
      * the `<slot name=X slot=X>` forwarder into the markdown element's own
      * light DOM is the wrapper's, and is the only hop that crosses that
      * element's shadow boundary.
+     *
+     * `hops` is how many forwarders stand between the relocated host and the
+     * markdown element's own shadow slot, and therefore how many nested shadow
+     * roots the harness builds. It matches the three shipped topologies: 1 is
+     * the React `ChatContainer`, 2 is `cds-aichat-container`, 3 is
+     * `cds-aichat-custom-element` wrapping that container. The outermost level
+     * hosts, every level below it defers and forwards the name inward, and the
+     * innermost holds the markdown element.
      */
-    async function createRelocationHarness() {
+    async function createRelocationHarness(hops = 1) {
       const harness = await fixture<HTMLElement>(
         html`<cds-test-markdown-relocation-host></cds-test-markdown-relocation-host>`
       );
+      const levels: HTMLElement[] = [harness];
+      for (let depth = 1; depth < hops; depth += 1) {
+        const level = document.createElement(HARNESS_TAG);
+        levels[depth - 1].shadowRoot?.appendChild(level);
+        levels.push(level);
+      }
+      const innermost = levels[levels.length - 1];
       const mounted: Array<{
         owner: Element;
         slotName: string;
         host: HTMLElement;
       }> = [];
 
+      /**
+       * Stands in for a container's `${slotNames.map(...)}` render: one
+       * `<slot name=X slot=X>` per live name, in the next level's light DOM.
+       */
+      const forwardInto = (level: HTMLElement) => (slotNames: string[]) => {
+        for (const child of [...level.children]) {
+          if (
+            child instanceof HTMLSlotElement &&
+            !slotNames.includes(child.getAttribute('name') ?? '')
+          ) {
+            child.remove();
+          }
+        }
+        for (const slotName of slotNames) {
+          if (!level.querySelector(`:scope > slot[name="${slotName}"]`)) {
+            const forwarder = document.createElement('slot');
+            forwarder.setAttribute('name', slotName);
+            forwarder.setAttribute('slot', slotName);
+            level.appendChild(forwarder);
+          }
+        }
+      };
+
       // The container half is the shipped one, so this harness cannot drift
       // from the surfaces it stands in for.
-      const controller = createMarkdownPluginHostController(harness);
+      const controller = createMarkdownPluginHostController(
+        harness,
+        hops > 1 ? { onSlotNamesChange: forwardInto(levels[1]) } : {}
+      );
       controller.connect();
+
+      // Levels between the host and the markdown element host nothing but
+      // still forward the name inward — a `cds-aichat-container` nested in a
+      // `cds-aichat-custom-element`.
+      for (let depth = 1; depth < levels.length - 1; depth += 1) {
+        createMarkdownPluginHostController(levels[depth], {
+          onSlotNamesChange: forwardInto(levels[depth + 1]),
+          shouldDefer: () => true,
+        }).connect();
+      }
 
       // Bookkeeping only. Nothing here mints a forwarder: the markdown element
       // mints the innermost hop itself, for both claim kinds, in the pass that
@@ -1625,7 +1676,7 @@ HTTP: http://example.com
         }
       );
 
-      /** Mounts a markdown element inside the harness's shadow root. */
+      /** Mounts a markdown element inside the innermost shadow root. */
       async function addMarkdown(
         markdown: string,
         props: Partial<MarkdownElementInstance> = {}
@@ -1634,13 +1685,14 @@ HTTP: http://example.com
           MARKDOWN_ELEMENT_TAG
         ) as MarkdownElementInstance;
         Object.assign(el, props, { markdown });
-        harness.shadowRoot?.appendChild(el);
+        innermost.shadowRoot?.appendChild(el);
         await el.updateComplete;
         return el;
       }
 
       return {
         harness,
+        levels,
         mounted,
         pluginHosts: controller.hosts,
         addMarkdown,
@@ -1988,9 +2040,215 @@ HTTP: http://example.com
         harness.querySelector(`[slot="${slotName}"]:not(slot)`)
       );
     });
+
+    // Every case above runs at one shadow boundary, which is only the React
+    // topology. The two web-component containers compose two and three, and a
+    // chain that resolves at one hop can still break at three — a missing
+    // middle forwarder, or a name the deferring level never tracked. These run
+    // the same protocol at each depth.
+    describe('across composed shadow boundaries', () => {
+      const TOPOLOGIES: Array<{ hops: number; surface: string }> = [
+        { hops: 1, surface: 'React ChatContainer' },
+        { hops: 2, surface: 'cds-aichat-container' },
+        { hops: 3, surface: 'cds-aichat-custom-element' },
+      ];
+
+      const MAX_HOPS = TOPOLOGIES[TOPOLOGIES.length - 1].hops;
+
+      /**
+       * Resolves the projection one hop at a time and returns the forwarders
+       * it passed through. `assignedElements({ flatten: true })` collapses the
+       * whole chain, so it cannot tell a three-hop chain from a host that
+       * never left the element; this counts the hops and names the one that
+       * broke.
+       */
+      function walkProjection(slot: HTMLSlotElement) {
+        const forwarders: HTMLSlotElement[] = [];
+        let current = slot;
+        while (forwarders.length <= MAX_HOPS) {
+          const assigned = current.assignedElements();
+          expect(
+            assigned.length,
+            `slot "${current.getAttribute('name')}" must have exactly one assigned element`
+          ).to.equal(1);
+          const [next] = assigned;
+          if (!(next instanceof HTMLSlotElement)) {
+            return { forwarders, projected: next as HTMLElement };
+          }
+          forwarders.push(next);
+          current = next;
+        }
+        throw new Error('the forwarder chain never reached a host');
+      }
+
+      /** The markdown element's own shadow slot for `slotName`. */
+      function shadowSlot(el: MarkdownElementInstance, slotName: string) {
+        const slot = el.shadowRoot?.querySelector(
+          `slot[name="${slotName}"]`
+        ) as HTMLSlotElement | null;
+        expect(
+          slot,
+          `the element should render slot "${slotName}"`
+        ).to.not.equal(null);
+        return slot as HTMLSlotElement;
+      }
+
+      for (const { hops, surface } of TOPOLOGIES) {
+        it(`customRenderers.table: projects the relocated host through ${hops} hop(s) (${surface})`, async () => {
+          const { harness, mounted, addMarkdown } =
+            await createRelocationHarness(hops);
+          const rendered = document.createElement('div');
+          rendered.className = 'cds-test-multihop-table';
+
+          const el = await addMarkdown(tableMarkdown, {
+            customRenderers: { table: () => rendered },
+          } as Partial<MarkdownElementInstance>);
+
+          expect(
+            mounted.length,
+            'the offer reaches the outermost surface, whatever the depth'
+          ).to.equal(1);
+          const { host, slotName } = mounted[0];
+          expect(
+            host.parentElement,
+            'the outermost surface is the one that hosts'
+          ).to.equal(harness);
+          expect(
+            host.firstElementChild,
+            'the element keeps writing the consumer node into the host'
+          ).to.equal(rendered);
+
+          const { forwarders, projected } = walkProjection(
+            shadowSlot(el, slotName)
+          );
+          expect(
+            forwarders.length,
+            'one forwarder per shadow boundary between the host and the element'
+          ).to.equal(hops);
+          expect(
+            forwarders[0].parentElement,
+            'the element mints the innermost hop itself'
+          ).to.equal(el);
+          expect(
+            projected,
+            'the chain must land on the relocated host, not on a fallback'
+          ).to.equal(host);
+        });
+
+        it(`pluginFallback: projects the relocated host through ${hops} hop(s) (${surface})`, async () => {
+          const { harness, pluginHosts, addMarkdown } =
+            await createRelocationHarness(hops);
+
+          const el = await addMarkdown('Hi :tag:', {
+            markdownItPlugins: [tagPlugin],
+          } as Partial<MarkdownElementInstance>);
+
+          expect(pluginHosts.size, 'the container hosts the string').to.equal(
+            1
+          );
+          const [slotName] = [...pluginHosts.keys()];
+          const host = pluginHosts.get(slotName) as HTMLElement;
+          expect(
+            host.parentElement,
+            'the outermost surface is the one that hosts'
+          ).to.equal(harness);
+          expect(host.querySelector('.cds-test-tag')).to.not.equal(null);
+
+          const { forwarders, projected } = walkProjection(
+            shadowSlot(el, slotName)
+          );
+          expect(
+            forwarders.length,
+            'one forwarder per shadow boundary between the host and the element'
+          ).to.equal(hops);
+          expect(
+            forwarders[0].parentElement,
+            'the wrapper mints the innermost hop for a plugin-fallback claim'
+          ).to.equal(el);
+          expect(
+            projected,
+            'the chain must land on the relocated host, not on a fallback'
+          ).to.equal(host);
+        });
+
+        it(`customRenderers.table: retires every hop when the callback returns null (${hops} hop(s))`, async () => {
+          const { harness, levels, mounted, addMarkdown } =
+            await createRelocationHarness(hops);
+
+          const el = await addMarkdown(tableMarkdown, {
+            customRenderers: { table: () => document.createElement('div') },
+          } as Partial<MarkdownElementInstance>);
+          const { slotName } = mounted[0];
+          expect(
+            walkProjection(shadowSlot(el, slotName)).forwarders.length
+          ).to.equal(hops);
+
+          el.customRenderers = { table: () => null };
+          await el.updateComplete;
+
+          expect(
+            harness.querySelector(`[slot="${slotName}"]:not(slot)`),
+            'the relocated node leaves the outermost surface'
+          ).to.equal(null);
+          levels.forEach((level, depth) => {
+            expect(
+              level.querySelector(`slot[name="${slotName}"]`),
+              `the forwarder at depth ${depth} must retire with the claim`
+            ).to.equal(null);
+          });
+          expect(
+            el.querySelector(`slot[name="${slotName}"]`),
+            'and so must the hop the element minted'
+          ).to.equal(null);
+          expect(
+            shadowSlot(el, slotName).assignedNodes().length,
+            'any surviving hop keeps the default table suppressed'
+          ).to.equal(0);
+          expect(
+            el.shadowRoot?.querySelector('cds-aichat-table'),
+            'the default table comes back at every depth'
+          ).to.not.equal(null);
+        });
+
+        it(`pluginFallback: retires every hop when the token leaves the content (${hops} hop(s))`, async () => {
+          const { harness, levels, pluginHosts, addMarkdown } =
+            await createRelocationHarness(hops);
+
+          const el = await addMarkdown('Hi :tag:', {
+            markdownItPlugins: [tagPlugin],
+          } as Partial<MarkdownElementInstance>);
+          const [slotName] = [...pluginHosts.keys()];
+          expect(
+            walkProjection(shadowSlot(el, slotName)).forwarders.length
+          ).to.equal(hops);
+
+          el.markdown = 'Hi.';
+          await el.updateComplete;
+
+          expect(
+            pluginHosts.size,
+            'the container drops the host it created'
+          ).to.equal(0);
+          expect(
+            harness.querySelector(`[slot="${slotName}"]`),
+            'and nothing is left in the outermost light DOM'
+          ).to.equal(null);
+          levels.forEach((level, depth) => {
+            expect(
+              level.querySelector(`slot[name="${slotName}"]`),
+              `the forwarder at depth ${depth} must retire with the claim`
+            ).to.equal(null);
+          });
+          expect(
+            el.querySelector(`slot[name="${slotName}"]`),
+            'the wrapper retires its hop on the unmount event'
+          ).to.equal(null);
+        });
+      }
+    });
   });
 
-  // ── The mount detail's `kind` discriminant (#2273) ────────────────────
+  // ── The mount detail's `kind` discriminant ────────────────────────────
   // Both dispatch sites offer a host over the same event, and a listener used
   // to tell them apart by testing whether `detail.element` was set — the shape
   // was the discriminant. `kind` publishes what the element already knows.
@@ -2120,6 +2378,111 @@ HTTP: http://example.com
       });
 
       expect(controller.hosts.get('no-html-update')?.innerHTML).to.equal('');
+    });
+  });
+
+  // Both web-component containers build the controller in a field initializer
+  // and only `connect()` / `disconnect()` from their lifecycle callbacks, so
+  // one controller survives a DOM move. `disconnect()` keeps the forwarder
+  // slot names on purpose: the markdown element re-offers every claim once it
+  // reconnects, and retiring the names mid-move would drop the forwarder a
+  // relocated `customRenderers` node still needs to project.
+  describe('plugin-host container across a disconnect', () => {
+    async function createReconnectTarget() {
+      const target = await fixture<HTMLElement>(html`<div></div>`);
+      const announced: string[][] = [];
+      const controller = createMarkdownPluginHostController(target, {
+        onSlotNamesChange: (slotNames) => {
+          announced.push(slotNames);
+        },
+      });
+      controller.connect();
+
+      function mount(detail: MarkdownPluginHostMountDetailInput) {
+        target.dispatchEvent(
+          new CustomEvent('cds-aichat-markdown-plugin-host-mount', {
+            bubbles: true,
+            composed: true,
+            cancelable: true,
+            detail,
+          })
+        );
+      }
+
+      return { target, controller, announced, mount };
+    }
+
+    it('drops the hosts it created and keeps the slot names', async () => {
+      const { target, controller, announced, mount } =
+        await createReconnectTarget();
+      const relocated = document.createElement('div');
+      mount({
+        kind: 'pluginFallback',
+        slotName: 'reconnect-fallback',
+        html: '<i>x</i>',
+        isInline: false,
+      });
+      mount({
+        kind: 'customRenderer',
+        slotName: 'reconnect-renderer',
+        element: relocated,
+        isInline: false,
+      });
+
+      controller.disconnect();
+
+      expect(controller.hosts.size).to.equal(0);
+      expect(target.querySelector('[slot="reconnect-fallback"]')).to.equal(
+        null
+      );
+      // Never created here, so never destroyed here — the node belongs to the
+      // markdown element and rides along with the container's DOM move.
+      expect(relocated.parentElement).to.equal(target);
+      expect(
+        announced,
+        'a retirement would announce a third, shorter list'
+      ).to.deep.equal([
+        ['reconnect-fallback'],
+        ['reconnect-fallback', 'reconnect-renderer'],
+      ]);
+    });
+
+    it('hosts one node per mount once it reconnects', async () => {
+      const { target, controller, announced, mount } =
+        await createReconnectTarget();
+      const detail: MarkdownPluginHostMountDetailInput = {
+        kind: 'pluginFallback',
+        slotName: 'reconnect-rehost',
+        html: '<i>x</i>',
+        isInline: false,
+      };
+      mount(detail);
+
+      controller.disconnect();
+      controller.connect();
+      mount(detail);
+
+      expect(
+        target.querySelectorAll('[slot="reconnect-rehost"]').length
+      ).to.equal(1);
+      expect(controller.hosts.get('reconnect-rehost')?.innerHTML).to.equal(
+        '<i>x</i>'
+      );
+
+      mount({
+        kind: 'pluginFallback',
+        slotName: 'reconnect-second',
+        html: '<i>y</i>',
+        isInline: false,
+      });
+
+      expect(
+        announced,
+        'the retained name is not re-announced, and the new one extends it'
+      ).to.deep.equal([
+        ['reconnect-rehost'],
+        ['reconnect-rehost', 'reconnect-second'],
+      ]);
     });
   });
 

--- a/packages/ai-chat-components/src/components/markdown/__tests__/markdown.test.ts
+++ b/packages/ai-chat-components/src/components/markdown/__tests__/markdown.test.ts
@@ -9,6 +9,11 @@
 
 import { expect, fixture, html, waitUntil } from '@open-wc/testing';
 import CDSAIChatMarkdownElement from '../src/markdown.js';
+import {
+  createMarkdownPluginHostController,
+  resolveMarkdownPluginHostMountDetail,
+} from '../src/utils/plugin-host-container.js';
+import type { MarkdownPluginHostMountDetailInput } from '../src/utils/plugin-host-container.js';
 const MARKDOWN_ELEMENT_TAG = 'cds-aichat-markdown';
 
 const TEXT = `Carbon <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 32 32" onclick="window.open('https://carbondesignsystem.com', '_blank')"><defs><style>.cls-1{fill:none;}</style></defs><title>If you click on this icon, it will go to https://carbondesignsystem.com. This is here to test "shouldSanitizeHTML". If true, the click shouldn't work!</title><path d="M13.5,30.8149a1.0011,1.0011,0,0,1-.4927-.13l-8.5-4.815A1,1,0,0,1,4,25V15a1,1,0,0,1,.5073-.87l8.5-4.815a1.0013,1.0013,0,0,1,.9854,0l8.5,4.815A1,1,0,0,1,23,15V25a1,1,0,0,1-.5073.87l-8.5,4.815A1.0011,1.0011,0,0,1,13.5,30.8149ZM6,24.417l7.5,4.2485L21,24.417V15.583l-7.5-4.2485L6,15.583Z"/><path d="M28,17H26V7.583L18.5,3.3345,10.4927,7.87,9.5073,6.13l8.5-4.815a1.0013,1.0013,0,0,1,.9854,0l8.5,4.815A1,1,0,0,1,28,7Z"/><rect class="cls-1" width="32" height="32" transform="translate(32 32) rotate(180)"/></svg> is a **chemical element** with the *atomic number* 6 and symbol **C**. \`C + O₂ → CO₂\` represents one of carbon's most fundamental reactions.
@@ -1499,30 +1504,31 @@ HTTP: http://example.com
   // weren't, two messages whose code block both started on line 0 minted the
   // same name: the first element's slot gathered both hosts and the second
   // gathered none. See issue #2099.
+  // Minimal inline plugin whose output goes through the plugin-fallback slot
+  // path (the same page-level hoisting, a separate slot-name mint site). Shared
+  // by the two describes below; both need a plugin-fallback descriptor.
+  function tagPlugin(md: any) {
+    md.inline.ruler.before(
+      'text',
+      'cds_test_tag',
+      (state: any, silent: boolean) => {
+        if (!state.src.slice(state.pos).startsWith(':tag:')) {
+          return false;
+        }
+        if (!silent) {
+          state.push('cds_test_tag', '', 0);
+        }
+        state.pos += ':tag:'.length;
+        return true;
+      }
+    );
+    md.renderer.rules.cds_test_tag = () =>
+      `<span class="cds-test-tag">tag</span>`;
+  }
+
   describe('slot names across markdown elements', () => {
     const HARNESS_TAG = 'cds-test-markdown-relocation-host';
     const codeMarkdown = '```json\n{ "name": "Alice" }\n```';
-
-    // Minimal inline plugin whose output goes through the plugin-fallback slot
-    // path (the same page-level hoisting, a separate slot-name mint site).
-    function tagPlugin(md: any) {
-      md.inline.ruler.before(
-        'text',
-        'cds_test_tag',
-        (state: any, silent: boolean) => {
-          if (!state.src.slice(state.pos).startsWith(':tag:')) {
-            return false;
-          }
-          if (!silent) {
-            state.push('cds_test_tag', '', 0);
-          }
-          state.pos += ':tag:'.length;
-          return true;
-        }
-      );
-      md.renderer.rules.cds_test_tag = () =>
-        `<span class="cds-test-tag">tag</span>`;
-    }
 
     if (!customElements.get(HARNESS_TAG)) {
       customElements.define(
@@ -1538,11 +1544,15 @@ HTTP: http://example.com
     }
 
     /**
-     * Stands in for a chat container: accepts every host-mount offer, relocates
-     * the host into its own light DOM, and renders one `<slot name=X slot=X>`
-     * forwarder per slot name — deduplicated by name, exactly as the real
-     * containers dedupe `_pluginSlotNames`. Mirrors `ChatContainer.tsx` and
-     * `cds-aichat-container`.
+     * A whole delegating topology in one object: the shipped container
+     * controller does the hosting, and a second listener adds the React
+     * `Markdown` wrapper's forwarder on top. It cannot drift from the
+     * containers, because it runs their code.
+     *
+     * The two halves belong to different layers. Hosting is a container's job;
+     * the `<slot name=X slot=X>` forwarder into the markdown element's own
+     * light DOM is the wrapper's, and is the only hop that crosses that
+     * element's shadow boundary.
      */
     async function createRelocationHarness() {
       const harness = await fixture<HTMLElement>(
@@ -1553,29 +1563,25 @@ HTTP: http://example.com
         slotName: string;
         host: HTMLElement;
       }> = [];
-      const forwarderOwners = new Map<string, Element>();
-      const pluginHosts = new Map<string, HTMLElement>();
 
+      // The container half is the shipped one, so this harness cannot drift
+      // from the surfaces it stands in for.
+      const controller = createMarkdownPluginHostController(harness);
+      controller.connect();
+
+      // Bookkeeping only. Nothing here mints a forwarder: the markdown element
+      // mints the innermost hop itself, for both claim kinds, in the pass that
+      // reads the claim. A second `<slot name=X>` in this tree would compete
+      // with it for the same assignment.
       harness.addEventListener(
         'cds-aichat-markdown-plugin-host-mount',
         (event) => {
-          const detail = (
-            event as CustomEvent<{
-              slotName: string;
-              html?: string;
-              element?: HTMLElement;
-              isInline: boolean;
-            }>
-          ).detail;
+          const detail = resolveMarkdownPluginHostMountDetail(
+            (event as CustomEvent<MarkdownPluginHostMountDetailInput>).detail
+          );
           const owner = event.composedPath()[0] as Element;
 
-          // Custom-renderer hosts (table/codeBlock) carry a live element that
-          // the markdown element manages directly. Do not preventDefault or
-          // hoist — the markdown element will call appendChild itself, keeping
-          // the shadow slot occupied. A stale forwarder or a missing host
-          // causes the slot to fall back to the default component, which
-          // triggers heavy async work (e.g. CodeMirror) that hangs updateComplete.
-          if (detail.element) {
+          if (detail.kind === 'customRenderer') {
             mounted.push({
               owner,
               slotName: detail.slotName,
@@ -1584,45 +1590,10 @@ HTTP: http://example.com
             return;
           }
 
-          event.preventDefault();
-
-          // Plugin fallbacks forward an HTML string; the container hosts it.
-          const host =
-            pluginHosts.get(detail.slotName) ??
-            document.createElement(detail.isInline ? 'span' : 'div');
-          host.innerHTML = detail.html ?? '';
-          pluginHosts.set(detail.slotName, host);
-          host.setAttribute('slot', detail.slotName);
-          if (host.parentElement !== harness) {
-            harness.appendChild(host);
+          const host = controller.hosts.get(detail.slotName);
+          if (host) {
+            mounted.push({ owner, slotName: detail.slotName, host });
           }
-
-          if (!forwarderOwners.has(detail.slotName)) {
-            forwarderOwners.set(detail.slotName, owner);
-            // Both attributes carry weight, and both mirror what the real
-            // containers render (`<slot name=${slot} slot=${slot}>`). `name`
-            // makes the forwarder gather the hoisted host back out of the
-            // harness light DOM; `slot` assigns the forwarder itself into the
-            // markdown element's own shadow slot, which is the second hop the
-            // `assignedElements({ flatten: true })` assertion below resolves
-            // through. Without `slot`, nothing is assigned to that shadow slot
-            // and `flatten` yields its fallback content instead of the host.
-            const forwarder = document.createElement('slot');
-            forwarder.setAttribute('name', detail.slotName);
-            forwarder.setAttribute('slot', detail.slotName);
-            owner.appendChild(forwarder);
-          }
-          mounted.push({ owner, slotName: detail.slotName, host });
-        }
-      );
-      harness.addEventListener(
-        'cds-aichat-markdown-plugin-host-unmount',
-        (event) => {
-          const { slotName } = (event as CustomEvent<{ slotName: string }>)
-            .detail;
-          forwarderOwners.delete(slotName);
-          pluginHosts.get(slotName)?.remove();
-          pluginHosts.delete(slotName);
         }
       );
 
@@ -1640,7 +1611,12 @@ HTTP: http://example.com
         return el;
       }
 
-      return { harness, mounted, forwarderOwners, pluginHosts, addMarkdown };
+      return {
+        harness,
+        mounted,
+        pluginHosts: controller.hosts,
+        addMarkdown,
+      };
     }
 
     /** Returns a `codeBlock` renderer stamping its result with `owner`. */
@@ -1688,7 +1664,7 @@ HTTP: http://example.com
     });
 
     it('projects exactly one host into each markdown element', async () => {
-      const { mounted, addMarkdown } = await createRelocationHarness();
+      const { harness, mounted, addMarkdown } = await createRelocationHarness();
 
       const elA = await addMarkdown(codeMarkdown, {
         customRenderers: { codeBlock: taggedCodeBlockRenderer('a') },
@@ -1701,16 +1677,17 @@ HTTP: http://example.com
       const [a, b] = mounted;
       expect(a.slotName).to.not.equal(b.slotName);
 
-      // custom-renderer hosts: markdown element adopts the host directly
-      // (no hoist to harness, no forwarder). Each element owns its own host.
+      // custom-renderer hosts: relocated into the harness light DOM and
+      // projected back through the forwarder the element minted. Each element
+      // still projects only its own host — the names are namespaced.
       for (const [{ slotName, host }, el] of [
         [a, elA],
         [b, elB],
       ] as Array<[{ slotName: string; host: HTMLElement }, HTMLElement]>) {
         expect(
           host.parentElement,
-          'host should be a direct child of the markdown element'
-        ).to.equal(el);
+          'host should be relocated into the container light DOM'
+        ).to.equal(harness);
         const slot = el.shadowRoot?.querySelector(
           `slot[name="${slotName}"]`
         ) as HTMLSlotElement | null;
@@ -1787,15 +1764,15 @@ HTTP: http://example.com
 
     // ── customRenderers.table — container topology ──────────────────────────
     // These tests use createRelocationHarness so the mount event is seen by a
-    // container-like ancestor. custom-renderer hosts carry detail.element —
-    // the container does NOT call preventDefault or hoist. The markdown element
-    // adopts the host as its own light-DOM child and the shadow slot projects
-    // it directly (single hop, no forwarder needed).
+    // container-like ancestor. The container claims the live element and
+    // re-parents it into its own light DOM; the markdown element mints
+    // `<slot name=X slot=X>` into its own light DOM in the same updated()
+    // pass, so the shadow slot resolves through two hops.
 
     const tableMarkdown = `| h1 | h2 |\n| --- | --- |\n| a | b |\n\nTrailer`;
 
-    it('customRenderers.table: host is a direct child of the markdown element', async () => {
-      const { mounted, addMarkdown } = await createRelocationHarness();
+    it('customRenderers.table: host is relocated and forwarded from the element', async () => {
+      const { harness, mounted, addMarkdown } = await createRelocationHarness();
 
       const el = await addMarkdown(tableMarkdown, {
         customRenderers: {
@@ -1813,17 +1790,24 @@ HTTP: http://example.com
       ).to.equal(1);
       const { host, slotName } = mounted[0];
 
-      // Host is owned by the markdown element directly (no hoist to container).
       expect(
         host.parentElement,
-        'host should be a direct child of the markdown element'
-      ).to.equal(el);
+        'host should be relocated into the container light DOM'
+      ).to.equal(harness);
       expect(
         host.getAttribute('slot'),
         'host should carry the slot name attribute'
       ).to.equal(slotName);
+      expect(
+        host.style.marginBlockStart,
+        'no inline style may outrank the page CSS this relocation admits'
+      ).to.equal('');
+      expect(
+        el.querySelectorAll(`slot[name="${slotName}"][slot="${slotName}"]`)
+          .length,
+        'the element mints exactly one hop back to it'
+      ).to.equal(1);
 
-      // Shadow slot projects the host directly — no two-hop forwarder needed.
       const slotEl = el.shadowRoot?.querySelector(
         `slot[name="${slotName}"]`
       ) as HTMLSlotElement | null;
@@ -1831,14 +1815,15 @@ HTTP: http://example.com
         null
       );
       const assigned = slotEl?.assignedElements({ flatten: true }) ?? [];
+      expect(assigned.length).to.equal(1);
       expect(
-        assigned.length,
-        'slot should project exactly one element'
-      ).to.be.greaterThan(0);
+        assigned[0],
+        'the slot must resolve to the relocated host, not to its fallback'
+      ).to.equal(host);
     });
 
     it('customRenderers.table: restores default table when callback returns null (container topology)', async () => {
-      const { addMarkdown } = await createRelocationHarness();
+      const { harness, addMarkdown } = await createRelocationHarness();
 
       const el = await addMarkdown(tableMarkdown, {
         customRenderers: {
@@ -1850,30 +1835,402 @@ HTTP: http://example.com
         },
       } as Partial<MarkdownElementInstance>);
 
-      // First render: custom element should be visible through the slot.
       const slotEl = el.shadowRoot?.querySelector(
         'slot[name*="cds-aichat-markdown-renderer-table"]'
       ) as HTMLSlotElement | null;
       expect(slotEl, 'named slot should exist on first render').to.not.equal(
         null
       );
+      const slotName = slotEl?.getAttribute('name') as string;
+      const host = harness.querySelector<HTMLElement>(
+        `[slot="${slotName}"]:not(slot)`
+      );
       expect(
-        slotEl?.assignedElements({ flatten: true }).length ?? 0,
+        slotEl?.assignedElements({ flatten: true })[0],
         'custom host should be projected on first render'
-      ).to.be.greaterThan(0);
+      ).to.equal(host);
 
-      // Switch to null — the slot host is removed and the slot's fallback
-      // (default cds-aichat-table) should render instead. This is the exact
-      // regression: in the broken version, markdown.tsx added a stale <slot>
-      // forwarder that kept the named slot occupied even after the host was
-      // removed, so the fallback never appeared.
+      // Switch to null. The element removes the host wherever it lives and
+      // retires its own forwarder in the same pass — a surviving forwarder is
+      // an assigned node, and an assigned node suppresses the slot's fallback,
+      // so the default table would never come back.
       el.customRenderers = { table: () => null };
       await el.updateComplete;
 
       expect(
+        slotEl?.assignedNodes().length,
+        'nothing may stay assigned, or the fallback stays suppressed'
+      ).to.equal(0);
+      expect(
+        el.querySelector(`slot[name="${slotName}"]`),
+        'the element retires its own hop with the claim'
+      ).to.equal(null);
+      expect(
+        harness.querySelector(`[slot="${slotName}"]:not(slot)`),
+        'and the relocated node leaves the container'
+      ).to.equal(null);
+      expect(
         el.shadowRoot?.querySelector('cds-aichat-table'),
         'default cds-aichat-table should appear after callback returns null'
       ).to.not.equal(null);
+    });
+
+    it('customRenderers.table: retires host, forwarder and container node when the table leaves the content', async () => {
+      const { harness, mounted, addMarkdown } = await createRelocationHarness();
+
+      const el = await addMarkdown(tableMarkdown, {
+        customRenderers: { table: () => document.createElement('div') },
+      } as Partial<MarkdownElementInstance>);
+      const { slotName } = mounted[0];
+      expect(
+        harness.querySelector(`[slot="${slotName}"]:not(slot)`)
+      ).to.not.equal(null);
+
+      el.markdown = 'No table here.';
+      await el.updateComplete;
+
+      expect(
+        harness.querySelector(`[slot="${slotName}"]:not(slot)`),
+        'the element detaches the node it relocated'
+      ).to.equal(null);
+      expect(
+        el.querySelector(`slot[name="${slotName}"]`),
+        'and retires its own hop in the same pass'
+      ).to.equal(null);
+    });
+
+    it('customRenderers.table: mints one host and one forwarder across a streaming run', async () => {
+      const { harness, mounted, addMarkdown } = await createRelocationHarness();
+      const stable = document.createElement('div');
+      stable.className = 'cds-test-stream-table';
+
+      const el = await addMarkdown(tableMarkdown, {
+        streaming: true,
+        customRenderers: { table: () => stable },
+      } as Partial<MarkdownElementInstance>);
+      const { slotName } = mounted[0];
+
+      for (const tail of ['a', 'ab', 'abc']) {
+        el.markdown = `${tableMarkdown}${tail}`;
+        await el.updateComplete;
+      }
+
+      expect(mounted.length, 'one offer for the one table').to.equal(1);
+      expect(
+        harness.querySelectorAll(`[slot="${slotName}"]:not(slot)`).length,
+        'one relocated host'
+      ).to.equal(1);
+      expect(
+        el.querySelectorAll(`slot[name="${slotName}"]`).length,
+        'one forwarder'
+      ).to.equal(1);
+    });
+
+    it('customRenderers.table: mints one forwarder, not two, across a disconnect and reconnect', async () => {
+      const { harness, mounted, addMarkdown } = await createRelocationHarness();
+
+      const el = await addMarkdown(tableMarkdown, {
+        customRenderers: { table: () => document.createElement('div') },
+      } as Partial<MarkdownElementInstance>);
+      const { slotName } = mounted[0];
+
+      el.remove();
+      expect(
+        harness.querySelector(`[slot="${slotName}"]:not(slot)`),
+        'disconnect detaches the relocated node'
+      ).to.equal(null);
+      expect(
+        el.querySelector(`slot[name="${slotName}"]`),
+        'and retires the forwarder with it'
+      ).to.equal(null);
+
+      harness.shadowRoot?.appendChild(el);
+      await el.updateComplete;
+
+      // The namespace is minted at construction, so the reconnect re-offers
+      // under the same name and a leaked forwarder would win by tree order.
+      expect(mounted.length, 'the reconnect re-offers the host').to.equal(2);
+      expect(el.querySelectorAll(`slot[name="${slotName}"]`).length).to.equal(
+        1
+      );
+      const slot = el.shadowRoot?.querySelector(
+        `slot[name="${slotName}"]`
+      ) as HTMLSlotElement | null;
+      expect(slot?.assignedElements({ flatten: true })[0]).to.equal(
+        harness.querySelector(`[slot="${slotName}"]:not(slot)`)
+      );
+    });
+  });
+
+  // ── The mount detail's `kind` discriminant (#2273) ────────────────────
+  // Both dispatch sites offer a host over the same event, and a listener used
+  // to tell them apart by testing whether `detail.element` was set — the shape
+  // was the discriminant. `kind` publishes what the element already knows.
+  describe('plugin-host mount detail kind', () => {
+    const KIND_HARNESS_TAG = 'cds-test-markdown-kind-host';
+
+    if (!customElements.get(KIND_HARNESS_TAG)) {
+      customElements.define(
+        KIND_HARNESS_TAG,
+        class extends HTMLElement {
+          connectedCallback() {
+            if (!this.shadowRoot) {
+              this.attachShadow({ mode: 'open' });
+            }
+          }
+        }
+      );
+    }
+
+    /** Records every mount detail without claiming anything. */
+    async function createDetailRecorder() {
+      const harness = await fixture<HTMLElement>(
+        html`<cds-test-markdown-kind-host></cds-test-markdown-kind-host>`
+      );
+      const details: Array<Record<string, unknown>> = [];
+      harness.addEventListener(
+        'cds-aichat-markdown-plugin-host-mount',
+        (event) => {
+          details.push((event as CustomEvent<Record<string, unknown>>).detail);
+        }
+      );
+      async function addMarkdown(
+        markdown: string,
+        props: Partial<MarkdownElementInstance> = {}
+      ) {
+        const el = document.createElement(
+          MARKDOWN_ELEMENT_TAG
+        ) as MarkdownElementInstance;
+        Object.assign(el, props, { markdown });
+        harness.shadowRoot?.appendChild(el);
+        await el.updateComplete;
+        return el;
+      }
+      return { harness, details, addMarkdown };
+    }
+
+    it('marks a plugin-fallback offer as pluginFallback', async () => {
+      const { details, addMarkdown } = await createDetailRecorder();
+
+      await addMarkdown('Hi :tag: there', {
+        markdownItPlugins: [tagPlugin],
+      } as Partial<MarkdownElementInstance>);
+
+      expect(
+        details.length,
+        'the plugin token should offer a host'
+      ).to.be.at.least(1);
+      expect(details[0].kind).to.equal('pluginFallback');
+      expect(details[0].html).to.be.a('string');
+      expect(details[0].element).to.equal(undefined);
+    });
+
+    it('marks a customRenderers offer as customRenderer', async () => {
+      const { details, addMarkdown } = await createDetailRecorder();
+
+      await addMarkdown('```json\n{ "a": 1 }\n```', {
+        customRenderers: { codeBlock: () => document.createElement('div') },
+      } as Partial<MarkdownElementInstance>);
+
+      expect(
+        details.length,
+        'the code block should offer a host'
+      ).to.be.at.least(1);
+      expect(details[0].kind).to.equal('customRenderer');
+      expect(details[0].element).to.be.instanceOf(HTMLElement);
+      expect(details[0].html).to.equal(undefined);
+    });
+  });
+
+  // `html` is typed `string` on the plugin-fallback detail, so a payload
+  // missing it cannot come from the markdown element — it comes from an
+  // emitter this compiler never saw, which is the audience the protocol was
+  // published for. Hence the synthesized events: no element produces these.
+  describe('plugin-host container: a payload carrying no html', () => {
+    async function createHostTarget() {
+      const target = await fixture<HTMLElement>(html`<div></div>`);
+      const controller = createMarkdownPluginHostController(target);
+      controller.connect();
+
+      function dispatch(type: string, detail: Record<string, unknown>) {
+        target.dispatchEvent(
+          new CustomEvent(type, {
+            bubbles: true,
+            composed: true,
+            cancelable: true,
+            detail,
+          })
+        );
+      }
+
+      return { controller, dispatch };
+    }
+
+    it('hosts a mount with no html as an empty host', async () => {
+      const { controller, dispatch } = await createHostTarget();
+
+      dispatch('cds-aichat-markdown-plugin-host-mount', {
+        kind: 'pluginFallback',
+        slotName: 'no-html-mount',
+        isInline: false,
+      });
+
+      expect(controller.hosts.get('no-html-mount')?.innerHTML).to.equal('');
+    });
+
+    it('empties the host on an update with no html', async () => {
+      const { controller, dispatch } = await createHostTarget();
+
+      dispatch('cds-aichat-markdown-plugin-host-mount', {
+        kind: 'pluginFallback',
+        slotName: 'no-html-update',
+        html: '<i>x</i>',
+        isInline: false,
+      });
+      dispatch('cds-aichat-markdown-plugin-host-update', {
+        slotName: 'no-html-update',
+      });
+
+      expect(controller.hosts.get('no-html-update')?.innerHTML).to.equal('');
+    });
+  });
+
+  // ── Slot-name stability across render commits ─────────────────────────
+  // A plugin-fallback slot name ends in a positional index minted by a counter
+  // that `renderMarkdownTree` resets once per call. But `renderFallback` runs
+  // inside a lit-html `repeat()` callback, so it evaluates when lit-html
+  // *commits*, and one render result can be committed more than once. These
+  // cases pin the name to the token rather than to the commit count.
+  describe('plugin-fallback slot names across render commits', () => {
+    const COMMIT_HARNESS_TAG = 'cds-test-markdown-commit-host';
+
+    if (!customElements.get(COMMIT_HARNESS_TAG)) {
+      customElements.define(
+        COMMIT_HARNESS_TAG,
+        class extends HTMLElement {
+          connectedCallback() {
+            if (!this.shadowRoot) {
+              this.attachShadow({ mode: 'open' });
+            }
+          }
+        }
+      );
+    }
+
+    /** A delegating container that also records every offer and retirement. */
+    async function createCommitRecorder() {
+      const harness = await fixture<HTMLElement>(
+        html`<cds-test-markdown-commit-host></cds-test-markdown-commit-host>`
+      );
+      const mounts: string[] = [];
+      const unmounts: string[] = [];
+
+      const controller = createMarkdownPluginHostController(harness);
+      controller.connect();
+      harness.addEventListener(
+        'cds-aichat-markdown-plugin-host-mount',
+        (event) => {
+          const detail = resolveMarkdownPluginHostMountDetail(
+            (event as CustomEvent<MarkdownPluginHostMountDetailInput>).detail
+          );
+          if (detail.kind === 'pluginFallback') {
+            mounts.push(detail.slotName);
+          }
+        }
+      );
+      harness.addEventListener(
+        'cds-aichat-markdown-plugin-host-unmount',
+        (event) => {
+          unmounts.push(
+            (event as CustomEvent<{ slotName: string }>).detail.slotName
+          );
+        }
+      );
+
+      async function addMarkdown(markdown: string) {
+        const el = document.createElement(
+          MARKDOWN_ELEMENT_TAG
+        ) as MarkdownElementInstance;
+        Object.assign(el, {
+          markdownItPlugins: [tagPlugin],
+          markdown,
+        } as Partial<MarkdownElementInstance>);
+        harness.shadowRoot?.appendChild(el);
+        await el.updateComplete;
+        return el;
+      }
+
+      return { harness, mounts, unmounts, addMarkdown };
+    }
+
+    /** Names of the plugin-fallback slots the element currently renders. */
+    function fallbackSlotNames(el: MarkdownElementInstance) {
+      return [...(el.shadowRoot?.querySelectorAll('slot') ?? [])]
+        .map((slot) => slot.getAttribute('name') ?? '')
+        .filter((name) => name.includes('pluginFallback'));
+    }
+
+    it('keeps one slot when the markdown changes around the token', async () => {
+      const { mounts, unmounts, addMarkdown } = await createCommitRecorder();
+
+      const el = await addMarkdown('Hi :tag:');
+      const [first] = fallbackSlotNames(el);
+
+      el.markdown = 'Hi :tag: there';
+      await el.updateComplete;
+
+      expect(mounts, 'one offer per token, not per commit').to.deep.equal([
+        first,
+      ]);
+      expect(unmounts, 'nothing should need retiring').to.deep.equal([]);
+      expect(fallbackSlotNames(el)).to.deep.equal([first]);
+    });
+
+    it('keeps the same slot name across a re-render that changes nothing', async () => {
+      const { mounts, addMarkdown } = await createCommitRecorder();
+
+      const el = await addMarkdown('Hi :tag:');
+      const [first] = fallbackSlotNames(el);
+
+      el.requestUpdate();
+      await el.updateComplete;
+
+      expect(fallbackSlotNames(el)).to.deep.equal([first]);
+      expect(mounts).to.deep.equal([first]);
+    });
+
+    it('mints one slot per token over a streaming run, not one per chunk', async () => {
+      const { mounts, unmounts, addMarkdown } = await createCommitRecorder();
+
+      const el = await addMarkdown('');
+      el.streaming = true;
+      for (const chunk of [
+        'Hi',
+        'Hi :',
+        'Hi :tag:',
+        'Hi :tag: a',
+        'Hi :tag: ab',
+      ]) {
+        el.markdown = chunk;
+        await el.updateComplete;
+      }
+
+      expect(mounts.length, 'one host for the one plugin token').to.equal(1);
+      expect(unmounts).to.deep.equal([]);
+    });
+
+    it('gives two plugin tokens distinct names that survive a re-render', async () => {
+      const { addMarkdown } = await createCommitRecorder();
+
+      const el = await addMarkdown('a :tag: b :tag: c');
+      const before = fallbackSlotNames(el);
+      expect(before.length, 'one slot per token').to.equal(2);
+      expect(before[0], 'names must not collide').to.not.equal(before[1]);
+
+      el.requestUpdate();
+      await el.updateComplete;
+
+      expect(fallbackSlotNames(el)).to.deep.equal(before);
     });
   });
 

--- a/packages/ai-chat-components/src/components/markdown/__tests__/markdown.test.ts
+++ b/packages/ai-chat-components/src/components/markdown/__tests__/markdown.test.ts
@@ -950,6 +950,12 @@ HTTP: http://example.com
       md.renderer.rules.paragraph_close = () => `</section>`;
     }
 
+    // Break override — should be IGNORED (breaks not in allow-list).
+    function breakOverridePlugin(md: any) {
+      md.renderer.rules.hardbreak = () => `<i class="cds-test-hardbreak"></i>`;
+      md.renderer.rules.softbreak = () => `<i class="cds-test-softbreak"></i>`;
+    }
+
     it('routes fence through a closure-wrapping plugin rule', async () => {
       const el = await fixture<MarkdownElementInstance>(
         html`<cds-aichat-markdown
@@ -1081,6 +1087,28 @@ HTTP: http://example.com
       // Container overrides are intentionally NOT honored — native <p> wins.
       expect(root?.querySelector('p')).to.not.equal(null);
       expect(root?.querySelector('.cds-test-section')).to.equal(null);
+    });
+
+    it('ignores plugin overrides on break tokens (hardbreak/softbreak)', async () => {
+      const el = await fixture<MarkdownElementInstance>(
+        html`<cds-aichat-markdown
+          .markdownItPlugins=${[breakOverridePlugin]}
+          .markdown=${'line one  \nline two\nline three'}></cds-aichat-markdown>`
+      );
+      await el.updateComplete;
+      // Delegation is priced per token, so a break override would mint a slot
+      // host and a mount/unmount event pair for every line break. Native <br>
+      // wins instead.
+      expect(el.shadowRoot?.querySelectorAll('br').length).to.equal(2);
+      expect(
+        el.querySelectorAll('.cds-test-hardbreak, .cds-test-softbreak').length,
+        'plugin break HTML should not be adopted as a light-DOM host'
+      ).to.equal(0);
+      expect(
+        el.shadowRoot?.querySelectorAll('slot[name*="pluginFallback"]')
+          .length ?? 0,
+        'break tokens must not mint a plugin-fallback slot'
+      ).to.equal(0);
     });
 
     it('preserves sanitization on plugin-emitted HTML', async () => {

--- a/packages/ai-chat-components/src/components/markdown/__tests__/markdown.test.ts
+++ b/packages/ai-chat-components/src/components/markdown/__tests__/markdown.test.ts
@@ -3318,7 +3318,7 @@ describe('renderTokenTree — softbreak with breaks: false', () => {
 
 describe('cds-aichat-markdown line breaks inside merged inline-HTML runs', () => {
   // `combineConsecutiveHtmlInline` collapses consecutive html_inline / text /
-  // break tokens into one `html_container` node serialized by
+  // break tokens into one `html_inline` node serialized by
   // `serializeInlineToken`. Before the fix, both softbreak and hardbreak
   // returned token.content (the empty string) and the break was deleted.
 

--- a/packages/ai-chat-components/src/components/markdown/__tests__/markdown.test.ts
+++ b/packages/ai-chat-components/src/components/markdown/__tests__/markdown.test.ts
@@ -3315,3 +3315,140 @@ describe('renderTokenTree — softbreak with breaks: false', () => {
     ).to.include('\n');
   });
 });
+
+describe('cds-aichat-markdown line breaks inside merged inline-HTML runs', () => {
+  // `combineConsecutiveHtmlInline` collapses consecutive html_inline / text /
+  // break tokens into one `html_container` node serialized by
+  // `serializeInlineToken`. Before the fix, both softbreak and hardbreak
+  // returned token.content (the empty string) and the break was deleted.
+
+  type RenderOptions = { sanitize?: boolean; removeHtml?: boolean };
+
+  async function renderMarkdown(markdown: string, opts: RenderOptions = {}) {
+    const el = await fixture<MarkdownElementInstance>(
+      html`<cds-aichat-markdown
+        ?sanitize-html=${opts.sanitize ?? false}
+        ?remove-html=${opts.removeHtml ?? false}
+        .markdown=${markdown}></cds-aichat-markdown>`
+    );
+    await el.updateComplete;
+    return el;
+  }
+
+  // Lit brackets each rendered part with comment markers, so what landed either
+  // side of the break has to be read past them.
+  function contentNodes(parent: Element) {
+    return Array.from(parent.childNodes).filter(
+      (node) => node.nodeType !== Node.COMMENT_NODE
+    );
+  }
+
+  const BREAK_CASES = [
+    { label: 'soft break', markdown: '<span>one\ntwo</span>' },
+    { label: 'hard break', markdown: '<span>one  \ntwo</span>' },
+  ];
+
+  // Default mode — neither flag — is the one that hands the serialized run to
+  // unsafeHTML with nothing filtering it in between.
+  const MERGING_MODES: Array<{ label: string; opts: RenderOptions }> = [
+    { label: 'default', opts: {} },
+    { label: 'sanitize-html', opts: { sanitize: true } },
+  ];
+
+  for (const { label, markdown } of BREAK_CASES) {
+    for (const mode of MERGING_MODES) {
+      it(`renders a ${label} inside a merged inline-HTML run as one <br> (${mode.label})`, async () => {
+        const el = await renderMarkdown(markdown, mode.opts);
+        const span = el.shadowRoot?.querySelector('span');
+        expect(span, '<span> should be in the shadow root').to.not.equal(null);
+        expect(
+          span?.querySelectorAll('br').length,
+          `${label} inside span should produce exactly one <br>`
+        ).to.equal(1);
+        expect(span?.textContent, 'text content should be "onetwo"').to.equal(
+          'onetwo'
+        );
+      });
+    }
+
+    // remove-html parses with `html: false`, so `<span>` is never tokenized as
+    // html_inline and the run is never merged — the serializer does not run
+    // here at all. What this mode still owes is narrower: the tag stays inert
+    // text and the break splits it.
+    it(`renders a ${label} with remove-html set, keeping the tag as inert text`, async () => {
+      const el = await renderMarkdown(markdown, { removeHtml: true });
+      expect(
+        el.shadowRoot?.querySelector('span'),
+        'remove-html must not produce a live <span>'
+      ).to.equal(null);
+
+      const paragraph = el.shadowRoot?.querySelector('p');
+      if (!paragraph) {
+        throw new Error('Expected a <p> in the shadow root');
+      }
+
+      const nodes = contentNodes(paragraph);
+      const breaks = nodes.filter(
+        (node) => node.nodeName.toLowerCase() === 'br'
+      );
+      expect(
+        breaks.length,
+        `${label} should produce exactly one <br>`
+      ).to.equal(1);
+
+      const textAround = (from: number, to: number) =>
+        nodes
+          .slice(from, to)
+          .map((node) => node.textContent)
+          .join('');
+      const breakIndex = nodes.indexOf(breaks[0]);
+      expect(
+        textAround(0, breakIndex),
+        'the escaped opening tag should survive'
+      ).to.equal('<span>one');
+      expect(
+        textAround(breakIndex + 1, nodes.length),
+        'the escaped closing tag should survive'
+      ).to.equal('two</span>');
+    });
+  }
+
+  for (const mode of MERGING_MODES) {
+    it(`the <br> node has no adjacent stray whitespace text node (${mode.label})`, async () => {
+      const el = await renderMarkdown('<span>one\ntwo</span>', mode.opts);
+      const span = el.shadowRoot?.querySelector('span');
+      expect(span).to.not.equal(null);
+      if (!span) {
+        return;
+      }
+      const childNodes = Array.from(span.childNodes);
+      expect(
+        childNodes.length,
+        `span should have exactly 3 child nodes, got: ${childNodes.map((n) => (n.nodeType === 3 ? JSON.stringify(n.textContent) : n.nodeName)).join(', ')}`
+      ).to.equal(3);
+      // Text, not just node type: a serializer emitting '<br />\n' also yields
+      // three nodes, because the newline is parsed into the following text
+      // node. The exact strings are what separate it from '<br />'.
+      expect(childNodes[0].textContent, 'first node is text "one"').to.equal(
+        'one'
+      );
+      expect(
+        childNodes[1].nodeName.toLowerCase(),
+        'second node should be <br>'
+      ).to.equal('br');
+      expect(childNodes[2].textContent, 'third node is text "two"').to.equal(
+        'two'
+      );
+    });
+  }
+
+  it('inline HTML with no line break serializes exactly as before (no-op)', async () => {
+    const el = await renderMarkdown('<span>hello world</span>', {
+      sanitize: true,
+    });
+    const span = el.shadowRoot?.querySelector('span');
+    expect(span).to.not.equal(null);
+    expect(span?.textContent).to.equal('hello world');
+    expect(span?.querySelector('br')).to.equal(null);
+  });
+});

--- a/packages/ai-chat-components/src/components/markdown/index.ts
+++ b/packages/ai-chat-components/src/components/markdown/index.ts
@@ -23,5 +23,11 @@ export type {
   MarkdownRendererTableArgs,
   MarkdownRendererTableData,
 } from './src/markdown-renderer-types.js';
+export type {
+  MarkdownCustomRendererMountDetail,
+  MarkdownPluginFallbackMountDetail,
+  MarkdownPluginHostMountDetail,
+  MarkdownPluginHostMountDetailInput,
+} from './src/utils/plugin-host-container.js';
 export type { MarkdownItPlugin, TokenTree } from './src/markdown-token-tree.js';
 export { markdownToMarkdownItTokens } from './src/markdown-token-tree.js';

--- a/packages/ai-chat-components/src/components/markdown/src/markdown-renderer-types.ts
+++ b/packages/ai-chat-components/src/components/markdown/src/markdown-renderer-types.ts
@@ -436,7 +436,7 @@ export interface RenderTokenTreeOptions {
    *
    * @internal
    */
-  pluginSlotCounter?: { next: () => number };
+  pluginSlotCounter?: { next: (node: TokenTree) => number };
 
   /**
    * Namespace appended to every slot name minted during this render, supplied

--- a/packages/ai-chat-components/src/components/markdown/src/markdown-renderer.ts
+++ b/packages/ai-chat-components/src/components/markdown/src/markdown-renderer.ts
@@ -195,10 +195,28 @@ export function renderMarkdownTree(
 } {
   const batch: MarkdownRendererSlotDescriptor[] = [];
   let pluginSlotIndex = 0;
+  // Memoized per node, not just counted. `renderFallback` runs inside a
+  // lit-html `repeat()` callback, so it evaluates when lit-html commits the
+  // template — and one render result gets committed again on any later Lit
+  // update that leaves `renderedContent` alone. A bare counter would hand the
+  // same token a fresh index on each commit, minting a second slot the very
+  // next reconcile retires. First evaluation still assigns 0, 1, 2 in walk
+  // order, so a single-commit render is unchanged.
+  const pluginSlotIndexes = new WeakMap<TokenTree, number>();
   const template = renderTokenTree(node, {
     ...options,
     recordCustomRender: (descriptor) => batch.push(descriptor),
-    pluginSlotCounter: { next: () => pluginSlotIndex++ },
+    pluginSlotCounter: {
+      next: (forNode: TokenTree) => {
+        const existing = pluginSlotIndexes.get(forNode);
+        if (existing !== undefined) {
+          return existing;
+        }
+        const index = pluginSlotIndex++;
+        pluginSlotIndexes.set(forNode, index);
+        return index;
+      },
+    },
   });
   return { template, batch };
 }

--- a/packages/ai-chat-components/src/components/markdown/src/markdown-renderer.ts
+++ b/packages/ai-chat-components/src/components/markdown/src/markdown-renderer.ts
@@ -278,20 +278,9 @@ export function renderTokenTree(
   }
 
   // Hard and soft line breaks. Handled before the tag-based dispatch because
-  // hardbreak has tag="br" but is not a plugin-introduced token and must not
-  // route through the plugin-fallback slot machinery on the default path.
-  // A plugin that overrides md.renderer.rules.hardbreak / .softbreak takes
-  // precedence via the normal shouldDelegateToPluginRule check.
+  // hardbreak has tag="br", which `renderWithStaticTag` does not know and would
+  // route through the plugin-fallback slot machinery.
   if (token.type === 'hardbreak' || token.type === 'softbreak') {
-    if (shouldDelegateToPluginRule(token, options.md) && options.md) {
-      return renderFallback(
-        token as Token,
-        node,
-        options.md,
-        sanitize,
-        options
-      );
-    }
     return token.type === 'softbreak' && options.md?.options.breaks === false
       ? html`${'\n'}`
       : html`<br />`;

--- a/packages/ai-chat-components/src/components/markdown/src/markdown-token-tree.ts
+++ b/packages/ai-chat-components/src/components/markdown/src/markdown-token-tree.ts
@@ -67,7 +67,12 @@ export interface TokenTree {
  * elements (cds-unordered-list, cds-list-item, cds-aichat-table) and break
  * streaming-friendly per-child diffing for the subtree. Link tokens are
  * excluded because the native `<a>` dispatch injects `target="_blank"` for
- * chat-link safety.
+ * chat-link safety. Break tokens (softbreak, hardbreak) are excluded because
+ * delegation is priced per token — a slot host and a mount/unmount event pair
+ * for every line break — and because `./utils/html-helpers.ts` folds breaks
+ * into merged inline-HTML runs and `./utils/table-helpers.ts` flattens them to
+ * text, so the override would be honored in some positions and silently
+ * dropped in others.
  *
  * @internal
  */
@@ -76,8 +81,6 @@ export const PLUGIN_DELEGABLE_TOKEN_TYPES: ReadonlySet<string> = new Set([
   'image',
   'code_inline',
   'html_block',
-  'softbreak',
-  'hardbreak',
 ]);
 
 /**

--- a/packages/ai-chat-components/src/components/markdown/src/markdown.ts
+++ b/packages/ai-chat-components/src/components/markdown/src/markdown.ts
@@ -23,6 +23,10 @@ import {
   type MarkdownItPlugin,
   type TokenTree,
 } from './markdown-token-tree.js';
+import type {
+  MarkdownCustomRendererMountDetail,
+  MarkdownPluginFallbackMountDetail,
+} from './utils/plugin-host-container.js';
 import {
   renderMarkdownTree,
   type MarkdownCustomRenderers,
@@ -250,8 +254,10 @@ class CDSAIChatMarkdown extends LitElement {
    * default Carbon rendering. Returning the same element reference across
    * renders avoids DOM churn.
    *
-   * The consumer's returned element lives in this element's light DOM, not
-   * in its shadow root, so external CSS applies normally.
+   * Inside a chat, a container relocates the returned element into its own
+   * light DOM — page DOM at the top of the chain — and this element forwards
+   * it back into the named slot, so consumer-loaded page CSS reaches it.
+   * Standalone (no chat ancestor), it stays a light-DOM child of this element.
    */
   @property({ attribute: false })
   customRenderers?: MarkdownCustomRenderers;
@@ -271,6 +277,20 @@ class CDSAIChatMarkdown extends LitElement {
   private slotHosts: Map<string, HTMLElement> = new Map();
 
   /**
+   * `<slot name=X slot=X>` forwarders minted for {@link customRenderers} hosts
+   * an outer listener relocated into its own light DOM, keyed by slot name.
+   *
+   * Appended imperatively rather than rendered: Lit commits into the shadow
+   * root, and this hop has to be a light-DOM child of this element to gather
+   * the relocated host out of the chat element's light DOM and hand it to the
+   * shadow `<slot>` the renderer emitted. Minted where the claim is read
+   * rather than by a subscriber, because the mount event fires once per host
+   * and is never replayed — a listener that subscribes later cannot mint it.
+   * @internal
+   */
+  private rendererForwarders: Map<string, HTMLSlotElement> = new Map();
+
+  /**
    * Namespace appended to every slot name this element mints, so two markdown
    * elements rendering identical markdown never collide in the shared
    * page-level host container a chat container hoists slot hosts into.
@@ -285,8 +305,8 @@ class CDSAIChatMarkdown extends LitElement {
 
   /**
    * Slot names whose host was created by an outer listener (a chat container
-   * that called `preventDefault()` on the host-mount event). We track these
-   * so we can fire matching unmount events without trying to remove a host we
+   * that called `preventDefault()` on the host-mount event). We track these so
+   * we can fire matching unmount events without trying to remove a host we
    * never appended.
    * @internal
    */
@@ -386,17 +406,12 @@ class CDSAIChatMarkdown extends LitElement {
       host.remove();
     }
     this.slotHosts.clear();
-    // Ask any delegating chat container to drop its hosts too.
-    for (const slotName of this.delegatedPluginSlots) {
-      this.dispatchEvent(
-        new CustomEvent('cds-aichat-markdown-plugin-host-unmount', {
-          bubbles: true,
-          composed: true,
-          detail: { slotName },
-        })
-      );
+    // Ask any delegating chat container to drop its hosts too. The loop above
+    // already detached every relocated node — `slotHosts` holds the reference
+    // wherever the node ended up — so this retires forwarders and announces.
+    for (const slotName of this.delegatedPluginSlots.keys()) {
+      this.retireDelegatedSlot(slotName);
     }
-    this.delegatedPluginSlots.clear();
     this.latestRendererDescriptors = [];
   }
 
@@ -772,6 +787,44 @@ class CDSAIChatMarkdown extends LitElement {
   }
 
   /**
+   * Drops a claim: retires the forwarder minted for it, if any, then tells the
+   * container to let go.
+   *
+   * The forwarder goes first. An assigned node suppresses the shadow slot's
+   * fallback content for as long as it exists, so a surviving forwarder turns
+   * a removed host into a blank region instead of the default rendering.
+   * @internal
+   */
+  /**
+   * Records a claim and mints the innermost hop back to the host the listener
+   * just relocated. Called in the same pass that read the claim because the
+   * mount event fires once per host and is never replayed — minting here is
+   * what makes a claim without its forwarder unrepresentable.
+   * @internal
+   */
+  private adoptDelegatedSlot(slotName: string) {
+    this.delegatedPluginSlots.add(slotName);
+    const forwarder = document.createElement('slot');
+    forwarder.setAttribute('name', slotName);
+    forwarder.setAttribute('slot', slotName);
+    this.rendererForwarders.set(slotName, forwarder);
+    this.appendChild(forwarder);
+  }
+
+  private retireDelegatedSlot(slotName: string) {
+    this.rendererForwarders.get(slotName)?.remove();
+    this.rendererForwarders.delete(slotName);
+    this.delegatedPluginSlots.delete(slotName);
+    this.dispatchEvent(
+      new CustomEvent('cds-aichat-markdown-plugin-host-unmount', {
+        bubbles: true,
+        composed: true,
+        detail: { slotName },
+      })
+    );
+  }
+
+  /**
    * Invoke the consumer's `customRenderers` callbacks once per descriptor and
    * adopt their returned `HTMLElement` as a `<span slot="…">` (for inline
    * plugin tokens) or `<div slot="…">` (block tokens and consumer renderers)
@@ -806,15 +859,16 @@ class CDSAIChatMarkdown extends LitElement {
               composed: true,
               cancelable: true,
               detail: {
+                kind: 'pluginFallback',
                 slotName: descriptor.slotName,
                 html: descriptor.html,
                 isInline: descriptor.isInline,
-              },
+              } satisfies MarkdownPluginFallbackMountDetail,
             }
           );
           this.dispatchEvent(mountEvent);
           if (mountEvent.defaultPrevented) {
-            this.delegatedPluginSlots.add(descriptor.slotName);
+            this.adoptDelegatedSlot(descriptor.slotName);
           }
         } else if (alreadyDelegated) {
           // The chain owns this slot; push HTML updates through a second
@@ -897,8 +951,9 @@ class CDSAIChatMarkdown extends LitElement {
         // element's own light DOM sits inside the chat's shadow root, where it
         // cannot. Mirrors the plugin-fallback path above, but forwards the live
         // host element instead of an HTML string; the markdown element keeps
-        // ownership of the host's content across renders. If no ancestor takes
-        // over (standalone usage, e.g. storybook), host it locally.
+        // ownership of the host's content across renders, and mints the slot
+        // hop back to it below. If no ancestor takes over (standalone usage,
+        // e.g. storybook), host it locally.
         const mountEvent = new CustomEvent(
           'cds-aichat-markdown-plugin-host-mount',
           {
@@ -906,15 +961,16 @@ class CDSAIChatMarkdown extends LitElement {
             composed: true,
             cancelable: true,
             detail: {
+              kind: 'customRenderer',
               slotName: descriptor.slotName,
               element: host,
               isInline: false,
-            },
+            } satisfies MarkdownCustomRendererMountDetail,
           }
         );
         this.dispatchEvent(mountEvent);
         if (mountEvent.defaultPrevented) {
-          this.delegatedPluginSlots.add(descriptor.slotName);
+          this.adoptDelegatedSlot(descriptor.slotName);
         } else {
           this.appendChild(host);
         }
@@ -931,18 +987,12 @@ class CDSAIChatMarkdown extends LitElement {
       }
     }
 
-    // Tell any delegating chat container to drop hosts whose descriptor
-    // disappeared (e.g. a streaming chunk removed a math node).
-    for (const slotName of this.delegatedPluginSlots) {
+    // Drop claims whose descriptor disappeared (a streaming chunk removed a
+    // math node, a `customRenderers` callback returned null): the host was
+    // already detached above, so this retires the hop and announces.
+    for (const slotName of this.delegatedPluginSlots.keys()) {
       if (!wanted.has(slotName)) {
-        this.dispatchEvent(
-          new CustomEvent('cds-aichat-markdown-plugin-host-unmount', {
-            bubbles: true,
-            composed: true,
-            detail: { slotName },
-          })
-        );
-        this.delegatedPluginSlots.delete(slotName);
+        this.retireDelegatedSlot(slotName);
       }
     }
   }

--- a/packages/ai-chat-components/src/components/markdown/src/utils/html-helpers.ts
+++ b/packages/ai-chat-components/src/components/markdown/src/utils/html-helpers.ts
@@ -349,11 +349,19 @@ function serializeInlineToken(tokenTree: TokenTree): string {
   const token = tokenTree.token;
   const type = token.type ?? '';
 
+  // Break tokens carry no content — return the HTML void element directly so
+  // the merged node renders a visible line break instead of the empty string.
+  // Not `'<br />\n'` — the trailing newline would add a stray whitespace text
+  // node as the run's sibling. The merged node keeps `type: 'html_inline'` and
+  // still routes through sanitizeHtmlContent → unsafeHTML; DOMPurify's default
+  // allow-list keeps <br>, so the element survives sanitize-html.
+  if (type === 'softbreak' || type === 'hardbreak') {
+    return '<br />';
+  }
+
   if (
     type === 'text' ||
     type === 'code_inline' ||
-    type === 'softbreak' ||
-    type === 'hardbreak' ||
     type === 'entity' ||
     type === 'html_inline'
   ) {

--- a/packages/ai-chat-components/src/components/markdown/src/utils/plugin-fallback.ts
+++ b/packages/ai-chat-components/src/components/markdown/src/utils/plugin-fallback.ts
@@ -225,7 +225,7 @@ export function renderFallback(
     }
   }
 
-  const index = options.pluginSlotCounter?.next() ?? 0;
+  const index = options.pluginSlotCounter?.next(node) ?? 0;
   const slotName = withInstanceNamespace(
     `${PLUGIN_FALLBACK_SLOT_PREFIX}-${index}`,
     options

--- a/packages/ai-chat-components/src/components/markdown/src/utils/plugin-fallback.ts
+++ b/packages/ai-chat-components/src/components/markdown/src/utils/plugin-fallback.ts
@@ -190,9 +190,12 @@ function sliceForFallback(token: Token, node: TokenTree): Token[] {
 
 /**
  * Renders an unknown token via markdown-it's HTML renderer and emits a named
- * `<slot>` placeholder. The markdown element adopts a light-DOM
- * `<div slot="…">` host containing the sanitized HTML so consumer-supplied
- * CSS (e.g. KaTeX's stylesheet) reaches the rendered output.
+ * `<slot>` placeholder carrying the token's text as its fallback content. The
+ * markdown element adopts a light-DOM `<div slot="…">` host containing the
+ * sanitized HTML so consumer-supplied CSS (e.g. KaTeX's stylesheet) reaches the
+ * rendered output; the fallback is what a reader sees if that host never
+ * arrives — a container claimed the slot and no forwarder was minted — so a
+ * stranded host degrades to plain text instead of vanishing.
  *
  * For leaf token types in {@link PLUGIN_DELEGABLE_TOKEN_TYPES} the rendered
  * HTML is cached on the {@link TokenTree} node and inherited across
@@ -237,5 +240,11 @@ export function renderFallback(
     html: safe,
     isInline: token.block === false,
   });
-  return html`<slot name=${slotName}></slot>`;
+  // Text, not `safe`: the rendered markup already exists once as the light-DOM
+  // host, and duplicating it inside the slot doubles the DOM of a plugin-heavy
+  // message — 40 KaTeX expressions measured 3,288 extra elements. Prefer the
+  // author's own source, which is what a formula or diagram token carries, and
+  // fall back to the output's text for marker tokens that carry no source.
+  const fallbackText = token.content || safe.replace(/<[^>]*>/g, '');
+  return html`<slot name=${slotName}>${fallbackText}</slot>`;
 }

--- a/packages/ai-chat-components/src/components/markdown/src/utils/plugin-host-container.ts
+++ b/packages/ai-chat-components/src/components/markdown/src/utils/plugin-host-container.ts
@@ -25,8 +25,6 @@
 
 /**
  * Mount detail for plugin output the element hands over as an HTML string.
- *
- * @category Messaging
  */
 export interface MarkdownPluginFallbackMountDetail {
   /** Marks the payload as an HTML string rather than a live element. */
@@ -65,8 +63,6 @@ export interface MarkdownPluginFallbackMountDetail {
  * synchronously, and nothing else: never rewrite its content, never style it,
  * never remove it. The markdown element renders the `<slot>` hop that projects
  * it back.
- *
- * @category Messaging
  */
 export interface MarkdownCustomRendererMountDetail {
   /** Marks the payload as a live element rather than an HTML string. */
@@ -100,8 +96,6 @@ export interface MarkdownCustomRendererMountDetail {
  * Narrow on `kind`, never on which of `html` / `element` is present — the two
  * members deliberately declare only their own fields, so reading the wrong one
  * is a compile error rather than a silent `undefined`.
- *
- * @category Messaging
  */
 export type MarkdownPluginHostMountDetail =
   MarkdownPluginFallbackMountDetail | MarkdownCustomRendererMountDetail;
@@ -115,8 +109,6 @@ export type MarkdownPluginHostMountDetail =
  * `resolveMarkdownPluginHostMountDetail`, exported from
  * `@carbon/ai-chat-components/es/components/markdown/src/utils/plugin-host-container.js`,
  * and narrow on the result.
- *
- * @category Messaging
  */
 export type MarkdownPluginHostMountDetailInput =
   | MarkdownPluginHostMountDetail

--- a/packages/ai-chat-components/src/components/markdown/src/utils/plugin-host-container.ts
+++ b/packages/ai-chat-components/src/components/markdown/src/utils/plugin-host-container.ts
@@ -1,0 +1,271 @@
+/*
+ *  Copyright IBM Corp. 2026
+ *
+ *  This source code is licensed under the Apache-2.0 license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ *  @license
+ */
+
+/**
+ * The container half of the plugin-host protocol.
+ *
+ * `<cds-aichat-markdown>` offers a host for plugin output to whichever chat
+ * element is outermost, over three composed events — `-mount`, `-update` and
+ * `-unmount`. Accepting the offer means calling `preventDefault()` on the
+ * mount event and putting the host somewhere consumer-loaded CSS can reach it,
+ * which the markdown element's own light DOM is not: it sits inside the chat's
+ * shadow root. A plugin-fallback offer hands over an HTML string this
+ * controller renders into a host it creates; a `customRenderers` offer hands
+ * over a live element this controller only re-parents.
+ *
+ * A container supplies only the element hosts are appended to, and whatever
+ * policy the framework cannot infer.
+ */
+
+/** Mount detail for plugin output the element hands over as an HTML string. */
+export interface MarkdownPluginFallbackMountDetail {
+  kind: 'pluginFallback';
+  slotName: string;
+  html: string;
+  isInline: boolean;
+}
+
+/**
+ * Mount detail for a `customRenderers` host. It carries a live element the
+ * markdown element created, keeps writing to across renders, and removes.
+ * Claiming it means re-parenting that element into your own light DOM,
+ * synchronously, and nothing else: never rewrite its content, never style it,
+ * never remove it. The markdown element renders the `<slot>` hop that projects
+ * it back.
+ */
+export interface MarkdownCustomRendererMountDetail {
+  kind: 'customRenderer';
+  slotName: string;
+  element: HTMLElement;
+  isInline: boolean;
+}
+
+/**
+ * The `cds-aichat-markdown-plugin-host-mount` detail, discriminated on `kind`.
+ *
+ * Narrow on `kind`, never on which of `html` / `element` is present — the two
+ * members deliberately declare only their own fields, so reading the wrong one
+ * is a compile error rather than a silent `undefined`.
+ */
+export type MarkdownPluginHostMountDetail =
+  MarkdownPluginFallbackMountDetail | MarkdownCustomRendererMountDetail;
+
+/**
+ * A mount detail as it arrives on the wire, `kind` included or not.
+ *
+ * `kind` is newer than the events themselves, and `@carbon/ai-chat` depends on
+ * this package through a caret range, so a listener can still receive the
+ * original shape from an older build. Pass anything you receive through
+ * {@link resolveMarkdownPluginHostMountDetail} and narrow on the result.
+ */
+export type MarkdownPluginHostMountDetailInput =
+  | MarkdownPluginHostMountDetail
+  | Omit<MarkdownPluginFallbackMountDetail, 'kind'>
+  | Omit<MarkdownCustomRendererMountDetail, 'kind'>;
+
+/**
+ * Fills in `kind` for a detail emitted before the field existed.
+ *
+ * The one place the payload's shape is still consulted, and only when there is
+ * nothing else to go on. Delete it once the floor on `@carbon/ai-chat-components`
+ * rises past the release that added `kind`.
+ */
+export function resolveMarkdownPluginHostMountDetail(
+  detail: MarkdownPluginHostMountDetailInput
+): MarkdownPluginHostMountDetail {
+  if ('kind' in detail) {
+    return detail;
+  }
+  return 'element' in detail
+    ? { ...detail, kind: 'customRenderer' }
+    : { ...detail, kind: 'pluginFallback' };
+}
+
+export interface MarkdownPluginHostControllerOptions {
+  /**
+   * Called with a fresh array whenever the set of slot names this surface
+   * should forward inward changes. Surfaces one shadow boundary from the
+   * markdown element render no forwarder of their own and omit it — the React
+   * `ChatContainer` is the one in this repo.
+   *
+   * Both kinds, and including names this surface declined to host: a container
+   * nested inside an outer chat element still has to forward the slot the
+   * outer one is hosting. The innermost hop — into the markdown element's own
+   * shadow slot — is never one of these; the element mints that one, for
+   * either kind, in the pass that read the claim.
+   */
+  onSlotNamesChange?: (slotNames: string[]) => void;
+
+  /**
+   * Return `true` to forward the slot without hosting it, because an outer
+   * chat element will. Omitted by surfaces that are always outermost.
+   */
+  shouldDefer?: (event: Event) => boolean;
+}
+
+export interface MarkdownPluginHostController {
+  /** Subscribes to the three events. Safe to call again without disconnecting. */
+  connect(): void;
+  /**
+   * Unsubscribes and removes the hosts this controller created. Relocated
+   * `customRenderers` elements are left parented — they belong to the markdown
+   * element, and as children of `target` they ride along with a DOM move.
+   * Forwarded slot names survive too.
+   */
+  disconnect(): void;
+  /**
+   * Plugin-fallback hosts this controller created, keyed by slot name.
+   * Relocated `customRenderers` elements are deliberately absent.
+   */
+  readonly hosts: ReadonlyMap<string, HTMLElement>;
+}
+
+const MOUNT = 'cds-aichat-markdown-plugin-host-mount';
+const UPDATE = 'cds-aichat-markdown-plugin-host-update';
+const UNMOUNT = 'cds-aichat-markdown-plugin-host-unmount';
+
+/**
+ * Answers the plugin-host offer on `target`'s behalf, hosting accepted offers
+ * as slot-attributed children of `target`.
+ *
+ * `target` is both the listener and the host parent because in every chat
+ * surface they are the same element — the offer is claimed by whichever chat
+ * element is outermost, and that is the element whose light DOM is page DOM.
+ *
+ * Not part of this package's advertised surface: it is deliberately absent from
+ * `components/markdown/index.ts`, where only the detail types above are
+ * exported. It is not marked with the internal JSDoc tag either — this package
+ * compiles with `stripInternal`, which would drop the declaration from the
+ * emitted `.d.ts`, and every caller lives in the sibling package and resolves
+ * its types through exactly that file. (Do not write that tag's name anywhere
+ * in this comment: `stripInternal` matches the string, not just a real tag.)
+ */
+export function createMarkdownPluginHostController(
+  target: HTMLElement,
+  options: MarkdownPluginHostControllerOptions = {}
+): MarkdownPluginHostController {
+  const { onSlotNamesChange, shouldDefer } = options;
+  // Keyed by slot name alone: the markdown element namespaces every name it
+  // mints per element (see `./slot-names.js`), so two messages rendering the
+  // same markdown can't collide here. Only hosts this controller created —
+  // a relocated `customRenderers` element is parented to `target` but never
+  // entered here, which is what keeps `handleUpdate` from clobbering a
+  // consumer's node and `disconnect()` from destroying one.
+  const hosts = new Map<string, HTMLElement>();
+  let slotNames: string[] = [];
+
+  // Built once, not per `connect()`: a Lit `connectedCallback` can fire again
+  // without an intervening disconnect, and fresh closures would register a
+  // second time and handle every mount twice.
+  const handleMount = (event: Event) => {
+    const raw = (
+      event as CustomEvent<MarkdownPluginHostMountDetailInput | undefined>
+    ).detail;
+    if (!raw?.slotName) {
+      return;
+    }
+    const detail = resolveMarkdownPluginHostMountDetail(raw);
+
+    // Track before deferring: a container nested inside an outer chat element
+    // hosts nothing but still has to forward the slot inward.
+    if (!slotNames.includes(detail.slotName)) {
+      slotNames = [...slotNames, detail.slotName];
+      onSlotNamesChange?.(slotNames);
+    }
+    if (shouldDefer?.(event)) {
+      return;
+    }
+
+    event.preventDefault();
+    if (detail.kind === 'customRenderer') {
+      // A live node the markdown element created, keeps writing to and
+      // removes: re-parent it and nothing else. No inline spacing — the stack
+      // gap lives on the `<slot>` placeholder in the element's own shadow CSS,
+      // and a style attribute here would outrank the page stylesheet this
+      // relocation exists to admit.
+      detail.element.setAttribute('slot', detail.slotName);
+      // Re-appending a node already parented here detaches and reattaches the
+      // consumer's whole subtree, running its disconnect/connect teardown.
+      if (detail.element.parentElement !== target) {
+        target.appendChild(detail.element);
+      }
+      return;
+    }
+    let host = hosts.get(detail.slotName);
+    if (!host) {
+      host = document.createElement(detail.isInline ? 'span' : 'div');
+      host.setAttribute('slot', detail.slotName);
+      // Match `.cds-aichat-markdown-stack > *:not(:first-child)` spacing;
+      // shadow CSS doesn't reach a host in page light DOM, so apply it inline.
+      // Inline output flows with text and gets no extra spacing.
+      if (!detail.isInline) {
+        host.style.marginBlockStart = '1rem';
+      }
+      hosts.set(detail.slotName, host);
+      target.appendChild(host);
+    }
+    // `?? ''` here and in `handleUpdate`: `html` is typed `string`, but the
+    // emitter can be a third-party element this compiler never saw, and
+    // `innerHTML = undefined` writes the literal string "undefined".
+    if (host.innerHTML !== (detail.html ?? '')) {
+      host.innerHTML = detail.html ?? '';
+    }
+  };
+
+  const handleUpdate = (event: Event) => {
+    const detail = (
+      event as CustomEvent<{ slotName: string; html: string } | undefined>
+    ).detail;
+    if (!detail?.slotName) {
+      return;
+    }
+    const host = hosts.get(detail.slotName);
+    if (host && host.innerHTML !== (detail.html ?? '')) {
+      host.innerHTML = detail.html ?? '';
+    }
+  };
+
+  const handleUnmount = (event: Event) => {
+    const detail = (event as CustomEvent<{ slotName: string } | undefined>)
+      .detail;
+    if (!detail?.slotName) {
+      return;
+    }
+    if (slotNames.includes(detail.slotName)) {
+      slotNames = slotNames.filter((name) => name !== detail.slotName);
+      onSlotNamesChange?.(slotNames);
+    }
+    const host = hosts.get(detail.slotName);
+    if (host) {
+      host.remove();
+      hosts.delete(detail.slotName);
+    }
+  };
+
+  return {
+    hosts,
+    connect() {
+      target.addEventListener(MOUNT, handleMount);
+      target.addEventListener(UPDATE, handleUpdate);
+      target.addEventListener(UNMOUNT, handleUnmount);
+    },
+    disconnect() {
+      target.removeEventListener(MOUNT, handleMount);
+      target.removeEventListener(UPDATE, handleUpdate);
+      target.removeEventListener(UNMOUNT, handleUnmount);
+      for (const host of hosts.values()) {
+        host.remove();
+      }
+      hosts.clear();
+      // Slot names deliberately survive: a reconnect re-hosts from the events
+      // that follow, and clearing here would make the next mount replace the
+      // consumer's list rather than extend it.
+    },
+  };
+}

--- a/packages/ai-chat-components/src/components/markdown/src/utils/plugin-host-container.ts
+++ b/packages/ai-chat-components/src/components/markdown/src/utils/plugin-host-container.ts
@@ -23,11 +23,38 @@
  * policy the framework cannot infer.
  */
 
-/** Mount detail for plugin output the element hands over as an HTML string. */
+/**
+ * Mount detail for plugin output the element hands over as an HTML string.
+ *
+ * @category Messaging
+ */
 export interface MarkdownPluginFallbackMountDetail {
+  /** Marks the payload as an HTML string rather than a live element. */
   kind: 'pluginFallback';
+  /**
+   * Name to put on the host's `slot` attribute, and the key the matching
+   * `-update` and `-unmount` events arrive under. Unique across every markdown
+   * element on the page, and reused across renders while the token stays put,
+   * so a streaming message rewrites one host instead of growing a new one per
+   * chunk. Treat the value as opaque; its format is not part of the API.
+   */
   slotName: string;
+  /**
+   * The plugin rule's rendered HTML, to assign to the host's `innerHTML`.
+   *
+   * DOMPurify runs over it only when the markdown element has `sanitize-html`
+   * set, and that setting is off by default. `remove-html` does not stand in
+   * for it either — that one escapes HTML written in the markdown source and
+   * never filters what a plugin's renderer rule emits. Treat the string as
+   * exactly as trustworthy as the markdown-it plugins the page registered.
+   */
   html: string;
+  /**
+   * True when the plugin's token is inline, such as a `math_inline` span.
+   * Picks the host tag — `span` when true, so the output stays in paragraph
+   * flow, `div` when false — and gates the block spacing that matches the
+   * markdown element's own stack gap.
+   */
   isInline: boolean;
 }
 
@@ -38,11 +65,32 @@ export interface MarkdownPluginFallbackMountDetail {
  * synchronously, and nothing else: never rewrite its content, never style it,
  * never remove it. The markdown element renders the `<slot>` hop that projects
  * it back.
+ *
+ * @category Messaging
  */
 export interface MarkdownCustomRendererMountDetail {
+  /** Marks the payload as a live element rather than an HTML string. */
   kind: 'customRenderer';
+  /**
+   * Name already set on `element`'s `slot` attribute, and the key the matching
+   * `-unmount` event arrives under. Page-unique, reused across renders and
+   * opaque, like the plugin-fallback name. No `-update` event follows this
+   * one: the markdown element writes the consumer's node into `element`
+   * itself.
+   */
   slotName: string;
+  /**
+   * The host to re-parent. The markdown element created it, replaces its
+   * children on every render, and removes it when the renderer stops matching
+   * — a claimant only moves it.
+   */
   element: HTMLElement;
+  /**
+   * True when the claimed output is inline flow content. Always `false` here:
+   * the markdown element hosts every `customRenderers` result in a `<div>` it
+   * created, so a claimant has no host tag to choose. Declared on both members
+   * so a listener can read it before narrowing on `kind`.
+   */
   isInline: boolean;
 }
 
@@ -52,6 +100,8 @@ export interface MarkdownCustomRendererMountDetail {
  * Narrow on `kind`, never on which of `html` / `element` is present — the two
  * members deliberately declare only their own fields, so reading the wrong one
  * is a compile error rather than a silent `undefined`.
+ *
+ * @category Messaging
  */
 export type MarkdownPluginHostMountDetail =
   MarkdownPluginFallbackMountDetail | MarkdownCustomRendererMountDetail;
@@ -62,7 +112,11 @@ export type MarkdownPluginHostMountDetail =
  * `kind` is newer than the events themselves, and `@carbon/ai-chat` depends on
  * this package through a caret range, so a listener can still receive the
  * original shape from an older build. Pass anything you receive through
- * {@link resolveMarkdownPluginHostMountDetail} and narrow on the result.
+ * `resolveMarkdownPluginHostMountDetail`, exported from
+ * `@carbon/ai-chat-components/es/components/markdown/src/utils/plugin-host-container.js`,
+ * and narrow on the result.
+ *
+ * @category Messaging
  */
 export type MarkdownPluginHostMountDetailInput =
   | MarkdownPluginHostMountDetail
@@ -263,9 +317,12 @@ export function createMarkdownPluginHostController(
         host.remove();
       }
       hosts.clear();
-      // Slot names deliberately survive: a reconnect re-hosts from the events
-      // that follow, and clearing here would make the next mount replace the
-      // consumer's list rather than extend it.
+      // Slot names deliberately survive. `handleUpdate` drops an update whose
+      // host is missing, so retention would strand a slot if only this element
+      // cycled — it is safe because the markdown element is a shadow-including
+      // descendant, so it cycles too, clears its own claims and re-offers a
+      // mount rather than an update. Clearing here would also make that next
+      // mount replace the consumer's list rather than extend it.
     },
   };
 }

--- a/packages/ai-chat-components/src/react/markdown.tsx
+++ b/packages/ai-chat-components/src/react/markdown.tsx
@@ -138,14 +138,6 @@ const Markdown = forwardRef<CDSAIChatMarkdown, MarkdownProps>(function Markdown(
   const hostsRef = useRef<Map<string, HTMLDivElement>>(new Map());
   const [portalEntries, setPortalEntries] = useState<PortalEntry[]>([]);
 
-  // Active plugin-fallback slot names that an outer chat container is hosting
-  // in page light DOM. When a chat-container ancestor catches the
-  // `cds-aichat-markdown-plugin-host-mount` event (and calls preventDefault),
-  // the markdown element skips its own local-host fallback and relies on
-  // these forwarders to project the page-level host element through every
-  // shadow boundary into its named slot. Storybook standalone usage stays on
-  // the local-host path — no listener consumes the event there.
-  const [pluginSlotNames, setPluginSlotNames] = useState<string[]>([]);
   const markdownRef = useRef<CDSAIChatMarkdown | null>(null);
   const setMarkdownRef = useCallback(
     (node: CDSAIChatMarkdown | null) => {
@@ -160,62 +152,6 @@ const Markdown = forwardRef<CDSAIChatMarkdown, MarkdownProps>(function Markdown(
     },
     [forwardedRef]
   );
-
-  useEffect(() => {
-    const node = markdownRef.current;
-    if (!node) {
-      return undefined;
-    }
-    const handleMount = (event: Event) => {
-      const detail = (
-        event as CustomEvent<{ slotName: string; element?: HTMLElement }>
-      ).detail;
-      if (!detail?.slotName) {
-        return;
-      }
-      // Consumer-renderer hosts (table/codeBlock) forward a live element that
-      // is adopted directly by the markdown element's own reconcile. They do
-      // not need a <slot> forwarder here — adding one would suppress the
-      // slot's fallback content if the callback later returns null.
-      if (detail.element) {
-        return;
-      }
-      setPluginSlotNames((prev) =>
-        prev.includes(detail.slotName) ? prev : [...prev, detail.slotName]
-      );
-    };
-    const handleUnmount = (event: Event) => {
-      const slotName = (event as CustomEvent<{ slotName: string }>).detail
-        ?.slotName;
-      if (!slotName) {
-        return;
-      }
-      setPluginSlotNames((prev) =>
-        prev.includes(slotName) ? prev.filter((n) => n !== slotName) : prev
-      );
-    };
-    // Optimistic: we render a `<slot>` forwarder for every slot the markdown
-    // element emits. If a chat container ancestor takes over hosting (by
-    // calling `preventDefault()` on the mount event), the forwarder projects
-    // the page-level host through the chain. If nothing intercepts
-    // (standalone storybook), the markdown element creates its own local host
-    // alongside, and the empty forwarder is harmless.
-    node.addEventListener('cds-aichat-markdown-plugin-host-mount', handleMount);
-    node.addEventListener(
-      'cds-aichat-markdown-plugin-host-unmount',
-      handleUnmount
-    );
-    return () => {
-      node.removeEventListener(
-        'cds-aichat-markdown-plugin-host-mount',
-        handleMount
-      );
-      node.removeEventListener(
-        'cds-aichat-markdown-plugin-host-unmount',
-        handleUnmount
-      );
-    };
-  }, []);
 
   const setPortalForSlot = useCallback(
     (slotName: string, host: HTMLDivElement, node: ReactNode) => {
@@ -331,11 +267,8 @@ const Markdown = forwardRef<CDSAIChatMarkdown, MarkdownProps>(function Markdown(
       <BaseMarkdown
         {...rest}
         ref={setMarkdownRef as React.Ref<HTMLElement>}
-        customRenderers={bridgedRenderers as never}>
-        {pluginSlotNames.map((slotName) => (
-          <slot key={slotName} name={slotName} slot={slotName} />
-        ))}
-      </BaseMarkdown>
+        customRenderers={bridgedRenderers as never}
+      />
       {portalEntries.map((entry) => (
         <React.Fragment key={entry.slotName}>
           {createPortal(entry.node, entry.host)}

--- a/packages/ai-chat/src/aiChatEntry.tsx
+++ b/packages/ai-chat/src/aiChatEntry.tsx
@@ -332,7 +332,11 @@ export { CdsAiChatCustomElementAttributes } from './web-components/cds-aichat-cu
 export {
   ChatContainerPropsMarkdown,
   CustomMarkdownRenderers,
+  MarkdownCustomRendererMountDetail,
   MarkdownCustomRenderers,
+  MarkdownPluginFallbackMountDetail,
+  MarkdownPluginHostMountDetail,
+  MarkdownPluginHostMountDetailInput,
   MarkdownRendererChecklist,
   MarkdownRendererChecklistItemArgs,
   MarkdownRendererChecklistToggleArgs,

--- a/packages/ai-chat/src/chat/components-legacy/MessageRichUserContent.tsx
+++ b/packages/ai-chat/src/chat/components-legacy/MessageRichUserContent.tsx
@@ -180,9 +180,7 @@ function renderParagraphInline(
       afterLeading.length - trailing.length
     );
     if (leading) {
-      out.push(
-        <React.Fragment key={`${key}-ws-pre`}>{leading}</React.Fragment>
-      );
+      out.push(...renderBoundaryWhitespace(leading, `${key}-ws-pre`));
     }
     if (trimmed) {
       out.push(
@@ -192,9 +190,7 @@ function renderParagraphInline(
       );
     }
     if (trailing) {
-      out.push(
-        <React.Fragment key={`${key}-ws-post`}>{trailing}</React.Fragment>
-      );
+      out.push(...renderBoundaryWhitespace(trailing, `${key}-ws-post`));
     }
     textRun = '';
   };
@@ -223,6 +219,62 @@ function renderParagraphInline(
 
   flushTextRun(`${messageId}::${blockIndex}.tail`);
 
+  // The block parser drops a break at the very start or end of a paragraph, so
+  // the chip path drops it too. Without this a chip-bearing paragraph renders a
+  // blank first or last line that the same text without a chip does not. The
+  // scan steps over whitespace because `renderBoundaryWhitespace` emits the
+  // spaces around a break as their own sibling, so the break is not always the
+  // edge node; that whitespace goes with it, matching what the block parser
+  // trims. Whitespace with no break beside it is left alone — it is the chip
+  // spacing the boundary capture exists for.
+  const isBreak = (node: React.ReactNode) =>
+    React.isValidElement(node) && node.type === 'br';
+  const isBlankText = (node: React.ReactNode) =>
+    React.isValidElement(node) &&
+    node.type === React.Fragment &&
+    !String((node.props as { children?: unknown }).children ?? '').trim();
+
+  let start = 0;
+  for (let index = 0; index < out.length; index++) {
+    if (isBreak(out[index])) {
+      start = index + 1;
+    } else if (!isBlankText(out[index])) {
+      break;
+    }
+  }
+  let end = out.length;
+  for (let index = out.length - 1; index >= start; index--) {
+    if (isBreak(out[index])) {
+      end = index;
+    } else if (!isBlankText(out[index])) {
+      break;
+    }
+  }
+
+  return out.slice(start, end);
+}
+
+/**
+ * A `hardBreak` contributes a `\n` to the run, so a break adjacent to a chip is
+ * captured as boundary whitespace and never reaches the inline token walker
+ * that turns breaks into `<br>`. Emit it here instead; the spaces around it
+ * stay plain text so the boundary-whitespace behavior is unchanged.
+ */
+function renderBoundaryWhitespace(
+  whitespace: string,
+  keyPrefix: string
+): React.ReactNode[] {
+  const out: React.ReactNode[] = [];
+  whitespace.split('\n').forEach((segment, index) => {
+    if (index > 0) {
+      out.push(<br key={`${keyPrefix}-br-${index}`} />);
+    }
+    if (segment) {
+      out.push(
+        <React.Fragment key={`${keyPrefix}-${index}`}>{segment}</React.Fragment>
+      );
+    }
+  });
   return out;
 }
 

--- a/packages/ai-chat/src/chat/components/helpers/InlineMarkdown/InlineMarkdown.tsx
+++ b/packages/ai-chat/src/chat/components/helpers/InlineMarkdown/InlineMarkdown.tsx
@@ -81,9 +81,6 @@ function renderInlineTokenList(tokens: Token[] | null): ReactNode {
         break;
 
       case 'softbreak':
-        pushChild(<Fragment key={nextKey()}> </Fragment>);
-        break;
-
       case 'hardbreak':
         pushChild(<br key={nextKey()} />);
         break;

--- a/packages/ai-chat/src/chat/components/helpers/InlineMarkdown/InlineMarkdown.tsx
+++ b/packages/ai-chat/src/chat/components/helpers/InlineMarkdown/InlineMarkdown.tsx
@@ -94,7 +94,9 @@ function renderInlineTokenList(tokens: Token[] | null): ReactNode {
       case 's_open':
         stack.push({ type: 's', attrs: {}, children: [] });
         break;
-      case 'mark_open':
+      // Our ==highlight== plugin pushes `highlight_open` / `highlight_close`
+      // with tag `mark`; markdown-it itself has no `mark_*` token type.
+      case 'highlight_open':
         stack.push({ type: 'mark', attrs: {}, children: [] });
         break;
       case 'link_open': {
@@ -111,7 +113,7 @@ function renderInlineTokenList(tokens: Token[] | null): ReactNode {
       case 'strong_close':
       case 'em_close':
       case 's_close':
-      case 'mark_close':
+      case 'highlight_close':
       case 'link_close': {
         const frame = stack.pop();
         if (!frame) {

--- a/packages/ai-chat/src/chat/components/helpers/MarkdownWithDefaults/MarkdownWithDefaults.tsx
+++ b/packages/ai-chat/src/chat/components/helpers/MarkdownWithDefaults/MarkdownWithDefaults.tsx
@@ -147,33 +147,7 @@ function MarkdownWithDefaults(props: MarkdownWithDefaultsProps) {
   );
 }
 
-const MarkdownWithDefaultsExport = React.memo(
-  MarkdownWithDefaults,
-  (prevProps, nextProps) => {
-    // Custom comparison to prevent re-render when only streaming changes but content is the same
-    const textEqual = prevProps.text === nextProps.text;
-    const htmlConversionEqual = prevProps.removeHTML === nextProps.removeHTML;
-    const sanitizeEqual =
-      prevProps.overrideSanitize === nextProps.overrideSanitize;
-    const highlightEqual = prevProps.highlight === nextProps.highlight;
-
-    // If text content is identical, we don't need to re-render regardless of streaming state
-    if (textEqual && htmlConversionEqual && sanitizeEqual && highlightEqual) {
-      return true; // Skip re-render
-    }
-
-    // If text content changed, check if streaming state is relevant
-    const streamingEqual = prevProps.streaming === nextProps.streaming;
-
-    return (
-      textEqual &&
-      htmlConversionEqual &&
-      sanitizeEqual &&
-      highlightEqual &&
-      streamingEqual
-    );
-  }
-);
+const MarkdownWithDefaultsExport = React.memo(MarkdownWithDefaults);
 
 export { MarkdownWithDefaultsExport as MarkdownWithDefaults };
 export default MarkdownWithDefaultsExport;

--- a/packages/ai-chat/src/react/ChatContainer.tsx
+++ b/packages/ai-chat/src/react/ChatContainer.tsx
@@ -22,6 +22,7 @@ import { createPortal } from 'react-dom';
 import ChatAppEntry from '../chat/ChatAppEntry';
 import { carbonElement } from '@carbon/ai-chat-components/es/globals/decorators/index.js';
 import { ChatContainerProps } from '../types/component/ChatContainer';
+import { createMarkdownPluginHostController } from '@carbon/ai-chat-components/es/components/markdown/src/utils/plugin-host-container.js';
 import { ChatInstance } from '../types/instance/ChatInstance';
 import { BusEventType } from '../types/events/eventBusTypes';
 import {
@@ -210,112 +211,18 @@ function ChatContainer(
    * Plugin-fallback slot hosts (e.g. KaTeX rendered by a markdown-it plugin)
    * need to live in the page light DOM so a consumer-loaded stylesheet can
    * reach them — the markdown element's own light DOM sits inside this
-   * wrapper's shadow root, where global CSS doesn't apply. The markdown
-   * element bubbles a composed `cds-aichat-markdown-plugin-host-mount` event
-   * for each new plugin slot; we accept the offer (`preventDefault()`),
-   * create the host as a slot-attributed child of the wrapper (= page light
-   * DOM, since this is the outermost chat element on the React path), and
-   * tear it down when the matching unmount event fires.
+   * wrapper's shadow root, where global CSS doesn't apply. The wrapper is the
+   * outermost chat element on the React path, so it is the one that claims the
+   * offer. Nothing forwards a slot name here: the React `Markdown` wrapper in
+   * `@carbon/ai-chat-components` supplies the single hop this topology needs.
    */
   useEffect(() => {
     if (!wrapper) {
       return undefined;
     }
-    // Keyed by slot name alone: the markdown element namespaces every name it
-    // mints per element (see `markdown/src/utils/slot-names.ts` in
-    // `@carbon/ai-chat-components`), so two messages rendering the same
-    // markdown can't collide here.
-    const hosts = new Map<string, HTMLElement>();
-    const handleMount = (event: Event) => {
-      const detail = (
-        event as CustomEvent<{
-          slotName: string;
-          html?: string;
-          element?: HTMLElement;
-          isInline: boolean;
-        }>
-      ).detail;
-      if (!detail?.slotName) {
-        return;
-      }
-      // Custom-renderer hosts (table/codeBlock) forward a live element that
-      // the markdown element manages directly — do not preventDefault or hoist,
-      // or the named slot loses its host and falls back to the default Carbon
-      // component. Plugin fallbacks forward an HTML string instead.
-      if (detail.element) {
-        return;
-      }
-      event.preventDefault();
-      let host = hosts.get(detail.slotName);
-      if (!host) {
-        host = document.createElement(detail.isInline ? 'span' : 'div');
-        host.setAttribute('slot', detail.slotName);
-        // Match the spacing applied to direct children of
-        // `.cds-aichat-markdown-stack`; shadow CSS doesn't reach this host
-        // (we mounted it in page light DOM), so apply it inline. Inline
-        // plugin output flows with text and gets no extra spacing.
-        if (!detail.isInline) {
-          host.style.marginBlockStart = '1rem';
-        }
-        hosts.set(detail.slotName, host);
-        wrapper.appendChild(host);
-      }
-      if (host.innerHTML !== (detail.html ?? '')) {
-        host.innerHTML = detail.html ?? '';
-      }
-    };
-    const handleUpdate = (event: Event) => {
-      const detail = (event as CustomEvent<{ slotName: string; html: string }>)
-        .detail;
-      if (!detail?.slotName) {
-        return;
-      }
-      const host = hosts.get(detail.slotName);
-      if (host && host.innerHTML !== detail.html) {
-        host.innerHTML = detail.html;
-      }
-    };
-    const handleUnmount = (event: Event) => {
-      const detail = (event as CustomEvent<{ slotName: string }>).detail;
-      if (!detail?.slotName) {
-        return;
-      }
-      const host = hosts.get(detail.slotName);
-      if (host) {
-        host.remove();
-        hosts.delete(detail.slotName);
-      }
-    };
-    wrapper.addEventListener(
-      'cds-aichat-markdown-plugin-host-mount',
-      handleMount
-    );
-    wrapper.addEventListener(
-      'cds-aichat-markdown-plugin-host-update',
-      handleUpdate
-    );
-    wrapper.addEventListener(
-      'cds-aichat-markdown-plugin-host-unmount',
-      handleUnmount
-    );
-    return () => {
-      wrapper.removeEventListener(
-        'cds-aichat-markdown-plugin-host-mount',
-        handleMount
-      );
-      wrapper.removeEventListener(
-        'cds-aichat-markdown-plugin-host-update',
-        handleUpdate
-      );
-      wrapper.removeEventListener(
-        'cds-aichat-markdown-plugin-host-unmount',
-        handleUnmount
-      );
-      for (const host of hosts.values()) {
-        host.remove();
-      }
-      hosts.clear();
-    };
+    const controller = createMarkdownPluginHostController(wrapper);
+    controller.connect();
+    return () => controller.disconnect();
   }, [wrapper]);
 
   const onBeforeRenderOverride = useCallback(

--- a/packages/ai-chat/src/serverEntry.ts
+++ b/packages/ai-chat/src/serverEntry.ts
@@ -324,7 +324,11 @@ export {
 export {
   ChatContainerPropsMarkdown,
   CustomMarkdownRenderers,
+  MarkdownCustomRendererMountDetail,
   MarkdownCustomRenderers,
+  MarkdownPluginFallbackMountDetail,
+  MarkdownPluginHostMountDetail,
+  MarkdownPluginHostMountDetailInput,
   MarkdownRendererChecklist,
   MarkdownRendererChecklistItemArgs,
   MarkdownRendererChecklistToggleArgs,

--- a/packages/ai-chat/src/types/component/ChatContainer.ts
+++ b/packages/ai-chat/src/types/component/ChatContainer.ts
@@ -9,7 +9,11 @@
 
 import { type ReactNode } from 'react';
 import type {
+  MarkdownCustomRendererMountDetail as _MarkdownCustomRendererMountDetail,
   MarkdownCustomRenderers as _MarkdownCustomRenderers,
+  MarkdownPluginFallbackMountDetail as _MarkdownPluginFallbackMountDetail,
+  MarkdownPluginHostMountDetail as _MarkdownPluginHostMountDetail,
+  MarkdownPluginHostMountDetailInput as _MarkdownPluginHostMountDetailInput,
   MarkdownRendererChecklist as _MarkdownRendererChecklist,
   MarkdownRendererChecklistItemArgs as _MarkdownRendererChecklistItemArgs,
   MarkdownRendererChecklistToggleArgs as _MarkdownRendererChecklistToggleArgs,
@@ -377,6 +381,62 @@ export type MarkdownRendererChecklistToggleArgs =
  * @interface
  */
 export type MarkdownCustomRenderers = _MarkdownCustomRenderers;
+
+/**
+ * Payload of the `cds-aichat-markdown-plugin-host-mount` event when the
+ * markdown element hands over plugin output as an HTML string.
+ *
+ * Claiming the offer means calling `preventDefault()` on the event and
+ * appending a host carrying {@link MarkdownPluginFallbackMountDetail.html} to
+ * a tree the page's own stylesheet can reach. Only a container hosting
+ * markdown output on the element's behalf needs this; application code does
+ * not.
+ *
+ * @category Messaging
+ * @interface
+ */
+export type MarkdownPluginFallbackMountDetail =
+  _MarkdownPluginFallbackMountDetail;
+
+/**
+ * Payload of the `cds-aichat-markdown-plugin-host-mount` event when the
+ * markdown element hands over a live `customRenderers` host.
+ *
+ * Claiming it means re-parenting
+ * {@link MarkdownCustomRendererMountDetail.element} into your own light DOM,
+ * synchronously, and nothing else: never rewrite its content, never style it,
+ * never remove it. The markdown element owns that node across renders and
+ * renders the `<slot>` hop that projects it back.
+ *
+ * @category Messaging
+ * @interface
+ */
+export type MarkdownCustomRendererMountDetail =
+  _MarkdownCustomRendererMountDetail;
+
+/**
+ * The `cds-aichat-markdown-plugin-host-mount` detail, discriminated on `kind`.
+ *
+ * Narrow on `kind`, never on which of `html` / `element` is present — the two
+ * members deliberately declare only their own fields, so reading the wrong one
+ * is a compile error rather than a silent `undefined`.
+ *
+ * @category Messaging
+ */
+export type MarkdownPluginHostMountDetail = _MarkdownPluginHostMountDetail;
+
+/**
+ * A mount detail as it arrives on the wire, `kind` included or not.
+ *
+ * `kind` is newer than the events themselves, and `@carbon/ai-chat` depends on
+ * `@carbon/ai-chat-components` through a caret range, so a listener can still
+ * receive the original shape from an older build. Pass anything you receive
+ * through `resolveMarkdownPluginHostMountDetail` and narrow on the result.
+ *
+ * @category Messaging
+ */
+export type MarkdownPluginHostMountDetailInput =
+  _MarkdownPluginHostMountDetailInput;
 
 /**
  * Per-element renderer overrides for the React `ChatContainer`. Each callback

--- a/packages/ai-chat/src/web-components/cds-aichat-container/index.ts
+++ b/packages/ai-chat/src/web-components/cds-aichat-container/index.ts
@@ -17,6 +17,7 @@ import { html } from 'lit';
 import { property, state } from 'lit/decorators.js';
 
 import { carbonElement } from '@carbon/ai-chat-components/es/globals/decorators/index.js';
+import { createMarkdownPluginHostController } from '@carbon/ai-chat-components/es/components/markdown/src/utils/plugin-host-container.js';
 import { PublicConfig } from '../../types/config/PublicConfig';
 import { FlattenedConfigElement } from '../shared/FlattenedConfigElement';
 import { ChatInstance } from '../../types/instance/ChatInstance';
@@ -161,18 +162,6 @@ class ChatContainer extends FlattenedConfigElement {
    */
   @state()
   _pluginSlotNames: string[] = [];
-
-  /**
-   * Page-level host elements created for plugin-output slots, keyed by slot
-   * name. Created in this element's outer light DOM so consumer-loaded
-   * stylesheets (e.g. KaTeX) reach the rendered HTML normally.
-   *
-   * Keying by slot name alone is safe because the markdown element namespaces
-   * every name it mints per element (see `markdown/src/utils/slot-names.ts` in
-   * `@carbon/ai-chat-components`), so two messages rendering the same markdown
-   * can't collide here.
-   */
-  private _pluginHosts: Map<string, HTMLElement> = new Map();
 
   /**
    * The chat instance.
@@ -446,117 +435,27 @@ class ChatContainer extends FlattenedConfigElement {
     return false;
   }
 
-  private handlePluginHostMount = (event: Event) => {
-    const detail = (
-      event as CustomEvent<{
-        slotName: string;
-        html?: string;
-        element?: HTMLElement;
-        isInline: boolean;
-      }>
-    ).detail;
-    if (!detail?.slotName) {
-      return;
-    }
-    // Track the slot regardless of who owns hosting so our render forwarder
-    // projects the page-level content into cds-aichat-internal's slot.
-    if (!this._pluginSlotNames.includes(detail.slotName)) {
-      this._pluginSlotNames = [...this._pluginSlotNames, detail.slotName];
-    }
-    if (this.hasOuterChatHandler(event)) {
-      // An outer chat element will create the page-level host; just forward.
-      // This applies to the live-element path too: appending here would land
-      // the node in this element's light DOM (inside the outer chat element's
-      // shadow root), where global CSS still wouldn't reach it.
-      return;
-    }
-    // Custom-renderer hosts (table/codeBlock) forward a live element that
-    // the markdown element manages directly — do not preventDefault or hoist,
-    // or the named slot loses its host and falls back to the default Carbon
-    // component. Plugin fallbacks forward an HTML string instead.
-    if (detail.element) {
-      return;
-    }
-    event.preventDefault();
-    let host = this._pluginHosts.get(detail.slotName);
-    if (!host) {
-      host = document.createElement(detail.isInline ? 'span' : 'div');
-      host.setAttribute('slot', detail.slotName);
-      // Match `.cds-aichat-markdown-stack > *:not(:first-child)` spacing;
-      // shadow CSS doesn't reach this host (it lives in this element's
-      // outer light DOM), so apply it inline. Inline output flows with
-      // text and gets no extra spacing.
-      if (!detail.isInline) {
-        host.style.marginBlockStart = '1rem';
-      }
-      this._pluginHosts.set(detail.slotName, host);
-      this.appendChild(host);
-    }
-    if (host.innerHTML !== (detail.html ?? '')) {
-      host.innerHTML = detail.html ?? '';
-    }
-  };
-
-  private handlePluginHostUpdate = (event: Event) => {
-    const detail = (event as CustomEvent<{ slotName: string; html: string }>)
-      .detail;
-    if (!detail?.slotName) {
-      return;
-    }
-    const host = this._pluginHosts.get(detail.slotName);
-    if (host && host.innerHTML !== detail.html) {
-      host.innerHTML = detail.html;
-    }
-  };
-
-  private handlePluginHostUnmount = (event: Event) => {
-    const detail = (event as CustomEvent<{ slotName: string }>).detail;
-    if (!detail?.slotName) {
-      return;
-    }
-    this._pluginSlotNames = this._pluginSlotNames.filter(
-      (n) => n !== detail.slotName
-    );
-    const host = this._pluginHosts.get(detail.slotName);
-    if (host) {
-      host.remove();
-      this._pluginHosts.delete(detail.slotName);
-    }
-  };
+  /**
+   * The container half of the plugin-host protocol. Hosts land in this
+   * element's own light DOM — page DOM when this element is outermost — so a
+   * consumer-loaded stylesheet reaches the plugin output; the markdown
+   * element's own light DOM sits inside the chat's shadow root, where it
+   * cannot.
+   */
+  private pluginHostController = createMarkdownPluginHostController(this, {
+    onSlotNamesChange: (slotNames) => {
+      this._pluginSlotNames = slotNames;
+    },
+    shouldDefer: (event) => this.hasOuterChatHandler(event),
+  });
 
   connectedCallback() {
     super.connectedCallback();
-    this.addEventListener(
-      'cds-aichat-markdown-plugin-host-mount',
-      this.handlePluginHostMount
-    );
-    this.addEventListener(
-      'cds-aichat-markdown-plugin-host-update',
-      this.handlePluginHostUpdate
-    );
-    this.addEventListener(
-      'cds-aichat-markdown-plugin-host-unmount',
-      this.handlePluginHostUnmount
-    );
+    this.pluginHostController.connect();
   }
 
   disconnectedCallback() {
-    this.removeEventListener(
-      'cds-aichat-markdown-plugin-host-mount',
-      this.handlePluginHostMount
-    );
-    this.removeEventListener(
-      'cds-aichat-markdown-plugin-host-update',
-      this.handlePluginHostUpdate
-    );
-    this.removeEventListener(
-      'cds-aichat-markdown-plugin-host-unmount',
-      this.handlePluginHostUnmount
-    );
-    for (const host of this._pluginHosts.values()) {
-      host.remove();
-    }
-    this._pluginHosts.clear();
+    this.pluginHostController.disconnect();
     super.disconnectedCallback();
   }
 

--- a/packages/ai-chat/src/web-components/cds-aichat-custom-element/index.ts
+++ b/packages/ai-chat/src/web-components/cds-aichat-custom-element/index.ts
@@ -18,6 +18,7 @@ import { html } from 'lit';
 import { property, state } from 'lit/decorators.js';
 
 import { carbonElement } from '@carbon/ai-chat-components/es/globals/decorators/index.js';
+import { createMarkdownPluginHostController } from '@carbon/ai-chat-components/es/components/markdown/src/utils/plugin-host-container.js';
 import { PublicConfig } from '../../types/config/PublicConfig';
 import { FlattenedConfigElement } from '../shared/FlattenedConfigElement';
 import { ChatInstance } from '../../types/instance/ChatInstance';
@@ -199,18 +200,6 @@ class ChatCustomElement extends FlattenedConfigElement {
   @state()
   private _pluginSlotNames: string[] = [];
 
-  /**
-   * Page-level host elements created for plugin-output slots, keyed by slot
-   * name. Created in this element's outer light DOM so consumer-loaded
-   * stylesheets (e.g. KaTeX) reach the rendered HTML normally.
-   *
-   * Keying by slot name alone is safe because the markdown element namespaces
-   * every name it mints per element (see `markdown/src/utils/slot-names.ts` in
-   * `@carbon/ai-chat-components`), so two messages rendering the same markdown
-   * can't collide here.
-   */
-  private _pluginHosts: Map<string, HTMLElement> = new Map();
-
   @state()
   private _instance!: ChatInstance;
 
@@ -238,111 +227,26 @@ class ChatCustomElement extends FlattenedConfigElement {
     }
   };
 
-  private handlePluginHostMount = (event: Event) => {
-    const detail = (
-      event as CustomEvent<{
-        slotName: string;
-        html?: string;
-        element?: HTMLElement;
-        isInline: boolean;
-      }>
-    ).detail;
-    if (!detail?.slotName) {
-      return;
-    }
-    if (!this._pluginSlotNames.includes(detail.slotName)) {
-      this._pluginSlotNames = [...this._pluginSlotNames, detail.slotName];
-    }
-    // cds-aichat-custom-element is always the outermost chat element in its
-    // shadow chain; there is no further chat ancestor to defer to. Take
-    // hosting unconditionally.
-    // Custom-renderer hosts (table/codeBlock) forward a live element that
-    // the markdown element manages directly — do not preventDefault or hoist,
-    // or the named slot loses its host and falls back to the default Carbon
-    // component. Plugin fallbacks forward an HTML string instead.
-    if (detail.element) {
-      return;
-    }
-    event.preventDefault();
-    let host = this._pluginHosts.get(detail.slotName);
-    if (!host) {
-      host = document.createElement(detail.isInline ? 'span' : 'div');
-      host.setAttribute('slot', detail.slotName);
-      // Match `.cds-aichat-markdown-stack > *:not(:first-child)` spacing;
-      // shadow CSS doesn't reach this host (it lives in this element's
-      // outer light DOM), so apply it inline. Inline output flows with
-      // text and gets no extra spacing.
-      if (!detail.isInline) {
-        host.style.marginBlockStart = '1rem';
-      }
-      this._pluginHosts.set(detail.slotName, host);
-      this.appendChild(host);
-    }
-    if (host.innerHTML !== (detail.html ?? '')) {
-      host.innerHTML = detail.html ?? '';
-    }
-  };
-
-  private handlePluginHostUpdate = (event: Event) => {
-    const detail = (event as CustomEvent<{ slotName: string; html: string }>)
-      .detail;
-    if (!detail?.slotName) {
-      return;
-    }
-    const host = this._pluginHosts.get(detail.slotName);
-    if (host && host.innerHTML !== detail.html) {
-      host.innerHTML = detail.html;
-    }
-  };
-
-  private handlePluginHostUnmount = (event: Event) => {
-    const detail = (event as CustomEvent<{ slotName: string }>).detail;
-    if (!detail?.slotName) {
-      return;
-    }
-    this._pluginSlotNames = this._pluginSlotNames.filter(
-      (n) => n !== detail.slotName
-    );
-    const host = this._pluginHosts.get(detail.slotName);
-    if (host) {
-      host.remove();
-      this._pluginHosts.delete(detail.slotName);
-    }
-  };
+  /**
+   * The container half of the plugin-host protocol. Hosts land in this
+   * element's own light DOM — page DOM, since a `cds-aichat-custom-element` is
+   * always the outermost chat element in its shadow chain — so a
+   * consumer-loaded stylesheet reaches the plugin output. There is no outer
+   * chat ancestor to defer to, so this surface takes hosting unconditionally.
+   */
+  private pluginHostController = createMarkdownPluginHostController(this, {
+    onSlotNamesChange: (slotNames) => {
+      this._pluginSlotNames = slotNames;
+    },
+  });
 
   connectedCallback() {
     super.connectedCallback();
-    this.addEventListener(
-      'cds-aichat-markdown-plugin-host-mount',
-      this.handlePluginHostMount
-    );
-    this.addEventListener(
-      'cds-aichat-markdown-plugin-host-update',
-      this.handlePluginHostUpdate
-    );
-    this.addEventListener(
-      'cds-aichat-markdown-plugin-host-unmount',
-      this.handlePluginHostUnmount
-    );
+    this.pluginHostController.connect();
   }
 
   disconnectedCallback() {
-    this.removeEventListener(
-      'cds-aichat-markdown-plugin-host-mount',
-      this.handlePluginHostMount
-    );
-    this.removeEventListener(
-      'cds-aichat-markdown-plugin-host-update',
-      this.handlePluginHostUpdate
-    );
-    this.removeEventListener(
-      'cds-aichat-markdown-plugin-host-unmount',
-      this.handlePluginHostUnmount
-    );
-    for (const host of this._pluginHosts.values()) {
-      host.remove();
-    }
-    this._pluginHosts.clear();
+    this.pluginHostController.disconnect();
     super.disconnectedCallback();
   }
 

--- a/packages/ai-chat/tests/components/spec/markdownWithDefaults_spec.tsx
+++ b/packages/ai-chat/tests/components/spec/markdownWithDefaults_spec.tsx
@@ -82,4 +82,25 @@ describe('MarkdownWithDefaults', () => {
     renderWithStore(<MarkdownWithDefaults text="# Hello" />);
     expect(capturedProps[0].customRenderers).toBeUndefined();
   });
+
+  it('re-renders when streaming flips with the text unchanged', () => {
+    // MarkdownWithErrorHandling swaps the text source from the joined chunks to
+    // the final message text at the same moment it flips `streaming` off. When
+    // those two strings match, the only changed prop is `streaming`, and the
+    // element needs it to leave its trailing-table loading mode.
+    const store = makeConfigStore({});
+    const tree = (streaming: boolean) => (
+      <StoreProvider store={store}>
+        <MarkdownWithDefaults text="| a |\n| - |" streaming={streaming} />
+      </StoreProvider>
+    );
+
+    const { rerender } = render(tree(true));
+    expect(capturedProps).toHaveLength(1);
+    expect(capturedProps[0].streaming).toBe(true);
+
+    rerender(tree(false));
+    expect(capturedProps).toHaveLength(2);
+    expect(capturedProps[1].streaming).toBe(false);
+  });
 });

--- a/packages/ai-chat/tests/components/spec/messageRichUserContentChipSpacing_spec.tsx
+++ b/packages/ai-chat/tests/components/spec/messageRichUserContentChipSpacing_spec.tsx
@@ -68,6 +68,22 @@ function messageWith(content: JSONContent): MessageRequest {
   } as unknown as MessageRequest;
 }
 
+/** Count <br> elements inside every <p> in the rendered bubble. */
+function brCount(content: JSONContent): number {
+  const { container } = render(
+    <StoreProvider store={makeStore()}>
+      <MessageRichUserContent
+        content={content}
+        message={messageWith(content)}
+      />
+    </StoreProvider>
+  );
+  return Array.from(container.querySelectorAll('p')).reduce(
+    (n, p) => n + p.querySelectorAll('br').length,
+    0
+  );
+}
+
 /** Return the text content of every <p> in the rendered bubble, joined. */
 function renderedText(content: JSONContent): string {
   const { container } = render(
@@ -222,5 +238,196 @@ describe('MessageRichUserContent chip spacing (issue #2155)', () => {
       ],
     };
     expect(renderedText(content)).toBe('run deploy now');
+  });
+
+  it('a Shift+Enter renders a <br> with a chip and keeps its newline without one (issue #2272)', () => {
+    // A `hardBreak` TipTap node encodes Shift+Enter. The chip-bearing path
+    // routes through renderInlineMarkdown and emits the <br> itself. The
+    // all-textual path flattens to a string for MarkdownWithDefaults, which
+    // is mocked to a passthrough here, so all this side can pin is that the
+    // newline reaches the element intact; rendering it as a <br> belongs to
+    // the element and is covered in @carbon/ai-chat-components.
+    const withChip: JSONContent = {
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            { type: 'mention', attrs: { id: 'u1', label: 'Alice' } },
+            { type: 'text', text: ' line one' },
+            { type: 'hardBreak' },
+            { type: 'text', text: 'line two' },
+          ],
+        },
+      ],
+    };
+    expect(brCount(withChip)).toBe(1);
+
+    const noChip: JSONContent = {
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            { type: 'text', text: 'line one' },
+            { type: 'hardBreak' },
+            { type: 'text', text: 'line two' },
+          ],
+        },
+      ],
+    };
+    const { getByTestId } = render(
+      <StoreProvider store={makeStore()}>
+        <MessageRichUserContent
+          content={noChip}
+          message={messageWith(noChip)}
+        />
+      </StoreProvider>
+    );
+    expect(getByTestId('markdown').textContent).toBe('line one\nline two');
+  });
+
+  it('a Shift+Enter immediately before a chip renders a <br> (issue #2272)', () => {
+    // `carbon-mention` appends a text node after every inserted chip, so
+    // typing "line one" Shift+Enter "@Alice" "tail" flushes a run whose
+    // newline sits at the trailing boundary rather than inside the run.
+    const content: JSONContent = {
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            { type: 'text', text: 'line one' },
+            { type: 'hardBreak' },
+            { type: 'mention', attrs: { id: 'u1', label: 'Alice' } },
+            { type: 'text', text: ' tail' },
+          ],
+        },
+      ],
+    };
+    expect(brCount(content)).toBe(1);
+    expect(renderedText(content)).toBe('line oneAlice tail');
+  });
+
+  it('a Shift+Enter immediately after a chip renders a <br> (issue #2272)', () => {
+    // Mirror of the case above: the newline opens the run instead of closing
+    // it, so it lands at the leading boundary.
+    const content: JSONContent = {
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            { type: 'mention', attrs: { id: 'u1', label: 'Alice' } },
+            { type: 'hardBreak' },
+            { type: 'text', text: 'x' },
+          ],
+        },
+      ],
+    };
+    expect(brCount(content)).toBe(1);
+    expect(renderedText(content)).toBe('Alicex');
+  });
+
+  it('drops a break that opens the paragraph, as the block parser does', () => {
+    // markdown-it trims a leading newline, so the chip path has to as well —
+    // otherwise the same message renders a blank first line only when it
+    // carries a chip, which is the divergence #2272 exists to remove.
+    const content: JSONContent = {
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            { type: 'hardBreak' },
+            { type: 'mention', attrs: { id: 'u1', label: 'Alice' } },
+          ],
+        },
+      ],
+    };
+    expect(brCount(content)).toBe(0);
+  });
+
+  it('drops a break that closes the paragraph, as the block parser does', () => {
+    // The shape `carbon-mention` produces when Shift+Enter follows a chip: the
+    // appended text node plus the newline are both trailing boundary
+    // whitespace, so the break would land last.
+    const content: JSONContent = {
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            { type: 'mention', attrs: { id: 'u1', label: 'Alice' } },
+            { type: 'text', text: ' ' },
+            { type: 'hardBreak' },
+          ],
+        },
+      ],
+    };
+    expect(brCount(content)).toBe(0);
+  });
+
+  it('drops an opening break that a space separates from the edge', () => {
+    // The break is not the first node: the run's leading whitespace is " \n",
+    // which emits the space as its own sibling ahead of the <br>. A scan that
+    // only reads out[0] stops on that space and leaves a blank first line the
+    // same text without a chip does not have.
+    const content: JSONContent = {
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            { type: 'text', text: ' ' },
+            { type: 'hardBreak' },
+            { type: 'text', text: 'line one' },
+            { type: 'mention', attrs: { id: 'u1', label: 'Alice' } },
+          ],
+        },
+      ],
+    };
+    expect(brCount(content)).toBe(0);
+  });
+
+  it('drops a closing break that a space separates from the edge', () => {
+    // The mirror: `carbon-mention` appends a text node after the chip, so a
+    // trailing run of "\n " puts the space after the <br> and the break is no
+    // longer the last node.
+    const content: JSONContent = {
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            { type: 'mention', attrs: { id: 'u1', label: 'Alice' } },
+            { type: 'text', text: 'line one' },
+            { type: 'hardBreak' },
+            { type: 'text', text: ' ' },
+          ],
+        },
+      ],
+    };
+    expect(brCount(content)).toBe(0);
+  });
+
+  it('keeps a break between two spaces inside the paragraph', () => {
+    // The guard against over-correcting: an interior break surrounded by the
+    // same boundary whitespace must survive, or the trim eats real lines.
+    const content: JSONContent = {
+      type: 'doc',
+      content: [
+        {
+          type: 'paragraph',
+          content: [
+            { type: 'mention', attrs: { id: 'u1', label: 'Alice' } },
+            { type: 'text', text: ' ' },
+            { type: 'hardBreak' },
+            { type: 'text', text: ' line two' },
+          ],
+        },
+      ],
+    };
+    expect(brCount(content)).toBe(1);
   });
 });

--- a/packages/ai-chat/tests/typedoc/spec/alias_members_spec.ts
+++ b/packages/ai-chat/tests/typedoc/spec/alias_members_spec.ts
@@ -46,6 +46,10 @@ const NOT_OBJECT_SHAPED: Record<string, string> = {
     'enum — paired with `export const ChainOfThoughtStepStatus`',
   CHAT_BUTTON_KIND: 'enum — paired with `export const CHAT_BUTTON_KIND`',
   CHAT_BUTTON_SIZE: 'enum — paired with `export const CHAT_BUTTON_SIZE`',
+  MarkdownPluginHostMountDetail:
+    'union of the two plugin-host mount detail members, discriminated on `kind`',
+  MarkdownPluginHostMountDetailInput:
+    'union — the mount detail with `kind` optional, for details from an older build',
 };
 
 const TYPES_ROOT = resolve(__dirname, '../../../src/types');

--- a/packages/ai-chat/tests/utils/spec/inlineMarkdown_spec.tsx
+++ b/packages/ai-chat/tests/utils/spec/inlineMarkdown_spec.tsx
@@ -52,6 +52,13 @@ describe('renderInlineMarkdown', () => {
     expect(getByTestId('root').querySelector('s')?.textContent).toBe('strike');
   });
 
+  it('emits <mark> for ==highlight==', () => {
+    const { getByTestId } = renderInline('a ==marked== word');
+    const root = getByTestId('root');
+    expect(root.querySelector('mark')?.textContent).toBe('marked');
+    expect(root.textContent).toBe('a marked word');
+  });
+
   it('emits <a target=_blank rel=noopener> for links', () => {
     const { getByTestId } = renderInline('see [docs](https://example.com)');
     const a = getByTestId('root').querySelector('a');

--- a/packages/ai-chat/tests/utils/spec/inlineMarkdown_spec.tsx
+++ b/packages/ai-chat/tests/utils/spec/inlineMarkdown_spec.tsx
@@ -61,6 +61,21 @@ describe('renderInlineMarkdown', () => {
     expect(a?.textContent).toBe('docs');
   });
 
+  it('renders a soft break (single newline) as <br>', () => {
+    const { container } = renderInline('one\ntwo');
+    const root = container.querySelector('[data-testid=root]');
+    expect(root?.querySelectorAll('br')).toHaveLength(1);
+    // Exact text, not `toContain`: a half-fix that emitted the <br> and kept
+    // the old space Fragment would render the same two lines and still pass.
+    expect(root?.textContent).toBe('onetwo');
+  });
+
+  it('renders a hard break (two trailing spaces + newline) as <br>', () => {
+    const { container } = renderInline('one  \ntwo');
+    const root = container.querySelector('[data-testid=root]');
+    expect(root?.querySelectorAll('br')).toHaveLength(1);
+  });
+
   it('strips raw HTML (removeHTML=true at tokenize time)', () => {
     // Malicious-ish input: an inline <img> tag with onerror. With HTML disabled
     // in the tokenizer, the parser keeps the raw `<` text but does not produce

--- a/packages/ai-chat/tests/web-components/spec/pluginHostParity_spec.tsx
+++ b/packages/ai-chat/tests/web-components/spec/pluginHostParity_spec.tsx
@@ -1,0 +1,546 @@
+/*
+ *  Copyright IBM Corp. 2026
+ *
+ *  This source code is licensed under the Apache-2.0 license found in the
+ *  LICENSE file in the root directory of this source tree.
+ *
+ *  @license
+ */
+
+/**
+ * Three-container parity for the plugin-host protocol.
+ *
+ * `<cds-aichat-markdown>` offers plugin-fallback and custom-renderer hosts to
+ * an ancestor chat container over three composed events. The container half is
+ * implemented once per surface — React `ChatContainer`, `cds-aichat-container`
+ * and `cds-aichat-custom-element` — and nothing has ever checked that the three
+ * agree. This spec drives all three with one identical event sequence and
+ * compares the resulting host DOM.
+ *
+ * The events are synthesized rather than produced by a real markdown element:
+ * jsdom never upgrades `<cds-aichat-markdown>`, and the subject under test is
+ * the listener, not the dispatcher. The details below are the ones
+ * `reconcileCustomRendererHosts` actually dispatches — see
+ * `packages/ai-chat-components/src/components/markdown/src/markdown.ts`.
+ */
+
+import type {
+  MarkdownPluginHostMountDetail,
+  MarkdownPluginHostMountDetailInput,
+} from '@carbon/ai-chat-components/es/components/markdown/index.js';
+import { waitFor } from '@testing-library/react';
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+
+import '../../../src/web-components/cds-aichat-container';
+import '../../../src/web-components/cds-aichat-custom-element';
+import { ChatContainer } from '../../../src/react/ChatContainer';
+import { createBaseConfig, createBaseTestProps } from '../../test_helpers';
+
+// `cds-aichat-custom-element` spreads `root.adoptedStyleSheets` in its
+// `createRenderRoot` to append its hide-sheet, and jsdom's ShadowRoot has no
+// such property, so connecting it throws before any listener is wired. Same
+// class of environment gap as the `CSSStyleSheet` stub in `tests/setup.ts`,
+// kept local because this is the first spec to connect that element.
+const adopted = new WeakMap<ShadowRoot, unknown[]>();
+if (!('adoptedStyleSheets' in ShadowRoot.prototype)) {
+  Object.defineProperty(ShadowRoot.prototype, 'adoptedStyleSheets', {
+    configurable: true,
+    get(this: ShadowRoot) {
+      return adopted.get(this) ?? [];
+    },
+    set(this: ShadowRoot, sheets: unknown[]) {
+      adopted.set(this, sheets);
+    },
+  });
+}
+
+const MOUNT = 'cds-aichat-markdown-plugin-host-mount';
+const UPDATE = 'cds-aichat-markdown-plugin-host-update';
+const UNMOUNT = 'cds-aichat-markdown-plugin-host-unmount';
+
+/**
+ * Dispatches a mount offer the way the markdown element does. Typed against
+ * the union the components package publishes, so a detail that drifts from the
+ * shipped shape is a compile error rather than a passing test.
+ */
+function mountEvent(detail: MarkdownPluginHostMountDetailInput) {
+  return new CustomEvent(MOUNT, {
+    bubbles: true,
+    composed: true,
+    cancelable: true,
+    detail,
+  });
+}
+
+/** The kinded details every non-legacy case below is built from. */
+function fallbackDetail(
+  slotName: string,
+  html: string,
+  isInline: boolean
+): MarkdownPluginHostMountDetail {
+  return { kind: 'pluginFallback', slotName, html, isInline };
+}
+
+function rendererDetail(
+  slotName: string,
+  element: HTMLElement
+): MarkdownPluginHostMountDetail {
+  return { kind: 'customRenderer', slotName, element, isInline: false };
+}
+
+function plainEvent(type: string, detail: Record<string, unknown>) {
+  return new CustomEvent(type, { bubbles: true, composed: true, detail });
+}
+
+/**
+ * One container surface, reduced to what the protocol needs: the element that
+ * both listens and receives hosts, plus the element to dispatch from (the same
+ * node except where a nested topology is under test).
+ */
+interface Subject {
+  name: string;
+  /** Listener target and host parent. */
+  host: HTMLElement;
+  /** Node the markdown element would have dispatched from. */
+  source: HTMLElement;
+  /** Awaits a render pass, where the surface has one. */
+  settle: () => Promise<void>;
+}
+
+const subjects: Subject[] = [];
+let containerElement: HTMLElement;
+let customElement: HTMLElement;
+
+/** Boots every surface once — each boot is seconds, not milliseconds. */
+beforeAll(async () => {
+  containerElement = document.createElement('cds-aichat-container');
+  (containerElement as unknown as { config: unknown }).config =
+    createBaseConfig();
+  document.body.appendChild(containerElement);
+
+  customElement = document.createElement('cds-aichat-custom-element');
+  (customElement as unknown as { config: unknown }).config = createBaseConfig();
+  document.body.appendChild(customElement);
+
+  // A plain root rather than `@testing-library/react`'s `render`: its automatic
+  // cleanup unmounts between cases, and unmounting tears down the very effect
+  // that owns the listeners under test. Every surface here is booted once.
+  const reactMount = document.createElement('div');
+  document.body.appendChild(reactMount);
+  createRoot(reactMount).render(
+    React.createElement(ChatContainer, createBaseTestProps() as never)
+  );
+
+  let reactWrapper: HTMLElement | undefined;
+  // Wait for the listeners themselves, not for the element: they are attached
+  // by an effect keyed on the wrapper, which is set only after the shadow-ready
+  // handshake resolves. A probe offer is the only thing that proves they exist.
+  await waitFor(
+    () => {
+      const found = reactMount.querySelector<HTMLElement>('cds-aichat-react');
+      expect(found).not.toBeNull();
+      const probe = mountEvent(fallbackDetail('boot-probe', '', false));
+      found?.dispatchEvent(probe);
+      expect(probe.defaultPrevented).toBe(true);
+      reactWrapper = found ?? undefined;
+    },
+    { timeout: 8000 }
+  );
+  if (!reactWrapper) {
+    throw new Error('ChatContainer never produced a cds-aichat-react wrapper');
+  }
+  const wrapper = reactWrapper;
+  wrapper.dispatchEvent(plainEvent(UNMOUNT, { slotName: 'boot-probe' }));
+
+  subjects.push(
+    {
+      name: 'ChatContainer',
+      host: wrapper,
+      source: wrapper,
+      settle: async () => undefined,
+    },
+    {
+      name: 'cds-aichat-container',
+      host: containerElement,
+      source: containerElement,
+      settle: async () => {
+        await (containerElement as unknown as { updateComplete: Promise<void> })
+          .updateComplete;
+      },
+    },
+    {
+      name: 'cds-aichat-custom-element',
+      host: customElement,
+      source: customElement,
+      settle: async () => {
+        await (customElement as unknown as { updateComplete: Promise<void> })
+          .updateComplete;
+      },
+    }
+  );
+}, 30000);
+
+/**
+ * Runs `probe` against every surface and keys the results by name, so a single
+ * assertion covers all three. An `expect` inside the loop instead would abort
+ * at the first failing surface and leave the others unmeasured — which is the
+ * comparison this spec exists to make.
+ */
+async function acrossSubjects<T>(
+  probe: (subject: Subject) => Promise<T>
+): Promise<Record<string, T>> {
+  const results: Record<string, T> = {};
+  for (const subject of subjects) {
+    results[subject.name] = await probe(subject);
+  }
+  return results;
+}
+
+/** Builds the expectation every surface has to match. */
+function sameForAll<T>(value: (subject: Subject) => T): Record<string, T> {
+  return Object.fromEntries(subjects.map((s) => [s.name, value(s)]));
+}
+
+/** Slot names a surface forwards inward, or null where it forwards none. */
+function forwardedNames(subject: Subject): string[] | null {
+  return (
+    (subject.host as unknown as { _pluginSlotNames?: string[] })
+      ._pluginSlotNames ?? null
+  );
+}
+
+/** The host a container appended for `slotName`, if it appended one. */
+function hostFor(subject: Subject, slotName: string) {
+  // `:not(slot)` because a nested container's own forwarders are
+  // `<slot name=X slot=X>` light-DOM children carrying the same attribute.
+  return subject.host.querySelector<HTMLElement>(
+    `[slot="${slotName}"]:not(slot)`
+  );
+}
+
+describe('plugin-host protocol: all three containers agree', () => {
+  it.each([
+    ['block', false, 'DIV', '1rem'],
+    ['inline', true, 'SPAN', ''],
+  ])(
+    'hosts a %s plugin-fallback mount identically',
+    async (label, isInline, tagName, spacing) => {
+      const results = await acrossSubjects(async (subject) => {
+        const slotName = `parity-fallback-${label}-${subject.name}`;
+        const event = mountEvent(
+          fallbackDetail(slotName, '<i>x</i>', isInline)
+        );
+        subject.source.dispatchEvent(event);
+        await subject.settle();
+        const host = hostFor(subject, slotName);
+        return {
+          claimed: event.defaultPrevented,
+          tagName: host?.tagName,
+          slot: host?.getAttribute('slot'),
+          spacing: host?.style.marginBlockStart,
+          html: host?.innerHTML,
+        };
+      });
+
+      expect(results).toEqual(
+        sameForAll((subject) => ({
+          claimed: true,
+          tagName,
+          slot: `parity-fallback-${label}-${subject.name}`,
+          spacing,
+          html: '<i>x</i>',
+        }))
+      );
+    }
+  );
+
+  it('relocates a custom-renderer mount identically', async () => {
+    const results = await acrossSubjects(async (subject) => {
+      const slotName = `parity-renderer-${subject.name}`;
+      const live = document.createElement('div');
+      const event = mountEvent(rendererDetail(slotName, live));
+      subject.source.dispatchEvent(event);
+      await subject.settle();
+      const host = hostFor(subject, slotName);
+      return {
+        claimed: event.defaultPrevented,
+        sameNode: host === live,
+        slot: host?.getAttribute('slot'),
+        spacing: host?.style.marginBlockStart,
+      };
+    });
+
+    expect(results).toEqual(
+      sameForAll((subject) => ({
+        claimed: true,
+        sameNode: true,
+        slot: `parity-renderer-${subject.name}`,
+        spacing: '',
+      }))
+    );
+  });
+
+  it('rewrites host content in place on update', async () => {
+    const results = await acrossSubjects(async (subject) => {
+      const slotName = `parity-update-${subject.name}`;
+      subject.source.dispatchEvent(
+        mountEvent(fallbackDetail(slotName, '<i>one</i>', false))
+      );
+      await subject.settle();
+      const host = hostFor(subject, slotName);
+
+      subject.source.dispatchEvent(
+        plainEvent(UPDATE, { slotName, html: '<i>two</i>' })
+      );
+      await subject.settle();
+
+      return {
+        sameNode: hostFor(subject, slotName) === host,
+        html: host?.innerHTML,
+      };
+    });
+
+    expect(results).toEqual(
+      sameForAll(() => ({ sameNode: true, html: '<i>two</i>' }))
+    );
+  });
+
+  it('removes the host and drops the slot name on unmount', async () => {
+    const results = await acrossSubjects(async (subject) => {
+      const slotName = `parity-unmount-${subject.name}`;
+      subject.source.dispatchEvent(
+        mountEvent(fallbackDetail(slotName, '<i>x</i>', false))
+      );
+      await subject.settle();
+      const hostedBefore = hostFor(subject, slotName) !== null;
+      const forwardedBefore = forwardedNames(subject)?.includes(slotName);
+
+      subject.source.dispatchEvent(plainEvent(UNMOUNT, { slotName }));
+      await subject.settle();
+
+      return {
+        hostedBefore,
+        // `undefined` on a surface that forwards nothing, which is
+        // `ChatContainer` — the React `Markdown` wrapper owns its only hop.
+        forwardedBefore,
+        hostedAfter: hostFor(subject, slotName) !== null,
+        forwardedAfter: forwardedNames(subject)?.includes(slotName),
+      };
+    });
+
+    expect(results).toEqual(
+      sameForAll((subject) => ({
+        hostedBefore: true,
+        forwardedBefore: forwardedNames(subject) === null ? undefined : true,
+        hostedAfter: false,
+        forwardedAfter: forwardedNames(subject) === null ? undefined : false,
+      }))
+    );
+  });
+
+  it('ignores a mount with no slot name', async () => {
+    for (const subject of subjects) {
+      const before = subject.host.childElementCount;
+      // Deliberately malformed: the union requires `slotName`, so the cast is
+      // what lets the case exist at all — and it is exactly the payload the
+      // no-op lock says must be ignored.
+      const event = mountEvent({
+        kind: 'pluginFallback',
+        html: '<i>x</i>',
+        isInline: false,
+      } as unknown as MarkdownPluginHostMountDetailInput);
+      subject.source.dispatchEvent(event);
+      await subject.settle();
+
+      expect(event.defaultPrevented).toBe(false);
+      expect(subject.host.childElementCount).toBe(before);
+    }
+  });
+
+  /**
+   * The components dependency is a caret range, so an older build can still
+   * emit the pre-`kind` shape. It has to keep hosting.
+   */
+  it('hosts a legacy mount detail that carries no kind', async () => {
+    for (const subject of subjects) {
+      const slotName = `parity-legacy-${subject.name}`;
+      subject.source.dispatchEvent(
+        mountEvent({ slotName, html: '<i>legacy</i>', isInline: false })
+      );
+      await subject.settle();
+
+      const host = hostFor(subject, slotName);
+      expect(host?.tagName).toBe('DIV');
+      expect(host?.innerHTML).toBe('<i>legacy</i>');
+    }
+  });
+
+  it('relocates a legacy custom-renderer mount that carries no kind', async () => {
+    for (const subject of subjects) {
+      const slotName = `parity-legacy-renderer-${subject.name}`;
+      const live = document.createElement('div');
+      const event = mountEvent({ slotName, element: live, isInline: false });
+      subject.source.dispatchEvent(event);
+      await subject.settle();
+
+      expect(event.defaultPrevented).toBe(true);
+      expect(hostFor(subject, slotName)).toBe(live);
+    }
+  });
+
+  it('does not reattach a custom-renderer host it already holds', async () => {
+    for (const subject of subjects) {
+      const slotName = `renderer-idempotent-${subject.name}`;
+      const live = document.createElement('div');
+      subject.source.dispatchEvent(mountEvent(rendererDetail(slotName, live)));
+      await subject.settle();
+
+      const marker = document.createElement('span');
+      subject.host.appendChild(marker);
+      subject.source.dispatchEvent(mountEvent(rendererDetail(slotName, live)));
+      await subject.settle();
+
+      // A re-`appendChild` moves `live` past the marker — and detaching and
+      // reattaching runs the consumer subtree's disconnect/connect teardown.
+      expect(live.nextElementSibling).toBe(marker);
+      marker.remove();
+    }
+  });
+
+  it('ignores an update aimed at a relocated custom-renderer host', async () => {
+    for (const subject of subjects) {
+      const slotName = `renderer-update-${subject.name}`;
+      const live = document.createElement('div');
+      live.innerHTML = '<b>consumer</b>';
+      subject.source.dispatchEvent(mountEvent(rendererDetail(slotName, live)));
+      await subject.settle();
+
+      subject.source.dispatchEvent(
+        plainEvent(UPDATE, { slotName, html: '<i>clobbered</i>' })
+      );
+      await subject.settle();
+
+      expect(live.innerHTML).toBe('<b>consumer</b>');
+    }
+  });
+
+  it('drops a custom-renderer slot name on unmount but leaves the node parented', async () => {
+    for (const subject of subjects) {
+      const slotName = `renderer-unmount-${subject.name}`;
+      const live = document.createElement('div');
+      subject.source.dispatchEvent(mountEvent(rendererDetail(slotName, live)));
+      await subject.settle();
+
+      subject.source.dispatchEvent(plainEvent(UNMOUNT, { slotName }));
+      await subject.settle();
+
+      // The markdown element detaches its own node before it announces; a
+      // controller that removed it here would destroy what it never created.
+      expect(forwardedNames(subject)?.includes(slotName) ?? false).toBe(false);
+      expect(live.parentElement).toBe(subject.host);
+    }
+  });
+});
+
+describe('plugin-host protocol: forwarder slot names', () => {
+  it('forwards a plugin-fallback slot name', async () => {
+    for (const subject of subjects) {
+      const slotName = `forward-fallback-${subject.name}`;
+      subject.source.dispatchEvent(
+        mountEvent({
+          kind: 'pluginFallback',
+          slotName,
+          html: '<i>x</i>',
+          isInline: false,
+        })
+      );
+      await subject.settle();
+
+      const names = forwardedNames(subject);
+      if (names === null) {
+        // ChatContainer renders no forwarder; the React Markdown wrapper
+        // supplies the only hop on that topology.
+        continue;
+      }
+      expect(names).toContain(slotName);
+    }
+  });
+
+  /**
+   * A relocated custom-renderer host is one or more shadow boundaries out, so
+   * it needs the same forwarder chain a fallback host needs. Both kinds are
+   * forwarded here identically; the markdown element mints the innermost hop
+   * for either, from the claim.
+   */
+  it('forwards a custom-renderer slot name', async () => {
+    for (const subject of subjects) {
+      const slotName = `forward-renderer-${subject.name}`;
+      const live = document.createElement('div');
+      subject.source.dispatchEvent(mountEvent(rendererDetail(slotName, live)));
+      await subject.settle();
+
+      const names = forwardedNames(subject);
+      if (names === null) {
+        continue;
+      }
+      expect(names).toContain(slotName);
+    }
+  });
+});
+
+describe('plugin-host protocol: nested topology', () => {
+  it('cds-aichat-container declines when an outer chat element is present', async () => {
+    const inner = customElement.shadowRoot?.querySelector<HTMLElement>(
+      'cds-aichat-container'
+    );
+    if (!inner) {
+      throw new Error('cds-aichat-custom-element rendered no inner container');
+    }
+
+    const slotName = 'nested-fallback';
+    const event = mountEvent(fallbackDetail(slotName, '<i>x</i>', false));
+    inner.dispatchEvent(event);
+    await (inner as unknown as { updateComplete: Promise<void> })
+      .updateComplete;
+    await (customElement as unknown as { updateComplete: Promise<void> })
+      .updateComplete;
+
+    // The inner container forwards but does not host; the outer element hosts.
+    expect(inner.querySelector(`[slot="${slotName}"]:not(slot)`)).toBeNull();
+    expect(
+      (inner as unknown as { _pluginSlotNames: string[] })._pluginSlotNames
+    ).toContain(slotName);
+    expect(
+      customElement.querySelector(`[slot="${slotName}"]:not(slot)`)
+    ).not.toBeNull();
+  });
+
+  it('cds-aichat-container defers a custom-renderer mount to the outer chat element', async () => {
+    const inner = customElement.shadowRoot?.querySelector<HTMLElement>(
+      'cds-aichat-container'
+    );
+    if (!inner) {
+      throw new Error('cds-aichat-custom-element rendered no inner container');
+    }
+
+    const slotName = 'nested-renderer';
+    const live = document.createElement('div');
+    const event = mountEvent(rendererDetail(slotName, live));
+    inner.dispatchEvent(event);
+    await (inner as unknown as { updateComplete: Promise<void> })
+      .updateComplete;
+    await (customElement as unknown as { updateComplete: Promise<void> })
+      .updateComplete;
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(inner.querySelector(`[slot="${slotName}"]:not(slot)`)).toBeNull();
+    expect(
+      (inner as unknown as { _pluginSlotNames: string[] })._pluginSlotNames
+    ).toContain(slotName);
+    expect(customElement.querySelector(`[slot="${slotName}"]:not(slot)`)).toBe(
+      live
+    );
+    expect(live.style.marginBlockStart).toBe('');
+  });
+});


### PR DESCRIPTION
Closes #2270
Closes #2271
Closes #2272
Closes #2273

Consumer-loaded CSS stopped reaching `customRenderers` content.

That output is host-authored markup, and hosts style it with their own page stylesheet. #2222 changed the plugin-host path to leave it inside the markdown element's shadow root instead of relocating it into the host's light DOM. Slotted content is styled by the tree it *lives in*, not the tree it is projected into, and document stylesheets do not cross a shadow boundary — so every consumer rule written against custom-renderer content silently stopped applying.

It has not shipped: no tag contains #2222, and `main` is ahead of `v1.20.0-rc.1`. That is the reason to land this before the next cut.

The rest of the PR is the line-break work that was in flight alongside it, plus the defects found while tracing the regression.

#### Changelog

**New**

- Plugin-fallback slots carry the token's source text as fallback content, so a claimed-but-unforwarded host degrades to unstyled text instead of disappearing with no error. Text rather than the rendered markup: the markup already exists once as the light-DOM host, and duplicating it inside the slot doubled the DOM of a plugin-heavy message — 40 KaTeX expressions measured 3,288 extra elements.
- The four plugin-host detail types, documented and published through `@carbon/ai-chat` so they carry a `@category` and reach the docs site rather than being deep-import only. The line that earns its place is on `html`: it reaches a host's `innerHTML` unsanitized unless the element has `sanitize-html` set.
- A demo Playwright gate that injects a page stylesheet and asserts it reaches a `customRenderers.table` node, across all four container shapes, driven by a new `markdownCustomRenderers` setting and its sidebar switcher.

**Changed**

- `customRenderers` hosts are relocated into the outermost chat element's light DOM again, and forwarded back through one-, two- and three-hop slot chains.
- The plugin-host mount/update/unmount protocol now routes through a single `plugin-host-container.ts` instead of two divergent copies — the regression reached `main` through one of them while the other kept working.
- Plugin-fallback slot names are minted once per token, so a re-render cannot strand a forwarder on a name nothing assigns to.
- The markdown element mints the innermost `<slot>` hop for **both** claim kinds, in the pass that reads the claim. Previously only a `customRenderer` claim worked that way and a `pluginFallback` claim was seeded by the React wrapper from a public getter — two mechanisms for one job, the second of which had a race to close.
- Line breaks render inside merged inline-HTML runs (`<b>one<br>two</b>` no longer collapses to `onetwo`), for `softbreak` on the React inline path, and next to mention/command chips in the sent-message bubble.
- `==highlight==` renders `<mark>` on the chip path; the walker was switching on `mark_open`/`mark_close`, which markdown-it never emits.
- `MarkdownWithDefaults` re-renders when `streaming` changes with the text unchanged, so the markdown element learns a stream ended and leaves its trailing-table loading state.

**Removed**

- `softbreak` and `hardbreak` from `PLUGIN_DELEGABLE_TOKEN_TYPES`, added by #2222. Delegation cost a light-DOM host and a mount/unmount event pair per line break on the hottest path, and was silently skipped wherever a break is consumed before the renderer sees it. Unreleased and undocumented.
- The hand-written `React.memo` comparator on `MarkdownWithDefaults`. Its corrected form compares every prop in the interface, which is what `React.memo` does with no comparator.
- `delegatedPluginSlotNames`, the React wrapper's slot-name state and seed effect, and the two test harnesses built to model the late-subscriber race. Symmetric minting makes the race unrepresentable, so none of it has anything left to guard.

#### Scope note

Two fixes here are not covered by any of the four issues: the `React.memo` comparator removal and the `mark_open` → `highlight_open` rename. Both are net deletions in files this PR already edits, and both are one-line corrections to code that never ran as intended.

#2271 and #2273 carry closing comments that describe #2295 — an earlier attempt whose design this PR reverses. Superseding comments are posted on both; read those, not the older ones.

#### Testing / Reviewing

Commits are one defect each, in final form — no commit is corrected by a later one. Reviewable one at a time, worst-first: **the first commit is the regression**.

##### Check it by hand

Each fix has an existing example that isolates it. `npm run aiChat:build` first — the examples consume built artifacts — then `npm start` in the example directory.

**1. Consumer CSS reaches `customRenderers` output — the regression.** `examples/react/markdown-override` and `examples/web-components/markdown-override`. Send anything; the reply renders a markdown table through a Carbon `DataTable` and a fence through `cds-aichat-code-snippet`.

- The table should be a *styled* Carbon data table. Before this fix it rendered unstyled: the page's `@carbon/styles` could not cross into the shadow root the node was left in.
- In devtools, the returned node's host is a `<div slot="…">` child of the outermost chat element, not of `<cds-aichat-markdown>`.
- Type `.cds--data-table { outline: 3px solid magenta }` into the page's own stylesheet and confirm the outline lands.
- **Do the web-components one too.** It stacks more shadow boundaries, and that is the surface that broke.

**2. Plugin output still projects, and still gets page CSS.** `examples/*/markdown-plugin` (KaTeX). This is the path whose forwarder mechanism this PR replaces, so it is the one worth a second look.

- Math renders typeset, inline (`$E = mc^2$`) and block, in **both** replies — a second message must not steal the first one's slot.
- The KaTeX stylesheet comes from `index.html`, so typeset math at all is the CSS-reach proof. Confirm `getComputedStyle($0).fontFamily` on a `.katex` node reports `KaTeX_Main`.
- `<cds-aichat-markdown>` should have one `<slot name=… slot=…>` light-DOM child per math node, and the host `<div>` should sit in the outermost chat element.

**3. Line breaks next to chips.** `examples/*/prompt-line-mentions-and-commands`.

- Type `line one`, Shift+Enter, `line two`, send → two lines.
- Now do it again with an `@` mention chip in the message → still two lines, same as without the chip. That divergence is #2272.
- Put a space before the Shift+Enter, and separately after a chip, and send → no blank first or last line. Those are the paragraph-edge cases.
- Type `==highlight==` in a message containing a chip → renders as `<mark>`, not literal `==` text.

**4. Breaks inside inline HTML.** Demo (`demo/`), send **html**, or any reply whose markdown wraps a break in a tag: `<b>one` newline `two</b>` renders on two lines instead of collapsing to `onetwo`.

**5. Streaming leaves the loading state.** Demo, send **table (stream)**. The table must resolve to a real table when the stream ends. Before the memo fix, a reply whose final text equalled the assembled chunks never told the element the stream had ended, and a trailing table stayed a skeleton.

**6. Demo, all four container shapes.** Set **Chat Configuration → Markdown → Table rendering** to `customRenderers.table`, send **table**, and check the node lands in the chat element's own root with a page rule reaching it. Note the two web-component shapes put the chat element inside `<demo-app>`'s shadow root, so the rule goes in that root, not the document.

##### Automated

| suite | result |
| --- | --- |
| `@carbon/ai-chat-components` (Web Test Runner) | {{WTR}} |
| `@carbon/ai-chat-components` React wrappers (Jest) | {{RW}} |
| `@carbon/ai-chat` (Jest) | {{AC}} |
| `demo/` (Playwright) | 44 passed |
| examples (react-17, vite, jsdom, happydom) | 2 / 4 / 3 / 5 passed |

**The new gates are gates, not decoration.** The demo spec was falsified by re-running it against a build with the `customRenderer` claim removed from `handleMount`: 4 of 4 Chromium cases fail. The streaming-memo test was falsified against the old comparator: only one render reaches the element, stuck at `streaming: true`. The two paragraph-edge break cases were falsified against the un-fixed trim: both report one `<br>` where the block path renders none.

Replaces #2295, which mixed this work with changes that have since been dropped.
