### PR TITLE
test(markdown): capture addMarkdown return values in projection test

### DIFF
--- a/packages/ai-chat-components/src/components/markdown/__tests__/markdown.test.ts
+++ b/packages/ai-chat-components/src/components/markdown/__tests__/markdown.test.ts
@@ -1746,10 +1746,10 @@ HTTP: http://example.com
     it('projects exactly one host into each markdown element', async () => {
       const { harness, mounted, addMarkdown } = await createRelocationHarness();
 
-      await addMarkdown(codeMarkdown, {
+      const elA = await addMarkdown(codeMarkdown, {
         customRenderers: { codeBlock: taggedCodeBlockRenderer('a') },
       } as Partial<MarkdownElementInstance>);
-      await addMarkdown(codeMarkdown, {
+      const elB = await addMarkdown(codeMarkdown, {
         customRenderers: { codeBlock: taggedCodeBlockRenderer('b') },
       } as Partial<MarkdownElementInstance>);
 


### PR DESCRIPTION
The `projects exactly one host into each markdown element` test in `markdown.test.ts` referenced `elA` and `elB` without ever assigning them, causing a `ReferenceError` at runtime and failing CI on the release branch.

The return values of the two `addMarkdown()` calls were already used as the element references for the slot assertions — they just weren't captured. Assigning them to `const elA` and `const elB` is the complete fix.

This was introduced by the cherry-pick of `d5e90a24` (`fix(markdown): restore consumer CSS and fix line breaks #2299`) onto `release/v1.20.0`.