### PR TITLE
fix(card): update storybook styles

### DIFF
--- a/packages/ai-chat-components/src/components/card/__stories__/story-styles.scss
+++ b/packages/ai-chat-components/src/components/card/__stories__/story-styles.scss
@@ -31,13 +31,16 @@
   .preview-card-small,
   .standard-card {
     h4 {
-      @include type-style('heading-01');
+      @include type-style('body-compact-01');
 
+      color: theme.$text-primary;
       margin-block-end: layout.$spacing-04;
     }
 
     p {
-      @include type-style('body-01');
+      @include type-style('helper-text-01');
+
+      color: theme.$text-secondary;
     }
   }
 


### PR DESCRIPTION
Closes #1489

Audit fixes for the Card component. Moved the source card variant support to #2300, which is to be completed once v12 is available. Changes in this PR are storybook-only since the style changes referenced in the original issues are set by the user.

#### Changelog

**Changed**

- `story-styles.scss`: Changed heading text from $heading-01 to $body-compact-01 and body text from $body-01, $ text-primary to $helper-text-01, $text-secondary

#### Testing / Reviewing

- Verify visual changes in Chromatic
